### PR TITLE
fixed bug in filtering by comm or uts_name

### DIFF
--- a/main.go
+++ b/main.go
@@ -455,8 +455,8 @@ func parseStringFilter(operatorAndValues string, stringFilter *tracee.StringFilt
 	values := strings.Split(valuesString, ",")
 
 	for i := range values {
-		if len(values[i]) > 32 {
-			return fmt.Errorf("Filtering strings of length bigger than 32 is not supported: %s", values[i])
+		if len(values[i]) > 16 {
+			return fmt.Errorf("Filtering strings of length bigger than 16 is not supported: %s", values[i])
 		}
 		switch operatorString {
 		case "=":

--- a/main_test.go
+++ b/main_test.go
@@ -135,7 +135,7 @@ func TestPrepareFilter(t *testing.T) {
 			testName:       "invalid uts",
 			filters:        []string{"uts=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 			expectedFilter: tracee.Filter{},
-			expectedError:  errors.New("Filtering strings of length bigger than 32 is not supported: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			expectedError:  errors.New("Filtering strings of length bigger than 16 is not supported: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		},
 		{
 			testName:       "invalid uid",

--- a/tracee/tracee.bpf.c
+++ b/tracee/tracee.bpf.c
@@ -44,11 +44,11 @@
 #define PT_REGS_PARM6(x) (((PT_REGS_ARM64 *)(x))->regs[5])
 #endif
 
-#define MAX_PERCPU_BUFSIZE  (1 << 15)     // This value is actually set by the kernel as an upper bound
-#define MAX_STRING_SIZE     4096          // Choosing this value to be the same as PATH_MAX
-#define MAX_STR_ARR_ELEM    40            // String array elements number should be bounded due to instructions limit
-#define MAX_PATH_PREF_SIZE  64            // Max path prefix should be bounded due to instructions limit
-#define MAX_STR_FILTER_SIZE 32            // Max string filter size should be bounded due to instructions limit
+#define MAX_PERCPU_BUFSIZE  (1 << 15)      // This value is actually set by the kernel as an upper bound
+#define MAX_STRING_SIZE     4096           // Choosing this value to be the same as PATH_MAX
+#define MAX_STR_ARR_ELEM    40             // String array elements number should be bounded due to instructions limit
+#define MAX_PATH_PREF_SIZE  64             // Max path prefix should be bounded due to instructions limit
+#define MAX_STR_FILTER_SIZE TASK_COMM_LEN  // Max string filter size should be bounded due to instructions limit
 
 #define SUBMIT_BUF_IDX      0
 #define STRING_BUF_IDX      1


### PR DESCRIPTION
Recent changes broke the ability to filter by uts_name or comm.

You can confirm this by running `trace --filter comm=whoami` then running a `whoami`.

This bug was created when the shift to using `comm` as the key into the `comm_filter` map - the call to lookup the key is essentially a mem compare, but the filter string 32-Bytes (`MAX_STR_FILTER_SIZE`), but the com name in the context struct was only 16, making the compare/lookup alway fail.

Currently only `comm` and `uts_name` use the string filter option, both of which are only 16-Bytes long, so it's OK to keep the size of `string_filter` to this. But if something else comes along later that wants to filter on something more than that, then the code will have to change, probably to copy the string-to-compare to the larger array, prior to doing the key lookup.

