### PR TITLE
improve signature error handling

### DIFF
--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -22,7 +22,10 @@ func main() {
 			}
 			if c.Bool("list") {
 				for _, sig := range sigs {
-					meta := sig.GetMetadata()
+					meta, err := sig.GetMetadata()
+					if err != nil {
+						continue
+					}
 					fmt.Printf("%s: %s\n", meta.Name, meta.Description)
 				}
 				return nil

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -43,7 +43,10 @@ func prepareJSONPayload(res types.Finding) (string, error) {
 		Time         time.Time              `json:"time"`
 		OutputFields map[string]interface{} `json:"output_fields"`
 	}
-	sigmeta := res.Signature.GetMetadata()
+	sigmeta, err := res.Signature.GetMetadata()
+	if err != nil {
+		return "", err
+	}
 	fields := make(map[string]interface{})
 	if te, ok := res.Context.(types.TraceeEvent); ok {
 		fields["value"] = te.ReturnValue

--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -29,7 +29,7 @@ func getSignatures(rulesDir string, rules []string) ([]types.Signature, error) {
 	} else {
 		for _, s := range gosigs {
 			for _, r := range rules {
-				if s.GetMetadata().Name == r {
+				if m, err := s.GetMetadata(); err != nil && m.Name == r {
 					res = append(res, s)
 				}
 			}

--- a/tracee-rules/signatures/golang/example.go
+++ b/tracee-rules/signatures/golang/example.go
@@ -30,18 +30,18 @@ func (sig *counter) Init(cb types.SignatureHandler) error {
 }
 
 // GetMetadata implements the Signature interface by declaring information about the signature
-func (sig *counter) GetMetadata() types.SignatureMetadata {
+func (sig *counter) GetMetadata() (types.SignatureMetadata, error) {
 	return types.SignatureMetadata{
 		Name: "count to " + strconv.Itoa(sig.target),
-	}
+	}, nil
 }
 
 // GetSelectedEvents implements the Signature interface by declaring which events this signature subscribes to
-func (sig *counter) GetSelectedEvents() []types.SignatureEventSelector {
+func (sig *counter) GetSelectedEvents() ([]types.SignatureEventSelector, error) {
 	return []types.SignatureEventSelector{{
 		Source: "tracee",
 		//Name:   "execve",
-	}}
+	}}, nil
 }
 
 // OnEvent implements the Signature interface by handling each Event passed by the Engine. this is the business logic of the signature

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -4,9 +4,9 @@ package types
 // Signature is the basic unit of business logic for the rule-engine
 type Signature interface {
 	//GetMetadata allows the signature to declare information about itself
-	GetMetadata() SignatureMetadata
+	GetMetadata() (SignatureMetadata, error)
 	//GetSelectedEvents allows the signature to declare which events it subscribes to
-	GetSelectedEvents() []SignatureEventSelector
+	GetSelectedEvents() ([]SignatureEventSelector, error)
 	//Init allows the signature to initialize its internal state
 	Init(cb SignatureHandler) error
 	//OnEvent allows the signature to process events passed by the Engine. this is the business logic of the signature


### PR DESCRIPTION
in rego signatures, metadata and eventSelectors are queries at runtime so we need to be able to return an error