### PR TITLE
Move from gobpf to bpfwrap (libbpf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 .idea
+.output
 /dist

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/libbpf"]
+	path = 3rdparty/libbpf
+	url = https://github.com/libbpf/libbpf

--- a/3rdparty/include/stdarg.h
+++ b/3rdparty/include/stdarg.h
@@ -1,0 +1,52 @@
+/*===---- stdarg.h - Variable argument handling ----------------------------===
+ *
+ * Copyright (c) 2008 Eli Friedman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __STDARG_H
+#define __STDARG_H
+
+#ifndef _VA_LIST
+typedef __builtin_va_list va_list;
+#define _VA_LIST
+#endif
+#define va_start(ap, param) __builtin_va_start(ap, param)
+#define va_end(ap)          __builtin_va_end(ap)
+#define va_arg(ap, type)    __builtin_va_arg(ap, type)
+
+/* GCC always defines __va_copy, but does not define va_copy unless in c99 mode
+ * or -ansi is not specified, since it was not part of C90.
+ */
+#define __va_copy(d,s) __builtin_va_copy(d,s)
+
+#if __STDC_VERSION__ >= 199901L || __cplusplus >= 201103L || !defined(__STRICT_ANSI__)
+#define va_copy(dest, src)  __builtin_va_copy(dest, src)
+#endif
+
+/* Hack required to make standard headers work, at least on Ubuntu */
+#ifndef __GNUC_VA_LIST
+#define __GNUC_VA_LIST 1
+#endif
+typedef __builtin_va_list __gnuc_va_list;
+
+#endif /* __STDARG_H */

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,22 @@
+OUTPUT := .output
+TARGET := event_monitor_ebpf
+KERN_RELEASE := $(shell uname -r)
+KERN_SRC := /lib/modules/$(KERN_RELEASE)/build
+ARCH := $(shell uname -m | sed 's/x86_64/x86/')
+LLC ?= llc
+CLANG ?= clang
+LLVM_STRIP ?= llvm-strip
+BPF_C = tracee/${TARGET:=.c}
+BPF_OBJ = ${OUTPUT}/${TARGET:=.o}
+LIBBPF_SRC = $(abspath 3rdparty/libbpf/src)
+LIBBPF_OBJ = $(abspath $(OUTPUT)/libbpf.a)
+CFLAGS ?= -I$(OUTPUT)/usr/include/
+
 SRC = $(shell find . -type f -name '*.go' ! -name '*_test.go' )
 ebpfProgramBase64 = $(shell base64 -w 0 tracee/event_monitor_ebpf.c)
 
 .PHONY: build
-build: dist/tracee
+build: llvm-check $(BPF_OBJ) dist/tracee
 
 .PHONY: build-docker
 build-docker: clean
@@ -21,6 +35,10 @@ test:
 .PHONY: clean
 clean:
 	rm -rf dist || true
+	cd $(LIBBPF_SRC) && $(MAKE) clean;
+	rm -f $(BPF_OBJ)
+	rm -f *.ll
+	rm -rf .output
 
 imageName ?= tracee
 .PHONY: docker
@@ -35,3 +53,60 @@ ifdef publish
 endif
 release:
 	EBPFPROGRAM_BASE64=$(ebpfProgramBase64) goreleaser release --rm-dist $(goreleaserFlags)
+
+.PHONY: $(CLANG) $(LLC)
+
+llvm-check: $(CLANG) $(LLC)
+	@for TOOL in $^ ; do \
+		if [ ! $$(command -v $${TOOL} 2>/dev/null) ]; then \
+			echo "*** ERROR: Cannot find tool $${TOOL}" ;\
+			exit 1; \
+		else true; fi; \
+	done
+
+$(OUTPUT):
+	mkdir -p $@
+
+$(LIBBPF_OBJ):
+	@if [ ! -d $(LIBBPF_SRC) ]; then \
+		echo "Error: Need libbpf submodule"; \
+		echo "May need to run git submodule update --init"; \
+		exit 1; \
+	else \
+		cd $(LIBBPF_SRC) && $(MAKE) BUILD_STATIC_ONLY=1; \
+		OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@) $(MAKE) install_headers; \
+	fi
+
+$(BPF_OBJ): ${BPF_C} $(LIBBPF_OBJ) | ${OUTPUT}
+	$(CLANG) -S \
+		-D __BPF_TRACING__ -D __KERNEL__ -D__TARGET_ARCH_$(ARCH) \
+		$(CFLAGS) \
+		-include $(KERN_SRC)/include/linux/kconfig.h \
+		-I $(KERN_SRC)/arch/$(ARCH)/include \
+		-I $(KERN_SRC)/arch/$(ARCH)/include/uapi \
+		-I $(KERN_SRC)/arch/$(ARCH)/include/generated \
+		-I $(KERN_SRC)/arch/$(ARCH)/include/generated/uapi \
+		-I $(KERN_SRC)/include \
+		-I $(KERN_SRC)/include/uapi \
+		-I $(KERN_SRC)/include/generated \
+		-I $(KERN_SRC)/include/generated/uapi \
+		-I 3rdparty/include \
+		-Wno-address-of-packed-member \
+		-Wno-compare-distinct-pointer-types \
+		-Wno-deprecated-declarations \
+		-Wno-gnu-variable-sized-type-not-at-end \
+		-Wno-pointer-sign \
+		-Wno-pragma-once-outside-heade \
+		-Wno-unknown-warning-option \
+		-Wno-unused-value \
+		-Wunused \
+		-Wall \
+		-fno-stack-protector \
+		-fno-jump-tables \
+		-fno-unwind-tables \
+		-fno-asynchronous-unwind-tables \
+		-x c \
+		-nostdinc \
+		-O2 -emit-llvm -c -g $< -o ${@:.o=.ll}
+	$(LLC) -march=bpf -filetype=obj -o $@ ${@:.o=.ll}
+	$(LLVM_STRIP) -g $@

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ To run, Tracee requires the following:
 - Linux kernel version > 4.14
 - Kernel headers
 - C standard library (currently tested with glibc)
