### PR TITLE
handle lost events and support configurable buffer size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/tracee
 go 1.13
 
 require (
-	github.com/iovisor/gobpf v0.0.0-20191219090757-e72091e3c5e6
+	github.com/iovisor/gobpf v0.0.0-20200417061255-f0a208deaea5
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli/v2 v2.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/iovisor/gobpf v0.0.0-20191017091429-c3024dcc6881 h1:DRdqUzrTOOIlh9Fzm
 github.com/iovisor/gobpf v0.0.0-20191017091429-c3024dcc6881/go.mod h1:+5U5qu5UOu8YJ5oHVLvWKH7/Dr5QNHU7mZ2RfPEeXg8=
 github.com/iovisor/gobpf v0.0.0-20191219090757-e72091e3c5e6 h1:iFG10/KLpx/+XAWkOp7cCg4cHC4ZJ1NfYyhy+ti6GMA=
 github.com/iovisor/gobpf v0.0.0-20191219090757-e72091e3c5e6/go.mod h1:+5U5qu5UOu8YJ5oHVLvWKH7/Dr5QNHU7mZ2RfPEeXg8=
+github.com/iovisor/gobpf v0.0.0-20200417061255-f0a208deaea5 h1:LuRmSIyYmbTLffmCAzvR1GcGJYQ2slcDexwiwq6fTjQ=
+github.com/iovisor/gobpf v0.0.0-20200417061255-f0a208deaea5/go.mod h1:+5U5qu5UOu8YJ5oHVLvWKH7/Dr5QNHU7mZ2RfPEeXg8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 				c.Bool("detect-original-syscall"),
 				c.Bool("show-exec-env"),
 				c.String("output"),
+				c.Int("perf-buffer-size"),
 			)
 			if err != nil {
 				return fmt.Errorf("error creating Tracee config: %v", err)
@@ -70,6 +71,12 @@ func main() {
 				Name:  "show-exec-env",
 				Value: false,
 				Usage: "when tracing execve/execveat, show environment variables",
+			},
+			&cli.IntFlag{
+				Name:    "perf-buffer-size",
+				Aliases: []string{"b"},
+				Value:   64,
+				Usage:   "size, in pages, of the internal perf ring buffer used to submit events from the kernel",
 			},
 		},
 	}

--- a/test/loader.sh
+++ b/test/loader.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+# example: `./loader.sh ls 4 5`
+# will run 4 threads that continuously run `ls` in a loop for 5 seconds
+# then run tracee with small buffer size to increase the chance for lost events:
+# `make build && sudo ./tracee_linux -e mmap -e close -e mprotect -e openat -e security_file_open -b 1`
+
+set -e
+command="$1"
+parallalism="$2"
+duration="$3"
+
+for i in 1.."$parallalism"; do
+  bash -c "while true; do $command > /dev/null; done" &
+done
+sleep "$duration"
+kill $(jobs -p)

--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -31,7 +31,7 @@ func (p tableEventPrinter) Print(ctx context, args []interface{}) {
 
 func (p tableEventPrinter) Epilogue() {
 	fmt.Printf("\nEnd of events stream\n")
-	fmt.Printf("Total events: %d, Total errors: %d", p.tracee.eventCounter, p.tracee.errorCounter)
+	fmt.Printf("Total events: %d, Lost events: %d, Unexpected errors: %d", p.tracee.eventCounter, p.tracee.lostCounter, p.tracee.errorCounter)
 }
 
 type jsonEventPrinter struct{}


### PR DESCRIPTION
- handle lost events (count and print them). uses https://github.com/iovisor/gobpf/pull/235
- support customizable buffer size. uses https://github.com/iovisor/gobpf/pull/218
- add a simple load test to test lost events

related: https://github.com/aquasecurity/tracee/issues/49