### PR TITLE
Add sched_process_exit event

### DIFF
--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -439,6 +439,7 @@ const (
 	VfsWriteEventID
 	VfsWritevEventID
 	MemProtAlertEventID
+	SchedProcessExitEventID
 )
 
 // 32bit syscall numbers
@@ -1212,13 +1213,14 @@ var EventsIDToEvent = map[int32]EventConfig{
 	RseqEventID:                {ID: RseqEventID, ID32Bit: sys32rseq, Name: "rseq", Probes: []probe{{event: "rseq", attach: sysCall, fn: "rseq"}}, Sets: []string{"syscalls"}},
 	SysEnterEventID:            {ID: SysEnterEventID, ID32Bit: sys32undefined, Name: "sys_enter", Probes: []probe{{event: "raw_syscalls:sys_enter", attach: rawTracepoint, fn: "tracepoint__raw_syscalls__sys_enter"}}, EssentialEvent: true, Sets: []string{}},
 	SysExitEventID:             {ID: SysExitEventID, ID32Bit: sys32undefined, Name: "sys_exit", Probes: []probe{{event: "raw_syscalls:sys_exit", attach: rawTracepoint, fn: "tracepoint__raw_syscalls__sys_exit"}}, EssentialEvent: true, Sets: []string{}},
-	DoExitEventID:              {ID: DoExitEventID, ID32Bit: sys32undefined, Name: "do_exit", Probes: []probe{{event: "do_exit", attach: kprobe, fn: "trace_do_exit"}}, EssentialEvent: true, Sets: []string{"default"}},
+	DoExitEventID:              {ID: DoExitEventID, ID32Bit: sys32undefined, Name: "do_exit", Probes: []probe{{event: "do_exit", attach: kprobe, fn: "trace_do_exit"}}, Sets: []string{"proc", "proc_life"}},
 	CapCapableEventID:          {ID: CapCapableEventID, ID32Bit: sys32undefined, Name: "cap_capable", Probes: []probe{{event: "cap_capable", attach: kprobe, fn: "trace_cap_capable"}}, Sets: []string{"default"}},
 	SecurityBprmCheckEventID:   {ID: SecurityBprmCheckEventID, ID32Bit: sys32undefined, Name: "security_bprm_check", Probes: []probe{{event: "security_bprm_check", attach: kprobe, fn: "trace_security_bprm_check"}}, Sets: []string{"default"}},
 	SecurityFileOpenEventID:    {ID: SecurityFileOpenEventID, ID32Bit: sys32undefined, Name: "security_file_open", Probes: []probe{{event: "security_file_open", attach: kprobe, fn: "trace_security_file_open"}}, Sets: []string{"default"}},
 	VfsWriteEventID:            {ID: VfsWriteEventID, ID32Bit: sys32undefined, Name: "vfs_write", Probes: []probe{{event: "vfs_write", attach: kprobe, fn: "trace_vfs_write"}, {event: "vfs_write", attach: kretprobe, fn: "trace_ret_vfs_write"}}, Sets: []string{"default"}},
 	VfsWritevEventID:           {ID: VfsWritevEventID, ID32Bit: sys32undefined, Name: "vfs_writev", Probes: []probe{{event: "vfs_writev", attach: kprobe, fn: "trace_vfs_writev"}, {event: "vfs_writev", attach: kretprobe, fn: "trace_ret_vfs_writev"}}, Sets: []string{"default"}},
 	MemProtAlertEventID:        {ID: MemProtAlertEventID, ID32Bit: sys32undefined, Name: "mem_prot_alert", Probes: []probe{{event: "security_mmap_addr", attach: kprobe, fn: "trace_mmap_alert"}, {event: "security_file_mprotect", attach: kprobe, fn: "trace_mprotect_alert"}}, Sets: []string{}},
+	SchedProcessExitEventID:    {ID: SchedProcessExitEventID, ID32Bit: sys32undefined, Name: "sched_process_exit", Probes: []probe{{event: "sched:sched_process_exit", attach: rawTracepoint, fn: "tracepoint__sched__sched_process_exit"}}, EssentialEvent: true, Sets: []string{"default", "proc", "proc_life"}},
 }
 
 type param struct {
@@ -1560,4 +1562,5 @@ var EventsIDToParams = map[int32][]param{
 	VfsWriteEventID:            {{pType: "const char*", pName: "pathname"}, {pType: "dev_t", pName: "dev"}, {pType: "unsigned long", pName: "inode"}, {pType: "size_t", pName: "count"}, {pType: "off_t", pName: "pos"}},
 	VfsWritevEventID:           {{pType: "const char*", pName: "pathname"}, {pType: "dev_t", pName: "dev"}, {pType: "unsigned long", pName: "inode"}, {pType: "unsigned long", pName: "vlen"}, {pType: "off_t", pName: "pos"}},
 	MemProtAlertEventID:        {{pType: "alert_t", pName: "alert"}},
+	SchedProcessExitEventID:    {},
 }

--- a/tracee/tracee.bpf.c
+++ b/tracee/tracee.bpf.c
@@ -103,7 +103,8 @@
 #define VFS_WRITE           341
 #define VFS_WRITEV          342
 #define MEM_PROT_ALERT      343
-#define MAX_EVENT_ID        344
+#define SCHED_PROCESS_EXIT  344
+#define MAX_EVENT_ID        345
 
 #define CONFIG_MODE             0
 #define CONFIG_SHOW_SYSCALL     1
@@ -1393,6 +1394,34 @@ int syscall__execveat(void *ctx)
 
 /*============================== OTHER HOOKS ==============================*/
 
+SEC("raw_tracepoint/sched_process_exit")
+int tracepoint__sched__sched_process_exit(
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0)
+void *ctx
+#else
+struct bpf_raw_tracepoint_args *ctx
+#endif
+)
+{
+    if (!should_trace())
+        return 0;
+
+    if (get_config(CONFIG_MODE) == MODE_CONTAINER_NEW)
+        remove_pid_ns_if_needed();
+    else
+        remove_pid();
+
+    buf_t *submit_p = get_buf(SUBMIT_BUF_IDX);
+    if (submit_p == NULL)
+        return 0;
+    set_buf_off(SUBMIT_BUF_IDX, sizeof(context_t));
+
+    init_and_save_context(submit_p, SCHED_PROCESS_EXIT, 0, 0);
+
+    events_perf_submit(ctx);
+    return 0;
+}
+
 SEC("kprobe/do_exit")
 int BPF_KPROBE(trace_do_exit)
 {
@@ -1407,11 +1436,6 @@ int BPF_KPROBE(trace_do_exit)
     long code = PT_REGS_PARM1(ctx);
 
     init_and_save_context(submit_p, DO_EXIT, 0, code);
-
-    if (get_config(CONFIG_MODE) == MODE_CONTAINER_NEW)
-        remove_pid_ns_if_needed();
-    else
-        remove_pid();
 
     events_perf_submit(ctx);
     return 0;


### PR DESCRIPTION
Add sched_process_exit event and set it as essential. Also set do_exit event as non essential.

As tracepoints are considered a more stable API, and as there are environments where tracepoints are enabled but kprobes are not, it is preferable to use sched_process_exit and not do_exit as an essential event.

Keep do_exit event as it has the process exit code, which is not available for the sched_process_exit event