### PR TITLE
Add ability to capture stack traces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/tracee
 go 1.15
 
 require (
-	github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210110080840-96ed00e0dd8d
+	github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210115081842-487d1e44fcda
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/urfave/cli/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210110080840-96ed00e0dd8d h1:zggREwmmm/tM4I/yPcUSGGPMrB4zeU8gwhGYdQJW4eg=
 github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210110080840-96ed00e0dd8d/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210114172620-409f21e80531 h1:U+B2QHE7+0UZIVLCnYeUdKkDEx1G3kNH/c5/FuxMTX8=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210114172620-409f21e80531/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210115081842-487d1e44fcda h1:ghWH8XcpEasEd4dfAvhLBDD+ib/DK9uJTQ2rWWHHNRI=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210115081842-487d1e44fcda/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 				SecurityAlerts:        c.Bool("security-alerts"),
 				EventsFile:            os.Stdout,
 				ErrorsFile:            os.Stderr,
+				StackAddresses:        c.Bool("stack-addresses"),
 			}
 			capture := c.StringSlice("capture")
 			for _, cap := range capture {
@@ -189,6 +190,11 @@ func main() {
 				Value:       "if-needed",
 				Usage:       "when to build the bpf program. possible options: 'never'/'always'/'if-needed'",
 				Destination: &buildPolicy,
+			},
+			&cli.BoolFlag{
+				Name:  "stack-addresses",
+				Value: false,
+				Usage: "Include stack memory addresses for each event",
 			},
 		},
 	}

--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -10,12 +10,17 @@ import (
 // config should match defined values in ebpf code
 type bpfConfig uint32
 
+// Max depth of each stack trace to track
+// Matches 'MAX_STACK_DEPTH' in eBPF code
+const maxStackDepth int = 20
+
 const (
 	configDetectOrigSyscall bpfConfig = iota + 1
 	configExecEnv
 	configCaptureFiles
 	configExtractDynCode
 	configTraceePid
+	configStackAddresses
 	configUIDFilter
 	configMntNsFilter
 	configPidNsFilter

--- a/tracee/external/external.go
+++ b/tracee/external/external.go
@@ -25,6 +25,7 @@ type Event struct {
 	EventName           string     `json:"eventName"`
 	ArgsNum             int        `json:"argsNum"`
 	ReturnValue         int        `json:"returnValue"`
+	StackAddresses      []uint64   `json:"stackAddresses"`
 	Args                []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
 }
 

--- a/tracee/pipeline.go
+++ b/tracee/pipeline.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/aquasecurity/tracee/tracee/external"
@@ -108,6 +109,36 @@ func (t *Tracee) processRawEvent(done <-chan struct{}, in <-chan RawEvent) (<-ch
 	return out, errc, nil
 }
 
+func (t *Tracee) getStackAddresses(StackID uint32) ([]uint64, error) {
+	StackAddresses := make([]uint64, maxStackDepth)
+	stackFrameSize := (strconv.IntSize / 8)
+
+	// Lookup the StackID in the map
+	// The ID could have aged out of the Map, as it only holds a finite number of
+	// Stack IDs in it's Map
+	stackBytes, err := t.StackAddressesMap.GetValue(StackID, stackFrameSize*maxStackDepth)
+	if err != nil {
+		return StackAddresses[0:0], nil
+	}
+
+	stackCounter := 0
+	for i := 0; i < len(stackBytes); i += stackFrameSize {
+		StackAddresses[stackCounter] = 0
+		stackAddr := binary.LittleEndian.Uint64(stackBytes[i : i+stackFrameSize])
+		if stackAddr == 0 {
+			break
+		}
+		StackAddresses[stackCounter] = stackAddr
+		stackCounter++
+	}
+
+	// Attempt to remove the ID from the map so we don't fill it up
+	// But if this fails continue on
+	_ = t.StackAddressesMap.DeleteKey(StackID)
+
+	return StackAddresses[0:stackCounter], nil
+}
+
 func (t *Tracee) prepareEventForPrint(done <-chan struct{}, in <-chan RawEvent) (<-chan external.Event, <-chan error, error) {
 	out := make(chan external.Event, 1000)
 	errc := make(chan error, 1)
@@ -135,7 +166,14 @@ func (t *Tracee) prepareEventForPrint(done <-chan struct{}, in <-chan RawEvent) 
 					continue
 				}
 			}
-			evt, err := newEvent(rawEvent.Ctx, argMetas, args)
+
+			// Add stack trace if needed
+			var StackAddresses []uint64
+			if t.config.StackAddresses {
+				StackAddresses, _ = t.getStackAddresses(rawEvent.Ctx.StackID)
+			}
+
+			evt, err := newEvent(rawEvent.Ctx, argMetas, args, StackAddresses)
 			if err != nil {
 				errc <- err
 				continue

--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -69,7 +69,7 @@ func newEventPrinter(kind string, containerMode bool, out io.Writer, err io.Writ
 	return res, nil
 }
 
-func newEvent(ctx context, argMetas []external.ArgMeta, args []interface{}) (external.Event, error) {
+func newEvent(ctx context, argMetas []external.ArgMeta, args []interface{}, StackAddresses []uint64) (external.Event, error) {
 	e := external.Event{
 		Timestamp:           float64(ctx.Ts) / 1000000.0,
 		ProcessID:           int(ctx.Pid),
@@ -88,6 +88,7 @@ func newEvent(ctx context, argMetas []external.ArgMeta, args []interface{}) (ext
 		ArgsNum:             int(ctx.Argnum),
 		ReturnValue:         int(ctx.Retval),
 		Args:                make([]external.Argument, 0, len(args)),
+		StackAddresses:      StackAddresses,
 	}
 	for i, arg := range args {
 		e.Args = append(e.Args, external.Argument{


### PR DESCRIPTION
eBPF Has the ability to capture stack traces at the location the program was called. This PR adds the ability to capture the stack traces into the outputted event JSON.

As this can have a performance impact, this feature is behind a `--capture-stack-traces` cli flag.

The PR has had to add or alter a number of different parts of tracee:
- Adding a new eBPF map of type `BPF_MAP_TYPE_STACK_TRACE`, to keep track of the stack traces
- Adding a new config option `CONFIG_CAPTURE_STACK_TRACES` to track if we wish to capture stacks or not
- A new function in `libbpfgo` to lookup a value from an eBPF Map
- Altering the `Event` struct to have a `StackTrace` param

Where necessary I've tried to make sure to be architecture-agnostic, e..g when calculating pointer sizes, etc.

By eBPF's design, the Stack Traces Map has a max number of different stack traces to keep track of, as well as a max stack trace depth. Currently, these are just hard-coded for simplicity.

I felt adding the stack traces to the `table` format wasn't necessary, as I feel stack traces fall into the 'very verbose' bucket. But they are available in the JSON output.

Currently, the stack trace output is just a string of comma-sepearted hex values. This could be changed to be an array or strings, I'm happy either way.


