### PR TITLE
fix events flag in python

### DIFF
--- a/start.py
+++ b/start.py
@@ -43,7 +43,7 @@ def parse_args(input_args):
                         help="save events in json format")
     parser.add_argument("-l", "--list", action="store_true",
                         help="list events")
-    parser.add_argument("-e", "--event", default = syscalls + sysevents, action=EventsToTraceAction,
+    parser.add_argument("-e", "--events", default = syscalls + sysevents, action=EventsToTraceAction,
                         help="trace only the specified events and syscalls (default: trace all)")
     parser.add_argument("--show-syscall", action="store_true",
                         help="show syscall name in kprobes")

--- a/tracee/tracer.py
+++ b/tracee/tracer.py
@@ -865,7 +865,7 @@ class EventMonitor:
         self.json = args.json
         self.ebpf = args.ebpf
         self.list_events = args.list
-        self.events_to_trace = args.events_to_trace
+        self.events_to_trace = args.events
         self.buf_pages = args.buf_pages
         self.show_syscall = args.show_syscall
         self.exec_env = args.exec_env


### PR DESCRIPTION
https://github.com/aquasecurity/tracee/pull/73 broke events selection in the python version. the PR fixes that. Also, it renames the flag in python to `events` because it accepts multiple entries unlike the go version which accepts one at a time and therefore is called `event`