### PR TITLE
Fix bad string size type

### DIFF
--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -985,7 +985,7 @@ func (t *Tracee) processFileWrites() {
 
 func readStringFromBuff(buff io.Reader) (string, error) {
 	var err error
-	var size int32
+	var size uint32
 	err = binary.Read(buff, binary.LittleEndian, &size)
 	if err != nil {
 		return "", fmt.Errorf("error reading string size: %v", err)


### PR DESCRIPTION
Using int32, string size can be negative, and crash Tracee when trying to allocate a byte slice which is huge (when unsigned).
Fix by using uint32