### PR TITLE
fix docker builds for libbpf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,21 @@
 FROM golang:1.13-buster as builder
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libtinfo5
-
-WORKDIR /bcc
-# aquasec/bcc-builder is built from the upstream bcc dockerfile using:
-# docker build --target=builder -t aquasec/bcc-builder:latest --file Dockerfile.ubuntu .
-COPY --from=aquasec/bcc-builder:latest /root/bcc/libbcc_*.deb /bcc/
-RUN DEBIAN_FRONTEND=noninteractive dpkg -i libbcc_*.deb && rm -rf /bcc
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm clang
 
 WORKDIR /tracee
-COPY . /tracee
-RUN make build
 
+COPY . /tracee
+
+RUN make build
 
 # must run privileged and with linux headers mounted
 # docker run --name tracee --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro aquasec/tracee
-FROM ubuntu:eoan
+FROM ubuntu:focal
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf1 libtinfo5
-
-WORKDIR /bcc
-# aquasec/bcc-builder is built from the upstream bcc dockerfile using:
-# docker build --target=builder -t aquasec/bcc-builder:latest --file Dockerfile.ubuntu .
-COPY --from=aquasec/bcc-builder:latest /root/bcc/libbcc_*.deb /bcc/
-RUN DEBIAN_FRONTEND=noninteractive dpkg -i libbcc_*.deb && rm -rf /bcc
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf1 llvm clang
 
 WORKDIR /tracee
+
 COPY --from=builder /tracee/dist/tracee /tracee/entrypoint.sh ./
+
 ENTRYPOINT ["./entrypoint.sh", "./tracee"]

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,15 +1,11 @@
 # must run privileged and with linux headers mounted
 # docker run --name tracee --rm --privileged -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro aquasec/tracee
-FROM ubuntu:eoan
+FROM ubuntu:focal
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf1 libtinfo5
-
-WORKDIR /bcc
-# aquasec/bcc-builder is built from the upstream bcc dockerfile using:
-# docker build --target=builder -t aquasec/bcc-builder:latest --file Dockerfile.ubuntu .
-COPY --from=aquasec/bcc-builder:latest /root/bcc/libbcc_*.deb /bcc/
-RUN DEBIAN_FRONTEND=noninteractive dpkg -i libbcc_*.deb && rm -rf /bcc
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf1 llvm clang
 
 WORKDIR /tracee
+
 COPY ./tracee ./entrypoint.sh ./
+
 ENTRYPOINT ["./entrypoint.sh", "./tracee"]


### PR DESCRIPTION
I also took the opportunity to upgrade the base image to ubuntu focal.
note that the builder image version will need to change to go 1.15 when libbpf is merged with master (currently libbpf is still on 1.13)