### PR TITLE
Add event filter

### DIFF
--- a/start.py
+++ b/start.py
@@ -6,12 +6,25 @@
 # arguments
 import argparse
 import sys
+import re
 
-from tracee.container_tracer import EventMonitor
+from tracee.container_tracer import EventMonitor, syscalls, sysevents
 
 examples = """examples:
     ./start.py -v
 """
+
+class EventsToTraceAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        events = re.split('\W+', values)
+        for e in events:
+            if e not in syscalls and e not in sysevents and e != "all":
+                parser.error("Invalid event {0}".format(e))
+
+        if "all" in events:
+            events = syscalls + sysevents
+
+        setattr(namespace, self.dest, events)
 
 
 def parse_args(input_args):
@@ -25,7 +38,8 @@ def parse_args(input_args):
                         help=argparse.SUPPRESS)
     parser.add_argument("-j", "--json", action="store_true",
                         help="save events in json format")
-    # args = parser.parse_args()
+    parser.add_argument("-e", "--events-to-trace", default = syscalls + sysevents, action=EventsToTraceAction,
+                        help="trace only the specified events and syscalls (default: trace all)")
     return parser.parse_args(input_args)
 
 

--- a/test_container_tracer.py
+++ b/test_container_tracer.py
@@ -1,9 +1,10 @@
+#!/usr/bin/python
 import ctypes
 import unittest
 import tracee
 import start
 
-from tracee.container_tracer import EventMonitor
+from tracee.container_tracer import EventMonitor, syscalls, sysevents
 
 
 class TestEventMonitor(unittest.TestCase):
@@ -140,6 +141,30 @@ class TestEventMonitor(unittest.TestCase):
             sockaddr_str = em.get_sockaddr_from_buf(ctypes.c_short(test_case["input"]))
             self.assertEqual(test_case["expected_sock_type"], sockaddr_str, "returned sock_type should be equal")
             self.assertEqual(test_case["expected_cur_off"], em.cur_off, "current offset should be 2")
+
+    def test_event_filter(self):
+
+        test_cases = [
+            {
+                "name": "default to all events",
+                "args": [],
+                "expected_events": syscalls + sysevents
+            },
+            {
+                "name": "include all events",
+                "args": ["-e", "all"],
+                "expected_events": syscalls + sysevents
+            },
+            {
+                "name": "specify one",
+                "args": ["-e", "open"],
+                "expected_events": ["open"]
+            }
+        ]
+
+        for test_case in test_cases:
+            em = tracee.container_tracer.EventMonitor(start.parse_args(test_case["args"]))
+            self.assertEqual(len(em.events_to_trace), len(test_case["expected_events"]), test_case["name"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `-e`/`--events-to-trace` option allowing user to specify the syscalls and events to be shown in the trace. 

For example: `tracee -e cap_capable,execve` shows only cap_capable and execve events in the output

Default is to include all events (can also be explicitly specified with `-e all`) 