### PR TITLE
Add user output formatting

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 				Name:    "output",
 				Aliases: []string{"o"},
 				Value:   "table",
-				Usage:   "output format: table/table-verbose/json/gob/go-template=<path>",
+				Usage:   "output format: table/table=<fields>/json/gob/go-template=<path>",
 			},
 			&cli.StringSliceFlag{
 				Name:    "event",

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -45,7 +45,7 @@ func (tc TraceeConfig) Validate() error {
 	if tc.EventsToTrace == nil {
 		return fmt.Errorf("eventsToTrace is nil")
 	}
-	if tc.OutputFormat != "table" && tc.OutputFormat != "table-verbose" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" && !strings.HasPrefix(tc.OutputFormat, "go-template=") {
+	if tc.OutputFormat != "table" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" && !strings.HasPrefix(tc.OutputFormat, "table=") && !strings.HasPrefix(tc.OutputFormat, "go-template=") {
 		return fmt.Errorf("unrecognized output format: %s", tc.OutputFormat)
 	}
 	for _, e := range tc.EventsToTrace {


### PR DESCRIPTION
Resolves #207 

For a sample command `./tracee -o table=pid, ppid, processName, args`, the trace appears as below:

```
30196 30107 runc pathname: /sys/kernel/mm/hugepages, flags: O_RDONLY|O_LARGEFILE, dev: 21, inode: 3326
30196 30107 runc dirfd: -100, pathname: /sys/kernel/mm/hugepages, flags: O_RDONLY|O_CLOEXEC, mode: 0
30196 30107 runc fd: 3, dirp: 0xC0000D4000, count: 8192
30196 30107 runc fd: 3, dirp: 0xC0000D4000, count: 8192
30196 30107 runc flags: CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, stack: 0x7F4B6A7FBFB0, parent_tid: 0x7F4B6A7FC9D0, child_tid: 0x0, tls: 139961886033664
30196 30107 runc pathname: /run/containerd/io.containerd.runtime.v1.linux/moby/1c5210ca342c210d1c5d1120fb53e3a9515fec6508202feceb4f301b5d1a060e/log.json, flags: O_WRONLY|O_CREAT|O_APPEND|O_SYNC|O_LARGEFILE, dev: 23, inode: 693
30196 30107 runc dirfd: -100, pathname: /run/containerd/io.containerd.runtime.v1.linux/moby/1c5210ca342c210d1c5d1120fb53e3a9515fec6508202feceb4f301b5d1a060e/log.json, flags: O_WRONLY|O_CREAT|O_APPEND|O_SYNC|O_CLOEXEC, mode: 0
30196 30107 runc pathname: /proc/30196/uid_map, flags: O_RDONLY|O_LARGEFILE, dev: 4, inode: 5986944
30196 30107 runc dirfd: -100, pathname: /proc/self/uid_map, flags: O_RDONLY|O_CLOEXEC, mode: 0
30196 30107 runc fd: 5
30196 30107 runc pathname: /run/docker/runtime-runc/moby/1c5210ca342c210d1c5d1120fb53e3a9515fec6508202feceb4f301b5d1a060e/state.json, flags: O_RDONLY|O_LARGEFILE, dev: 23, inode: 700
```

Signed-off-by: Sid Srinivas <siddharths2710@yahoo.com>