### PR TITLE
feat: Add ringbuffer support to libbpfgo

### DIFF
--- a/libbpfgo/libbpf_cb.go
+++ b/libbpfgo/libbpf_cb.go
@@ -20,3 +20,9 @@ func perfLostCallback(ctx unsafe.Pointer, cpu C.int, cnt C.ulonglong) {
 		lostChan <- uint64(cnt)
 	}
 }
+
+//export ringbufferCallback
+func ringbufferCallback(ctx unsafe.Pointer, data unsafe.Pointer, size C.int) C.int {
+	eventChannels[uintptr(ctx)] <- C.GoBytes(data, size)
+	return C.int(0)
+}

--- a/libbpfgo/selftest/ringbuffers/.gitignore
+++ b/libbpfgo/selftest/ringbuffers/.gitignore
@@ -1,0 +1,3 @@
+vmlinux.h
+self
+self.bpf.o

--- a/libbpfgo/selftest/ringbuffers/Makefile
+++ b/libbpfgo/selftest/ringbuffers/Makefile
@@ -1,0 +1,29 @@
+TARGET := self
+TARGET_BPF := $(TARGET).bpf.o
+
+GO_SRC := $(shell find . -type f -name '*.go')
+LIBBPFGO_SRC := $(shell find ../.. -type f -name '*.go')
+BPF_SRC := $(shell find . -type f -name '*.bpf.c')
+PWD := $(shell pwd)
+
+LIBBPF_HEADERS := /usr/include/bpf
+LIBBPF_OBJ := /usr/lib64/libbpf.a
+
+.PHONY: all
+all: vmlinux.h $(TARGET) $(TARGET_BPF)
+
+vmlinux.h:
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+
+go_env := CC=gcc CGO_CFLAGS="-I $(LIBBPF_HEADERS)" CGO_LDFLAGS="$(LIBBPF_OBJ)"
+$(TARGET): $(GO_SRC) $(LIBBPFGO_SRC)
+	$(go_env) go build -ldflags '-extldflags "-static"' -o $(TARGET) 
+
+$(TARGET_BPF): $(BPF_SRC)
+	clang \
+		-g -O2 -c -target bpf \
+		-o $@ $<
+
+.PHONY: clean
+clean: 
+	rm $(TARGET) $(TARGET_BPF) vmlinux.h

--- a/libbpfgo/selftest/ringbuffers/go.mod
+++ b/libbpfgo/selftest/ringbuffers/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/tracee/libbpfgo/selftests/5.8.15
+
+go 1.15
+
+replace github.com/aquasecurity/tracee/libbpfgo => ../../
+
+require github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b

--- a/libbpfgo/selftest/ringbuffers/go.sum
+++ b/libbpfgo/selftest/ringbuffers/go.sum
@@ -1,0 +1,3 @@
+github.com/aquasecurity/tracee v0.4.0 h1:fOfgeHWgjHSNK7vokaANNXOFljK9KOYSYriTxCfvMEU=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b h1:KfjLxlXFVCRx0UDYzzTV7Tt80mEkfVmwl+F7SzfII30=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=

