### PR TITLE
refactor output flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,16 +41,15 @@ func main() {
 			}
 
 			cfg := tracee.TraceeConfig{
-				DetectOriginalSyscall: c.Bool("detect-original-syscall"),
-				ShowExecEnv:           c.Bool("show-exec-env"),
-				OutputFormat:          c.String("output"),
-				PerfBufferSize:        c.Int("perf-buffer-size"),
-				BlobPerfBufferSize:    c.Int("blob-perf-buffer-size"),
-				SecurityAlerts:        c.Bool("security-alerts"),
-				EventsFile:            os.Stdout,
-				ErrorsFile:            os.Stderr,
-				StackAddresses:        c.Bool("stack-addresses"),
+				PerfBufferSize:     c.Int("perf-buffer-size"),
+				BlobPerfBufferSize: c.Int("blob-perf-buffer-size"),
+				SecurityAlerts:     c.Bool("security-alerts"),
 			}
+			output, err := prepareOutput(c.StringSlice("output"))
+			if err != nil {
+				return err
+			}
+			cfg.Output = &output
 			capture, err := prepareCapture(c.StringSlice("capture"))
 			if err != nil {
 				return err
@@ -99,15 +98,16 @@ func main() {
 				Value:   nil,
 				Usage:   "capture artifacts that were written, executed or found to be suspicious. run '--capture help' for more info.",
 			},
-			&cli.BoolFlag{
-				Name:  "detect-original-syscall",
-				Value: false,
-				Usage: "when tracing kernel functions which are not syscalls (such as cap_capable), detect and show the original syscall that called that function",
+			&cli.StringSliceFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Value:   cli.NewStringSlice("format:table"),
+				Usage:   "Control how and where output is printed. run '--output help' for more info.",
 			},
 			&cli.BoolFlag{
-				Name:  "show-exec-env",
+				Name:  "security-alerts",
 				Value: false,
-				Usage: "when tracing execve/execveat, show environment variables",
+				Usage: "alert on security related events",
 			},
 			&cli.IntFlag{
 				Name:    "perf-buffer-size",
@@ -120,21 +120,10 @@ func main() {
 				Value: 1024,
 				Usage: "size, in pages, of the internal perf ring buffer used to send blobs from the kernel",
 			},
-			&cli.StringFlag{
-				Name:    "output",
-				Aliases: []string{"o"},
-				Value:   "table",
-				Usage:   "output format: table/table-verbose/json/gob/go-template=<path>",
-			},
-			&cli.BoolFlag{
-				Name:  "security-alerts",
-				Value: false,
-				Usage: "alert on security related events",
-			},
 			&cli.BoolFlag{
 				Name:        "debug",
 				Value:       false,
-				Usage:       "write verbose debug messages to stdndard output and retain intermediate artifacts",
+				Usage:       "write verbose debug messages to standard output and retain intermediate artifacts",
 				Destination: &debug,
 			},
 			&cli.StringFlag{
@@ -149,11 +138,6 @@ func main() {
 				Usage:       "when to build the bpf program. possible options: 'never'/'always'/'if-needed'",
 				Destination: &buildPolicy,
 			},
-			&cli.BoolFlag{
-				Name:  "stack-addresses",
-				Value: false,
-				Usage: "Include stack memory addresses for each event",
-			},
 		},
 	}
 
@@ -161,6 +145,63 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func prepareOutput(outputSlice []string) (tracee.OutputConfig, error) {
+	outputHelp := `
+Control how and where output is printed.
+Possible options:
+
+[format:]{table,table-verbose,json,gob,gotemplate=/path/to/template}   output events in the specified format. for gotemplate, specify the mandatory template file
+out-file:/path/to/file                                                 write the output to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (deafult: stdout)
+err-file:/path/to/file                                                 write the errors to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (deafult: stderr)
+option:{eot,stacktrace,detect-syscall,exec-env}                        augment output according to given options (default: none)
+  eot                                                                add a final event that signals the end of event stream. this is an empty event with "EventName" set to the ASCII code 4, which is "End Of Transmission"
+  stack-addresses                                                    include stack memory addresses for each event
+  detect-syscall                                                     when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
+  exec-env                                                           when tracing execve/execveat, show the environment variables that were used for execution
+Examples:
+  --output json --output option:eot                        | output as json and add an EOT event
+  --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
+  --output out-file:/my/out err-file:/my/err               | output to /my/out and errors to /my/err
+
+Use this flag multiple times to choose multiple capture options	
+`
+
+	res := tracee.OutputConfig{}
+	if len(outputSlice) == 1 && outputSlice[0] == "help" {
+		return res, fmt.Errorf(outputHelp)
+	}
+
+	for _, o := range outputSlice {
+		outputParts := strings.SplitN(o, ":", 2)
+		numParts := len(outputParts)
+		if numParts == 1 {
+			outputParts = append(outputParts, outputParts[0])
+			outputParts[0] = "format"
+		}
+		if outputParts[0] == "format" {
+			res.Format = outputParts[1]
+		} else if outputParts[0] == "out-file" {
+			res.OutPath = outputParts[1]
+		} else if outputParts[0] == "err-file" {
+			res.ErrPath = outputParts[1]
+		} else if outputParts[0] == "option" {
+			switch outputParts[1] {
+			case "eot":
+				res.EOT = true
+			case "stack-addresses":
+				res.StackAddresses = true
+			case "detect-syscall":
+				res.DetectSyscall = true
+			case "exec-env":
+				res.ExecEnv = true
+			default:
+				return res, fmt.Errorf("invalid output option: %s, use '--option help' for more info", outputParts[1])
+			}
+		}
+	}
+	return res, nil
 }
 
 func prepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
@@ -178,9 +219,9 @@ dir:/path/to/dir        path where tracee will save produced artifacts. the arti
 clear-dir               clear the captured artifacts output dir before starting (default: false).
 
 Examples:
-	--capture exec                                           | capture executed files into the default output directory
-	--capture all --capture dir:/my/dir --capture clear-dir  | delete /my/dir/out and then capture all supported artifacts into it
-	--capture write=/usr/bin/* --capture write=/etc/*        | capture files that were written into anywhere under /usr/bin/ or /etc/
+  --capture exec                                           | capture executed files into the default output directory
+  --capture all --capture dir:/my/dir --capture clear-dir  | delete /my/dir/out and then capture all supported artifacts into it
+  --capture write=/usr/bin/* --capture write=/etc/*        | capture files that were written into anywhere under /usr/bin/ or /etc/
 
 Use this flag multiple times to choose multiple capture options
 `
@@ -270,28 +311,28 @@ The field 'set' selects a set of events to trace according to predefined sets, w
 The special 'follow' expression declares that not only processes that match the criteria will be traced, but also their descendants.
 
 Examples:
-	--trace pid=new                                              | only trace events from new processes
-	--trace pid=510,1709                                         | only trace events from pid 510 or pid 1709
-	--trace p=510 --trace p=1709                                 | only trace events from pid 510 or pid 1709 (same as above)
-	--trace container=new                                        | only trace events from newly created containers
-	--trace container                                            | only trace events from containers
-	--trace c                                                    | only trace events from containers (same as above)
-	--trace '!container'                                         | only trace events from the host
-	--trace uid=0                                                | only trace events from uid 0
-	--trace mntns=4026531840                                     | only trace events from mntns id 4026531840
-	--trace pidns!=4026531836                                    | only trace events from pidns id not equal to 4026531840
-	--trace 'uid>0'                                              | only trace events from uids greater than 0
-	--trace 'pid>0' --trace 'pid<1000'                           | only trace events from pids between 0 and 1000
-	--trace 'u>0' --trace u!=1000                                | only trace events from uids greater than 0 but not 1000
-	--trace event=execve,open                                    | only trace execve and open events
-	--trace set=fs                                               | trace all file-system related events
-	--trace s=fs --trace e!=open,openat                          | trace all file-system related events, but not open(at)
-	--trace uts!=ab356bc4dd554                                   | don't trace events from uts name ab356bc4dd554
-	--trace comm=ls                                              | only trace events from ls command
-	--trace close.fd=5                                           | only trace 'close' events that have 'fd' equals 5
-	--trace openat.pathname=/tmp*                                | only trace 'openat' events that have 'pathname' prefixed by "/tmp"
-	--trace openat.pathname!=/tmp/1,/bin/ls                      | don't trace 'openat' events that have 'pathname' equals /tmp/1 or /bin/ls
-	--trace comm=bash --trace follow                             | trace all events that originated from bash or from one of the processes spawned by bash
+  --trace pid=new                                              | only trace events from new processes
+  --trace pid=510,1709                                         | only trace events from pid 510 or pid 1709
+  --trace p=510 --trace p=1709                                 | only trace events from pid 510 or pid 1709 (same as above)
+  --trace container=new                                        | only trace events from newly created containers
+  --trace container                                            | only trace events from containers
+  --trace c                                                    | only trace events from containers (same as above)
+  --trace '!container'                                         | only trace events from the host
+  --trace uid=0                                                | only trace events from uid 0
+  --trace mntns=4026531840                                     | only trace events from mntns id 4026531840
+  --trace pidns!=4026531836                                    | only trace events from pidns id not equal to 4026531840
+  --trace 'uid>0'                                              | only trace events from uids greater than 0
+  --trace 'pid>0' --trace 'pid<1000'                           | only trace events from pids between 0 and 1000
+  --trace 'u>0' --trace u!=1000                                | only trace events from uids greater than 0 but not 1000
+  --trace event=execve,open                                    | only trace execve and open events
+  --trace set=fs                                               | trace all file-system related events
+  --trace s=fs --trace e!=open,openat                          | trace all file-system related events, but not open(at)
+  --trace uts!=ab356bc4dd554                                   | don't trace events from uts name ab356bc4dd554
+  --trace comm=ls                                              | only trace events from ls command
+  --trace close.fd=5                                           | only trace 'close' events that have 'fd' equals 5
+  --trace openat.pathname=/tmp*                                | only trace 'openat' events that have 'pathname' prefixed by "/tmp"
+  --trace openat.pathname!=/tmp/1,/bin/ls                      | don't trace 'openat' events that have 'pathname' equals /tmp/1 or /bin/ls
+  --trace comm=bash --trace follow                             | trace all events that originated from bash or from one of the processes spawned by bash
 
 
 Note: some of the above operators have special meanings in different shells.

--- a/main.go
+++ b/main.go
@@ -169,13 +169,18 @@ Capture artifacts that were written, executed or found to be suspicious.
 Captured artifacts will appear in the 'output-path' directory.
 Possible options:
 
-[artifact:]write[=/path/prefix*]   capture written files. A filter can be given to only capture file writes whose path starts with some prefix (up to 50 characters).
+[artifact:]write[=/path/prefix*]   capture written files. A filter can be given to only capture file writes whose path starts with some prefix (up to 50 characters). Up to 3 filters can be given.
 [artifact:]exec                    capture executed files.
 [artifact:]mem                     capture memory regions that had write+execute (w+x) protection, and then changed to execute (x) only.
 [artifact:]all                     capture all of the above artifacts.
 
-dir:/path/to/dir        path where tracee will save produced artifacts (default: /tmp/tracee).
+dir:/path/to/dir        path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
 clear-dir               clear the captured artifacts output dir before starting (default: false).
+
+Examples:
+	--capture exec                                           | capture executed files into the default output directory
+	--capture all --capture dir:/my/dir --capture clear-dir  | delete /my/dir/out and then capture all supported artifacts into it
+	--capture write=/usr/bin/* --capture write=/etc/*        | capture files that were written into anywhere under /usr/bin/ or /etc/
 
 Use this flag multiple times to choose multiple capture options
 `

--- a/main_test.go
+++ b/main_test.go
@@ -900,3 +900,148 @@ func TestPrepareCapture(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareOutput(t *testing.T) {
+
+	testCases := []struct {
+		testName       string
+		outputSlice    []string
+		expectedOutput tracee.OutputConfig
+		expectedError  error
+	}{
+		{
+			testName:    "invalid output option",
+			outputSlice: []string{"foo"},
+			// it's not the preparer job to validate input. in this case foo is considered an implicit output format.
+			expectedOutput: tracee.OutputConfig{
+				Format: "foo",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:       "invalid output option",
+			outputSlice:    []string{"option:"},
+			expectedOutput: tracee.OutputConfig{},
+			expectedError:  errors.New("invalid output option: , use '--option help' for more info"),
+		},
+		{
+			testName:       "invalid output option 2",
+			outputSlice:    []string{"option:foo"},
+			expectedOutput: tracee.OutputConfig{},
+			expectedError:  errors.New("invalid output option: foo, use '--option help' for more info"),
+		},
+		{
+			testName:    "format explicit",
+			outputSlice: []string{"format:json"},
+			expectedOutput: tracee.OutputConfig{
+				Format: "json",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "format implicit",
+			outputSlice: []string{"json"},
+			expectedOutput: tracee.OutputConfig{
+				Format: "json",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "format gotemplate",
+			outputSlice: []string{"gotemplate=/path/to/tmpl"},
+			expectedOutput: tracee.OutputConfig{
+				Format: "gotemplate=/path/to/tmpl",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "out",
+			outputSlice: []string{"out-file:/path/to/file"},
+			expectedOutput: tracee.OutputConfig{
+				OutPath: "/path/to/file",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "empty val",
+			outputSlice: []string{"out-file"},
+			expectedOutput: tracee.OutputConfig{
+				Format: "out-file",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "err",
+			outputSlice: []string{"err-file:/path/to/file"},
+			expectedOutput: tracee.OutputConfig{
+				ErrPath: "/path/to/file",
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "option eot",
+			outputSlice: []string{"option:eot"},
+			expectedOutput: tracee.OutputConfig{
+				EOT: true,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "option stack-addresses",
+			outputSlice: []string{"option:stack-addresses"},
+			expectedOutput: tracee.OutputConfig{
+				StackAddresses: true,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "option detect-syscall",
+			outputSlice: []string{"option:detect-syscall"},
+			expectedOutput: tracee.OutputConfig{
+				DetectSyscall: true,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "option exec-env",
+			outputSlice: []string{"option:exec-env"},
+			expectedOutput: tracee.OutputConfig{
+				ExecEnv: true,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "gob + eot",
+			outputSlice: []string{"format:gob", "option:eot"},
+			expectedOutput: tracee.OutputConfig{
+				Format: "gob",
+				EOT:    true,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:    "all",
+			outputSlice: []string{"gotemplate=/path/to/tmpl", "option:eot", "option:stack-addresses", "option:detect-syscall", "option:exec-env", "out-file:/path/to/file", "err-file:/path/to/file"},
+			expectedOutput: tracee.OutputConfig{
+				Format:         "gotemplate=/path/to/tmpl",
+				OutPath:        "/path/to/file",
+				ErrPath:        "/path/to/file",
+				EOT:            true,
+				StackAddresses: true,
+				DetectSyscall:  true,
+				ExecEnv:        true,
+			},
+			expectedError: nil,
+		},
+	}
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			output, err := prepareOutput(testcase.outputSlice)
+			if err != nil {
+				assert.Equal(t, testcase.expectedError, err)
+			} else {
+				assert.Equal(t, testcase.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/tracee/pipeline.go
+++ b/tracee/pipeline.go
@@ -169,7 +169,7 @@ func (t *Tracee) prepareEventForPrint(done <-chan struct{}, in <-chan RawEvent) 
 
 			// Add stack trace if needed
 			var StackAddresses []uint64
-			if t.config.StackAddresses {
+			if t.config.Output.StackAddresses {
 				StackAddresses, _ = t.getStackAddresses(rawEvent.Ctx.StackID)
 			}
 

--- a/tracee/tracee.go
+++ b/tracee/tracee.go
@@ -21,19 +21,14 @@ import (
 
 // TraceeConfig is a struct containing user defined configuration of tracee
 type TraceeConfig struct {
-	Filter                *Filter
-	Capture               *CaptureConfig
-	DetectOriginalSyscall bool
-	ShowExecEnv           bool
-	OutputFormat          string
-	PerfBufferSize        int
-	BlobPerfBufferSize    int
-	SecurityAlerts        bool
-	EventsFile            *os.File
-	ErrorsFile            *os.File
-	maxPidsCache          int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
-	BPFObjPath            string
-	StackAddresses        bool
+	Filter             *Filter
+	Capture            *CaptureConfig
+	Output             *OutputConfig
+	PerfBufferSize     int
+	BlobPerfBufferSize int
+	SecurityAlerts     bool
+	maxPidsCache       int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
+	BPFObjPath         string
 }
 
 type Filter struct {
@@ -90,21 +85,37 @@ type CaptureConfig struct {
 	Mem             bool
 }
 
+type OutputConfig struct {
+	Format         string
+	OutPath        string
+	ErrPath        string
+	EOT            bool
+	StackAddresses bool
+	DetectSyscall  bool
+	ExecEnv        bool
+}
+
+// Validate does static validation of the configuration
+func (cfg OutputConfig) Validate() error {
+	if cfg.Format != "table" && cfg.Format != "table-verbose" && cfg.Format != "json" && cfg.Format != "gob" && !strings.HasPrefix(cfg.Format, "gotemplate=") {
+		return fmt.Errorf("unrecognized output format: %s", cfg.Format)
+	}
+	return nil
+}
+
 // Validate does static validation of the configuration
 func (tc TraceeConfig) Validate() error {
 	if tc.Filter.EventsToTrace == nil {
 		return fmt.Errorf("eventsToTrace is nil")
 	}
-	if tc.OutputFormat != "table" && tc.OutputFormat != "table-verbose" && tc.OutputFormat != "json" && tc.OutputFormat != "gob" && !strings.HasPrefix(tc.OutputFormat, "go-template=") {
-		return fmt.Errorf("unrecognized output format: %s", tc.OutputFormat)
-	}
+
 	for _, e := range tc.Filter.EventsToTrace {
 		if _, ok := EventsIDToEvent[e]; !ok {
 			return fmt.Errorf("invalid event to trace: %d", e)
 		}
 	}
 	for eventID, eventFilters := range tc.Filter.ArgFilter.Filters {
-		for argName, _ := range eventFilters {
+		for argName := range eventFilters {
 			eventParams, ok := EventsIDToParams[eventID]
 			if !ok {
 				return fmt.Errorf("invalid argument filter event id: %d", eventID)
@@ -138,6 +149,11 @@ func (tc TraceeConfig) Validate() error {
 	}
 	_, err := os.Stat(tc.BPFObjPath)
 	if err == nil {
+		return err
+	}
+
+	err = tc.Output.Validate()
+	if err != nil {
 		return err
 	}
 	return nil
@@ -217,9 +233,29 @@ func New(cfg TraceeConfig) (*Tracee, error) {
 	t := &Tracee{
 		config: cfg,
 	}
+	outf := os.Stdout
+	if t.config.Output.OutPath != "" {
+		dir := filepath.Dir(t.config.Output.OutPath)
+		os.MkdirAll(dir, 0755)
+		os.Remove(t.config.Output.OutPath)
+		outf, err = os.Create(t.config.Output.OutPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	errf := os.Stderr
+	if t.config.Output.ErrPath != "" {
+		dir := filepath.Dir(t.config.Output.ErrPath)
+		os.MkdirAll(dir, 0755)
+		os.Remove(t.config.Output.ErrPath)
+		errf, err = os.Create(t.config.Output.ErrPath)
+		if err != nil {
+			return nil, err
+		}
+	}
 	ContainerMode := (t.config.Filter.ContFilter.Enabled && t.config.Filter.ContFilter.Value) ||
 		(t.config.Filter.NewContFilter.Enabled && t.config.Filter.NewContFilter.Value)
-	printObj, err := newEventPrinter(t.config.OutputFormat, ContainerMode, t.config.EventsFile, t.config.ErrorsFile)
+	printObj, err := newEventPrinter(t.config.Output.Format, ContainerMode, t.config.Output.EOT, outf, errf)
 	if err != nil {
 		return nil, err
 	}
@@ -573,12 +609,12 @@ func (t *Tracee) populateBPFMaps() error {
 
 	// Initialize config and pids maps
 	bpfConfigMap, _ := t.bpfModule.GetMap("config_map")
-	bpfConfigMap.Update(uint32(configDetectOrigSyscall), boolToUInt32(t.config.DetectOriginalSyscall))
-	bpfConfigMap.Update(uint32(configExecEnv), boolToUInt32(t.config.ShowExecEnv))
+	bpfConfigMap.Update(uint32(configDetectOrigSyscall), boolToUInt32(t.config.Output.DetectSyscall))
+	bpfConfigMap.Update(uint32(configExecEnv), boolToUInt32(t.config.Output.ExecEnv))
+	bpfConfigMap.Update(uint32(configStackAddresses), boolToUInt32(t.config.Output.StackAddresses))
 	bpfConfigMap.Update(uint32(configCaptureFiles), boolToUInt32(t.config.Capture.FileWrite))
 	bpfConfigMap.Update(uint32(configExtractDynCode), boolToUInt32(t.config.Capture.Mem))
 	bpfConfigMap.Update(uint32(configTraceePid), uint32(os.Getpid()))
-	bpfConfigMap.Update(uint32(configStackAddresses), boolToUInt32(t.config.StackAddresses))
 	bpfConfigMap.Update(uint32(configFollowFilter), boolToUInt32(t.config.Filter.Follow))
 
 	// Initialize tail calls program array
@@ -866,6 +902,7 @@ func (t *Tracee) Close() {
 	if t.bpfModule != nil {
 		t.bpfModule.Close()
 	}
+	t.printer.Close()
 }
 
 func boolToUInt32(b bool) uint32 {


### PR DESCRIPTION
related: https://github.com/aquasecurity/tracee/issues/397

this also fixes a small issue with --capture documentation 

There are a few practices here that if approved I think we should implement in the other preparers in the future.