### PR TITLE
Add a `--filter` flag and support for filtering of events by uid

### DIFF
--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -11,6 +11,7 @@ const (
 	configCaptureFiles
 	configExtractDynCode
 	configTraceePid
+	configFilterByUid
 )
 
 // an enum that specifies the index of a function to be used in a bpf tail call


### PR DESCRIPTION
_(I marked this as a draft because of a verifier issue, see context below)_

This adds a `--filter` flag to tracee. Currently the only supported value to filter by is `uid`. In this proposed solution users can specify filters of the form `<field>=<value>`, or multiple by using a comma separated list or specifying the flag multiple times:      `--filter <field>=<value1>,<value2>` or `--filter <field>=<value1> --filter <field>=<value2>`

In the case of uid filtering, the way I've implemented this is by parsing passed values, and sharing two values between user and kernel space: an array of the uids in their own BPF_ARRAY and a field in the BPF_HASH `config_map` for the length of this array. 


#### Verifier issue:
The issue is that the verifier complains about the loop in bpf which reads from the array of uids. Having the length of array (and therefore # of loop iterations) pulled from a variable is enough to reject the program.

I have a few thoughts on how we can get around this and their trade-offs:

- Is there a way of working around the verifier in bpf code that i'm not familiar with? I thought maybe declaring the length value as a const would help but it didn't.

- If we set a hard limit on the number of UIDs we can satisfy the verifier by bounding the loop at that limit. 
  - Can we picture someone specifying more than a handful of uids? Why would they not just create a group and pass a gid (once we add that as a supported filter option).
  - If so, what would we set this limit to? 15? 50? Regardless it seems like it would be arbitrary.

- We can move the filtering into Go code.
  - Likely takes a performance hit, but not sure how much, we need a bench marking suite in CI/CD for tracee. 
  - This would reduce the complexity of the bpf code. Is having filtering in bpf worth the number of instructions it takes up?
  - There may be fields we want to support filtering by that aren't surfaced to Go code and need to be done on the bpf side. There should be parity between all filter fields for the sake of code complexity. 

- We can just not have this feature at all and let users rely on unix tools like `grep` or `jq`
  - If someone wanted to consume tracee as a package in their own code this would limit the usefulness of the API.


Relevant issue: #312 