### PR TITLE
update release process after restructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+.PHONY: all
+all:
+	@echo "This make file is intended for releasing only. In order to build any of Tracee's components, use their respective make files."
+
+# RELEASE_TAG must be set to specify a name for the release
+OUT_DIR ?= dist
+OUT_DOCKER ?= tracee
+OUT_ARCHIVE := $(OUT_DIR)/tracee.tar.gz
+OUT_CHECKSUMS := $(OUT_DIR)/checksums.txt
+PUSH_DOCKER_REPO ?= aquasec/tracee
+PUSH_DOCKER_TAG ?= $(RELEASE_TAG:v%=%)
+
+CMD_DOCKER ?= docker
+CMD_GIT ?= git
+CMD_CHECKSUM ?= sha256sum
+CMD_GITHUB ?= gh
+CMD_TAR ?= tar
+CMD_CP ?= cp
+
+release_tools := $(CMD_DOCKER) $(CMD_GIT) $(CMD_CHECKSUM) $(CMD_GITHUB) $(CMD_TAR) $(CMP_CP)
+check_release_tools := $(shell for tool in $(release_tools); do command -v $$tool >/dev/null || (echo "missing required tool $$tool" ; false); done)
+
+$(OUT_DIR):
+	mkdir -p $@
+
+# make_artifact invokes another make from $1 to make the artifact $2 using additional flags $3
+define make_artifact
+	$(MAKE) -C $1 dist/$2 $3 OUT_DIR=dist && $(CMD_CP) -r $1/dist/$2 $(OUT_DIR)/$2
+endef
+
+$(OUT_DIR)/tracee: tracee-ebpf | $(OUT_DIR)
+	$(call make_artifact,$<,$(notdir $@),DOCKER=1)
+
+$(OUT_DIR)/tracee-rules $(OUT_DIR)/rules: tracee-rules | $(OUT_DIR)
+	$(call make_artifact,$<,$(notdir $@))
+
+release_archive_files := LICENSE $(OUT_DIR)/tracee $(OUT_DIR)/tracee-rules $(OUT_DIR)/rules
+$(OUT_ARCHIVE) $(OUT_CHECKSUMS) &: $(release_archive_files) | $(OUT_DIR)
+	$(CMD_TAR) -czf $(OUT_ARCHIVE) $(release_archive_files)
+	$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
+
+.PHONY: docker
+docker: tracee-ebpf
+	$(MAKE) -C tracee-ebpf docker docker-slim OUT_DOCKER=$(OUT_DOCKER)
+
+# release_docker_image accepts a docker image $1, pushes it as $2 to remote repository, and records it in the release notes
+define release_docker_image
+	$(CMD_DOCKER) tag $(1) $(2) && $(CMD_DOCKER) push $(2) && echo '- `docker pull docker.io/$(2)`' >> $(release_notes);
+endef
+
+release_notes := $(OUT_DIR)/release-notes.txt
+release_images_fat := $(PUSH_DOCKER_REPO):latest $(PUSH_DOCKER_REPO):$(PUSH_DOCKER_TAG)
+release_images_slim := $(PUSH_DOCKER_REPO):slim $(PUSH_DOCKER_REPO):slim-$(PUSH_DOCKER_TAG)
+.PHONY: release
+# before running this rule, need to authenticate git, gh, and docker tools
+release: $(OUT_ARCHIVE) $(OUT_CHECKSUMS) | docker $(check_release_tools)
+	test -n '$(RELEASE_TAG)' || (echo "missing required variable RELEASE_TAG" ; false)
+	-rm $(release_notes)
+	echo '## Changelog' > $(release_notes)
+	$(CMD_GIT) log --pretty=oneline --abbrev=commit --no-decorate --no-color tags/$(shell $(CMD_GIT) describe --tags --abbrev=0)..HEAD >> $(release_notes)
+	echo '' >> $(release_notes)
+	echo '## Docker images' >> $(release_notes)
+	$(foreach img,$(release_images_fat),$(call release_docker_image,$(OUT_DOCKER):latest,$(img)))
+	$(foreach img,$(release_images_slim),$(call release_docker_image,$(OUT_DOCKER):slim,$(img)))
+	echo '' >>$(release_notes)
+	$(CMD_GIT) tag $(RELEASE_TAG)
+	$(CMD_GIT) push origin $(RELEASE_TAG)
+	$(CMD_GITHUB) release create $(RELEASE_TAG) $(OUT_ARCHIVE) $(OUT_CHECKSUMS) --title $(RELEASE_TAG) --notes-file $(release_notes)
+
+.PHONY: mostlyclean
+mostlyclean:
+	-rm -rf $(OUT_DIR)
+	-$(MAKE) -C tracee-ebpf mostlyclean
+	-$(MAKE) -C tracee-rules mostlyclean
+
+.PHONY: clean
+clean:
+	-$(CMD_DOCKER) rmi $(OUT_DOCKER) $(release_images_fat) $(release_images_slim)
+	-$(MAKE) -c tracee-ebpf clean
+	-$(MAKE) -c tracee-rules clean

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ define make_artifact
 	$(MAKE) -C $1 dist/$2 $3 OUT_DIR=dist && $(CMD_CP) -r $1/dist/$2 $(OUT_DIR)/$2
 endef
 
