### PR TITLE
Add support for tracing specific containers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aquasecurity/tracee
 go 1.13
 
 require (
+	docker.io/go-docker v1.0.0
 	github.com/iovisor/gobpf v0.0.0-20200529092446-49b58e11a4b5
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+docker.io/go-docker v1.0.0 h1:VdXS/aNYQxyA9wdLD5z8Q8Ro688/hG8HzKxYVEVbE6s=
+docker.io/go-docker v1.0.0/go.mod h1:7tiAn5a0LFmjbPDbyTPOaTTOuG1ZRNXdPA6RvKY+fpY=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 				OutputFormat:          c.String("output"),
 				PerfBufferSize:        c.Int("perf-buffer-size"),
 				PidsToTrace:           c.IntSlice("pid"),
+				CtrIdsToTrace:         c.StringSlice("container-id"),
 				BlobPerfBufferSize:    c.Int("blob-perf-buffer-size"),
 				OutputPath:            c.String("output-path"),
 				FilterFileWrite:       c.StringSlice("filter-file-write"),
@@ -115,6 +116,12 @@ func main() {
 				Aliases: []string{"p"},
 				Value:   nil,
 				Usage:   "trace only the specified pid. use this flag multiple times to choose multiple pids",
+			},
+			&cli.StringSliceFlag{
+				Name:    "container-id",
+				Aliases: []string{"cid"},
+				Value:   nil,
+				Usage:   "trace only the specified container id. use this flag multiple times to choose multiple container ids",
 			},
 			&cli.BoolFlag{
 				Name:  "detect-original-syscall",


### PR DESCRIPTION
With the intent to resolve #221, this PR provides support for tracing a collection of specific Container IDs by 
- Fetching the Container PID mapped to the host
-  Tracing the container in PID mode using the PID obtained from above

Signed-off-by: Siddharth Srinivasan <siddharths2710@yahoo.com>