### PR TITLE
decouple tracee package from main (cli) package

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 				OutputPath:            c.String("output-path"),
 				CaptureFiles:          c.Bool("capture-files"),
 				FilterFileWrite:       c.StringSlice("filter-file-write"),
+				EventsFile:            os.Stdout,
 			}
 			if c.Bool("show-all-syscalls") {
 				cfg.EventsToTrace = append(cfg.EventsToTrace, tracee.EventsNameToID["raw_syscalls"])

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -73,6 +73,7 @@ type TraceeConfig struct {
 	OutputPath            string
 	CaptureFiles          bool
 	FilterFileWrite       []string
+	EventsFile            *os.File
 }
 
 // Validate does static validation of the configuration
@@ -162,10 +163,13 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 	switch t.config.OutputFormat {
 	case "table":
 		t.printer = tableEventPrinter{
+			out:    cfg.EventsFile,
 			tracee: t,
 		}
 	case "json":
-		t.printer = jsonEventPrinter{}
+		t.printer = jsonEventPrinter{
+			out: cfg.EventsFile,
+		}
 	}
 
 	p, err := getEBPFProgram()

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -102,53 +102,6 @@ func (tc TraceeConfig) Validate() error {
 	return nil
 }
 
-// NewConfig creates a new TraceeConfig instance based on the given configuration, or default values if missing
-// default values:
-//   eventsToTrace: all events
-//   outputFormat: table
-func NewConfig(eventsToTrace []string, containerMode bool, detectOriginalSyscall bool, showExecEnv bool, outputFormat string,
-	perfBufferSize int, outputPath string, captureFiles bool, filterFileWrite []string) (*TraceeConfig, error) {
-	var eventsToTraceInternal []int32
-	if eventsToTrace == nil {
-		eventsToTraceInternal = make([]int32, 0, len(EventsIDToName))
-		rawSyscallsId := EventsNameToID["raw_syscalls"]
-		for id := range EventsIDToName {
-			if id != rawSyscallsId {
-				eventsToTraceInternal = append(eventsToTraceInternal, id)
-			}
-		}
-	} else {
-		eventsToTraceInternal = make([]int32, 0, len(eventsToTrace))
-		for _, name := range eventsToTrace {
-			id, ok := EventsNameToID[name]
-			if !ok {
-				return nil, fmt.Errorf("invalid event to trace: %s", name)
-			}
-			eventsToTraceInternal = append(eventsToTraceInternal, id)
-		}
-	}
-	if outputFormat == "" {
-		outputFormat = "table"
-	}
-	tc := TraceeConfig{
-		EventsToTrace:         eventsToTraceInternal,
-		ContainerMode:         containerMode,
-		DetectOriginalSyscall: detectOriginalSyscall,
-		ShowExecEnv:           showExecEnv,
-		OutputFormat:          outputFormat,
-		PerfBufferSize:        perfBufferSize,
-		OutputPath:            outputPath,
-		CaptureFiles:          captureFiles,
-		FilterFileWrite:       filterFileWrite,
-	}
-
-	err := tc.Validate()
-	if err != nil {
-		return nil, fmt.Errorf("validation error: %v", err)
-	}
-	return &tc, nil
-}
-
 // This var is supposed to be injected *at build time* with the contents of the ebpf c program
 var ebpfProgramBase64Injected string
 


### PR DESCRIPTION
if we want to treat the "tracee" package as a library, it should never print to stdout directly. 