### PR TITLE
fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ os ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 .PHONY: build
 build: tracee_$(os)
 
-SRC = $(shell find . -type f -name '*.go')
+SRC = $(shell find . -type f -name '*.go' ! -name '*_test.go' )
 tracee_%: $(SRC)
 	GOOS=$* go build -o $(@F)
 
 .PHONY: test
-test: $(SRC)
+test:
 	go test -v ./...
 
 .PHONY: clean


### PR DESCRIPTION
the makefile was broken by https://github.com/aquasecurity/tracee/pull/58 which added `tracee_test.go`. this PR fixed that.