### PR TITLE
Change trace modes and filter UX

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -207,6 +207,10 @@ func TestPrepareFilter(t *testing.T) {
 					NotEqual: []string{},
 					Enabled:  false,
 				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
+				},
 			},
 			expectedError: nil,
 		},
@@ -255,6 +259,10 @@ func TestPrepareFilter(t *testing.T) {
 					Equal:    []string{},
 					NotEqual: []string{},
 					Enabled:  false,
+				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
 				},
 			},
 			expectedError: nil,
@@ -305,6 +313,10 @@ func TestPrepareFilter(t *testing.T) {
 					NotEqual: []string{},
 					Enabled:  false,
 				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
+				},
 			},
 			expectedError: nil,
 		},
@@ -353,6 +365,10 @@ func TestPrepareFilter(t *testing.T) {
 					Equal:    []string{},
 					NotEqual: []string{},
 					Enabled:  false,
+				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
 				},
 			},
 			expectedError: nil,
@@ -403,6 +419,10 @@ func TestPrepareFilter(t *testing.T) {
 					NotEqual: []string{},
 					Enabled:  false,
 				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
+				},
 			},
 			expectedError: nil,
 		},
@@ -451,6 +471,10 @@ func TestPrepareFilter(t *testing.T) {
 					Equal:    []string{},
 					NotEqual: []string{"deadbeaf"},
 					Enabled:  true,
+				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
 				},
 			},
 			expectedError: nil,
@@ -501,6 +525,10 @@ func TestPrepareFilter(t *testing.T) {
 					NotEqual: []string{},
 					Enabled:  false,
 				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
+				},
 			},
 			expectedError: nil,
 		},
