### PR TITLE
add output gob output format

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func main() {
 				Name:    "output",
 				Aliases: []string{"o"},
 				Value:   "table",
-				Usage:   "output format: table (default)/json",
+				Usage:   "output format: table/json/gob",
 			},
 			&cli.StringSliceFlag{
 				Name:    "event",

--- a/test/gob.go
+++ b/test/gob.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+)
+
+func main() {
+	var in io.Reader
+	file := flag.String("file", "/dev/stdin", "")
+	flag.Parse()
+	f, err := os.Open(*file)
+	if err != nil {
+		log.Fatalln("error invalid file: ", *file)
+	}
+	defer f.Close()
+	in = f
+	if in == nil {
+		log.Fatalln("error invalid input")
+	}
+
+	dec := gob.NewDecoder(in)
+	sig := make(chan os.Signal)
+	signal.Notify(sig, os.Interrupt)
+	log.Println("start")
+LOOP:
+	for {
+		select {
+		case <-sig:
+			break LOOP
+		default:
+			var ctx context
+			var args []interface{}
+
+			err = dec.Decode(&ctx)
+			if err != nil {
+				if err == io.EOF {
+					break LOOP
+				} else {
+					log.Fatalln(err)
+				}
+			}
+			err = dec.Decode(&args)
+			if err != nil {
+				if err == io.EOF {
+					break LOOP
+				} else {
+					log.Fatalln(err)
+				}
+			}
+			log.Println("event:")
+			log.Println(ctx)
+			log.Println(args)
+		}
+	}
+	log.Println("end")
+}
+
+// the following types are copy-pasted from tracee.go
+type taskComm [16]byte
+
+func (tc taskComm) String() string {
+	len := 0
+	for i, b := range tc {
+		if b == 0 {
+			len = i
+			break
+		}
+	}
+	return string(tc[:len])
+}
+
+func (tc taskComm) MarshalText() ([]byte, error) {
+	return []byte(tc.String()), nil
+}
+
+type context struct {
+	Ts      uint64   `json:"time"`
+	Pid     uint32   `json:"pid"`
+	Tid     uint32   `json:"tid"`
+	Ppid    uint32   `json:"ppid"`
+	Uid     uint32   `json:"uid"`
+	MntId   uint32   `json:"mnt_ns"`
+	PidId   uint32   `json:"pid_ns"`
+	Comm    taskComm `json:"process_name"`
+	UtsName taskComm `json:"uts_name"`
+	Eventid int32    `json:"api"`
+	Argnum  uint8    `json:"arguments_count"`
+	_       [3]byte  // padding for Argnum
+	Retval  int64    `json:"return_value"`
+}

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -81,7 +81,7 @@ func (tc TraceeConfig) Validate() error {
 	if tc.EventsToTrace == nil {
 		return fmt.Errorf("eventsToTrace is nil")
 	}
-	if tc.OutputFormat != "table" && tc.OutputFormat != "json" {
+	if tc.OutputFormat != "table" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" {
 		return fmt.Errorf("unrecognized output format: %s", tc.OutputFormat)
 	}
 	for _, e := range tc.EventsToTrace {
@@ -162,15 +162,20 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 	}
 	switch t.config.OutputFormat {
 	case "table":
-		t.printer = tableEventPrinter{
+		t.printer = &tableEventPrinter{
 			out:    cfg.EventsFile,
 			tracee: t,
 		}
 	case "json":
-		t.printer = jsonEventPrinter{
+		t.printer = &jsonEventPrinter{
+			out: cfg.EventsFile,
+		}
+	case "gob":
+		t.printer = &gobEventPrinter{
 			out: cfg.EventsFile,
 		}
 	}
+	t.printer.Init()
 
 	p, err := getEBPFProgram()
 	if err != nil {


### PR DESCRIPTION
this allows tracee to communicate with another golang consumer using [gob encoding](https://golang.org/pkg/encoding/gob/) which is efficient binary encoding and avoids needless serialization when the consumer is a go program