### PR TITLE
process event hook, raw_syscall show name, capture executed files

### DIFF
--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -341,6 +341,51 @@ func (t *Tracee) processEvent(ctx *context, args []interface{}) error {
 		}
 	}
 
+	//capture executed files
+	if t.config.CaptureFiles && (eventName == "execve") {
+		var err error
+
+		destinationDirPath := filepath.Join(t.config.OutputPath, strconv.Itoa(int(ctx.Mnt_id)), "executed-files")
+		err = ensureOutputDir(destinationDirPath)
+		if err != nil {
+			return err
+		}
+		sourceFilePath, ok := args[0].(string)
+		if !ok {
+			return fmt.Errorf("error parsing execve args")
+		}
+		destinationFilePath := filepath.Join(destinationDirPath, fmt.Sprintf("%d-%s", ctx.Ts, filepath.Base(sourceFilePath)))
+		err = copyFileByPath(sourceFilePath, destinationFilePath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyFileByPath(src, dst string) error {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !sourceFileStat.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", src)
+	}
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+	_, err = io.Copy(destination, source)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -331,6 +331,14 @@ func (t Tracee) shouldPrintEvent(e int32) bool {
 	return true
 }
 
+func processEvent(ctx *context, args []interface{}) {
+	if EventsIDToName[ctx.Event_id] == "raw_syscalls" {
+		if id, ok := args[0].(int32); ok {
+			args[0] = EventsIDToName[id]
+		}
+	}
+}
+
 func (t *Tracee) processEvents() {
 	for {
 		select {
@@ -349,6 +357,7 @@ func (t *Tracee) processEvents() {
 					continue
 				}
 			}
+			processEvent(&ctx, args)
 			if t.shouldPrintEvent(ctx.Event_id) {
 				t.stats.eventCounter.Increment()
 				evt, err := newEvent(ctx, args)


### PR DESCRIPTION
This PR has 3 commits that build on one another:
1. add a hook in the processevents loop that allows to further transform and enrich events. this is an initial implementation, it will be improved in a future PR. This also implements a minor change that shows the syscall names for raw_syscalls instead of the ID.
2. put vfs captured files in a sub directory, as preparation for capture executed files
3. use the hook in (1) to capture executed files (execve).