### PR TITLE
add support for tracepoints and implement raw_syscalls tracepoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,9 @@ func main() {
 				c.String("output"),
 				c.Int("perf-buffer-size"),
 			)
+			if c.Bool("show-all-syscalls") {
+				cfg.EventsToTrace = append(cfg.EventsToTrace, tracee.EventsNameToID["raw_syscalls"])
+			}
 			if err != nil {
 				return fmt.Errorf("error creating Tracee config: %v", err)
 			}
@@ -78,6 +81,12 @@ func main() {
 				Value:   64,
 				Usage:   "size, in pages, of the internal perf ring buffer used to submit events from the kernel",
 			},
+			&cli.BoolFlag{
+				Name:    "show-all-syscalls",
+				Aliases: []string{"a"},
+				Value:   false,
+				Usage:   "log all syscalls invocations, including syscalls which were not fully traced by tracee (shortcut to -e raw_syscalls)",
+			},
 		},
 	}
 
@@ -96,7 +105,15 @@ func printList() {
 	}
 	fmt.Println("System calls:")
 	fmt.Println(strings.TrimSuffix(b.String(), sep))
+	b.Reset()
+	fmt.Println()
 
+	for _, name := range tracee.EventsTracepoints {
+		b.WriteString(name)
+		b.WriteString(sep)
+	}
+	fmt.Println("Tracepoints:")
+	fmt.Println(strings.TrimSuffix(b.String(), sep))
 	b.Reset()
 	fmt.Println()
 

--- a/start.py
+++ b/start.py
@@ -34,6 +34,8 @@ def parse_args(input_args):
         epilog=examples)
     parser.add_argument("-c", "--container", action="store_true",
                         help="only trace newly created containers")
+    parser.add_argument("-r", "--raw-syscalls", action="store_true",
+                        help="trace raw syscalls")
     parser.add_argument("-b", "--buf-pages", type=int, default=64,
                         choices=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
                         help="number of pages for perf buffer, defaults to %(default)s")

--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -387,13 +387,21 @@ var EventsSyscalls = map[int32]string{
 	//	349: reserved
 }
 
+// EventsTracepoints is list of supported tracepoints events, indexed by their ID
+// Currently the item name is the tracepoint category and the actuall tracepoint is always sys_enter
+// Tracepoints are explained here: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#3-tracepoints
+var EventsTracepoints = map[int32]string{
+	// Trace all syscalls
+	350: "raw_syscalls",
+}
+
 // EventsKprobes is list of supported kprobes events, indexed by their ID
 // Kprobes are explained here: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-kprobes
 var EventsKprobes = map[int32]string{
-	350: "do_exit",
-	351: "cap_capable",
-	352: "security_bprm_check",
-	353: "security_file_open",
+	351: "do_exit",
+	352: "cap_capable",
+	353: "security_bprm_check",
+	354: "security_file_open",
 }
 
 // EventsIDToName holds all the events that tracee can trace, indexed by their ID
@@ -407,6 +415,10 @@ func init() {
 	EventsIDToName = make(map[int32]string, len)
 	EventsNameToID = make(map[string]int32, len)
 	for id, name := range EventsSyscalls {
+		EventsIDToName[id] = name
+		EventsNameToID[name] = id
+	}
+	for id, name := range EventsTracepoints {
 		EventsIDToName[id] = name
 		EventsNameToID[name] = id
 	}

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -258,7 +258,17 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 			if err != nil {
 				return fmt.Errorf("error attaching kprobe %s: %v", eName, err)
 			}
+		} else if eName, isTracepoint := EventsTracepoints[e]; isTracepoint {
+			tp, err := t.bpfModule.LoadTracepoint(fmt.Sprintf("tracepoint__%s__sys_enter", eName))
+			if err != nil {
+				return fmt.Errorf("error loading tracepoint %s: %v", eName, err)
+			}
+			err = t.bpfModule.AttachTracepoint(fmt.Sprintf("%s:sys_enter", eName), tp)
+			if err != nil {
+				return fmt.Errorf("error attaching tracepoint %s: %v", eName, err)
+			}
 		}
+
 	}
 
 	bpfConfig := bpf.NewTable(t.bpfModule.TableId("config_map"), t.bpfModule)

--- a/tracee/tracer.py
+++ b/tracee/tracer.py
@@ -588,10 +588,11 @@ event_id = {
     #348: reserved
     #349: reserved
     # Non syscall events start here
-    350: "do_exit",
-    351: "cap_capable",
-    352: "security_bprm_check",
-    353: "security_file_open",
+    350: "raw_syscall",
+    351: "do_exit",
+    352: "cap_capable",
+    353: "security_bprm_check",
+    354: "security_file_open"
 }
 
 # argument types should match defined values in ebpf file code
@@ -877,6 +878,7 @@ class EventMonitor:
 
         # input arguments
         self.cont_mode = args.container
+        self.raw_syscalls = args.raw_syscalls
         self.json = args.json
         self.ebpf = args.ebpf
         self.list_events = args.list
@@ -922,6 +924,9 @@ class EventMonitor:
 
         for sysevent in se:
             self.bpf.attach_kprobe(event=sysevent, fn_name="trace_" + sysevent)
+
+        if self.raw_syscalls:
+            self.events_to_trace.append("raw_syscall")
 
         if not self.json:
             log.info("%-14s %-16s %-12s %-12s %-6s %-16s %-16s %-6s %-6s %-6s %-12s %s" % (

--- a/tracee/tracer.py
+++ b/tracee/tracer.py
@@ -588,7 +588,7 @@ event_id = {
     #348: reserved
     #349: reserved
     # Non syscall events start here
-    350: "raw_syscall",
+    350: "raw_syscalls",
     351: "do_exit",
     352: "cap_capable",
     353: "security_bprm_check",
@@ -926,7 +926,7 @@ class EventMonitor:
             self.bpf.attach_kprobe(event=sysevent, fn_name="trace_" + sysevent)
 
         if self.raw_syscalls:
-            self.events_to_trace.append("raw_syscall")
+            self.events_to_trace.append("raw_syscalls")
 
         if not self.json:
             log.info("%-14s %-16s %-12s %-12s %-6s %-16s %-16s %-6s %-6s %-6s %-12s %s" % (


### PR DESCRIPTION
option to log all syscalls invocations, including syscalls which were not fully traced by tracee
adds support for tracepoint attachment which at this point is limited to "sys_enter" only