-$(OUT_DIR)/tracee: tracee-ebpf | $(OUT_DIR)
+$(OUT_DIR)/tracee-ebpf: tracee-ebpf | $(OUT_DIR)
 	$(call make_artifact,$<,$(notdir $@),DOCKER=1)
 
 $(OUT_DIR)/tracee-rules $(OUT_DIR)/rules: tracee-rules | $(OUT_DIR)

--- a/tracee-ebpf/Dockerfile
+++ b/tracee-ebpf/Dockerfile
@@ -21,5 +21,5 @@ RUN apk --no-cache update && apk --no-cache add libc6-compat elfutils-dev
 # docker run --name tracee --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee aquasec/tracee
 FROM $BASE
 WORKDIR /tracee
-COPY --from=build /tracee/dist/tracee /tracee/entrypoint.sh ./
-ENTRYPOINT ["./entrypoint.sh", "./tracee"]
+COPY --from=build /tracee/dist/tracee-ebpf /tracee/entrypoint.sh ./
+ENTRYPOINT ["./entrypoint.sh", "./tracee-ebpf"]

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -52,7 +52,7 @@ $(OUT_BIN): $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(filter-out *_test.go,$(GO_SRC)) $(
 	-ldflags "-X main.bpfBundleInjected=$$(base64 -w 0 $(BPF_BUNDLE)) -X main.version=$(VERSION)"	
 else 
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
-	$(call docker_builder_make,$($@))
+	$(call docker_builder_make,$@)
 endif
 
 bpf_compile_tools = $(CMD_LLC) $(CMD_CLANG)
@@ -119,7 +119,7 @@ $(OUT_BPF): $(BPF_SRC) $(LIBBPF_HEADERS) | $(OUT_DIR) $(bpf_compile_tools)
 	rm $(@:.o=.ll)
 else
 $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR) 
-	$(call docker_builder_make,$($@))
+	$(call docker_builder_make,$@)
 endif
 
 
@@ -129,7 +129,7 @@ test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
 	$(go_env)	go test -v ./...
 else
 test: $(DOCKER_BUILDER)
-	$(call docker_builder_make,test)
+	$(call docker_builder_make,$@)
 endif
 
 .PHONY: $(DOCKER_BUILDER)

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -15,7 +15,7 @@ ARCH ?= $(ARCH_UNAME:aarch64=arm64)
 KERN_RELEASE ?= $(shell uname -r)
 KERN_BLD_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),/lib/modules/$(KERN_RELEASE)/build)
 KERN_SRC_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),$(if $(wildcard /lib/modules/$(KERN_RELEASE)/source),/lib/modules/$(KERN_RELEASE)/source,$(KERN_BLD_PATH)))
-VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags))
+VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '0'))
 # inputs and outputs:
 OUT_DIR ?= dist
 GO_SRC := $(shell find . -type f -name '*.go')
@@ -52,7 +52,7 @@ $(OUT_BIN): $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(filter-out *_test.go,$(GO_SRC)) $(
 	-ldflags "-X main.bpfBundleInjected=$$(base64 -w 0 $(BPF_BUNDLE)) -X main.version=$(VERSION)"	
 else 
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
-	$(call docker_builder_make,$@)
+	$(call docker_builder_make,$@ VERSION=$(VERSION))
 endif
 
 bpf_compile_tools = $(CMD_LLC) $(CMD_CLANG)

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -137,7 +137,7 @@ endif
 docker_builder_file := $(OUT_DIR)/$(DOCKER_BUILDER)
 .PHONY: $(DOCKER_BUILDER)
 $(DOCKER_BUILDER) $(docker_builder_file) &: Dockerfile.builder | $(OUT_DIR) check_$(CMD_DOCKER)
-	$(CMD_DOCKER) build -f Dockerfile.builder -t $(DOCKER_BUILDER) --iidfile $(docker_builder_file) .
+	$(CMD_DOCKER) build -t $(DOCKER_BUILDER) --iidfile $(docker_builder_file) - < $<
 
 $(OUT_DIR)/$(DOCKER_BUILDER): $(GO_SRC) $(BPF_SRC) $(MAKEFILE_LIST) Dockerfile | $(OUT_DIR)
 	$(CMD_DOCKER) build -f Dockerfile.builder -t $(DOCKER_BUILDER) --iidfile $(OUT_DIR)/$(DOCKER_BUILDER) --target builder .

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -7,8 +7,6 @@ CMD_CLANG ?= clang
 CMD_LLVM_STRIP ?= llvm-strip
 CMD_DOCKER ?= docker
 CMD_GIT ?= git
-CMD_CHECKSUM ?= sha256sum
-CMD_GITHUB ?= gh
 # environment:
 ARCH_UNAME := $(shell uname -m)
 ARCH ?= $(ARCH_UNAME:aarch64=arm64)
@@ -34,10 +32,6 @@ DOCKER_BUILDER_KERN_BLD ?= $(if $(shell readlink $(KERN_BLD_PATH)),$(shell readl
 DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink $(KERN_SRC_PATH)),$(shell readlink $(KERN_SRC_PATH)),$(KERN_SRC_PATH))
 # DOCKER_BUILDER_KERN_SRC_MNT is the kernel headers directory to mount into the docker builder container. DOCKER_BUILDER_KERN_SRC should usually be a decendent of this path.
 DOCKER_BUILDER_KERN_SRC_MNT ?= $(dir $(DOCKER_BUILDER_KERN_SRC))
-RELEASE_ARCHIVE := $(OUT_DIR)/tracee.tar.gz
-RELEASE_CHECKSUMS := $(OUT_DIR)/checksums.txt
-RELEASE_DOCKER ?= aquasec/tracee
-RELEASE_DOCKER_TAG ?= $(RELEASE_TAG:v%=%)
 
 $(OUT_DIR):
 	mkdir -p $@
@@ -122,7 +116,6 @@ $(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@)
 endif
 
-
 .PHONY: test 
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
@@ -132,15 +125,11 @@ test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)
 endif
 
-.PHONY: $(DOCKER_BUILDER)
 # record built image id to prevent unnecessary building and for cleanup
 docker_builder_file := $(OUT_DIR)/$(DOCKER_BUILDER)
 .PHONY: $(DOCKER_BUILDER)
 $(DOCKER_BUILDER) $(docker_builder_file) &: Dockerfile.builder | $(OUT_DIR) check_$(CMD_DOCKER)
 	$(CMD_DOCKER) build -t $(DOCKER_BUILDER) --iidfile $(docker_builder_file) - < $<
