### PR TITLE
Use filters instead of modes in bpf code

### DIFF
--- a/tracee/consts.go
+++ b/tracee/consts.go
@@ -11,8 +11,7 @@ import (
 type bpfConfig uint32
 
 const (
-	configMode bpfConfig = iota
-	configDetectOrigSyscall
+	configDetectOrigSyscall bpfConfig = iota + 1
 	configExecEnv
 	configCaptureFiles
 	configExtractDynCode
@@ -25,6 +24,8 @@ const (
 	configPidFilter
 	configContFilter
 	configFollowFilter
+	configNewPidFilter
+	configNewPidNsFilter
 )
 
 const (

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -561,7 +561,13 @@ func (t *Tracee) populateBPFMaps() error {
 
 	// Initialize config and pids maps
 	bpfConfigMap, _ := t.bpfModule.GetMap("config_map")
-	bpfConfigMap.Update(uint32(configMode), t.config.Mode)
+	// TODO: BPF code doesn't care anymore about modes, but filters - remove modes from userspace as well
+	switch t.config.Mode {
+	case ModeNew:
+		bpfConfigMap.Update(uint32(configNewPidFilter), t.config.Mode)
+	case ModePidNs:
+		bpfConfigMap.Update(uint32(configNewPidNsFilter), t.config.Mode)
+	}
 	bpfConfigMap.Update(uint32(configDetectOrigSyscall), boolToUInt32(t.config.DetectOriginalSyscall))
 	bpfConfigMap.Update(uint32(configExecEnv), boolToUInt32(t.config.ShowExecEnv))
 	bpfConfigMap.Update(uint32(configCaptureFiles), boolToUInt32(t.config.CaptureWrite))


### PR DESCRIPTION
Remove trace "mode" from bpf code and use filters instead.
The "new" and "pidns" modes are changed to NEW_PID_FILTER and NEW_PIDNS_FILTER in bpf code.

This PR does **not** change anything in the flags UX, but it will allow us to easilly move these two trace modes (and the "all" mode as well) to the filter flag if we decide to do so.