### PR TITLE
Use tracepoints instead of kprobes for syscalls

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 				}
 			}
 			if c.Bool("show-all-syscalls") {
-				cfg.EventsToTrace = append(cfg.EventsToTrace, tracee.RawSyscallsEventID)
+				cfg.EventsToTrace = append(cfg.EventsToTrace, tracee.SysEnterEventID)
 			}
 			if c.Bool("security-alerts") {
 				cfg.EventsToTrace = append(cfg.EventsToTrace, tracee.MemProtAlertEventID)
@@ -238,7 +238,7 @@ func printList() {
 	var b strings.Builder
 	b.WriteString("System Calls:           Sets:\n")
 	b.WriteString("____________            ____\n\n")
-	for i := 0; i < int(tracee.RawSyscallsEventID); i++ {
+	for i := 0; i < int(tracee.SysEnterEventID); i++ {
 		event := tracee.EventsIDToEvent[int32(i)]
 		if event.Name == "reserved" {
 			continue
@@ -252,7 +252,7 @@ func printList() {
 	}
 	b.WriteString("\n\nOther Events:           Sets:\n")
 	b.WriteString("____________            ____\n\n")
-	for i := int(tracee.RawSyscallsEventID); i < len(tracee.EventsIDToEvent); i++ {
+	for i := int(tracee.SysEnterEventID); i < len(tracee.EventsIDToEvent); i++ {
 		event := tracee.EventsIDToEvent[int32(i)]
 		if event.Sets != nil {
 			eventSets := fmt.Sprintf("%-20s    %v\n", event.Name, event.Sets)

--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -202,9 +202,9 @@ var argNames = map[argTag]string{
 }
 
 // ProbeType is an enum that describes the mechanism used to attach the event
-// Syscall tracepoints are explained here: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#8-system-call-tracepoints
 // Kprobes are explained here: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-kprobes
 // Tracepoints are explained here: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#3-tracepoints
+// Raw tracepoints are explained here: https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#7-raw-tracepoints
 type probeType uint8
 
 const (
@@ -212,6 +212,7 @@ const (
 	kprobe
 	kretprobe
 	tracepoint
+	rawTracepoint
 )
 
 type probe struct {
@@ -581,7 +582,8 @@ const (
 	Reserved347EventID
 	Reserved348EventID
 	Reserved349EventID
-	RawSyscallsEventID
+	SysEnterEventID
+	SysExitEventID
 	DoExitEventID
 	CapCapableEventID
 	SecurityBprmCheckEventID
@@ -942,7 +944,8 @@ var EventsIDToEvent = map[int32]EventConfig{
 	Reserved347EventID:         EventConfig{ID: Reserved347EventID, Name: "reserved", Probes: []probe{probe{event: "reserved", attach: sysCall, fn: "reserved"}}, EssentialEvent: false, Sets: []string{}},
 	Reserved348EventID:         EventConfig{ID: Reserved348EventID, Name: "reserved", Probes: []probe{probe{event: "reserved", attach: sysCall, fn: "reserved"}}, EssentialEvent: false, Sets: []string{}},
 	Reserved349EventID:         EventConfig{ID: Reserved349EventID, Name: "reserved", Probes: []probe{probe{event: "reserved", attach: sysCall, fn: "reserved"}}, EssentialEvent: false, Sets: []string{}},
-	RawSyscallsEventID:         EventConfig{ID: RawSyscallsEventID, Name: "raw_syscalls", Probes: []probe{probe{event: "raw_syscalls:sys_enter", attach: tracepoint, fn: "tracepoint__raw_syscalls__sys_enter"}}, EssentialEvent: false, Sets: []string{}},
+	SysEnterEventID:            EventConfig{ID: SysEnterEventID, Name: "sys_enter", Probes: []probe{probe{event: "raw_syscalls:sys_enter", attach: rawTracepoint, fn: "raw_tracepoint__sys_enter"}}, EssentialEvent: true, Sets: []string{}},
+	SysExitEventID:             EventConfig{ID: SysExitEventID, Name: "sys_exit", Probes: []probe{probe{event: "raw_syscalls:sys_exit", attach: rawTracepoint, fn: "raw_tracepoint__sys_exit"}}, EssentialEvent: true, Sets: []string{}},
 	DoExitEventID:              EventConfig{ID: DoExitEventID, Name: "do_exit", Probes: []probe{probe{event: "do_exit", attach: kprobe, fn: "trace_do_exit"}}, EssentialEvent: true, Sets: []string{"default"}},
 	CapCapableEventID:          EventConfig{ID: CapCapableEventID, Name: "cap_capable", Probes: []probe{probe{event: "cap_capable", attach: kprobe, fn: "trace_cap_capable"}}, EssentialEvent: false, Sets: []string{"default"}},
 	SecurityBprmCheckEventID:   EventConfig{ID: SecurityBprmCheckEventID, Name: "security_bprm_check", Probes: []probe{probe{event: "security_bprm_check", attach: kprobe, fn: "trace_security_bprm_check"}}, EssentialEvent: false, Sets: []string{"default"}},

--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -165,7 +165,6 @@ func (p tableEventPrinter) Epilogue(stats statsStore) {
 	fmt.Println()
 	fmt.Fprintf(p.out, "End of events stream\n")
 	fmt.Fprintf(p.out, "Stats: %+v\n", stats)
-	fmt.Fprintf(p.out, "Tracee is closing...\n")
 }
 
 type jsonEventPrinter struct {


### PR DESCRIPTION
This patch changes the way we attach to syscalls.
Instead of using a kprobe for each syscall, we use raw_syscalls
tracepoint as an entry point, and dispatch to the relevant syscall
handler using tail calls.
We first try to use the newer raw tracepoints (kernel ver >= 4.17), as
it is more performant, and fallback to "regular" tracepoint otherwise.

This change has the following advantages:
1. Stability between kernel versions
2. Better performance (see https://lwn.net/Articles/748352 for
   comparison)
3. Faster start time and stopping of tracee as there are less probes
   (only one for all syscalls)
4. It will allow us to support 32 bit userspace programs without adding
   additional probes