-
-$(OUT_DIR)/$(DOCKER_BUILDER): $(GO_SRC) $(BPF_SRC) $(MAKEFILE_LIST) Dockerfile | $(OUT_DIR)
-	$(CMD_DOCKER) build -f Dockerfile.builder -t $(DOCKER_BUILDER) --iidfile $(OUT_DIR)/$(DOCKER_BUILDER) --target builder .
 
 # docker_builder_make runs a make command in the tracee-builder container
 define docker_builder_make
@@ -170,31 +159,3 @@ docker:
 .PHONY: docker-slim
 docker-slim:
 	$(CMD_DOCKER) build --build-arg VERSION=$(VERSION) -t $(OUT_DOCKER):slim --build-arg BASE=slim .
-
-# release_docker_image accepts a local docker image reference (first argument), pushes it under a new name  (second argument) to remote repository, and records it in the release notes
-define release_docker_image
-	$(CMD_DOCKER) tag $(1) $(2) && $(CMD_DOCKER) push $(2) &&	echo '- `docker pull docker.io/$(2)`' >> $(release_notes);
-endef
-
-$(RELEASE_ARCHIVE) $(RELEASE_CHECKSUMS) &: $(OUT_BIN) LICENSE | $(OUT_DIR) check_$(CMD_CHECKSUM)
-	tar -czf $(RELEASE_ARCHIVE) $(OUT_BIN) LICENSE
-	$(CMD_CHECKSUM) $(RELEASE_ARCHIVE) > $(RELEASE_CHECKSUMS)
-
-release_notes := $(OUT_DIR)/release-notes.txt
-release_images_fat := $(RELEASE_DOCKER):latest $(RELEASE_DOCKER):$(RELEASE_DOCKER_TAG)
-release_images_slim := $(RELEASE_DOCKER):slim $(RELEASE_DOCKER):slim-$(RELEASE_DOCKER_TAG)
-.PHONY: release
-# before running this rule, need to authenticate git, gh, and docker tools.
-release: | check_$(CMD_GITHUB) $(RELEASE_ARCHIVE) $(RELEASE_CHECKSUMS) docker docker-slim
-	test -n '$(RELEASE_TAG)' || (echo "missing required variable RELEASE_TAG" ; false)
-	-rm $(release_notes)
-	echo '## Changelog' > $(release_notes)
-	$(CMD_GIT) log --pretty=oneline --abbrev=commit --no-decorate --no-color tags/$(shell $(CMD_GIT) describe --tags --abbrev=0)..HEAD >> $(release_notes)
-	echo '' >> $(release_notes)
-	echo '## Docker images' >> $(release_notes)
-	$(foreach img,$(release_images_fat),$(call release_docker_image,$(OUT_DOCKER):latest,$(img)))
-	$(foreach img,$(release_images_slim),$(call release_docker_image,$(OUT_DOCKER):slim,$(img)))
-	echo '' >>$(release_notes)
-	$(CMD_GIT) tag $(RELEASE_TAG)
-	$(CMD_GIT) push origin $(RELEASE_TAG)
-	$(CMD_GITHUB) release create $(RELEASE_TAG) $(RELEASE_ARCHIVE) $(RELEASE_CHECKSUMS) --title $(RELEASE_TAG) --notes-file $(release_notes)

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -17,7 +17,7 @@ VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags
 # inputs and outputs:
 OUT_DIR ?= dist
 GO_SRC := $(shell find . -type f -name '*.go')
-OUT_BIN := $(OUT_DIR)/tracee
+OUT_BIN := $(OUT_DIR)/tracee-ebpf
 BPF_SRC := tracee/tracee.bpf.c 
 OUT_BPF := $(OUT_DIR)/tracee.bpf.$(subst .,_,$(KERN_RELEASE)).$(subst .,_,$(VERSION)).o
 BPF_HEADERS := 3rdparty/include

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -150,13 +150,15 @@ define docker_builder_make
 	--entrypoint make $(DOCKER_BUILDER) KERN_BLD_PATH=$(DOCKER_BUILDER_KERN_BLD) KERN_SRC_PATH=$(DOCKER_BUILDER_KERN_SRC) $(1)
 endef
 
