### PR TITLE
Update minimal kernel version requirement to 4.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Other than tracing, Tracee is also capable of capturing files written to disk or
 ### Prerequisites
 
 To run, Tracee requires the following:
-- Linux kernel version > 4.14
+- Linux kernel version > 4.18
 - Kernel headers
 - C standard library (currently tested with glibc)
 - [BCC](https://github.com/iovisor/bcc)


### PR DESCRIPTION
As we have verifier issues with kernel 4.14,
Update minimal kernel version requirement to 4.18.
This will also allow us to support BPF CO-RE, and use BPF_FUNC_get_current_cgroup_id()