### PR TITLE
update go version to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/tracee
 
-go 1.13
+go 1.15
 
 require (
 	github.com/iovisor/gobpf v0.0.0-20200529092446-49b58e11a4b5


### PR DESCRIPTION
no sure exactly what happened but https://github.com/aquasecurity/tracee/pull/248 changed everything but the main go.mod file