### PR TITLE
build distributable binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 .idea
-/tracee_*
+/dist
 *__pycache__*
 venv
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ COPY --from=aquasec/bcc-builder:latest /root/bcc/libbcc_*.deb /bcc/
 RUN DEBIAN_FRONTEND=noninteractive dpkg -i libbcc_*.deb && rm -rf /bcc
 
 WORKDIR /tracee
-COPY --from=builder /tracee/tracee_linux /tracee/entrypoint.sh ./
-COPY --from=builder /tracee/tracee/event_monitor_ebpf.c ./tracee/
-ENTRYPOINT ["./entrypoint.sh", "./tracee_linux"]
+COPY --from=builder /tracee/tracee /tracee/entrypoint.sh ./
+COPY --from=builder ./tracee/
+ENTRYPOINT ["./entrypoint.sh", "./tracee"]

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-os ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
-
 .PHONY: build
-build: tracee_$(os)
+build: dist/tracee tracee/event_monitor_ebpf.c
 
 SRC = $(shell find . -type f -name '*.go' ! -name '*_test.go' )
-tracee_%: $(SRC)
-	GOOS=$* go build -o $(@F)
+ebpfProgramBase64 = $(shell base64 -w 0 tracee/event_monitor_ebpf.c)
+dist/tracee: $(SRC)
+	GOOS=linux go build -v -o dist/tracee -ldflags "-X github.com/aquasecurity/tracee/tracee.ebpfProgramBase64Injected=$(ebpfProgramBase64)"
 
 .PHONY: test
 test:
@@ -13,7 +12,7 @@ test:
 
 .PHONY: clean
 clean:
-	rm tracee_*
+	rm -rf dist || true
 
 python-test:
 	python -m unittest -v test_container_tracer

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For convenience we provide a Docker container of Tracee that includes glibc and 
 ### Getting Tracee
 Currently we don't yet have a release process for Tracee. You can build Tracee from source using `make build` or use the Docker image: `aquasec/tracee` from Docker Hub.
 
-If you build Tracee from source code, you can run it directly as an executable on the host. It will look for the file `./tracee/event_monitor_ebpf.c` so make sure it's available, and you'll need to run it with root permissions in order to load the eBPF code. 
+If run Tracee binary, you'll need to run it with root permissions in order to load the eBPF code. 
 If you use the Docker container, you should run it with the `--privileged` flag.
 
 ### Quickstart

--- a/test/loader.sh
+++ b/test/loader.sh
@@ -3,7 +3,7 @@
 # example: `./loader.sh ls 4 5`
 # will run 4 threads that continuously run `ls` in a loop for 5 seconds
 # then run tracee with small buffer size to increase the chance for lost events:
-# `make build && sudo ./tracee_linux -e mmap -e close -e mprotect -e openat -e security_file_open -b 1`
+# `make build && sudo ./tracee -e mmap -e close -e mprotect -e openat -e security_file_open -b 1`
 
 set -e
 command="$1"


### PR DESCRIPTION
this PR builds tracee distributable binary, in preparation to start releasing tracee.
it also embeds the ebpf c code in the binary.
additionally it removes the multi-os support from the makefile since tracee is linux only

fix: https://github.com/aquasecurity/tracee/issues/67
related: https://github.com/aquasecurity/tracee/issues/69