@@ -550,12 +578,69 @@ func TestPrepareFilter(t *testing.T) {
 					NotEqual: []string{},
 					Enabled:  false,
 				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: false,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			testName: "container",
+			filters:  []string{"container"},
+			expectedFilter: tracee.Filter{
+				UIDFilter: &tracee.UintFilter{
+					Equal:    []uint64{},
+					NotEqual: []uint64{},
+					Less:     tracee.LessNotSet,
+					Greater:  tracee.GreaterNotSet,
+					Is32Bit:  true,
+					Enabled:  false,
+				},
+				PIDFilter: &tracee.UintFilter{
+					Equal:    []uint64{},
+					NotEqual: []uint64{},
+					Less:     tracee.LessNotSet,
+					Greater:  tracee.GreaterNotSet,
+					Is32Bit:  true,
+					Enabled:  false,
+				},
+				MntNSFilter: &tracee.UintFilter{
+					Equal:    []uint64{},
+					NotEqual: []uint64{},
+					Less:     tracee.LessNotSet,
+					Greater:  tracee.GreaterNotSet,
+					Is32Bit:  false,
+					Enabled:  false,
+				},
+				PidNSFilter: &tracee.UintFilter{
+					Equal:    []uint64{},
+					NotEqual: []uint64{},
+					Less:     tracee.LessNotSet,
+					Greater:  tracee.GreaterNotSet,
+					Is32Bit:  false,
+					Enabled:  false,
+				},
+				CommFilter: &tracee.StringFilter{
+					Equal:    []string{},
+					NotEqual: []string{},
+					Enabled:  false,
+				},
+				UTSFilter: &tracee.StringFilter{
+					Equal:    []string{},
+					NotEqual: []string{},
+					Enabled:  false,
+				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   true,
+					Enabled: true,
+				},
 			},
 			expectedError: nil,
 		},
 		{
 			testName: "multiple filters",
-			filters:  []string{"uid<1", "mntns=5", "pidns!=3", "pid!=10", "comm=ps", "uts!=abc"},
+			filters:  []string{"uid<1", "mntns=5", "pidns!=3", "pid!=10", "comm=ps", "uts!=abc", "!c"},
 			expectedFilter: tracee.Filter{
 				UIDFilter: &tracee.UintFilter{
 					Equal:    []uint64{},
@@ -599,6 +684,10 @@ func TestPrepareFilter(t *testing.T) {
 					NotEqual: []string{"abc"},
 					Enabled:  true,
 				},
+				ContFilter: &tracee.BoolFilter{
+					Value:   false,
+					Enabled: true,
+				},
 			},
 			expectedError: nil,
 		},
@@ -612,6 +701,7 @@ func TestPrepareFilter(t *testing.T) {
 			assert.Equal(t, testcase.expectedFilter.PidNSFilter, filter.PidNSFilter)
 			assert.Equal(t, testcase.expectedFilter.UTSFilter, filter.UTSFilter)
 			assert.Equal(t, testcase.expectedFilter.CommFilter, filter.CommFilter)
+			assert.Equal(t, testcase.expectedFilter.ContFilter, filter.ContFilter)
 			assert.Equal(t, testcase.expectedError, err)
 		})
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -39,13 +39,13 @@ func TestPrepareFilter(t *testing.T) {
 			testName:       "invalid operator",
 			filters:        []string{"uid\t0"},
 			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("invalid filter operator: \t"),
+			expectedError:  errors.New("invalid filter option specified, use '--filter help' for more info"),
 		},
 		{
 			testName:       "invalid operator",
 			filters:        []string{"mntns\t0"},
 			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("invalid filter operator: \t"),
+			expectedError:  errors.New("invalid filter option specified, use '--filter help' for more info"),
 		},
 		{
 			testName:       "invalid filter type",
@@ -111,13 +111,13 @@ func TestPrepareFilter(t *testing.T) {
 			testName:       "invalid uid",
 			filters:        []string{"uid="},
 			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("invalid filter value: "),
+			expectedError:  errors.New("invalid operator and/or values given to filter: ="),
 		},
 		{
 			testName:       "invalid mntns",
 			filters:        []string{"mntns="},
 			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("invalid filter value: "),
+			expectedError:  errors.New("invalid operator and/or values given to filter: ="),
 		},
 		{
 			testName: "invalid uid",

--- a/main_test.go
+++ b/main_test.go
@@ -135,7 +135,7 @@ func TestPrepareFilter(t *testing.T) {
 			testName:       "invalid uts",
 			filters:        []string{"uts=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("Filtering strings of length bigger than 16 is not supported: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			expectedError:  errors.New("Filtering strings of length bigger than 32 is not supported: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		},
 		{
 			testName:       "invalid uid",

--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -19,6 +19,7 @@ const (
 	configUTSNsFilter
 	configCommFilter
 	configPidFilter
+	configContFilter
 )
 
 const (
@@ -62,13 +63,10 @@ const (
 type binType uint8
 
 const (
-	ModeProcessAll uint32 = iota + 1
-	ModeProcessNew
-	ModeProcessFollow
-	ModeContainerAll
-	ModeContainerNew
-	ModeHostAll
-	ModeHostNew
+	ModeAll uint32 = iota + 1
+	ModeNew
+	ModePidNs
+	ModeFollow
 )
 
 const (

--- a/tracee/tracee.bpf.c
+++ b/tracee/tracee.bpf.c
@@ -48,7 +48,7 @@
 #define MAX_STRING_SIZE     4096          // Choosing this value to be the same as PATH_MAX
 #define MAX_STR_ARR_ELEM    40            // String array elements number should be bounded due to instructions limit
 #define MAX_PATH_PREF_SIZE  64            // Max path prefix should be bounded due to instructions limit
-#define MAX_STR_FILTER_SIZE 16            // Max string filter size should be bounded due to instructions limit
+#define MAX_STR_FILTER_SIZE 32            // Max string filter size should be bounded due to instructions limit
 
 #define SUBMIT_BUF_IDX      0
 #define STRING_BUF_IDX      1

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -20,7 +20,6 @@ import (
 
 // TraceeConfig is a struct containing user defined configuration of tracee
 type TraceeConfig struct {
-	EventsToTrace         []int32
 	Mode                  uint32
 	Filter                *Filter
 	DetectOriginalSyscall bool
@@ -41,13 +40,14 @@ type TraceeConfig struct {
 }
 
 type Filter struct {
-	UIDFilter   *UintFilter
-	PIDFilter   *UintFilter
-	MntNSFilter *UintFilter
-	PidNSFilter *UintFilter
-	UTSFilter   *StringFilter
-	CommFilter  *StringFilter
-	ContFilter  *BoolFilter
+	EventsToTrace []int32
+	UIDFilter     *UintFilter
+	PIDFilter     *UintFilter
+	MntNSFilter   *UintFilter
+	PidNSFilter   *UintFilter
+	UTSFilter     *StringFilter
+	CommFilter    *StringFilter
+	ContFilter    *BoolFilter
 }
 
 type UintFilter struct {
@@ -72,13 +72,13 @@ type BoolFilter struct {
 
 // Validate does static validation of the configuration
 func (tc TraceeConfig) Validate() error {
-	if tc.EventsToTrace == nil {
+	if tc.Filter.EventsToTrace == nil {
 		return fmt.Errorf("eventsToTrace is nil")
 	}
 	if tc.OutputFormat != "table" && tc.OutputFormat != "table-verbose" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" && !strings.HasPrefix(tc.OutputFormat, "go-template=") {
 		return fmt.Errorf("unrecognized output format: %s", tc.OutputFormat)
 	}
-	for _, e := range tc.EventsToTrace {
+	for _, e := range tc.Filter.EventsToTrace {
 		if _, ok := EventsIDToEvent[e]; !ok {
 			return fmt.Errorf("invalid event to trace: %d", e)
 		}
@@ -181,8 +181,8 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 		return nil, err
 	}
 	t.printer = printObj
-	t.eventsToTrace = make(map[int32]bool, len(t.config.EventsToTrace))
-	for _, e := range t.config.EventsToTrace {
+	t.eventsToTrace = make(map[int32]bool, len(t.config.Filter.EventsToTrace))
+	for _, e := range t.config.Filter.EventsToTrace {
 		// Map value is true iff events requested by the user
 		t.eventsToTrace[e] = true
 	}


### PR DESCRIPTION
This PR introduces the changes as described in #377:

1. Tracing modes are simplified to: new/all/follow/pidns
2. pidns mode keeps the "container:new" semantics from before, meaning, tracing when "new container" is started. This name better describes how we traced new containers in the past - by looking for the creation of new pid namespaces (execution of pid 1).
3. Boolean container filter is added. Opposed to pidns (which is equivalent to container:new), filtering by container (with default 'new' trace mode) will trace all new processes created in any container, including existing containers. Using container filter with 'all' trace mode is equivalent to the old "container:all" mode.
4. move "--events" "--exclude-events" and "--set" flags into "--filter" flag
