### PR TITLE
Fix send bin chunk size

### DIFF
--- a/tracee/event_monitor_ebpf.c
+++ b/tracee/event_monitor_ebpf.c
@@ -1505,7 +1505,7 @@ int send_bin(struct pt_regs *ctx)
 #define F_SZ_OFF      (F_META_OFF + SEND_META_SIZE)
 #define F_POS_OFF     (F_SZ_OFF + sizeof(unsigned int))
 #define F_CHUNK_OFF   (F_POS_OFF + sizeof(off_t))
-#define F_CHUNK_SIZE  (MAX_PERCPU_BUFSIZE - F_CHUNK_OFF - 4)
+#define F_CHUNK_SIZE  (MAX_PERCPU_BUFSIZE >> 1)
 
     bpf_probe_read((void **)&(file_buf_p->buf[F_SEND_TYPE]), sizeof(u8), &bin_args->type);
 


### PR DESCRIPTION
Commit d58cd29cba127702f05ddd5e39d7f00eb67e6a0c (fix kernel 4.14) inadvertently introduced a bug in send bin chunk size.
When sending last commit, we now perform bitwise AND operation on the chunk size with (MAX_PERCPU_BUFSIZE >> 1).
This means that the chunk size can't be bigger than this value, which is not the case.
Set chunk size to this value to avoid corrupted data