### PR TITLE
change readiness file format

### DIFF
--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -214,7 +214,7 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 	if err := os.MkdirAll(t.config.OutputPath, 0755); err != nil {
 		return nil, fmt.Errorf("error creating output path: %v", err)
 	}
-	err = ioutil.WriteFile(path.Join(t.config.OutputPath, fmt.Sprintf("tracee.%d", os.Getpid())), nil, 0640)
+	err = ioutil.WriteFile(path.Join(t.config.OutputPath, "tracee.pid"), []byte(strconv.Itoa(os.Getpid())+"\n"), 0640)
 	if err != nil {
 		return nil, fmt.Errorf("error creating readiness file: %v", err)
 	}


### PR DESCRIPTION
instead of `tracee.${pid}`, will be `tracee.pid` with the ${pid} written in it