-- [BCC](https://github.com/iovisor/bcc)
+- clang (currently tested with version > 10)
 
 ### Getting Tracee
 
 You can get Tracee in any of the following ways:
 1. Download the binary from the GitHub Releases tab (`tracee.tar.gz`).
-2. Use the docker image from Docker Hub: `aquasec/tracee`. The image already includes libc and bcc but you will need to mount the kernel headers in (see below for example).
+2. Use the docker image from Docker Hub: `aquasec/tracee`. The image already includes the required dependencies but you will need to mount the kernel headers in (see below for example).
 3. Build from source, using `make build` (or via Docker using `make build-docker`).
 
 ### Permissions
@@ -37,7 +37,7 @@ If you use the Docker container, you should run it with the `--privileged` flag.
 
 ### Quickstart with Docker
 
-We will use the Tracee Docker image, which includes glibc and BCC. The host that Docker is running on needs to satisfy the other requirements, kernel version and kernel headers. If you use a recent version of Ubuntu, you are good to go as it satisfies those requirements, but any other Linux distribution will work as well.
+We will use the Tracee Docker image, which includes the required dependencies. The host that Docker is running on needs to satisfy the other requirements, kernel version and kernel headers. If you use a recent version of Ubuntu, you are good to go as it satisfies those requirements, but any other Linux distribution will work as well.
 To run Tracee using docker:
 
 ```bash

--- a/bpfwrap/libbpf_perf_cb.go
+++ b/bpfwrap/libbpf_perf_cb.go
@@ -1,0 +1,22 @@
+package bpfwrap
+
+import (
+	"C"
+	"unsafe"
+)
+
+// This callback definition needs to be in a different file from where it is declared in C
+// Otherwise, multiple definition compilation error will occur
+
+//export perfCallback
+func perfCallback(ctx unsafe.Pointer, cpu C.int, data unsafe.Pointer, size C.int) {
+	eventChannels[uintptr(ctx)] <- C.GoBytes(data, size)
+}
+
+//export perfLostCallback
+func perfLostCallback(ctx unsafe.Pointer, cpu C.int, cnt C.ulonglong) {
+	lostChan := lostChannels[uintptr(ctx)]
+	if lostChan != nil {
+		lostChan <- uint64(cnt)
+	}
+}

--- a/bpfwrap/libbpf_wrapper.go
+++ b/bpfwrap/libbpf_wrapper.go
@@ -1,0 +1,511 @@
+package bpfwrap
+
+/*
+#cgo CFLAGS: -I${SRCDIR}/../3rdparty/libbpf/src
+#cgo LDFLAGS: ${SRCDIR}/../3rdparty/libbpf/src/libbpf.a -lelf -lz
+
+#include <bpf.h>
+#include <libbpf.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+
+#include <asm-generic/unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/perf_event.h>
+#include <linux/unistd.h>
+#include <string.h>
+#include <unistd.h>
+
+extern void perfCallback(void *ctx, int cpu, void *data, __u32 size);
+extern void perfLostCallback(void *ctx, int cpu, __u64 cnt);
+
+int libbpf_print_fn(enum libbpf_print_level level,
+			   const char *format, va_list args)
+{
+	if (level != LIBBPF_WARN)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+void set_print_fn() {
+	libbpf_set_print(libbpf_print_fn);
+}
+
+struct perf_buffer * init_perf_buf(int map_fd, int page_cnt) {
+    struct perf_buffer_opts pb_opts = {};
+    struct perf_buffer *pb = NULL;
+    pb_opts.sample_cb = perfCallback;
+    pb_opts.lost_cb = perfLostCallback;
+    __u64 ctx = map_fd;
+    pb_opts.ctx = (void*)ctx;
+    pb = perf_buffer__new(map_fd, page_cnt, &pb_opts);
+    if (pb < 0) {
+        fprintf(stderr, "Failed to initialize perf buffer!\n");
+        return NULL;
+    }
+    return pb;
+}
+
+int poke_kprobe_events(bool add, const char* name, bool ret) {
+    char buf[256];
+    int fd, err;
+    char pr;
+
+    fd = open("/sys/kernel/debug/tracing/kprobe_events", O_WRONLY | O_APPEND, 0);
+    if (fd < 0) {
+        err = -errno;
+        fprintf(stderr, "failed to open kprobe_events file: %d\n", err);
+        return err;
+    }
+
+    pr = ret ? 'r' : 'p';
+
+    if (add)
+        snprintf(buf, sizeof(buf), "%c:kprobes/%c%s %s", pr, pr, name, name);
+    else
+        snprintf(buf, sizeof(buf), "-:kprobes/%c%s", pr, name);
+
+    err = write(fd, buf, strlen(buf));
+    if (err < 0) {
+        err = -errno;
+        fprintf(
+            stderr,
+            "failed to %s kprobe '%s': %d\n",
+            add ? "add" : "remove",
+            buf,
+            err);
+    }
+    close(fd);
+    return err >= 0 ? 0 : err;
+}
+
+int add_kprobe_event(const char* func_name, bool is_kretprobe) {
+    return poke_kprobe_events(true, func_name, is_kretprobe);
+}
+
+int remove_kprobe_event(const char* func_name, bool is_kretprobe) {
+    return poke_kprobe_events(false, func_name, is_kretprobe);
+}
+
+struct bpf_link* attach_kprobe_legacy(
+    struct bpf_program* prog,
+    const char* func_name,
+    bool is_kretprobe) {
+    char fname[256];
+    struct perf_event_attr attr;
+    struct bpf_link* link;
+    int fd = -1, err, id;
+    FILE* f = NULL;
+    char pr;
+
+    err = add_kprobe_event(func_name, is_kretprobe);
+    if (err) {
+        fprintf(stderr, "failed to create kprobe event: %d\n", err);
+        return NULL;
+    }
+
+	pr = is_kretprobe ? 'r' : 'p';
+
+    snprintf(
+        fname,
+        sizeof(fname),
+        "/sys/kernel/debug/tracing/events/kprobes/%c%s/id",
+        pr, func_name);
+    f = fopen(fname, "r");
+    if (!f) {
+        fprintf(stderr, "failed to open kprobe id file '%s': %d\n", fname, -errno);
+        goto err_out;
+    }
+
+    if (fscanf(f, "%d\n", &id) != 1) {
+        fprintf(stderr, "failed to read kprobe id from '%s': %d\n", fname, -errno);
+        goto err_out;
+    }
+
+    fclose(f);
+    f = NULL;
+
+    memset(&attr, 0, sizeof(attr));
+    attr.size = sizeof(attr);
+    attr.config = id;
+    attr.type = PERF_TYPE_TRACEPOINT;
+    attr.sample_period = 1;
+    attr.wakeup_events = 1;
+
+    fd = syscall(__NR_perf_event_open, &attr, -1, 0, -1, PERF_FLAG_FD_CLOEXEC);
+    if (fd < 0) {
+        fprintf(
+            stderr,
+            "failed to create perf event for kprobe ID %d: %d\n",
+            id,
+            -errno);
+        goto err_out;
+    }
+
+    link = bpf_program__attach_perf_event(prog, fd);
+    err = libbpf_get_error(link);
+    if (err) {
+        fprintf(stderr, "failed to attach to perf event FD %d: %d\n", fd, err);
+        goto err_out;
+    }
+
+    return link;
+
+err_out:
+    if (f)
+        fclose(f);
+    if (fd >= 0)
+        close(fd);
+    remove_kprobe_event(func_name, is_kretprobe);
+    return NULL;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+type Module struct {
+	obj      *C.struct_bpf_object
+	links    []*BpfLink
+	perfBufs []*PerfBuffer
+}
+
+type BpfMap struct {
+	name   string
+	fd     C.int
+	module *Module
+}
+
+type BpfProg struct {
+	name   string
+	prog   *C.struct_bpf_program
+	module *Module
+}
+
+type LinkType int
+
+const (
+	Tracepoint LinkType = iota
+	RawTracepoint
+	Kprobe
+	Kretprobe
+	KprobeLegacy
+	KretprobeLegacy
+)
+
+type BpfLink struct {
+	link      *C.struct_bpf_link
+	prog      *BpfProg
+	linkType  LinkType
+	eventName string
+}
+
+type PerfBuffer struct {
+	pb     *C.struct_perf_buffer
+	bpfMap *BpfMap
+	stop   chan bool
+}
+
+// BPF is using locked memory for BPF maps and various other things.
+// By default, this limit is very low - increase to avoid failures
+func bumpMemlockRlimit() error {
+	var rLimit syscall.Rlimit
+	rLimit.Max = 512 << 20 /* 512 MBs */
+	rLimit.Cur = 512 << 20 /* 512 MBs */
+	err := syscall.Setrlimit(C.RLIMIT_MEMLOCK, &rLimit)
+	if err != nil {
+		fmt.Errorf("error setting rlimit: %v", err)
+	}
+	return nil
+}
+
+func NewModule(bpfObjFile string) (*Module, error) {
+	C.set_print_fn()
+	bumpMemlockRlimit()
+	cs := C.CString(bpfObjFile)
+	obj := C.bpf_object__open(cs)
+	C.free(unsafe.Pointer(cs))
+	if obj == nil {
+		return nil, fmt.Errorf("failed to open BPF object %s", bpfObjFile)
+	}
+
+	return &Module{
+		obj: obj,
+	}, nil
+}
+
+func (m *Module) Close() {
+	for _, pb := range m.perfBufs {
+		C.perf_buffer__free(pb.pb)
+	}
+	for _, link := range m.links {
+		C.bpf_link__destroy(link.link)
+		if link.linkType == KprobeLegacy {
+			cs := C.CString(link.eventName)
+			C.remove_kprobe_event(cs, false)
+			C.free(unsafe.Pointer(cs))
+		}
+		if link.linkType == KretprobeLegacy {
+			cs := C.CString(link.eventName)
+			C.remove_kprobe_event(cs, true)
+			C.free(unsafe.Pointer(cs))
+		}
+	}
+	C.bpf_object__close(m.obj)
+}
+
+func (m *Module) BpfLoadObject() error {
+	ret := C.bpf_object__load(m.obj)
+	if ret != 0 {
+		return fmt.Errorf("failed to load BPF object")
+	}
+
+	return nil
+}
+
+func (m *Module) GetMap(mapName string) (*BpfMap, error) {
+	cs := C.CString(mapName)
+	bpfMap := C.bpf_object__find_map_by_name(m.obj, cs)
+	C.free(unsafe.Pointer(cs))
+	if bpfMap == nil {
+		return nil, fmt.Errorf("failed to find BPF map %s", mapName)
+	}
+
+	return &BpfMap{
+		name:   mapName,
+		fd:     C.bpf_map__fd(bpfMap),
+		module: m,
+	}, nil
+}
+
+func (b *BpfMap) Update(key, value interface{}) error {
+	var keyPtr, valuePtr unsafe.Pointer
+	if k, isType := key.(int32); isType {
+		keyPtr = unsafe.Pointer(&k)
+	} else if k, isType := key.(uint32); isType {
+		keyPtr = unsafe.Pointer(&k)
+	} else if k, isType := key.(int64); isType {
+		keyPtr = unsafe.Pointer(&k)
+	} else if k, isType := key.(uint64); isType {
+		keyPtr = unsafe.Pointer(&k)
+	} else {
+		return fmt.Errorf("failed to update map %s: unknown key type %T", b.name, key)
+	}
+	if v, isType := value.(int32); isType {
+		valuePtr = unsafe.Pointer(&v)
+	} else if v, isType := value.(uint32); isType {
+		valuePtr = unsafe.Pointer(&v)
+	} else if v, isType := value.(int64); isType {
+		valuePtr = unsafe.Pointer(&v)
+	} else if v, isType := value.(uint64); isType {
+		valuePtr = unsafe.Pointer(&v)
+	} else if v, isType := value.([]byte); isType {
+		valuePtr = unsafe.Pointer(&v[0])
+	} else {
+		return fmt.Errorf("failed to update map %s: unknown value type %T", b.name, value)
+	}
+
+	err := C.bpf_map_update_elem(b.fd, keyPtr, valuePtr, C.BPF_ANY)
+	if err != 0 {
+		return fmt.Errorf("failed to update map %s", b.name)
+	}
+	return nil
+}
+
+func (m *Module) GetProgram(progName string) (*BpfProg, error) {
+	cs := C.CString(progName)
+	prog := C.bpf_object__find_program_by_name(m.obj, cs)
+	C.free(unsafe.Pointer(cs))
+	if prog == nil {
+		return nil, fmt.Errorf("failed to find BPF program %s", progName)
+	}
+
+	return &BpfProg{
+		name:   progName,
+		prog:   prog,
+		module: m,
+	}, nil
+}
+
+func (p *BpfProg) GetFd() C.int {
+	return C.bpf_program__fd(p.prog)
+}
+
+func (p *BpfProg) SetTracepoint() error {
+	err := C.bpf_program__set_tracepoint(p.prog)
+	if err != 0 {
+		return fmt.Errorf("failed to set bpf program as tracepoint")
+	}
+	return nil
+}
+
+func (p *BpfProg) AttachTracepoint(tp string) (*BpfLink, error) {
+	tpEvent := strings.Split(tp, ":")
+	tpCategory := C.CString(tpEvent[0])
+	tpName := C.CString(tpEvent[1])
+	link := C.bpf_program__attach_tracepoint(p.prog, tpCategory, tpName)
+	C.free(unsafe.Pointer(tpCategory))
+	C.free(unsafe.Pointer(tpName))
+	if link == nil {
+		return nil, fmt.Errorf("failed to attach tracepoint %s to program %s", tp, p.name)
+	}
+
+	bpfLink := &BpfLink{
+		link:      link,
+		prog:      p,
+		linkType:  Tracepoint,
+		eventName: tp,
+	}
+	p.module.links = append(p.module.links, bpfLink)
+	return bpfLink, nil
+}
+
+func (p *BpfProg) AttachRawTracepoint(tpEvent string) (*BpfLink, error) {
+	cs := C.CString(tpEvent)
+	link := C.bpf_program__attach_raw_tracepoint(p.prog, cs)
+	C.free(unsafe.Pointer(cs))
+	if link == nil {
+		return nil, fmt.Errorf("failed to attach raw tracepoint %s to program", tpEvent, p.name)
+	}
+
+	bpfLink := &BpfLink{
+		link:      link,
+		prog:      p,
+		linkType:  RawTracepoint,
+		eventName: tpEvent,
+	}
+	p.module.links = append(p.module.links, bpfLink)
+	return bpfLink, nil
+}
+
+// this API should be used for kernels > 4.17
+func (p *BpfProg) AttachKprobe(kp string) (*BpfLink, error) {
+	return doAttachKprobe(p, kp, false)
+}
+
+// this API should be used for kernels > 4.17
+func (p *BpfProg) AttachKretprobe(kp string) (*BpfLink, error) {
+	return doAttachKprobe(p, kp, true)
+}
+
+func doAttachKprobe(prog *BpfProg, kp string, isKretprobe bool) (*BpfLink, error) {
+	cs := C.CString(kp)
+	cbool := C.bool(isKretprobe)
+	link := C.bpf_program__attach_kprobe(prog.prog, cbool, cs)
+	C.free(unsafe.Pointer(cs))
+	if link == nil {
+		return nil, fmt.Errorf("failed to attach %s k(ret)probe to program %s", kp, prog.name)
+	}
+
+	kpType := Kprobe
+	if isKretprobe {
+		kpType = Kretprobe
+	}
+
+	bpfLink := &BpfLink{
+		link:      link,
+		prog:      prog,
+		linkType:  kpType,
+		eventName: kp,
+	}
+	prog.module.links = append(prog.module.links, bpfLink)
+	return bpfLink, nil
+}
+
+func (p *BpfProg) AttachKprobeLegacy(kp string) (*BpfLink, error) {
+	return doAttachKprobeLegacy(p, kp, false)
+}
+
+func (p *BpfProg) AttachKretprobeLegacy(kp string) (*BpfLink, error) {
+	return doAttachKprobeLegacy(p, kp, true)
+}
+
+func doAttachKprobeLegacy(prog *BpfProg, kp string, isKretprobe bool) (*BpfLink, error) {
+	cs := C.CString(kp)
+	cbool := C.bool(isKretprobe)
+	link := C.attach_kprobe_legacy(prog.prog, cs, cbool)
+	C.free(unsafe.Pointer(cs))
+	if link == nil {
+		return nil, fmt.Errorf("failed to attach %s k(ret)probe using legacy debugfs API", kp)
+	}
+
+	kpType := KprobeLegacy
+	if isKretprobe {
+		kpType = KretprobeLegacy
+	}
+
+	bpfLink := &BpfLink{
+		link:      link,
+		prog:      prog,
+		linkType:  kpType,
+		eventName: kp,
+	}
+	prog.module.links = append(prog.module.links, bpfLink)
+	return bpfLink, nil
+}
+
+var eventChannels = make(map[uintptr]chan []byte)
+var lostChannels = make(map[uintptr]chan uint64)
+
+func (m *Module) InitPerfBuf(mapName string, eventsChan chan []byte, lostChan chan uint64, pageCnt int) (*PerfBuffer, error) {
+	bpfMap, err := m.GetMap(mapName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init perf buffer: %v", err)
+	}
+	ctx := uintptr(bpfMap.fd)
+	if eventsChan == nil {
+		return nil, fmt.Errorf("failed to init perf buffer: events channel can not be nil!")
+	}
+	eventChannels[ctx] = eventsChan
+	lostChannels[ctx] = lostChan
+	pb := C.init_perf_buf(bpfMap.fd, C.int(pageCnt))
+	if pb == nil {
+		return nil, fmt.Errorf("failed to initialize perf buffer")
+	}
+
+	perfBuf := &PerfBuffer{
+		pb:     pb,
+		bpfMap: bpfMap,
+		stop:   make(chan bool),
+	}
+	m.perfBufs = append(m.perfBufs, perfBuf)
+	return perfBuf, nil
+}
+
+func (pb *PerfBuffer) Start() {
+	go pb.poll()
+}
+
+func (pb *PerfBuffer) Stop() {
+	pb.stop <- true
+}
+
+func (pb *PerfBuffer) Free() {
+	C.perf_buffer__free(pb.pb)
+}
+
+// todo: consider writing the perf polling in go as c to go calls (callback) are expensive
+func (pb *PerfBuffer) poll() error {
+	for {
+		select {
+		case <-pb.stop:
+			return nil
+		default:
+			err := C.perf_buffer__poll(pb.pb, 300)
+			if err < 0 {
+				if syscall.Errno(-err) == syscall.EINTR {
+					continue
+				}
+				return fmt.Errorf("Error polling perf buffer: %d", err)
+			}
+		}
+	}
+	return nil
+}

--- a/tracee/event_monitor_ebpf.c
+++ b/tracee/event_monitor_ebpf.c
@@ -804,7 +804,7 @@ static __always_inline int save_file_path_to_str_buf(buf_t *string_p, struct fil
         dentry = d_parent;
     }
 
-    if (buf_off == MAX_PERCPU_BUFSIZE - MAX_STRING_SIZE) {
+    if (buf_off == (MAX_PERCPU_BUFSIZE >> 1)) {
         // memfd files have no path in the filesystem -> extract their name
         buf_off = 0;
         struct qstr d_name = get_d_name_from_dentry(dentry);

--- a/tracee/event_monitor_ebpf.c
+++ b/tracee/event_monitor_ebpf.c
@@ -19,6 +19,18 @@
 #include <linux/socket.h>
 #include <linux/version.h>
 
+#include <uapi/linux/bpf.h>
+#include <linux/kconfig.h>
+#include <linux/types.h>
+#include <linux/version.h>
+
+#undef container_of
+//#include "bpf_core_read.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+#define PT_REGS_PARM6(ctx)  ((ctx)->r9)
+
 #define MAX_PERCPU_BUFSIZE  (1 << 15)     // This value is actually set by the kernel as an upper bound
 #define MAX_STRING_SIZE     4096          // Choosing this value to be the same as PATH_MAX
 #define MAX_STR_ARR_ELEM    40            // String array elements number should be bounded due to instructions limit
@@ -95,16 +107,36 @@
 #define MODE_PID        1
 #define MODE_CONTAINER  2
 
-// re-define container_of as bcc complains
-#define my_container_of(ptr, type, member) ({          \
-    const typeof(((type *)0)->member) * __mptr = (ptr); \
-    (type *)((char *)__mptr - offsetof(type, member)); })
+#define DEV_NULL_STR    0
 
 #define READ_KERN(ptr) ({ typeof(ptr) _val;                             \
                           __builtin_memset(&_val, 0, sizeof(_val));     \
                           bpf_probe_read(&_val, sizeof(_val), &ptr);    \
                           _val;                                         \
                         })
+
+#define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries) \
+struct bpf_map_def SEC("maps") _name = { \
+  .type = _type, \
+  .key_size = sizeof(_key_type), \
+  .value_size = sizeof(_value_type), \
+  .max_entries = _max_entries, \
+};
+
+#define BPF_HASH(_name, _key_type, _value_type) \
+BPF_MAP(_name, BPF_MAP_TYPE_HASH, _key_type, _value_type, 10240);
+
+#define BPF_ARRAY(_name, _value_type, _max_entries) \
+BPF_MAP(_name, BPF_MAP_TYPE_ARRAY, u32, _value_type, _max_entries);
+
+#define BPF_PERCPU_ARRAY(_name, _value_type, _max_entries) \
+BPF_MAP(_name, BPF_MAP_TYPE_PERCPU_ARRAY, u32, _value_type, _max_entries);
+
+#define BPF_PROG_ARRAY(_name, _max_entries) \
+BPF_MAP(_name, BPF_MAP_TYPE_PROG_ARRAY, u32, u32, _max_entries);
+
+#define BPF_PERF_OUTPUT(_name) \
+BPF_MAP(_name, BPF_MAP_TYPE_PERF_EVENT_ARRAY, int, __u32, 1024);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
 #error Minimal required kernel version is 4.14
@@ -184,7 +216,7 @@ struct mount {
 /*=================================== MAPS =====================================*/
 
 BPF_HASH(config_map, u32, u32);                     // Various configurations
-BPF_HASH(chosen_events_map, u32, u32);              // Various configurations
+BPF_HASH(chosen_events_map, u32, u32);              // Events chosen by the user
 BPF_HASH(pids_map, u32, u32);                       // Save container pid namespaces
 BPF_HASH(args_map, u64, args_t);                    // Persist args info between function entry and return
 BPF_HASH(ret_map, u64, u64);                        // Persist return value to be used in tail calls
@@ -193,6 +225,7 @@ BPF_HASH(sys_32_to_64_map, u32, u32);               // Map 32bit syscalls number
 BPF_HASH(params_types_map, u32, u64);               // Encoded parameters types for event
 BPF_HASH(params_names_map, u32, u64);               // Encoded parameters names for event
 BPF_ARRAY(file_filter, path_filter_t, 3);           // Used to filter vfs_write events
+BPF_ARRAY(string_store, path_filter_t, 1);          // Store strings from userspace
 BPF_PERCPU_ARRAY(bufs, buf_t, MAX_BUFFERS);         // Percpu global buffer variables
 BPF_PERCPU_ARRAY(bufs_off, u32, MAX_BUFFERS);       // Holds offsets to bufs respectively
 BPF_PROG_ARRAY(prog_array, MAX_TAIL_CALL);          // Used to store programs for tail calls
@@ -286,7 +319,7 @@ static __always_inline int get_syscall_ev_id_from_regs()
 
     if (is_x86_compat(task)) {
         // Translate 32bit syscalls to 64bit syscalls (which also represent the event ids)
-        u32 *id_64 = sys_32_to_64_map.lookup(&syscall_nr);
+        u32 *id_64 = bpf_map_lookup_elem(&sys_32_to_64_map, &syscall_nr);
         if (id_64 == 0)
             return -1;
 
@@ -343,16 +376,16 @@ static __always_inline unsigned long get_vma_flags(struct vm_area_struct *vma)
 
 static inline struct mount *real_mount(struct vfsmount *mnt)
 {
-    return my_container_of(mnt, struct mount, mnt);
+    return container_of(mnt, struct mount, mnt);
 }
 
 /*============================== HELPER FUNCTIONS ==============================*/
 
-static __inline int is_prefix(char *prefix, char *str)
+static __inline int has_prefix(char *prefix, char *str, int n)
 {
     int i;
     #pragma unroll
-    for (i = 0; i < MAX_PATH_PREF_SIZE; prefix++, str++, i++) {
+    for (i = 0; i < n; prefix++, str++, i++) {
         if (!*prefix)
             return 1;
         if (*prefix != *str) {
@@ -367,7 +400,7 @@ static __inline int is_prefix(char *prefix, char *str)
 static __always_inline u32 lookup_pid()
 {
     u32 pid = bpf_get_current_pid_tgid();
-    if (pids_map.lookup(&pid) == 0)
+    if (bpf_map_lookup_elem(&pids_map, &pid) == 0)
         return 0;
 
     return pid;
@@ -377,7 +410,7 @@ static __always_inline u32 lookup_pid_ns(struct task_struct *task)
 {
     u32 task_pid_ns = get_task_pid_ns_id(task);
 
-    u32 *pid_ns = pids_map.lookup(&task_pid_ns);
+    u32 *pid_ns = bpf_map_lookup_elem(&pids_map, &task_pid_ns);
     if (pid_ns == 0)
         return 0;
 
@@ -386,14 +419,14 @@ static __always_inline u32 lookup_pid_ns(struct task_struct *task)
 
 static __always_inline void add_pid_fork(u32 pid)
 {
-    pids_map.update(&pid, &pid);
+    bpf_map_update_elem(&pids_map, &pid, &pid, BPF_ANY);
 }
 
 static __always_inline u32 add_pid()
 {
     u32 pid = bpf_get_current_pid_tgid();
-    if (pids_map.lookup(&pid) == 0)
-        pids_map.update(&pid, &pid);
+    if (bpf_map_lookup_elem(&pids_map, &pid) == 0)
+        bpf_map_update_elem(&pids_map, &pid, &pid, BPF_ANY);
 
     return pid;
 }
@@ -404,14 +437,14 @@ static __always_inline u32 add_pid_ns_if_needed()
     task = (struct task_struct *)bpf_get_current_task();
 
     u32 pid_ns = get_task_pid_ns_id(task);
-    if (pids_map.lookup(&pid_ns) != 0)
+    if (bpf_map_lookup_elem(&pids_map, &pid_ns) != 0)
         // Container pidns was already added to map
         return pid_ns;
 
     // If pid equals 1 - start tracing the container
     if (get_task_ns_pid(task) == 1) {
         // A new container/pod was started - add pid namespace to map
-        pids_map.update(&pid_ns, &pid_ns);
+        bpf_map_update_elem(&pids_map, &pid_ns, &pid_ns, BPF_ANY);
         return pid_ns;
     }
 
@@ -422,8 +455,8 @@ static __always_inline u32 add_pid_ns_if_needed()
 static __always_inline void remove_pid()
 {
     u32 pid = bpf_get_current_pid_tgid();
-    if (pids_map.lookup(&pid) != 0)
-        pids_map.delete(&pid);
+    if (bpf_map_lookup_elem(&pids_map, &pid) != 0)
+        bpf_map_delete_elem(&pids_map, &pid);
 }
 
 static __always_inline void remove_pid_ns_if_needed()
@@ -432,17 +465,17 @@ static __always_inline void remove_pid_ns_if_needed()
     task = (struct task_struct *)bpf_get_current_task();
 
     u32 pid_ns = get_task_pid_ns_id(task);
-    if (pids_map.lookup(&pid_ns) != 0) {
+    if (bpf_map_lookup_elem(&pids_map, &pid_ns) != 0) {
         // If pid equals 1 - stop tracing this pid namespace
         if (get_task_ns_pid(task) == 1) {
-            pids_map.delete(&pid_ns);
+            bpf_map_delete_elem(&pids_map, &pid_ns);
         }
     }
 }
 
 static __always_inline int get_config(u32 key)
 {
-    u32 *config = config_map.lookup(&key);
+    u32 *config = bpf_map_lookup_elem(&config_map, &key);
 
     if (config == NULL)
         return 0;
@@ -468,7 +501,7 @@ static __always_inline int should_trace()
 
 static __always_inline int event_chosen(u32 key)
 {
-    u32 *config = chosen_events_map.lookup(&key);
+    u32 *config = bpf_map_lookup_elem(&chosen_events_map, &key);
     if (config == NULL)
         return 0;
 
@@ -503,17 +536,17 @@ static __always_inline int init_context(context_t *context)
 
 static __always_inline buf_t* get_buf(int idx)
 {
-    return bufs.lookup(&idx);
+    return bpf_map_lookup_elem(&bufs, &idx);
 }
 
 static __always_inline void set_buf_off(int buf_idx, u32 new_off)
 {
-    bufs_off.update(&buf_idx, &new_off);
+    bpf_map_update_elem(&bufs_off, &buf_idx, &new_off, BPF_ANY);
 }
 
 static __always_inline u32* get_buf_off(int buf_idx)
 {
-    return bufs_off.lookup(&buf_idx);
+    return bpf_map_lookup_elem(&bufs_off, &buf_idx);
 }
 
 // Context will always be at the start of the submission buffer
@@ -563,16 +596,18 @@ static __always_inline int save_to_submit_buf(buf_t *submit_p, void *ptr, u32 si
 
     *off += 1;
 
-    // Save argument tag
-    if (tag != TAG_NONE) {
-        rc = bpf_probe_read(&(submit_p->buf[*off & (MAX_PERCPU_BUFSIZE-1)]), 1, &tag);
-        if (rc != 0) {
-            *off -= 1;
-            return 0;
-        }
+    if (*off > MAX_PERCPU_BUFSIZE - MAX_ELEMENT_SIZE)
+        // Satisfy validator for probe read
+        return 0;
 
-        *off += 1;
+    // Save argument tag
+    rc = bpf_probe_read(&(submit_p->buf[*off]), 1, &tag);
+    if (rc != 0) {
+        *off -= 1;
+        return 0;
     }
+    *off += 1;
+
     if (*off > MAX_PERCPU_BUFSIZE - MAX_ELEMENT_SIZE) {
         // Satisfy validator for probe read
         *off -= 2;
@@ -754,8 +789,8 @@ static __always_inline int save_file_path_to_str_buf(buf_t *string_p, struct fil
         unsigned int off = buf_off - len;
         // Is string buffer big enough for dentry name?
         int sz = 0;
-        if (off <= MAX_PERCPU_BUFSIZE - MAX_STRING_SIZE)
-            sz = bpf_probe_read_str(&(string_p->buf[off]), len, (void *)d_name.name);
+        if (off <= buf_off) // verify no wrap occured
+            sz = bpf_probe_read_str(&(string_p->buf[off & ((MAX_PERCPU_BUFSIZE >> 1)-1)]), len, (void *)d_name.name);
         else
             break;
         if (sz > 1) {
@@ -770,10 +805,10 @@ static __always_inline int save_file_path_to_str_buf(buf_t *string_p, struct fil
     }
 
     if (buf_off == MAX_PERCPU_BUFSIZE - MAX_STRING_SIZE) {
-	// memfd files have no path in the filesystem -> extract their name
+        // memfd files have no path in the filesystem -> extract their name
         buf_off = 0;
         struct qstr d_name = get_d_name_from_dentry(dentry);
-        int sz = bpf_probe_read_str(&(string_p->buf[0]), MAX_STRING_SIZE, (void *)d_name.name);
+        bpf_probe_read_str(&(string_p->buf[0]), MAX_STRING_SIZE, (void *)d_name.name);
     } else {
         // Add leading slash
         buf_off -= 1;
@@ -798,7 +833,7 @@ static __always_inline int events_perf_submit(void *ctx)
     /* satisfy validator by setting buffer bounds */
     int size = *off & (MAX_PERCPU_BUFSIZE-1);
     void * data = submit_p->buf;
-    return events.perf_submit(ctx, data, size);
+    return bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, data, size);
 }
 
 static __always_inline int is_container()
@@ -814,7 +849,7 @@ static __always_inline int save_args(args_t *args, u32 event_id)
     u64 id = event_id;
     u32 tid = bpf_get_current_pid_tgid();
     id = id << 32 | tid;
-    args_map.update(&id, args);
+    bpf_map_update_elem(&args_map, &id, args, BPF_ANY);
 
     return 0;
 }
@@ -850,7 +885,7 @@ static __always_inline int load_args(args_t *args, bool delete, u32 event_id)
     u64 id = event_id;
     id = id << 32 | tid;
 
-    saved_args = args_map.lookup(&id);
+    saved_args = bpf_map_lookup_elem(&args_map, &id);
     if (saved_args == 0) {
         // missed entry or not a container
         return -1;
@@ -864,7 +899,7 @@ static __always_inline int load_args(args_t *args, bool delete, u32 event_id)
     args->args[5] = saved_args->args[5];
 
     if (delete)
-        args_map.delete(&id);
+        bpf_map_delete_elem(&args_map, &id);
 
     return 0;
 }
@@ -875,7 +910,7 @@ static __always_inline int del_args(u32 event_id)
     u64 id = event_id;
     id = id << 32 | tid;
 
-    args_map.delete(&id);
+    bpf_map_delete_elem(&args_map, &id);
 
     return 0;
 }
@@ -886,7 +921,7 @@ static __always_inline int save_retval(u64 retval, u32 event_id)
     u32 tid = bpf_get_current_pid_tgid();
     id = id << 32 | tid;
 
-    ret_map.update(&id, &retval);
+    bpf_map_update_elem(&ret_map, &id, &retval, BPF_ANY);
 
     return 0;
 }
@@ -897,14 +932,14 @@ static __always_inline int load_retval(u64 *retval, u32 event_id)
     u32 tid = bpf_get_current_pid_tgid();
     id = id << 32 | tid;
 
-    u64 *saved_retval = ret_map.lookup(&id);
+    u64 *saved_retval = bpf_map_lookup_elem(&ret_map, &id);
     if (saved_retval == 0) {
         // missed entry or not traced
         return -1;
     }
 
     *retval = *saved_retval;
-    ret_map.delete(&id);
+    bpf_map_delete_elem(&ret_map, &id);
 
     return 0;
 }
@@ -915,7 +950,7 @@ static __always_inline int del_retval(u32 event_id)
     u32 tid = bpf_get_current_pid_tgid();
     id = id << 32 | tid;
 
-    ret_map.delete(&id);
+    bpf_map_delete_elem(&ret_map, &id);
 
     return 0;
 }
@@ -1053,11 +1088,18 @@ int trace_ret_##name(void *ctx)                                         \
 
 /*============================== SYSCALL HOOKS ==============================*/
 
+struct trace_event_raw_sys_enter {
+  unsigned long long unused;
+  long int id;
+  long unsigned int args[6];
+};
+
 // include/trace/events/syscalls.h:
 // TP_PROTO(struct pt_regs *regs, long id)
+SEC("raw_tracepoint/sys_enter")
 int tracepoint__raw_syscalls__sys_enter(
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
-struct tracepoint__raw_syscalls__sys_enter *args
+struct trace_event_raw_sys_enter *args
 #else
 struct bpf_raw_tracepoint_args *ctx
 #endif
@@ -1092,7 +1134,7 @@ struct bpf_raw_tracepoint_args *ctx
 
     if (is_x86_compat(task)) {
         // Translate 32bit syscalls to 64bit syscalls so we can send to the correct handler
-        u32 *id_64 = sys_32_to_64_map.lookup(&id);
+        u32 *id_64 = bpf_map_lookup_elem(&sys_32_to_64_map, &id);
         if (id_64 == 0)
             return 0;
 
@@ -1120,7 +1162,7 @@ struct bpf_raw_tracepoint_args *ctx
 
         context_t context = init_and_save_context(submit_p, RAW_SYS_ENTER, 1 /*argnum*/, 0 /*ret*/);
 
-        u64 *tags = params_names_map.lookup(&context.eventid);
+        u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
         if (!tags) {
             return -1;
         }
@@ -1136,15 +1178,22 @@ struct bpf_raw_tracepoint_args *ctx
 
     // call syscall handler, if exists
     // enter tail calls should never delete saved args
-    sys_enter_tails.call(ctx, id);
+    bpf_tail_call(ctx, &sys_enter_tails, id);
     return 0;
 }
 
+struct trace_event_raw_sys_exit {
+  unsigned long long unused;
+  long int id;
+  long int ret;
+};
+
 // include/trace/events/syscalls.h:
 // TP_PROTO(struct pt_regs *regs, long ret)
+SEC("raw_tracepoint/sys_exit")
 int tracepoint__raw_syscalls__sys_exit(
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
-struct tracepoint__raw_syscalls__sys_exit *args
+struct trace_event_raw_sys_exit *args
 #else
 struct bpf_raw_tracepoint_args *ctx
 #endif
@@ -1160,13 +1209,13 @@ struct bpf_raw_tracepoint_args *ctx
     ret = args->ret;
 #else
     struct pt_regs *regs = (struct pt_regs*)ctx->args[0];
-    id = regs->orig_ax;
+    id = READ_KERN(regs->orig_ax);
     ret = ctx->args[1];
 #endif
 
     if (is_x86_compat(task)) {
         // Translate 32bit syscalls to 64bit syscalls so we can send to the correct handler
-        u32 *id_64 = sys_32_to_64_map.lookup(&id);
+        u32 *id_64 = bpf_map_lookup_elem(&sys_32_to_64_map, &id);
         if (id_64 == 0)
             return 0;
 
@@ -1198,7 +1247,7 @@ struct bpf_raw_tracepoint_args *ctx
 
         context_t context = init_and_save_context(submit_p, RAW_SYS_EXIT, 1 /*argnum*/, ret);
 
-        u64 *tags = params_names_map.lookup(&context.eventid);
+        u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
         if (!tags) {
             return -1;
         }
@@ -1212,8 +1261,8 @@ struct bpf_raw_tracepoint_args *ctx
         u64 tags = 0;
         bool submit_event = true;
         if (id != SYS_EXECVE && id != SYS_EXECVEAT) {
-            u64 *saved_types = params_types_map.lookup(&id);
-            u64 *saved_tags = params_names_map.lookup(&id);
+            u64 *saved_types = bpf_map_lookup_elem(&params_types_map, &id);
+            u64 *saved_tags = bpf_map_lookup_elem(&params_names_map, &id);
             if (!saved_types || !saved_tags) {
                 return -1;
             }
@@ -1235,12 +1284,13 @@ struct bpf_raw_tracepoint_args *ctx
     save_args(&saved_args, id);
     save_retval(ret, id);
     // exit tail calls should always delete args and retval before return
-    sys_exit_tails.call(ctx, id);
+    bpf_tail_call(ctx, &sys_exit_tails, id);
     del_retval(id);
     del_args(id);
     return 0;
 }
 
+SEC("raw_tracepoint/sys_execve")
 int syscall__execve(void *ctx)
 {
     args_t args = {};
@@ -1259,7 +1309,7 @@ int syscall__execve(void *ctx)
 
     context_t context = init_and_save_context(submit_p, SYS_EXECVE, 2 /*argnum*/, 0 /*ret*/);
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1276,6 +1326,7 @@ int syscall__execve(void *ctx)
     return 0;
 }
 
+SEC("raw_tracepoint/sys_execveat")
 int syscall__execveat(void *ctx)
 {
     args_t args = {};
@@ -1294,7 +1345,7 @@ int syscall__execveat(void *ctx)
 
     context_t context = init_and_save_context(submit_p, SYS_EXECVEAT, 4 /*argnum*/, 0 /*ret*/);
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1315,7 +1366,8 @@ int syscall__execveat(void *ctx)
 
 /*============================== OTHER HOOKS ==============================*/
 
-int trace_do_exit(struct pt_regs *ctx, long code)
+SEC("kprobe/do_exit")
+int BPF_KPROBE(trace_do_exit)
 {
     if (!should_trace())
         return 0;
@@ -1324,6 +1376,8 @@ int trace_do_exit(struct pt_regs *ctx, long code)
     if (submit_p == NULL)
         return 0;
     set_buf_off(SUBMIT_BUF_IDX, sizeof(context_t));
+
+    long code = PT_REGS_PARM1(ctx);
 
     init_and_save_context(submit_p, DO_EXIT, 0, code);
 
@@ -1336,7 +1390,8 @@ int trace_do_exit(struct pt_regs *ctx, long code)
     return 0;
 }
 
-int trace_security_bprm_check(struct pt_regs *ctx, struct linux_binprm *bprm)
+SEC("kprobe/security_bprm_check")
+int BPF_KPROBE(trace_security_bprm_check)
 {
     if (!should_trace())
         return 0;
@@ -1348,6 +1403,7 @@ int trace_security_bprm_check(struct pt_regs *ctx, struct linux_binprm *bprm)
 
     context_t context = init_and_save_context(submit_p, SECURITY_BPRM_CHECK, 3 /*argnum*/, 0 /*ret*/);
 
+    struct linux_binprm *bprm = (struct linux_binprm *)PT_REGS_PARM1(ctx);
     struct file* file = get_file_ptr_from_bprm(bprm);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
@@ -1361,7 +1417,7 @@ int trace_security_bprm_check(struct pt_regs *ctx, struct linux_binprm *bprm)
     if (off == NULL)
         return -1;
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1374,7 +1430,8 @@ int trace_security_bprm_check(struct pt_regs *ctx, struct linux_binprm *bprm)
     return 0;
 }
 
-int trace_security_file_open(struct pt_regs *ctx, struct file *file)
+SEC("kprobe/security_file_open")
+int BPF_KPROBE(trace_security_file_open)
 {
     if (!should_trace())
         return 0;
@@ -1386,6 +1443,7 @@ int trace_security_file_open(struct pt_regs *ctx, struct file *file)
 
     context_t context = init_and_save_context(submit_p, SECURITY_FILE_OPEN, 4 /*argnum*/, 0 /*ret*/);
 
+    struct file *file = (struct file *)PT_REGS_PARM1(ctx);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
 
@@ -1403,7 +1461,7 @@ int trace_security_file_open(struct pt_regs *ctx, struct file *file)
     if (off == NULL)
         return -1;
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1417,8 +1475,8 @@ int trace_security_file_open(struct pt_regs *ctx, struct file *file)
     return 0;
 }
 
-int trace_cap_capable(struct pt_regs *ctx, const struct cred *cred,
-    struct user_namespace *targ_ns, int cap, int cap_opt)
+SEC("kprobe/cap_capable")
+int BPF_KPROBE(trace_cap_capable)
 {
     int audit;
 
@@ -1432,6 +1490,11 @@ int trace_cap_capable(struct pt_regs *ctx, const struct cred *cred,
 
     context_t context = init_and_save_context(submit_p, CAP_CAPABLE, 1 /*argnum*/, 0 /*ret*/);
 
+    //const struct cred *cred = (const struct cred *)PT_REGS_PARM1(ctx);
+    //struct user_namespace *targ_ns = (struct user_namespace *)PT_REGS_PARM2(ctx);
+    int cap = PT_REGS_PARM3(ctx);
+    int cap_opt = PT_REGS_PARM4(ctx);
+
   #ifdef CAP_OPT_NONE
     audit = (cap_opt & 0b10) == 0;
   #else
@@ -1441,7 +1504,7 @@ int trace_cap_capable(struct pt_regs *ctx, const struct cred *cred,
     if (audit == 0)
         return 0;
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1459,7 +1522,8 @@ int trace_cap_capable(struct pt_regs *ctx, const struct cred *cred,
     return 0;
 };
 
-int send_bin(struct pt_regs *ctx)
+SEC("kprobe/send_bin")
+int BPF_KPROBE(send_bin)
 {
     // Note: sending the data to the userspace have the following constraints:
     // 1. We need a buffer that we know it's exact size (so we can send chunks of known sizes in BPF)
@@ -1471,7 +1535,7 @@ int send_bin(struct pt_regs *ctx)
 
     u64 id = bpf_get_current_pid_tgid();
 
-    bin_args_t *bin_args = bin_args_map.lookup(&id);
+    bin_args_t *bin_args = bpf_map_lookup_elem(&bin_args_map, &id);
     if (bin_args == 0) {
         // missed entry or not traced
         return 0;
@@ -1486,15 +1550,15 @@ int send_bin(struct pt_regs *ctx)
             bpf_probe_read(&io_vec, sizeof(struct iovec), &bin_args->vec[bin_args->iov_idx]);
             bin_args->ptr = io_vec.iov_base;
             bin_args->full_size = io_vec.iov_len;
-            prog_array.call(ctx, TAIL_SEND_BIN);
+            bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
         }
-        bin_args_map.delete(&id);
+        bpf_map_delete_elem(&bin_args_map, &id);
         return 0;
     }
 
     buf_t *file_buf_p = get_buf(FILE_BUF_IDX);
     if (file_buf_p == NULL) {
-        bin_args_map.delete(&id);
+        bpf_map_delete_elem(&bin_args_map, &id);
         return 0;
     }
 
@@ -1504,7 +1568,7 @@ int send_bin(struct pt_regs *ctx)
 #define F_SZ_OFF      (F_META_OFF + SEND_META_SIZE)
 #define F_POS_OFF     (F_SZ_OFF + sizeof(unsigned int))
 #define F_CHUNK_OFF   (F_POS_OFF + sizeof(off_t))
-#define F_CHUNK_SIZE  (MAX_PERCPU_BUFSIZE - F_CHUNK_OFF - 4)
+#define F_CHUNK_SIZE  (MAX_PERCPU_BUFSIZE >> 1)
 
     bpf_probe_read((void **)&(file_buf_p->buf[F_SEND_TYPE]), sizeof(u8), &bin_args->type);
 
@@ -1536,7 +1600,7 @@ int send_bin(struct pt_regs *ctx)
         bin_args->ptr += F_CHUNK_SIZE;
         bin_args->start_off += F_CHUNK_SIZE;
 
-        file_writes.perf_submit(ctx, data, F_CHUNK_OFF+F_CHUNK_SIZE);
+        bpf_perf_event_output(ctx, &file_writes, BPF_F_CURRENT_CPU, data, F_CHUNK_OFF+F_CHUNK_SIZE);
     }
 
     chunk_size = bin_args->full_size - i*F_CHUNK_SIZE;
@@ -1544,19 +1608,20 @@ int send_bin(struct pt_regs *ctx)
     if (chunk_size > F_CHUNK_SIZE) {
         // Handle the rest of the write recursively
         bin_args->full_size = chunk_size;
-        prog_array.call(ctx, TAIL_SEND_BIN);
-        bin_args_map.delete(&id);
+        bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
+        bpf_map_delete_elem(&bin_args_map, &id);
         return 0;
     }
 
     // Save last chunk
+    chunk_size = (chunk_size) & ((MAX_PERCPU_BUFSIZE >> 1) - 1);
     bpf_probe_read((void **)&(file_buf_p->buf[F_CHUNK_OFF]), chunk_size, bin_args->ptr);
     bpf_probe_read((void **)&(file_buf_p->buf[F_SZ_OFF]), sizeof(unsigned int), &chunk_size);
     bpf_probe_read((void **)&(file_buf_p->buf[F_POS_OFF]), sizeof(off_t), &bin_args->start_off);
 
     // Satisfy validator by setting buffer bounds
     int size = (F_CHUNK_OFF+chunk_size) & (MAX_PERCPU_BUFSIZE - 1);
-    file_writes.perf_submit(ctx, data, size);
+    bpf_perf_event_output(ctx, &file_writes, BPF_F_CURRENT_CPU, data, size);
 
     // We finished writing an element of the vector - continue to next element
     bin_args->iov_idx++;
@@ -1566,10 +1631,10 @@ int send_bin(struct pt_regs *ctx)
         bpf_probe_read(&io_vec, sizeof(struct iovec), &bin_args->vec[bin_args->iov_idx]);
         bin_args->ptr = io_vec.iov_base;
         bin_args->full_size = io_vec.iov_len;
-        prog_array.call(ctx, TAIL_SEND_BIN);
+        bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
     }
 
-    bin_args_map.delete(&id);
+    bpf_map_delete_elem(&bin_args_map, &id);
     return 0;
 }
 
@@ -1598,7 +1663,7 @@ static __always_inline int do_vfs_write_writev(struct pt_regs *ctx, u32 event_id
     #pragma unroll
     for (int i = 0; i < 3; i++) {
         int idx = i;
-        path_filter_t *filter_p = file_filter.lookup(&idx);
+        path_filter_t *filter_p = bpf_map_lookup_elem(&file_filter, &idx);
         if (filter_p == NULL)
             return -1;
 
@@ -1610,8 +1675,8 @@ static __always_inline int do_vfs_write_writev(struct pt_regs *ctx, u32 event_id
         if (*off > MAX_PERCPU_BUFSIZE - MAX_STRING_SIZE)
             break;
 
-        if (filter_p->path[0] && is_prefix(filter_p->path, &string_p->buf[*off]))
-            prog_array.call(ctx, tail_call_id);
+        if (has_prefix(filter_p->path, &string_p->buf[*off], MAX_PATH_PREF_SIZE))
+            bpf_tail_call(ctx, &prog_array, tail_call_id);
     }
 
     if (has_filter) {
@@ -1621,7 +1686,7 @@ static __always_inline int do_vfs_write_writev(struct pt_regs *ctx, u32 event_id
     }
 
     // No filter was given - continue
-    prog_array.call(ctx, tail_call_id);
+    bpf_tail_call(ctx, &prog_array, tail_call_id);
     return 0;
 }
 
@@ -1678,7 +1743,7 @@ static __always_inline int do_vfs_write_writev_tail(struct pt_regs *ctx, u32 eve
     if (start_pos != 0)
         start_pos -= PT_REGS_RC(ctx);
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1697,9 +1762,17 @@ static __always_inline int do_vfs_write_writev_tail(struct pt_regs *ctx, u32 eve
 
     u64 id = bpf_get_current_pid_tgid();
     u32 pid = context.pid;
+
+    int idx = DEV_NULL_STR;
+    path_filter_t *stored_str_p = bpf_map_lookup_elem(&string_store, &idx);
+    if (stored_str_p == NULL)
+        return -1;
+
     if (*off > MAX_PERCPU_BUFSIZE - MAX_STRING_SIZE)
         return -1;
-    if (!is_prefix("/dev/null", &string_p->buf[*off]))
+
+    // check for /dev/null
+    if (!has_prefix(stored_str_p->path, &string_p->buf[*off], 10))
         pid = 0;
 
     if (get_config(CONFIG_CAPTURE_FILES)) {
@@ -1723,39 +1796,46 @@ static __always_inline int do_vfs_write_writev_tail(struct pt_regs *ctx, u32 eve
                 bin_args.full_size = io_vec.iov_len;
             }
         }
-        bin_args_map.update(&id, &bin_args);
+        bpf_map_update_elem(&bin_args_map, &id, &bin_args, BPF_ANY);
 
         // Send file data
-        prog_array.call(ctx, TAIL_SEND_BIN);
+        bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
     }
     return 0;
 }
 
+SEC("kprobe/vfs_write")
 TRACE_ENT_FUNC(vfs_write, VFS_WRITE);
 
-int trace_ret_vfs_write(struct pt_regs *ctx)
+SEC("kretprobe/vfs_write")
+int BPF_KPROBE(trace_ret_vfs_write)
 {
     return do_vfs_write_writev(ctx, VFS_WRITE, TAIL_VFS_WRITE);
 }
 
-int trace_ret_vfs_write_tail(struct pt_regs *ctx)
+SEC("kretprobe/vfs_write_tail")
+int BPF_KPROBE(trace_ret_vfs_write_tail)
 {
     return do_vfs_write_writev_tail(ctx, VFS_WRITE);
 }
 
+SEC("kprobe/vfs_writev")
 TRACE_ENT_FUNC(vfs_writev, VFS_WRITEV);
 
-int trace_ret_vfs_writev(struct pt_regs *ctx)
+SEC("kretprobe/vfs_writev")
+int BPF_KPROBE(trace_ret_vfs_writev)
 {
     return do_vfs_write_writev(ctx, VFS_WRITEV, TAIL_VFS_WRITEV);
 }
 
-int trace_ret_vfs_writev_tail(struct pt_regs *ctx)
+SEC("kretprobe/vfs_writev_tail")
+int BPF_KPROBE(trace_ret_vfs_writev_tail)
 {
     return do_vfs_write_writev_tail(ctx, VFS_WRITEV);
 }
 
-int trace_mmap_alert(struct pt_regs *ctx)
+SEC("kprobe/security_mmap_addr")
+int BPF_KPROBE(trace_mmap_alert)
 {
     args_t args = {};
 
@@ -1771,7 +1851,7 @@ int trace_mmap_alert(struct pt_regs *ctx)
 
     context_t context = init_and_save_context(submit_p, MEM_PROT_ALERT, 1 /*argnum*/, 0 /*ret*/);
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1785,7 +1865,8 @@ int trace_mmap_alert(struct pt_regs *ctx)
     return 0;
 }
 
-int trace_mprotect_alert(struct pt_regs *ctx, struct vm_area_struct *vma, unsigned long reqprot, unsigned long prot)
+SEC("kprobe/security_file_mprotect")
+int BPF_KPROBE(trace_mprotect_alert)
 {
     args_t args = {};
     bin_args_t bin_args = {};
@@ -1794,6 +1875,10 @@ int trace_mprotect_alert(struct pt_regs *ctx, struct vm_area_struct *vma, unsign
     bool delete_args = false;
     if (load_args(&args, delete_args, SYS_MPROTECT) != 0)
         return 0;
+
+    struct vm_area_struct *vma = (struct vm_area_struct *)PT_REGS_PARM1(ctx);
+    unsigned long reqprot = PT_REGS_PARM2(ctx);
+    //unsigned long prot = PT_REGS_PARM3(ctx);
 
     void *addr = (void*)args.args[0];
     size_t len = args.args[1];
@@ -1813,7 +1898,7 @@ int trace_mprotect_alert(struct pt_regs *ctx, struct vm_area_struct *vma, unsign
 
     context_t context = init_and_save_context(submit_p, MEM_PROT_ALERT, 1 /*argnum*/, 0 /*ret*/);
 
-    u64 *tags = params_names_map.lookup(&context.eventid);
+    u64 *tags = bpf_map_lookup_elem(&params_names_map, &context.eventid);
     if (!tags) {
         return -1;
     }
@@ -1849,10 +1934,13 @@ int trace_mprotect_alert(struct pt_regs *ctx, struct vm_area_struct *vma, unsign
             bin_args.full_size = len;
 
             u64 id = bpf_get_current_pid_tgid();
-            bin_args_map.update(&id, &bin_args);
-            prog_array.call(ctx, TAIL_SEND_BIN);
+            bpf_map_update_elem(&bin_args_map, &id, &bin_args, BPF_ANY);
+            bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
         }
     }
 
     return 0;
 }
+
+char LICENSE[] SEC("license") = "GPL";
+int KERNEL_VERSION SEC("version") = LINUX_VERSION_CODE;

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -16,7 +16,7 @@ import (
 	"sync/atomic"
 	"syscall"
 
-	bpf "github.com/iovisor/gobpf/bcc"
+	bpf "github.com/aquasecurity/tracee/bpfwrap"
 )
 
 // TraceeConfig is a struct containing user defined configuration of tracee
@@ -107,8 +107,8 @@ type Tracee struct {
 	config        TraceeConfig
 	eventsToTrace map[int32]bool
 	bpfModule     *bpf.Module
-	eventsPerfMap *bpf.PerfMap
-	fileWrPerfMap *bpf.PerfMap
+	eventsPerfMap *bpf.PerfBuffer
+	fileWrPerfMap *bpf.PerfBuffer
 	eventsChannel chan []byte
 	fileWrChannel chan []byte
 	lostEvChannel chan uint64
@@ -376,24 +376,65 @@ func (t *Tracee) initEventsParams() map[int32][]eventParam {
 func (t *Tracee) initBPF(ebpfProgram string) error {
 	var err error
 
-	t.bpfModule = bpf.NewModule(ebpfProgram, []string{})
-
-	chosenEvents := bpf.NewTable(t.bpfModule.TableId("chosen_events_map"), t.bpfModule)
-	key := make([]byte, 4)
-	leaf := make([]byte, 4)
-	for e, _ := range t.eventsToTrace {
-		// Set chosen events map according to events chosen by the user
-		binary.LittleEndian.PutUint32(key, uint32(e))
-		binary.LittleEndian.PutUint32(leaf, boolToUInt32(true))
-		chosenEvents.Set(key, leaf)
+	// todo: update docker image to use new approach
+	// todo: search for object file in output path first
+	// todo: compile ebpfProgram with clang if object file wasn't found
+	// todo: add install target to makefile for installing bpf object file
+	// todo: don't load all programs during init - only requested ones
+	// todo: organize init as follows:
+	//       1. Open bpf object,
+	//       2. Get requested functions (including essential events),
+	//       3. Set program types and autoload,
+	//       4. Load bpf object,
+	//       5. Populate maps with values,
+	//       6. Attach probes,
+	//       7. Initialize perf buffers
+	t.bpfModule, err = bpf.NewModule(".output/event_monitor_ebpf.o")
+	if err != nil {
+		return err
 	}
 
-	sys32to64BPFTable := bpf.NewTable(t.bpfModule.TableId("sys_32_to_64_map"), t.bpfModule)
+	supportRawTracepoints, err := supportRawTP()
+	if err != nil {
+		return fmt.Errorf("Failed to find kernel version: %v", err)
+	}
+
+	// BpfLoadObject() will automatically load all bpf programs according to their section type
+	// As kernels < 4.17 don't support raw tracepoints, set these program types to "regular" tracepoint
+	if !supportRawTracepoints {
+		for _, event := range EventsIDToEvent {
+			for _, probe := range event.Probes {
+				var prog *bpf.BpfProg
+				if probe.attach == rawTracepoint {
+					prog, _ = t.bpfModule.GetProgram(probe.fn)
+				} else if probe.attach == sysCall {
+					prog, _ = t.bpfModule.GetProgram(fmt.Sprintf("syscall__%s", probe.fn))
+				}
+				if prog != nil {
+					err = prog.SetTracepoint()
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	err = t.bpfModule.BpfLoadObject()
+	if err != nil {
+		return err
+	}
+
+	chosenEventsMap, _ := t.bpfModule.GetMap("chosen_events_map")
+	for e, _ := range t.eventsToTrace {
+		// Set chosen events map according to events chosen by the user
+		chosenEventsMap.Update(e, boolToUInt32(true))
+	}
+
+	sys32to64BPFMap, _ := t.bpfModule.GetMap("sys_32_to_64_map")
 	for id, event := range EventsIDToEvent {
 		// Prepare 32bit to 64bit syscall number mapping
-		binary.LittleEndian.PutUint32(key, uint32(event.ID32Bit))
-		binary.LittleEndian.PutUint32(leaf, uint32(event.ID))
-		sys32to64BPFTable.Set(key, leaf)
+		sys32to64BPFMap.Update(event.ID32Bit, event.ID)
 
 		// Compile final list of events to trace including essential events
 		// If an essential event was not requested by the user, set its map value to false
@@ -404,14 +445,10 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 
 	eventsParams := t.initEventsParams()
 
-	supportRawTracepoints, err := supportRawTP()
-	if err != nil {
-		return fmt.Errorf("Failed to find kernel version: %v", err)
-	}
-	sysEnterTailsBPFTable := bpf.NewTable(t.bpfModule.TableId("sys_enter_tails"), t.bpfModule)
-	//sysExitTailsBPFTable := bpf.NewTable(t.bpfModule.TableId("sys_exit_tails"), t.bpfModule)
-	paramsTypesBPFTable := bpf.NewTable(t.bpfModule.TableId("params_types_map"), t.bpfModule)
-	paramsNamesBPFTable := bpf.NewTable(t.bpfModule.TableId("params_names_map"), t.bpfModule)
+	sysEnterTailsBPFMap, _ := t.bpfModule.GetMap("sys_enter_tails")
+	//sysExitTailsBPFMap := t.bpfModule.GetMap("sys_exit_tails")
+	paramsTypesBPFMap, _ := t.bpfModule.GetMap("params_types_map")
+	paramsNamesBPFMap, _ := t.bpfModule.GetMap("params_names_map")
 	for e, _ := range t.eventsToTrace {
 		params := eventsParams[e]
 		var paramsTypes uint64
@@ -420,13 +457,8 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 			paramsTypes = paramsTypes | (uint64(param.encType) << (8 * n))
 			paramsNames = paramsNames | (uint64(param.encName) << (8 * n))
 		}
-		leaf := make([]byte, 8)
-		binary.LittleEndian.PutUint32(key, uint32(e))
-		binary.LittleEndian.PutUint64(leaf, paramsTypes)
-		paramsTypesBPFTable.Set(key, leaf)
-		binary.LittleEndian.PutUint32(key, uint32(e))
-		binary.LittleEndian.PutUint64(leaf, paramsNames)
-		paramsNamesBPFTable.Set(key, leaf)
+		paramsTypesBPFMap.Update(e, paramsTypes)
+		paramsNamesBPFMap.Update(e, paramsNames)
 
 		event, ok := EventsIDToEvent[e]
 		if !ok {
@@ -439,62 +471,57 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 			}
 			if probe.attach == sysCall {
 				if e == ExecveEventID || e == ExecveatEventID {
-					var tp int
 					// execve functions require tail call on syscall enter as they perform extra work
-					if supportRawTracepoints {
-						tp, err = t.bpfModule.LoadRawTracepoint(fmt.Sprintf("syscall__%s", probe.fn))
-					} else {
-						tp, err = t.bpfModule.LoadTracepoint(fmt.Sprintf("syscall__%s", probe.fn))
-					}
+					prog, err := t.bpfModule.GetProgram(fmt.Sprintf("syscall__%s", probe.fn))
 					if err != nil {
-						return fmt.Errorf("error loading kprobe %s: %v", probe.fn, err)
+						return fmt.Errorf("error loading BPF program %s: %v", probe.fn, err)
 					}
-					binary.LittleEndian.PutUint32(key, uint32(e))
-					binary.LittleEndian.PutUint32(leaf, uint32(tp))
-					sysEnterTailsBPFTable.Set(key, leaf)
+					sysEnterTailsBPFMap.Update(e, int32(prog.GetFd()))
 				}
 				continue
 			}
 			if probe.attach == kprobe {
-				kp, err := t.bpfModule.LoadKprobe(probe.fn)
+				prog, err := t.bpfModule.GetProgram(probe.fn)
 				if err != nil {
 					return fmt.Errorf("error loading kprobe %s: %v", probe.fn, err)
 				}
-				err = t.bpfModule.AttachKprobe(probe.event, kp, -1)
+				// todo: after updating minimal kernel version to 4.18, use without legacy
+				_, err = prog.AttachKprobeLegacy(probe.event)
 				if err != nil {
 					return fmt.Errorf("error attaching kprobe %s: %v", probe.event, err)
 				}
 				continue
 			}
 			if probe.attach == kretprobe {
-				kp, err := t.bpfModule.LoadKprobe(probe.fn)
+				prog, err := t.bpfModule.GetProgram(probe.fn)
 				if err != nil {
 					return fmt.Errorf("error loading kprobe %s: %v", probe.fn, err)
 				}
-				err = t.bpfModule.AttachKretprobe(probe.event, kp, -1)
+				// todo: after updating minimal kernel version to 4.18, use without legacy
+				_, err = prog.AttachKretprobeLegacy(probe.event)
 				if err != nil {
 					return fmt.Errorf("error attaching kretprobe %s: %v", probe.event, err)
 				}
 				continue
 			}
 			if probe.attach == tracepoint {
-				tp, err := t.bpfModule.LoadTracepoint(probe.fn)
+				prog, err := t.bpfModule.GetProgram(probe.fn)
 				if err != nil {
 					return fmt.Errorf("error loading tracepoint %s: %v", probe.fn, err)
 				}
-				err = t.bpfModule.AttachTracepoint(probe.event, tp)
+				_, err = prog.AttachTracepoint(probe.event)
 				if err != nil {
 					return fmt.Errorf("error attaching tracepoint %s: %v", probe.event, err)
 				}
 				continue
 			}
 			if probe.attach == rawTracepoint {
-				tp, err := t.bpfModule.LoadRawTracepoint(probe.fn)
+				prog, err := t.bpfModule.GetProgram(probe.fn)
 				if err != nil {
 					return fmt.Errorf("error loading raw tracepoint %s: %v", probe.fn, err)
 				}
 				tpEvent := strings.Split(probe.event, ":")[1]
-				err = t.bpfModule.AttachRawTracepoint(tpEvent, tp)
+				_, err = prog.AttachRawTracepoint(tpEvent)
 				if err != nil {
 					return fmt.Errorf("error attaching raw tracepoint %s: %v", tpEvent, err)
 				}
@@ -503,8 +530,6 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 		}
 	}
 
-	bpfConfig := bpf.NewTable(t.bpfModule.TableId("config_map"), t.bpfModule)
-
 	mode := modeSystem
 	if t.config.ContainerMode {
 		mode = modeContainer
@@ -512,78 +537,60 @@ func (t *Tracee) initBPF(ebpfProgram string) error {
 		mode = modePid
 	}
 
-	binary.LittleEndian.PutUint32(key, uint32(configMode))
-	binary.LittleEndian.PutUint32(leaf, mode)
-	bpfConfig.Set(key, leaf)
-	binary.LittleEndian.PutUint32(key, uint32(configDetectOrigSyscall))
-	binary.LittleEndian.PutUint32(leaf, boolToUInt32(t.config.DetectOriginalSyscall))
-	bpfConfig.Set(key, leaf)
-	binary.LittleEndian.PutUint32(key, uint32(configExecEnv))
-	binary.LittleEndian.PutUint32(leaf, boolToUInt32(t.config.ShowExecEnv))
-	bpfConfig.Set(key, leaf)
-	binary.LittleEndian.PutUint32(key, uint32(configCaptureFiles))
-	binary.LittleEndian.PutUint32(leaf, boolToUInt32(t.config.CaptureWrite))
-	bpfConfig.Set(key, leaf)
-	binary.LittleEndian.PutUint32(key, uint32(configExtractDynCode))
-	binary.LittleEndian.PutUint32(leaf, boolToUInt32(t.config.CaptureMem))
-	bpfConfig.Set(key, leaf)
-	binary.LittleEndian.PutUint32(key, uint32(configTraceePid))
-	binary.LittleEndian.PutUint32(leaf, uint32(os.Getpid()))
-	bpfConfig.Set(key, leaf)
+	// Initialize config and pids maps
+	bpfConfigMap, _ := t.bpfModule.GetMap("config_map")
+	bpfConfigMap.Update(uint32(configMode), mode)
+	bpfConfigMap.Update(uint32(configDetectOrigSyscall), boolToUInt32(t.config.DetectOriginalSyscall))
+	bpfConfigMap.Update(uint32(configExecEnv), boolToUInt32(t.config.ShowExecEnv))
+	bpfConfigMap.Update(uint32(configCaptureFiles), boolToUInt32(t.config.CaptureWrite))
+	bpfConfigMap.Update(uint32(configExtractDynCode), boolToUInt32(t.config.CaptureMem))
+	bpfConfigMap.Update(uint32(configTraceePid), uint32(os.Getpid()))
 
-	pidsMap := bpf.NewTable(t.bpfModule.TableId("pids_map"), t.bpfModule)
+	pidsMap, _ := t.bpfModule.GetMap("pids_map")
 	for _, pid := range t.config.PidsToTrace {
-		binary.LittleEndian.PutUint32(key, uint32(pid))
-		binary.LittleEndian.PutUint32(leaf, uint32(pid))
-		pidsMap.Set(key, leaf)
+		pidsMap.Update(uint32(pid), uint32(pid))
 	}
 
-	// Load send_bin function to prog_array to be used as tail call
-	progArrayBPFTable := bpf.NewTable(t.bpfModule.TableId("prog_array"), t.bpfModule)
-	binary.LittleEndian.PutUint32(key, tailVfsWrite)
-	kp, err := t.bpfModule.LoadKprobe("trace_ret_vfs_write_tail")
+	// Initialize tail calls program array
+	bpfProgArrayMap, _ := t.bpfModule.GetMap("prog_array")
+	prog, err := t.bpfModule.GetProgram("trace_ret_vfs_write_tail")
 	if err != nil {
-		return fmt.Errorf("error loading function trace_ret_vfs_write_tail: %v", err)
+		return fmt.Errorf("error getting BPF program trace_ret_vfs_write_tail: %v", err)
 	}
-	binary.LittleEndian.PutUint32(leaf, uint32(kp))
-	progArrayBPFTable.Set(key, leaf)
+	bpfProgArrayMap.Update(uint32(tailVfsWrite), uint32(prog.GetFd()))
 
-	binary.LittleEndian.PutUint32(key, tailVfsWritev)
-	kp, err = t.bpfModule.LoadKprobe("trace_ret_vfs_writev_tail")
+	prog, err = t.bpfModule.GetProgram("trace_ret_vfs_writev_tail")
 	if err != nil {
-		return fmt.Errorf("error loading function trace_ret_vfs_writev_tail: %v", err)
+		return fmt.Errorf("error getting BPF program trace_ret_vfs_writev_tail: %v", err)
 	}
-	binary.LittleEndian.PutUint32(leaf, uint32(kp))
-	progArrayBPFTable.Set(key, leaf)
+	bpfProgArrayMap.Update(uint32(tailVfsWritev), uint32(prog.GetFd()))
 
-	binary.LittleEndian.PutUint32(key, tailSendBin)
-	kp, err = t.bpfModule.LoadKprobe("send_bin")
+	prog, err = t.bpfModule.GetProgram("send_bin")
 	if err != nil {
-		return fmt.Errorf("error loading function send_bin: %v", err)
+		return fmt.Errorf("error getting BPF program send_bin: %v", err)
 	}
-	binary.LittleEndian.PutUint32(leaf, uint32(kp))
-	progArrayBPFTable.Set(key, leaf)
+	bpfProgArrayMap.Update(uint32(tailSendBin), uint32(prog.GetFd()))
 
 	// Set filters given by the user to filter file write events
-	fileFilterTable := bpf.NewTable(t.bpfModule.TableId("file_filter"), t.bpfModule)
+	fileFilterMap, _ := t.bpfModule.GetMap("file_filter")
 	for i := 0; i < len(t.config.FilterFileWrite); i++ {
-		binary.LittleEndian.PutUint32(key, uint32(i))
-		leaf = []byte(t.config.FilterFileWrite[i])
-		fileFilterTable.Set(key, leaf)
+		fileFilterMap.Update(uint32(i), []byte(t.config.FilterFileWrite[i]))
 	}
 
-	eventsBPFTable := bpf.NewTable(t.bpfModule.TableId("events"), t.bpfModule)
+	stringStoreMap, _ := t.bpfModule.GetMap("string_store")
+	stringStoreMap.Update(uint32(0), []byte("/dev/null"))
+
+	// Initialize perf buffers
 	t.eventsChannel = make(chan []byte, 1000)
 	t.lostEvChannel = make(chan uint64)
-	t.eventsPerfMap, err = bpf.InitPerfMapWithPageCnt(eventsBPFTable, t.eventsChannel, t.lostEvChannel, t.config.PerfBufferSize)
+	t.eventsPerfMap, err = t.bpfModule.InitPerfBuf("events", t.eventsChannel, t.lostEvChannel, t.config.PerfBufferSize)
 	if err != nil {
 		return fmt.Errorf("error initializing events perf map: %v", err)
 	}
 
-	fileWritesBPFTable := bpf.NewTable(t.bpfModule.TableId("file_writes"), t.bpfModule)
 	t.fileWrChannel = make(chan []byte, 1000)
 	t.lostWrChannel = make(chan uint64)
-	t.fileWrPerfMap, err = bpf.InitPerfMapWithPageCnt(fileWritesBPFTable, t.fileWrChannel, t.lostWrChannel, t.config.BlobPerfBufferSize)
+	t.fileWrPerfMap, err = t.bpfModule.InitPerfBuf("file_writes", t.fileWrChannel, t.lostWrChannel, t.config.BlobPerfBufferSize)
 	if err != nil {
 		return fmt.Errorf("error initializing file_writes perf map: %v", err)
 	}
@@ -603,8 +610,8 @@ func (t *Tracee) Run() error {
 	go t.runEventPipeline(done)
 	go t.processFileWrites()
 	<-sig
-	t.eventsPerfMap.Stop() //TODO: should this be in Tracee.Close()?
-	t.fileWrPerfMap.Stop() //TODO: should this be in Tracee.Close()?
+	t.eventsPerfMap.Stop()
+	t.fileWrPerfMap.Stop()
 	t.printer.Epilogue(t.stats)
 	// Signal pipeline that Tracee exits by closing the done channel
 	close(done)


### PR DESCRIPTION
This PR replaces gobpf as the bpf library used by Tracee with bpfwrap.
bpfwrap is a wrapper to libbpf, which is written in C.
The advantages of using bpfwrap over gobpf are the following:
    - no bcc dependancy - only clang is required to compile the code
    - compile once - compilation can take place during installation
      on a given node. Then, the compiled object is used in future runs.
      This have the advantage that Tracee will not have unnecessary delays
      on start.
    - libbpf is being developed as part of the linux kernel. This means it
      will always get the latest features, and that it is well maintained.
    - the move to libbpf will allow us to add support for CO-RE in the
      future. With CO-RE, bpf object is Compiled Once, and can then
      Run Everywhere without the need to compile the code again for different
      kernels
