### PR TITLE
Output formatting via gotemplate

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 				Name:    "output",
 				Aliases: []string{"o"},
 				Value:   "table",
-				Usage:   "output format: table/table-verbose/json/gob",
+				Usage:   "output format: table/table-verbose/json/gob/go-template=<path>",
 			},
 			&cli.StringSliceFlag{
 				Name:    "event",

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -45,7 +45,7 @@ func (tc TraceeConfig) Validate() error {
 	if tc.EventsToTrace == nil {
 		return fmt.Errorf("eventsToTrace is nil")
 	}
-	if tc.OutputFormat != "table" && tc.OutputFormat != "table-verbose" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" {
+	if tc.OutputFormat != "table" && tc.OutputFormat != "table-verbose" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" && !strings.HasPrefix(tc.OutputFormat, "go-template=") {
 		return fmt.Errorf("unrecognized output format: %s", tc.OutputFormat)
 	}
 	for _, e := range tc.EventsToTrace {
@@ -173,7 +173,11 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 	t := &Tracee{
 		config: cfg,
 	}
-	t.printer = newEventPrinter(t.config.OutputFormat, t.config.ContainerMode, t.config.EventsFile, t.config.ErrorsFile)
+	printObj, err := newEventPrinter(t.config.OutputFormat, t.config.ContainerMode, t.config.EventsFile, t.config.ErrorsFile)
+	if err != nil {
+		return nil, err
+	}
+	t.printer = printObj
 	t.eventsToTrace = make(map[int32]bool, len(t.config.EventsToTrace))
 	for _, e := range t.config.EventsToTrace {
 		// Map value is true iff events requested by the user


### PR DESCRIPTION
To resolve #214, provided the `-o go-template=<path>` option.