### PR TITLE
Add process follow mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Option | Flag(s):
 Trace new processes (default) | no `--trace` flag, `--trace p`, `--trace process` or `--trace process:new`
 Trace existing and new processes | `--trace process:all`
 Trace specific PIDs | `--trace process:<pid>,<pid2>,...` or `--trace p:<pid>,<pid2>,...`
+Trace filtered process and all of its children | `--trace process:follow`
 Trace new containers | `--trace c`, `--trace container` or `--trace container:new`
 Trace existing and new containers | `--trace container:all`
 Trace new processes not in a container | `--trace h`, `--trace host` or `--trace host:new`

--- a/main.go
+++ b/main.go
@@ -469,6 +469,7 @@ func prepareTraceMode(traceString string) (uint32, []int, error) {
 	traceHelp += "'p' or 'process' or 'process:new'            | Trace new processes\n"
 	traceHelp += "'process:all'                                | Trace all processes\n"
 	traceHelp += "'process:<pid>,<pid2>,...' or 'p:<pid>,...'  | Trace specific PIDs\n"
+	traceHelp += "'process:follow'                             | Trace filtered process and all of its children\n"
 	traceHelp += "'c' or 'container' or 'container:new'        | Trace new containers\n"
 	traceHelp += "'container:all'                              | Trace all containers\n"
 	traceHelp += "''h' or 'host' or 'host:new'                 | Trace new processes not in a container\n"
@@ -500,6 +501,8 @@ func prepareTraceMode(traceString string) (uint32, []int, error) {
 			mode = tracee.ModeProcessAll
 		} else if traceOption == "new" {
 			mode = tracee.ModeProcessNew
+		} else if traceOption == "follow" {
+			mode = tracee.ModeProcessFollow
 		} else if len(traceOption) != 0 {
 			mode = tracee.ModeProcessList
 			// Attempt to split into PIDs

--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -44,6 +44,7 @@ const (
 	ModeProcessAll uint32 = iota + 1
 	ModeProcessNew
 	ModeProcessList
+	ModeProcessFollow
 	ModeContainerAll
 	ModeContainerNew
 	ModeHostAll


### PR DESCRIPTION
This PR adds a new tracing mode called process:follow. It enables tracing a specific binary in an easy way.
Today if we want to trace a binary, we can use process:new mode, and filter according to the process name (e.g. using the 'comm' filter). The problem with that approach is that if the process then executes a binary with a different name, it will not be tracced (as it will be filtered out). Removing the filter will enable tracing all new processes, however, there will also be noise from other new processes.
Using the new process:follow mode, a filter can be given, and Tracee will only trace processes according that filter. The difference, however, is that the children of the filtered process will be traced as well.
For example, say we want to trace a process named "example", which executes "sh".
We can trace it by using `tracee --trace process:follow --filter comm=example`
This will trace both "example" and "sh" binaries, and only them