+.PHONY: mostlyclean
+mostlyclean:
+	-rm -rf $(OUT_BIN) $(bpf_bundle_dir) $(OUT_BPF) $(BPF_BUNDLE)
+
 .PHONY: clean
 clean:
-ifdef CLEAN_ALL
 	-$(CMD_DOCKER) rmi $(file < $(docker_builder_file))
-endif
 	-rm -rf dist $(OUT_DIR)
-	-cd $(LIBBPF_SRC) && $(MAKE) clean;
+	$(MAKE) -C $(LIBBPF_SRC) clean
 	
 check_%:
 	@command -v $* >/dev/null || (echo "missing required tool $*" ; false)

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -134,7 +134,10 @@ endif
 
 .PHONY: $(DOCKER_BUILDER)
 # record built image id to prevent unnecessary building and for cleanup
-$(DOCKER_BUILDER): $(OUT_DIR)/$(DOCKER_BUILDER)
+docker_builder_file := $(OUT_DIR)/$(DOCKER_BUILDER)
+.PHONY: $(DOCKER_BUILDER)
+$(DOCKER_BUILDER) $(docker_builder_file) &: Dockerfile.builder | $(OUT_DIR) check_$(CMD_DOCKER)
+	$(CMD_DOCKER) build -f Dockerfile.builder -t $(DOCKER_BUILDER) --iidfile $(docker_builder_file) .
 
 $(OUT_DIR)/$(DOCKER_BUILDER): $(GO_SRC) $(BPF_SRC) $(MAKEFILE_LIST) Dockerfile | $(OUT_DIR)
 	$(CMD_DOCKER) build -f Dockerfile.builder -t $(DOCKER_BUILDER) --iidfile $(OUT_DIR)/$(DOCKER_BUILDER) --target builder .
@@ -149,7 +152,9 @@ endef
 
 .PHONY: clean
 clean:
-	-$(CMD_DOCKER) rmi $(file < $(DOCKER_BUILDER))
+ifdef CLEAN_ALL
+	-$(CMD_DOCKER) rmi $(file < $(docker_builder_file))
+endif
 	-rm -rf dist $(OUT_DIR)
 	-cd $(LIBBPF_SRC) && $(MAKE) clean;
 	

