### PR TITLE
dynamic configuration of the bpf code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ optional arguments:
 
 -c, --container       only trace newly created containers
 
---max-args MAX_ARGS   maximum number of arguments parsed and displayed, defaults to 20
+-b {1,2,4,8,16,32,64,128,256,512,1024}, --buf-pages {1,2,4,8,16,32,64,128,256,512,1024}
+                      number of pages for perf buffer, defaults to 64
 
 -j, --json            save events in json format
 

--- a/start.py
+++ b/start.py
@@ -34,10 +34,9 @@ def parse_args(input_args):
         epilog=examples)
     parser.add_argument("-c", "--container", action="store_true",
                         help="only trace newly created containers")
-    parser.add_argument("--max-args", default="20",
-                        help="maximum number of arguments parsed and displayed, defaults to 20")
-    parser.add_argument("-b", "--buf-pages", default="32",
-                        help="number of pages for perf buffer, defaults to 32")
+    parser.add_argument("-b", "--buf-pages", type=int, default=64,
+                        choices=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
+                        help="number of pages for perf buffer, defaults to %(default)s")
     parser.add_argument("--ebpf", action="store_true",
                         help=argparse.SUPPRESS)
     parser.add_argument("-j", "--json", action="store_true",


### PR DESCRIPTION
Remove BPF code replacement each time tracee is started.
By doing that, we will be able to compile Tracee's BPF code once per node.
Adding config map to communicate userspace configuration to BPF code.