### PR TITLE
add host pids to context

### DIFF
--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -50,20 +50,23 @@ func newEventPrinter(kind string, out io.Writer, err io.Writer) eventPrinter {
 
 // Event is a user facing data structure representing a single event
 type Event struct {
-	Timestamp       float64    `json:"timestamp"`
-	ProcessID       int        `json:"processId"`
-	ThreadID        int        `json:"threadId"`
-	ParentProcessID int        `json:"parentProcessId"`
-	UserID          int        `json:"userId"`
-	MountNS         int        `json:"mountNamespace"`
-	PIDNS           int        `json:"pidNamespace"`
-	ProcessName     string     `json:"processName"`
-	HostName        string     `json:"hostName"`
-	EventID         int        `json:"eventId,string"`
-	EventName       string     `json:"eventName"`
-	ArgsNum         int        `json:"argsNum"`
-	ReturnValue     int        `json:"returnValue"`
-	Args            []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
+	Timestamp           float64    `json:"timestamp"`
+	ProcessID           int        `json:"processId"`
+	ThreadID            int        `json:"threadId"`
+	ParentProcessID     int        `json:"parentProcessId"`
+	HostProcessID       int        `json:"hostProcessId"`
+	HostThreadID        int        `json:"hostThreadId"`
+	HostParentProcessID int        `json:"hostParentProcessId"`
+	UserID              int        `json:"userId"`
+	MountNS             int        `json:"mountNamespace"`
+	PIDNS               int        `json:"pidNamespace"`
+	ProcessName         string     `json:"processName"`
+	HostName            string     `json:"hostName"`
+	EventID             int        `json:"eventId,string"`
+	EventName           string     `json:"eventName"`
+	ArgsNum             int        `json:"argsNum"`
+	ReturnValue         int        `json:"returnValue"`
+	Args                []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
 }
 
 // Argument holds the information for one argument
@@ -74,20 +77,23 @@ type Argument struct {
 
 func newEvent(ctx context, argsNames []string, args []interface{}) (Event, error) {
 	e := Event{
-		Timestamp:       float64(ctx.Ts) / 1000000.0,
-		ProcessID:       int(ctx.Pid),
-		ThreadID:        int(ctx.Tid),
-		ParentProcessID: int(ctx.Ppid),
-		UserID:          int(ctx.Uid),
-		MountNS:         int(ctx.MntID),
-		PIDNS:           int(ctx.PidID),
-		ProcessName:     string(bytes.TrimRight(ctx.Comm[:], string(0))),
-		HostName:        string(bytes.TrimRight(ctx.UtsName[:], string(0))),
-		EventID:         int(ctx.EventID),
-		EventName:       EventsIDToEvent[int32(ctx.EventID)].Name,
-		ArgsNum:         int(ctx.Argnum),
-		ReturnValue:     int(ctx.Retval),
-		Args:            make([]Argument, 0, len(args)),
+		Timestamp:           float64(ctx.Ts) / 1000000.0,
+		ProcessID:           int(ctx.Pid),
+		ThreadID:            int(ctx.Tid),
+		ParentProcessID:     int(ctx.Ppid),
+		HostProcessID:       int(ctx.HostPid),
+		HostThreadID:        int(ctx.HostTid),
+		HostParentProcessID: int(ctx.HostPpid),
+		UserID:              int(ctx.Uid),
+		MountNS:             int(ctx.MntID),
+		PIDNS:               int(ctx.PidID),
+		ProcessName:         string(bytes.TrimRight(ctx.Comm[:], string(0))),
+		HostName:            string(bytes.TrimRight(ctx.UtsName[:], string(0))),
+		EventID:             int(ctx.EventID),
+		EventName:           EventsIDToEvent[int32(ctx.EventID)].Name,
+		ArgsNum:             int(ctx.Argnum),
+		ReturnValue:         int(ctx.Retval),
+		Args:                make([]Argument, 0, len(args)),
 	}
 	for i, arg := range args {
 		e.Args = append(e.Args, Argument{

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -584,19 +584,23 @@ func (t *Tracee) prepareArgsForPrint(ctx *context, args map[argTag]interface{}) 
 // context struct contains common metadata that is collected for all types of events
 // it is used to unmarshal binary data and therefore should match (bit by bit) to the `context_t` struct in the ebpf code.
 type context struct {
-	Ts      uint64
-	Pid     uint32
-	Tid     uint32
-	Ppid    uint32
-	Uid     uint32
-	MntID   uint32
-	PidID   uint32
-	Comm    [16]byte
-	UtsName [16]byte
-	EventID int32
-	Argnum  uint8
-	_       [3]byte
-	Retval  int64
+	Ts       uint64
+	Pid      uint32
+	Tid      uint32
+	Ppid     uint32
+	HostPid  uint32
+	HostTid  uint32
+	HostPpid uint32
+	Uid      uint32
+	MntID    uint32
+	PidID    uint32
+	Comm     [16]byte
+	UtsName  [16]byte
+	EventID  int32
+	Argnum   uint8
+	_        [3]byte //padding for Argnum (start address should be devisible by size of member)
+	Retval   int64
+	_        [4]byte //padding for the struct (size of struct should be devisible by size of largest member)
 }
 
 func (t *Tracee) processLostEvents() {


### PR DESCRIPTION
I didn't add it to the table output after all, only to the json/gob outputs. In future PR we can maybe make the printer aware of "container mode" change the output format accordingly