--- a/tracee-ebpf/Readme.md
+++ b/tracee-ebpf/Readme.md
@@ -34,13 +34,13 @@ This will run Tracee-eBPF with no arguments, which defaults to collecting a usef
 
 You can obtain Tracee-eBPF in any of the following ways:
 1. Download from the [GitHub Releases](https://github.com/aquasecurity/tracee/releases) (`tracee.tar.gz`).
-2. Use the docker image from Docker Hub: `aquasec/tracee` (includes all the required dependencies).
+2. Use the docker image from Docker Hub: `aquasec/tracee`.
 3. Build the executable from source using `make build`. For that you will need additional development tooling.
 4. Build the executable from source in a Docker container which includes all development tooling, using `make build DOCKER=1`.
 
 ### Setup options
 
-Tracee-eBPF is made of a userspace executable (`tracee`) that drives the eBPF program, and the eBPF program itself (`tracee.bpf.$kernelversion.$traceeversion.o`). When the `tracee` is started, it will look for the eBPF program in specific places and if not found, it will attempt to build the eBPF program automatically before it starts (you can control this using the `--build-policy` flag).
+Tracee-eBPF is made of a userspace executable (`tracee-ebpf`) that drives the eBPF program, and the eBPF program itself (`tracee.bpf.$kernelversion.$traceeversion.o`). When Tracee is started, it will look for the eBPF program in specific places and if not found, it will attempt to build the eBPF program automatically before it starts (you can control this using the `--build-policy` flag).
 
 The eBPF program is searched in the following places (in order):
 1. Path specified in `TRACEE_BPF_FILE` environment variable
@@ -48,7 +48,7 @@ The eBPF program is searched in the following places (in order):
 3. `/tmp/tracee`
 
 The easiest way to get started is to just let Tracee build the eBPF program for you automatically, as demonstrated in the previous section [Quickstart with Docker](#quickstart-with-docker).  
-Alternatively, you can pre-compile the eBPF program, and provide it to the `tracee` executable. There are some benefits to this approach as you will not need clang and kernel headers at runtime anymore, as well as reduced risk of invoking an external program at runtime.
+Alternatively, you can pre-compile the eBPF program, and provide it to Tracee. There are some benefits to this approach as you will not need clang and kernel headers at runtime anymore, as well as reduced risk of invoking an external program at runtime.
 
 You can build the eBPF program in the following ways:
 1. `make bpf`
@@ -91,7 +91,7 @@ Normally the files will be installed in `/lib/modules/${kernel_version}/build` w
 
 ## Using Tracee
 
-Use `tracee --help` to see a full description of available options. Some flags has specific help sections that can be accessed by passing `help` to the flag, for example `--output help`.
+Use `tracee-ebpf --help` to see a full description of available options. Some flags has specific help sections that can be accessed by passing `help` to the flag, for example `--output help`.
 This section covers some of the more common options.
 
 ### Understanding the output
@@ -165,4 +165,4 @@ For a complete list of capture options, run `--capture help`.
 
 ## Secure tracing
 
-When Tracee-eBPF reads information from user programs it is subject to a race condition where the user program might be able to change the arguments after Tracee has read them. For example, a program invoked `execve("/bin/ls", NULL, 0)`, Tracee picked that up and will report that, then the program changed the first argument from `/bin/ls` to `/bin/bash`, and this is what the kernel will execute. To mitigate this, Tracee also provide "LSM" (Linux Security Module) based events, for example, the `bprm_check` event which can be reported by tracee and cross-referenced with the reported regular syscall event.
+When Tracee-eBPF reads information from user programs it is subject to a race condition where the user program might be able to change the arguments after Tracee has read them. For example, a program invoked `execve("/bin/ls", NULL, 0)`, Tracee picked that up and will report that, then the program changed the first argument from `/bin/ls` to `/bin/bash`, and this is what the kernel will execute. To mitigate this, Tracee also provide "LSM" (Linux Security Module) based events, for example, the `bprm_check` event which can be reported by Tracee and cross-referenced with the reported regular syscall event.

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -11,15 +11,20 @@ OUT_GOSIGNATURES := $(OUT_RULES)/builtin.so
 REGO_SIGNATURES_DIR ?= signatures/rego
 REGO_SIGNATURES_SRC := $(shell find $(REGO_SIGNATURES_DIR) -type f -name '*.rego' ! -name '*_test.rego')
 
-$(OUT_RULES):
+$(OUT_DIR):
 	mkdir -p $@
 
 .PHONY: build
-build: $(filter-out *_test.go,$(GO_SRC))
+build: $(OUT_BIN)
+
+$(OUT_BIN): $(filter-out *_test.go,$(GO_SRC)) | $(OUT_DIR)
 	go build -o $(OUT_BIN)
 
 .PHONY: rules
-rules: $(GOSIGNATURES_DIR) $(REGO_SIGNATURES_SRC) | $(OUT_RULES)
+rules: $(OUT_RULES)
+
+$(OUT_RULES): $(GOSIGNATURES_DIR) $(REGO_SIGNATURES_SRC) | $(OUT_DIR)
+	mkdir -p $(OUT_RULES)
 	go build -buildmode=plugin -o $(OUT_GOSIGNATURES) $(GOSIGNATURES_SRC)
 	cp $(REGO_SIGNATURES_SRC) $(OUT_RULES)
 	


### PR DESCRIPTION
close: #465 
this doesn't address repackaging the container which will be done in a followup PR. this just "fixes" the release process to reflect the repo restructure

- rename tracee to tracee-ebpf
- adds a root level makefile 
- extracts release from the original tracee makefile (now tracee-ebpf) into root level makefile
- fix a few small issues with the makefile

