### PR TITLE
signal end of transmission for gob output

### DIFF
--- a/test/gob/go.mod
+++ b/test/gob/go.mod
@@ -1,6 +1,3 @@
 module github.com/aquasecurity/tracee/test/gob
 
 go 1.15
-
-replace (
-""github.com/aquasecurity/tracee/tracee" => "../../tracee"

--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -277,7 +277,7 @@ func (p *gobEventPrinter) Error(e error) {
 }
 
 func (p *gobEventPrinter) Epilogue(stats statsStore) {
-	err := p.out.Encode(Event{EventName: string(4)})
+	err := p.out.Encode(Event{EventName: string(rune(4))})
 	if err != nil {
 		p.Error(err)
 	}

--- a/tracee/printer.go
+++ b/tracee/printer.go
@@ -253,6 +253,9 @@ func (p jsonEventPrinter) Error(e error) {
 
 func (p jsonEventPrinter) Epilogue(stats statsStore) {}
 
+// gobEventPrinter is printing events using golang's builtin Gob serializer
+// an additional event is added at the end to signal end of transmission
+// this event can be identified by it's "EventName" which will be the ASCII "End Of Transmission" character
 type gobEventPrinter struct {
 	out *gob.Encoder
 	err *gob.Encoder
@@ -273,4 +276,9 @@ func (p *gobEventPrinter) Error(e error) {
 	_ = p.err.Encode(e)
 }
 
-func (p *gobEventPrinter) Epilogue(stats statsStore) {}
+func (p *gobEventPrinter) Epilogue(stats statsStore) {
+	err := p.out.Encode(Event{EventName: string(4)})
+	if err != nil {
+		p.Error(err)
+	}
+}


### PR DESCRIPTION
when tracee writes into a file, and something else read from this file, we can't rely on EOF to know when the producer has finished sending events. For example if the producer doesn't yet have events to report, the consumer will hit EOF immediately, or if the consumer is consuming events faster than the producer.
The solution is to explicitly signal end of transmission, using a special even that seals the events stream. For now I'm adding it by default for gob output, but in the future we should 1) make it optional and 2) add it to every output that can be consumed in "streaming" fashion