### PR TITLE
fea: added the pinned map for ns

### DIFF
--- a/libbpfgo/libbpfgo.go
+++ b/libbpfgo/libbpfgo.go
@@ -302,6 +302,14 @@ func (m *Module) GetMap(mapName string) (*BPFMap, error) {
 	}, nil
 }
 
+func (m *Module) ChangeMapPin(mapName string, pinning string) error {
+	cs := C.CString(mapName)
+	path := C.CString(pinning)
+	bpfMap := C.bpf_object__find_map_by_name(m.obj, cs)
+	C.bpf_map__set_pin_path(bpfMap, path)
+	return nil
+}
+
 func (b *BPFMap) Update(key, value interface{}) error {
 	var keyPtr, valuePtr unsafe.Pointer
 	if k, isType := key.(int8); isType {

--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -1,8 +1,9 @@
 package tracee
 
 import (
-	"github.com/aquasecurity/tracee/tracee/external"
 	"math"
+
+	"github.com/aquasecurity/tracee/tracee/external"
 )
 
 // bpfConfig is an enum that include various configurations that can be passed to bpf code
@@ -70,6 +71,7 @@ const (
 	ModeNew
 	ModePidNs
 	ModeFollow
+	ModeMapPinned
 )
 
 const (


### PR DESCRIPTION
This PR aims at adapting tracee to work with pinned maps with mount namespace ids. The implementation is done as a separate trace mode in order to not mess with other functions of tracee.

Usage example:
tracee --trace pinned_map --mntns_pin=/path/to/pinned/map
There is a point I would like to raise about this request beyond tracee mode extension itself. I have tested the application mainly with gadget-tracer from kinvolk because including tracee as an additional gadget is a primary purpose of my work. I have issues with legacy probes since several gadgets might work in parallel and use  same probes which leads to conflict and error. My problem was solved by using perf-based probes which libbpf.go already provides. 
I understand that legacy probes are used for compatibility reason. We can try to create a fall-back to older probes if error is raised or use older probes by default and fall back to perf-probes is case of an error, if it is still necessary to keep using legacy probes in newer version of tracee. Of course, any other suggestions about how to improve this request are very much welcome.  Thank you. 
@kinvolk @alban @mauriciovasquezbernal
