### PR TITLE
fix error printing line break

### DIFF
--- a/tracee/pipeline.go
+++ b/tracee/pipeline.go
@@ -129,7 +129,7 @@ func (t *Tracee) prepareEventForPrint(done <-chan struct{}, in <-chan RawEvent) 
 				if ok {
 					argsNames[i] = argName
 				} else {
-					errc <- fmt.Errorf("Invalid arg tag for event %d\n", rawEvent.Ctx.EventID)
+					errc <- fmt.Errorf("Invalid arg tag for event %d", rawEvent.Ctx.EventID)
 					continue
 				}
 			}

--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -158,7 +158,7 @@ func (p tableEventPrinter) Print(event Event) {
 }
 
 func (p tableEventPrinter) Error(err error) {
-	fmt.Fprintf(p.err, "%v", err)
+	fmt.Fprintf(p.err, "%v\n", err)
 }
 
 func (p tableEventPrinter) Epilogue(stats statsStore) {


### PR DESCRIPTION
Errors were incorrectly positioned with adjacent event. tailing newline should not be part of the message, it should be handled by the printer