### PR TITLE
fix file capture when dependent event is missing

### DIFF
--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -135,6 +135,13 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 		return nil, fmt.Errorf("validation error: %v", err)
 	}
 
+	if cfg.CaptureFilesExec {
+		essentialEvents[EventsNameToID["security_bprm_check"]] = false
+	}
+	if cfg.CaptureFilesWrite {
+		essentialEvents[EventsNameToID["vfs_write"]] = false
+	}
+
 	// create tracee
 	t := &Tracee{
 		config: cfg,


### PR DESCRIPTION
if the user specify `--capture-files` but didn't `-e write_vfs` or `-e security_bprm_check` appropriately, capture files will not work. This PR makes sure to trace these events, but in order to hide them from the output (the user didn't ask to trace them), I register them as essential events which achieve the same behavior. In a future PR we might rename essential events to something like hidden events and integrate it with EventConfig