### PR TITLE
fix a couple of issues with the makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/
     (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
 WORKDIR /tracee
 
+FROM builder as build
 ARG VERSION
-FROM tracee-builder as build
-ENV VERSION=$VERSION
 COPY . /tracee
-RUN make build
+RUN make build VERSION=$VERSION
 
 # base image for tracee which includes all tools to build the bpf object at runtime
 FROM ubuntu:focal as fat

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CMD_GITHUB ?= gh
 ARCH ?= $(shell uname -m)
 KERN_RELEASE ?= $(shell uname -r)
 KERN_SRC ?= /lib/modules/$(KERN_RELEASE)/build
-VERSION := $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags))
+VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags))
 # inputs and outputs:
 OUT_DIR ?= dist
 GO_SRC := $(shell find . -type f -name '*.go')

--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,9 @@ endef
 
 .PHONY: clean
 clean:
+	-$(CMD_DOCKER) rmi $(file < $(DOCKER_BUILDER))
 	-rm -rf dist $(OUT_DIR)
 	-cd $(LIBBPF_SRC) && $(MAKE) clean;
-	-$(CMD_DOCKER) rmi $(file < $(DOCKER_BUILDER))
 	
 check_%:
 	@command -v $* >/dev/null || (echo "missing required tool $*" ; false)

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ $(bpf_compile_tools): % : check_%
 $(LIBBPF_SRC):
 	test -d $(LIBBPF_SRC) || git submodule update --init || (echo "missing libbpf source" ; false)
 
-$(LIBBPF_HEADERS): | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC)
+$(LIBBPF_HEADERS) $(LIBBPF_HEADERS)/bpf $(LIBBPF_HEADERS)/linux: | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC)
 	cd $(LIBBPF_SRC) && $(MAKE) install_headers install_uapi_headers DESTDIR=$(abspath $(OUT_DIR))/libbpf
 
 $(LIBBPF_OBJ): | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC) 


### PR DESCRIPTION
1. make clean tried to read from a file after deleting it
2. libbpf headers target was `libbpf/usr/include`, but some targets required `libbpf/usr/include/bpf`, and there's no recipe for this target. This happened to work so far because usually some other rule tried to build `libbpf/usr/include` before the rule that needed `/bpf` run. but if the `/bpf` is called directly before the parent rule is called, which happens with `make release`, then it will try to build `libbpf/usr/include/bpf` which has no recipe. the solution is to change the libbpf headers target point to the specific desired path, (`/bpf`). another approach could be to specify exactly which headers files are needed whic I could do if you think it's better. another alternative is to define the `/bpf` as a target but since the parent dir is not used, I thought it's not better