### PR TITLE
work around gobpf memory leak

### DIFF
--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -230,6 +230,7 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 		}
 	}
 
+	sysPrefix := bpf.GetSyscallPrefix()
 	for _, e := range eventsToTraceFinal {
 		eName := EventsIDToName[e]
 		if IsEventSyscall(e) {
@@ -237,7 +238,7 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 			if err != nil {
 				return fmt.Errorf("error loading kprobe %s: %v", eName, err)
 			}
-			err = t.bpfModule.AttachKprobe(bpf.GetSyscallFnName(eName), kp, -1)
+			err = t.bpfModule.AttachKprobe(sysPrefix+eName, kp, -1)
 			if err != nil {
 				return fmt.Errorf("error attaching kprobe %s: %v", eName, err)
 			}
@@ -245,7 +246,7 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 			if err != nil {
 				return fmt.Errorf("error loading kprobe %s: %v", eName, err)
 			}
-			err = t.bpfModule.AttachKretprobe(bpf.GetSyscallFnName(eName), kp, -1)
+			err = t.bpfModule.AttachKretprobe(sysPrefix+eName, kp, -1)
 			if err != nil {
 				return fmt.Errorf("error attaching kretprobe %s: %v", eName, err)
 			}


### PR DESCRIPTION
Tracee go version was using excessive memory. The leak was correlated with multiple calls to `bpf.GetSyscallFnName`. The python version [does the same thing](https://github.com/aquasecurity/tracee/blob/master/tracee/tracer.py#L904) but in gobpf there's an issue where the symbol cache is not being reused as in python, and also not being released. I'm working on fixing this upstream, but in the meantime it's easy to work around this issue in tracee with this PR.