### PR TITLE
Use alpine image instead of ubuntu

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,5 @@
+FROM golang:1.15-buster as builder
+RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 && \
+    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
+WORKDIR /tracee

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ endif
 $(DOCKER_BUILDER): $(OUT_DIR)/$(DOCKER_BUILDER)
 
 $(OUT_DIR)/$(DOCKER_BUILDER): $(GO_SRC) $(BPF_SRC) $(MAKEFILE_LIST) Dockerfile | $(OUT_DIR)
-	$(CMD_DOCKER) build -t $(DOCKER_BUILDER) --iidfile $(OUT_DIR)/$(DOCKER_BUILDER) --target builder .
+	$(CMD_DOCKER) build -f Dockerfile.builder -t $(DOCKER_BUILDER) --iidfile $(OUT_DIR)/$(DOCKER_BUILDER) --target builder .
 
 # docker_builder_make runs a make command in the tracee-builder container
 define docker_builder_make

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 mount -t debugfs debugfs /sys/kernel/debug/
 exec "$@"


### PR DESCRIPTION
Use docker alpine image instead of ubuntu.
This change reduces the attack surface and shrinks the image sizes.
Image sizes (before compression in dockerhub):
- Fat: 327MB
- Slim: 15MB

Close #335 
Close #329 