### PR TITLE
fix capture exec for non-filesystem files

### DIFF
--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -403,6 +403,10 @@ func (t *Tracee) processEvent(ctx *context, args []interface{}) error {
 		if !ok {
 			return fmt.Errorf("error parsing security_bprm_check args")
 		}
+		// path should be absolute, except for e.g memfd_create files
+		if sourceFilePath[0] != '/' {
+			return nil
+		}
 		sourceFileStat, err := os.Stat(sourceFilePath)
 		if err != nil {
 			return err


### PR DESCRIPTION
`--capture exec ` for `memfd_create`d files was trying to get the file from the filesystem which failed. In the future we might want to get the file using it's device/inode but for now just suppress the error