### PR TITLE
feat: Add tests to CI/CD workflow

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -3,7 +3,7 @@ name: build-test
 on: pull_request
 
 jobs:
-  build-test:
+  build:
     runs-on: ubuntu-20.04
 
     env:
@@ -31,3 +31,14 @@ jobs:
 
       - name: Build Tracee
         run: make build-docker
+  
+  test:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Run Tests
+        run: make test-docker
+      


### PR DESCRIPTION
## Summary

Added tests as a job in the GitHub Actions workflow. Related to #254.

## Possible Alternative

We can also alternatively add a new section in the `Makefile` and run tests in a container. However, could not detect failing tests with that approach.

```makefile
.PHONY: test-docker
test-docker: clean
  img=$$(docker build --target builder -q .) && \
  cnt=$$(docker create $$img); \
  docker run -a stdout $$cnt make test; \
  docker rm $$cnt ; docker rmi $$img
```