--- a/libbpfgo/selftest/ringbuffers/main.go
+++ b/libbpfgo/selftest/ringbuffers/main.go
@@ -1,0 +1,55 @@
+package main
+
+import "C"
+
+import (
+	bpf "github.com/aquasecurity/tracee/libbpfgo"
+	"os"
+)
+
+func main() {
+
+	bpfModule, err := bpf.NewModuleFromFile("self.bpf.o")
+	if err != nil {
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	bpfModule.BPFLoadObject()
+	prog, err := bpfModule.GetProgram("kprobe__sys_mmap")
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	eventsChannel := make(chan []byte)
+	rb, err := bpfModule.InitRingBuf("events", eventsChannel)
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	rb.Start()
+
+	numberOfEventsReceived := 0
+
+recvLoop:
+	for {
+		_ = <-eventsChannel
+		numberOfEventsReceived++
+		if numberOfEventsReceived > 5 {
+			break recvLoop
+		}
+	}
+
+
+	// Test that it won't cause a panic or block if Stop or Close called multiple times
+	rb.Stop()
+	rb.Stop()
+	rb.Close()
+	rb.Close()
+	rb.Stop()
+}

--- a/libbpfgo/selftest/ringbuffers/run.sh
+++ b/libbpfgo/selftest/ringbuffers/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' 
+
+VERSION_LIMIT=5.8
+CURRENT_VERSION=$(uname -r | cut -d '.' -f1-2)
+
+# Check major version
+MAJOR_VERSION_LIMIT=$(echo $VERSION_LIMIT | cut -d '.' -f1)
+MAJOR_CURRENT_VERSION=$(echo $CURRENT_VERSION | cut -d '.' -f1)
+if (( $(echo "$MAJOR_CURRENT_VERSION < $MAJOR_VERSION_LIMIT") |bc -l)); then
+    echo -e "${RED}[*] OUTDATED MAJOR KERNEL VERSION${NC}"
+    exit 1
+fi
+
+# Check minor version
+MINOR_VERSION_LIMIT=$(echo $VERSION_LIMIT | cut -d '.' -f2)
+MINOR_CURRENT_VERSION=$(echo $CURRENT_VERSION | cut -d '.' -f2)
+if (( $(echo "$MINOR_CURRENT_VERSION < $MINOR_VERSION_LIMIT") |bc -l)); then
+    echo -e "${RED}[*] OUTDATED MINOR KERNEL VERSION${NC}"
+    exit 1
+else
+    echo -e "${GREEN}[*] SUFFICIENT KERNEL VERSION${NC}"
+fi
+
+make -f $PWD/Makefile
+if [ $? -ne 0 ]; then
+    echo -e "${RED}[*] MAKE FAILED"
+    exit 2
+else
+    echo -e "${GREEN}[*] MAKE RAN SUCCESFULLY${NC}"
+fi
+
+timeout 5 $PWD/self
+RETURN_CODE=$?
+if [ $RETURN_CODE -eq 124 ]; then
+    echo -e "${RED}[*] SELFTEST TIMEDOUT${NC}"
+    exit 3
+fi
+
+if [ $RETURN_CODE -ne 0 ]; then
+    echo -e "${RED}[*] ERROR IN SELFTEST${NC}"
+    exit 4
+fi
+
+echo -e "${GREEN}[*] SUCCESS${NC}"
+exit 0

--- a/libbpfgo/selftest/ringbuffers/self.bpf.c
+++ b/libbpfgo/selftest/ringbuffers/self.bpf.c
@@ -1,0 +1,42 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>  
+
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
+
+char LICENSE[] SEC("license") = "GPL";
+
+struct process_info {
+    int pid;
+    char comm[100];
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 1 << 24);
+} events SEC(".maps");
+
+long ringbuffer_flags = 0;
+
+SEC("kprobe/sys_mmap")
+int kprobe__sys_mmap(struct pt_regs *ctx)
+{
+    __u64 id = bpf_get_current_pid_tgid();
+    __u32 tgid = id >> 32;
+    struct process_info *process;
+
+    // Reserve space on the ringbuffer for the sample
+    process = bpf_ringbuf_reserve(&events, sizeof(struct process_info), ringbuffer_flags);
+    if (!process) {
+        return 0;
+    }
+
+    process->pid = tgid;
+    bpf_get_current_comm(&process->comm, 100);
+
+    bpf_ringbuf_submit(process, ringbuffer_flags);
+    return 0;
+}


### PR DESCRIPTION
This adds support for ringbuffers to libbpfgo. A good reference for ringbuffers can be found [here](https://nakryiko.com/posts/bpf-ringbuf/). There is not much difference in userspace between ringbuffers and perfbuffers besides the fact that ringbuffers API does not support a callback for lost events. That will have to be handled in kernel space for consumers of libbpfgo, like Tracee. 

I have a separate PR awaiting this which I can open as a draft seeing how it would be consumed in Tracee. 