### PR TITLE
updated to golang 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-buster as builder
+FROM golang:1.15-buster as builder
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libtinfo5
 

--- a/test/gob/go.mod
+++ b/test/gob/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/tracee/test/gob
 
-go 1.13
+go 1.15
 
 replace (
 ""github.com/aquasecurity/tracee/tracee" => "../../tracee"


### PR DESCRIPTION
Updated docker file to use build for golang 1.15 as 1.13 is now EOL as of 11thAug 2020