### PR TITLE
improve building in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.vscode
+.idea
+/dist

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .vscode
 .idea
 /dist
+Dockerfile
+*.md
+/images
+/.github

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Build Tracee
-        run: make build DOCKER=1
+        run: make all DOCKER=1
   
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Build Tracee
-        run: make build-docker
+        run: make build DOCKER=1
   
   test:
     runs-on: ubuntu-20.04
@@ -40,5 +40,5 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Tests
-        run: make test-docker
+        run: make test DOCKER=1
       

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tracee
 
 FROM tracee-builder as build
 COPY . /tracee
-RUN git submodule update --init && make build
+RUN make build
 
 # base image for tracee which includes all tools to build the bpf object at runtime
 FROM ubuntu:focal as fat

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@ WORKDIR /tracee
 
 COPY . /tracee
 
+
+FROM builder as build
+
 RUN git submodule update --init && make build
+
 
 # must run privileged and with linux headers mounted
 # docker run --name tracee --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro aquasec/tracee
@@ -18,6 +22,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-
 
 WORKDIR /tracee
 
-COPY --from=builder /tracee/dist/tracee /tracee/entrypoint.sh ./
+COPY --from=build /tracee/dist/tracee /tracee/entrypoint.sh ./
 
 ENTRYPOINT ["./entrypoint.sh", "./tracee"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM golang:1.15-buster as builder
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm clang
+RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 && \ 
+    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
 
 WORKDIR /tracee
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,29 @@
-FROM golang:1.15-buster as builder
+ARG BASE=fat
 
+FROM golang:1.15-buster as builder
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
     DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 && \ 
     (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
-
 WORKDIR /tracee
 
+FROM tracee-builder as build
 COPY . /tracee
-
-
-FROM builder as build
-
 RUN git submodule update --init && make build
 
+# base image for tracee which includes all tools to build the bpf object at runtime
+FROM ubuntu:focal as fat
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y ca-certificates gnupg && \
+    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 && \ 
+    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
+
+# base image for tracee which includes minimal dependencies and expects the bpf object to be provided at runtime
+FROM ubuntu:focal as slim
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y libelf1
 
 # must run privileged and with linux headers mounted
 # docker run --name tracee --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro aquasec/tracee
-FROM ubuntu:focal
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf1 llvm clang
-
+FROM $BASE
 WORKDIR /tracee
-
 COPY --from=build /tracee/dist/tracee /tracee/entrypoint.sh ./
-
 ENTRYPOINT ["./entrypoint.sh", "./tracee"]

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ bpf_compile_tools = $(CMD_LLC) $(CMD_CLANG)
 $(bpf_compile_tools): % : check_%
 
 $(LIBBPF_SRC):
-	test -d $(LIBBPF_SRC) || ( echo "missing libbpf source, try git submodule update --init" ; false )
+	test -d $(LIBBPF_SRC) || git submodule update --init || (echo "missing libbpf source" ; false)
 
 $(LIBBPF_HEADERS): | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC)
 	cd $(LIBBPF_SRC) && $(MAKE) install_headers install_uapi_headers DESTDIR=$(abspath $(OUT_DIR))/libbpf

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ $(BPF_BUNDLE): $(BPF_SRC) $(LIBBPF_HEADERS)/bpf $(BPF_HEADERS)
 bpf: $(BPF_OBJ)
 linux_arch := $(ARCH:x86_64=x86)
 $(BPF_OBJ): $(BPF_SRC) $(LIBBPF_HEADERS) | $(OUT_DIR) $(bpf_compile_tools)
-	@v=$$($(CLANG) --version); test $$(echo $${v#*version} | head -n1 | cut -d '.' -f1) -ge '7' || (echo 'required minimum clang version: 7' ; false)
+	@v=$$($(CLANG) --version); test $$(echo $${v#*version} | head -n1 | cut -d '.' -f1) -ge '9' || (echo 'required minimum clang version: 9' ; false)
 	$(CLANG) -S \
 		-D__BPF_TRACING__ \
 		-D__KERNEL__ \
@@ -106,7 +106,7 @@ $(BPF_OBJ): $(BPF_SRC) $(LIBBPF_HEADERS) | $(OUT_DIR) $(bpf_compile_tools)
 		-O2 -emit-llvm -c -g $< -o $(@:.o=.ll)
 	$(LLC) -march=bpf -filetype=obj -o $@ $(@:.o=.ll)
 	-$(LLVM_STRIP) -g $@
-	rm $(@:.o=.ll) 
+	rm $(@:.o=.ll)
 
 .PHONY: test 
 go_src_test := $(shell find . -type f -name '*_test.go')

--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ To run, Tracee requires the following:
 
 ### Getting Tracee
 
+Tracee is made of an executable that drives the eBPF code (`tracee`) and the eBPF code itself (`tracee.ebpf.o`). When the `tracee` executable is started, is will look for the eBPF code next to the executable, or in `/tmp/tracee`. If the eBPF is not found, the executable will attempt to build it (you can control this using the `--build-policy` flag).
+
 You can get Tracee in any of the following ways:
-1. Download the binary from the GitHub Releases tab (`tracee.tar.gz`).
-2. Use the docker image from Docker Hub: `aquasec/tracee`. The image already includes the required dependencies but you will need to mount the kernel headers in (see below for example).
-3. Build from source via docker, using `make build-docker`.
-4. Build from source, using `make build` (requires libelf-dev in addition to the above prerequisites).
+1. Download the executable from the [GitHub Releases](https://github.com/aquasecurity/tracee/releases) (`tracee.tar.gz`).
+2. Use the docker image from Docker Hub: `aquasec/tracee`.
+3. Build the executable from source using `make build`. For that you will need additional developement prerequisites such as golang and libelf.
+4. Build from executable from source in a Docker container which includes all the prerequisites, using `make build DOCKER=1`.
+5. Build the executable and the eBPF code from source, using `make all`, or in a Docker container using `make all DOCKER=1`.
 
 ### Permissions
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can get Tracee in any of the following ways:
 1. Download the executable from the [GitHub Releases](https://github.com/aquasecurity/tracee/releases) (`tracee.tar.gz`).
 2. Use the docker image from Docker Hub: `aquasec/tracee`.
 3. Build the executable from source using `make build`. For that you will need additional developement prerequisites such as golang and libelf.
-4. Build from executable from source in a Docker container which includes all the prerequisites, using `make build DOCKER=1`.
+4. Build the executable from source in a Docker container which includes all the prerequisites, using `make build DOCKER=1`.
 5. Build the executable and the eBPF code from source, using `make all`, or in a Docker container using `make all DOCKER=1`.
 
 ### Permissions

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To run, Tracee requires the following:
 - Linux kernel version > 4.14
 - Kernel headers
 - C standard library (currently tested with glibc)
-- clang > 7
+- clang > 9
 
 ### Getting Tracee
 

--- a/main.go
+++ b/main.go
@@ -515,8 +515,8 @@ func makeBPFObject(outFile string) error {
 		if debug {
 			fmt.Printf("warning: could not detect clang version from: %s", string(verOut))
 		}
-	} else if verMajor < 7 {
-		return fmt.Errorf("detected clang version: %d is older than required minimum version: 7", verMajor)
+	} else if verMajor < 9 {
+		return fmt.Errorf("detected clang version: %d is older than required minimum version: 9", verMajor)
 	}
 	llc := locateFile("llc", []string{os.Getenv("LLC")})
 	if llc == "" {


### PR DESCRIPTION
This PR is re-organizing the build in docker code, improving the build targets user experience, and adding visibility into the build progress. it also bumps the required llvm version from 7 to 9, as we found issues with 7.