### PR TITLE
Fix comm filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -455,9 +455,6 @@ func parseStringFilter(operatorAndValues string, stringFilter *tracee.StringFilt
 	values := strings.Split(valuesString, ",")
 
 	for i := range values {
-		if len(values[i]) > 32 {
-			return fmt.Errorf("Filtering strings of length bigger than 32 is not supported: %s", values[i])
-		}
 		switch operatorString {
 		case "=":
 			stringFilter.Equal = append(stringFilter.Equal, values[i])

--- a/main_test.go
+++ b/main_test.go
@@ -132,12 +132,6 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError:  errors.New("invalid filter value: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
 		},
 		{
-			testName:       "invalid uts",
-			filters:        []string{"uts=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
-			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("Filtering strings of length bigger than 32 is not supported: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-		},
-		{
 			testName:       "invalid uid",
 			filters:        []string{"uid=%s"},
 			expectedFilter: tracee.Filter{},

--- a/tracee/tracee.bpf.c
+++ b/tracee/tracee.bpf.c
@@ -48,7 +48,7 @@
 #define MAX_STRING_SIZE     4096          // Choosing this value to be the same as PATH_MAX
 #define MAX_STR_ARR_ELEM    40            // String array elements number should be bounded due to instructions limit
 #define MAX_PATH_PREF_SIZE  64            // Max path prefix should be bounded due to instructions limit
-#define MAX_STR_FILTER_SIZE 32            // Max string filter size should be bounded due to instructions limit
+#define MAX_STR_FILTER_SIZE 16            // Max string filter size should be bounded to the size of the compared values (comm, uts)
 
 #define SUBMIT_BUF_IDX      0
 #define STRING_BUF_IDX      1


### PR DESCRIPTION
In a previous commit we changed max string filter size from 16 to 32.
This made comm filter to stop working.
The reason for this, is the way we check for filter equality in the kernel, which is by treating the string as a key to a map (and not by comparing character by character)
In the linux kernel, comm char array has a length of 16. This made the comparison not to work, as the next 16 bytes doesn't belong to the comm field.
Fix this by changing string_filter max size back to 16 in the bpf code.
In the user space, we can remove the string size limit, as when updating a bpf map, the number of bytes taken are exactly as defined in the map, which make long strings trimmed to the size of the map.
