### PR TITLE
Refactor flags in tracee-rules

### DIFF
--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -21,7 +21,7 @@ Currently you need to build from source. `cd tracee-rules && make` will build th
 Running with Tracee-eBPF:
 
 ```bash
-sudo tracee-ebpf -o format:gob | tracee-rules --tracee-file /dev/stdin
+sudo tracee-ebpf -o format:gob | tracee-rules --input-tracee file:stdin --input-tracee format:gob
 ```
 
 This will:

--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -21,7 +21,7 @@ Currently you need to build from source. `cd tracee-rules && make` will build th
 Running with Tracee-eBPF:
 
 ```bash
-sudo tracee-ebpf -o format:gob -o option:eot | tracee-rules --tracee-file /dev/stdin
+sudo tracee-ebpf -o format:gob | tracee-rules --tracee-file /dev/stdin
 ```
 
 This will:

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -170,7 +170,7 @@ Examples:
 
 'tracee-rules --input-tracee file:./events.json --input-tracee format:json'
 'tracee-rules --input-tracee file:./events.gob --input-tracee format:gob'
-'sudo tracee-ebpf -o format:gob -o option:eot | tracee-rules --input-tracee file:stdin --input-tracee format:gob'
+'sudo tracee-ebpf -o format:gob | tracee-rules --input-tracee file:stdin --input-tracee format:gob'
 `
 
 	fmt.Println(traceeInputHelp)

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -16,7 +16,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
-var helpErr = errors.New("help me if you can im feeling down")
+var helpErr = errors.New("user has requested help text")
 
 type inputFormat uint8
 
@@ -29,7 +29,6 @@ const (
 type traceeInputOptions struct {
 	inputFile   *os.File
 	inputFormat inputFormat
-	closeOnEOF  bool
 }
 
 func setupInputSource(opts *traceeInputOptions) (chan types.Event, error) {
@@ -121,11 +120,6 @@ func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error)
 			if err != nil {
 				return nil, err
 			}
-		} else if kv[0] == "option" {
-			err = parseTraceeInputOption(&inputSourceOptions, kv[1])
-			if err != nil {
-				return nil, err
-			}
 		} else if kv[0] == "format" {
 			err = parseTraceeInputFormat(&inputSourceOptions, kv[1])
 			if err != nil {
@@ -153,15 +147,6 @@ func parseTraceeInputFile(option *traceeInputOptions, fileOpt string) error {
 		return fmt.Errorf("invalid file: %s", fileOpt)
 	}
 	option.inputFile = f
-	return nil
-}
-
-func parseTraceeInputOption(option *traceeInputOptions, optionString string) error {
-	if strings.ToUpper(optionString) == "EOF" {
-		option.closeOnEOF = true
-	} else {
-		return fmt.Errorf("unkown tracee input option: %s", optionString)
-	}
 	return nil
 }
 

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -4,47 +4,47 @@ import (
 	"bufio"
 	"encoding/gob"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
-func setupStdinSource(inputSource string) (chan types.Event, error) {
-	res := make(chan types.Event)
-	scanner := bufio.NewScanner(os.Stdin)
-	go func() {
-		for scanner.Scan() {
-			event := scanner.Bytes()
-			switch inputSource {
-			case "tracee":
-				var e tracee.Event
-				err := json.Unmarshal(event, &e)
-				if err != nil {
-					log.Printf("invalid json in %s: %v", string(event), err)
-				}
-				res <- types.Event(e)
-			}
-		}
-		close(res)
-	}()
-	return res, nil
+type inputFormat uint8
+
+const (
+	invalidInputFormat inputFormat = iota + 1
+	jsonInputFormat
+	gobInputFormat
+)
+
+type traceeInputOptions struct {
+	inputFile   *os.File
+	inputFormat inputFormat
+	closeOnEOF  bool
 }
 
-func setupTraceeSource(traceeFilePath string) (chan types.Event, error) {
-	_, err := os.Stat(traceeFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("invalid Tracee input file: %s", traceeFilePath)
+func setupInputSource(opts *traceeInputOptions) (chan types.Event, error) {
+
+	if opts.inputFormat == jsonInputFormat {
+		return setupJSONInputSource(opts)
 	}
-	f, err := os.Open(traceeFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("invalid file: %s", traceeFilePath)
+
+	if opts.inputFormat == gobInputFormat {
+		return setupGobInputSource(opts)
 	}
-	dec := gob.NewDecoder(f)
+
+	return nil, errors.New("could not set up input source")
+}
+
+func setupGobInputSource(opts *traceeInputOptions) (chan types.Event, error) {
+	dec := gob.NewDecoder(opts.inputFile)
 	res := make(chan types.Event)
 	go func() {
 		for {
@@ -66,8 +66,126 @@ func setupTraceeSource(traceeFilePath string) (chan types.Event, error) {
 				res <- event
 			}
 		}
-		f.Close()
+		opts.inputFile.Close()
 		close(res)
 	}()
 	return res, nil
+}
+
+func setupJSONInputSource(opts *traceeInputOptions) (chan types.Event, error) {
+	res := make(chan types.Event)
+	scanner := bufio.NewScanner(opts.inputFile)
+	go func() {
+		for scanner.Scan() {
+			event := scanner.Bytes()
+			var e tracee.Event
+			err := json.Unmarshal(event, &e)
+			if err != nil {
+				log.Printf("invalid json in %s: %v", string(event), err)
+			}
+			res <- tracee.Event(e)
+		}
+		opts.inputFile.Close()
+		close(res)
+	}()
+	return res, nil
+}
+
+func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error) {
+
+	var (
+		inputSourceOptions traceeInputOptions
+		err                error
+	)
+
+	for i := range inputOptions {
+		if inputOptions[i] == "help" {
+			printHelp()
+			os.Exit(0)
+		}
+
+		kv := strings.Split(inputOptions[i], ":")
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid input-tracee option: %s", inputOptions[i])
+		}
+		if kv[0] == "file" {
+			err = parseTraceeInputFile(&inputSourceOptions, kv[1])
+			if err != nil {
+				return nil, err
+			}
+		} else if kv[0] == "option" {
+			err = parseTraceeInputOption(&inputSourceOptions, kv[1])
+			if err != nil {
+				return nil, err
+			}
+		} else if kv[0] == "format" {
+			err = parseTraceeInputFormat(&inputSourceOptions, kv[1])
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, fmt.Errorf("invalid input-tracee option key: %s", kv[0])
+		}
+	}
+	return &inputSourceOptions, nil
+}
+
+func parseTraceeInputFile(option *traceeInputOptions, fileOpt string) error {
+
+	if fileOpt == "stdin" {
+		option.inputFile = os.Stdin
+		return nil
+	}
+	_, err := os.Stat(fileOpt)
+	if err != nil {
+		return fmt.Errorf("invalid Tracee input file: %s", fileOpt)
+	}
+	f, err := os.Open(fileOpt)
+	if err != nil {
+		return fmt.Errorf("invalid file: %s", fileOpt)
+	}
+	option.inputFile = f
+	return nil
+}
+
+func parseTraceeInputOption(option *traceeInputOptions, optionString string) error {
+	if strings.ToUpper(optionString) == "EOF" {
+		option.closeOnEOF = true
+	} else {
+		return fmt.Errorf("unkown tracee input option: %s", optionString)
+	}
+	return nil
+}
+
+func parseTraceeInputFormat(option *traceeInputOptions, formatString string) error {
+	formatString = strings.ToUpper(formatString)
+
+	if formatString == "JSON" {
+		option.inputFormat = jsonInputFormat
+	} else if formatString == "GOB" {
+		option.inputFormat = gobInputFormat
+	} else {
+		option.inputFormat = invalidInputFormat
+		return fmt.Errorf("invalid tracee input format specified: %s", formatString)
+	}
+	return nil
+}
+
+func printHelp() {
+	traceeInputHelp := `
+tracee-rules --input-tracee <key:value>,<key:value> --input-tracee <key:value>
+
+Specify various key value pairs for input options tracee-ebpf. The following key options are available:
+
+'file'   - Input file source. You can specify a relative or absolute path. You may also specify 'stdin' for standard input.
+'format' - Input format. Options currently include 'JSON' and 'GOB'. Both can be specified as output formats from tracee-ebpf.
+
+Examples:
+
+'tracee-rules --input-tracee file:./events.json --input-tracee format:json'
+'tracee-rules --input-tracee file:./events.gob --input-tracee format:gob'
+'sudo tracee-ebpf -o format:gob -o option:eot | tracee-rules --input-tracee file:stdin --input-tracee format:gob'
+`
+
+	fmt.Println(traceeInputHelp)
 }

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -30,20 +30,20 @@ type traceeInputOptions struct {
 	inputFormat inputFormat
 }
 
-func setupInputSource(opts *traceeInputOptions) (chan types.Event, error) {
+func setupTraceeInputSource(opts *traceeInputOptions) (chan types.Event, error) {
 
 	if opts.inputFormat == jsonInputFormat {
-		return setupJSONInputSource(opts)
+		return setupTraceeJSONInputSource(opts)
 	}
 
 	if opts.inputFormat == gobInputFormat {
-		return setupGobInputSource(opts)
+		return setupTraceeGobInputSource(opts)
 	}
 
 	return nil, errors.New("could not set up input source")
 }
 
-func setupGobInputSource(opts *traceeInputOptions) (chan types.Event, error) {
+func setupTraceeGobInputSource(opts *traceeInputOptions) (chan types.Event, error) {
 	dec := gob.NewDecoder(opts.inputFile)
 	res := make(chan types.Event)
 	go func() {
@@ -66,7 +66,7 @@ func setupGobInputSource(opts *traceeInputOptions) (chan types.Event, error) {
 	return res, nil
 }
 
-func setupJSONInputSource(opts *traceeInputOptions) (chan types.Event, error) {
+func setupTraceeJSONInputSource(opts *traceeInputOptions) (chan types.Event, error) {
 	res := make(chan types.Event)
 	scanner := bufio.NewScanner(opts.inputFile)
 	go func() {

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -77,7 +77,7 @@ func setupTraceeJSONInputSource(opts *traceeInputOptions) (chan types.Event, err
 			if err != nil {
 				log.Printf("invalid json in %s: %v", string(event), err)
 			}
-			res <- tracee.Event(e)
+			res <- e
 		}
 		opts.inputFile.Close()
 		close(res)

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	tracee "github.com/aquasecurity/tracee/tracee/external"
@@ -53,16 +52,10 @@ func setupGobInputSource(opts *traceeInputOptions) (chan types.Event, error) {
 			err := dec.Decode(&event)
 			if err != nil {
 				if err == io.EOF {
-					// ignore EOF because we assume events can keep streaming into the file
-					// this might create a backlog of events and depending on the implementation of the input source might lead to lost events
-					// TODO: investigate impact of this and research alternatives
-					time.Sleep(time.Millisecond * 150)
-					continue
+					break
 				} else {
 					log.Printf("Error while decoding event: %v", err)
 				}
-			} else if event.EventName[0] == 4 { // Tracee EOT signal
-				break
 			} else {
 				res <- event
 			}

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -16,10 +16,12 @@ import (
 	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
+var helpErr = errors.New("help me if you can im feeling down")
+
 type inputFormat uint8
 
 const (
-	invalidInputFormat inputFormat = iota + 1
+	invalidInputFormat inputFormat = iota
 	jsonInputFormat
 	gobInputFormat
 )
@@ -104,8 +106,7 @@ func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error)
 
 	for i := range inputOptions {
 		if inputOptions[i] == "help" {
-			printHelp()
-			os.Exit(0)
+			return nil, helpErr
 		}
 
 		kv := strings.Split(inputOptions[i], ":")

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -98,6 +98,10 @@ func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error)
 		err                error
 	)
 
+	if len(inputOptions) == 0 {
+		return nil, errors.New("no tracee input options specified")
+	}
+
 	for i := range inputOptions {
 		if inputOptions[i] == "help" {
 			printHelp()
@@ -107,6 +111,9 @@ func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error)
 		kv := strings.Split(inputOptions[i], ":")
 		if len(kv) != 2 {
 			return nil, fmt.Errorf("invalid input-tracee option: %s", inputOptions[i])
+		}
+		if kv[0] == "" || kv[1] == "" {
+			return nil, fmt.Errorf("empty key or value passed: key: >%s< value: >%s<", kv[0], kv[1])
 		}
 		if kv[0] == "file" {
 			err = parseTraceeInputFile(&inputSourceOptions, kv[1])

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -15,7 +15,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
-var helpErr = errors.New("user has requested help text")
+var errHelp = errors.New("user has requested help text")
 
 type inputFormat uint8
 
@@ -98,7 +98,7 @@ func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error)
 
 	for i := range inputOptions {
 		if inputOptions[i] == "help" {
-			return nil, helpErr
+			return nil, errHelp
 		}
 
 		kv := strings.Split(inputOptions[i], ":")

--- a/tracee-rules/input_test.go
+++ b/tracee-rules/input_test.go
@@ -22,19 +22,19 @@ func TestParseTraceeInputOptions(t *testing.T) {
 			expectedError:         errors.New("no tracee input options specified"),
 		},
 		{
-			testName:              "non-existant file specified",
+			testName:              "non-existent file specified",
 			optionStringSlice:     []string{"file:/iabxfdoabs22do2b"},
 			expectedResultOptions: nil,
 			expectedError:         errors.New("invalid Tracee input file: /iabxfdoabs22do2b"),
 		},
 		{
-			testName:              "non-existant file specified",
+			testName:              "non-existent file specified",
 			optionStringSlice:     []string{"file:/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
 			expectedResultOptions: nil,
 			expectedError:         errors.New("invalid Tracee input file: /AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
 		},
 		{
-			testName:              "non-existant file specified",
+			testName:              "non-existent file specified",
 			optionStringSlice:     []string{"file:"},
 			expectedResultOptions: nil,
 			expectedError:         errors.New("empty key or value passed: key: >file< value: ><"),

--- a/tracee-rules/input_test.go
+++ b/tracee-rules/input_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTraceeInputOptions(t *testing.T) {
+
+	testCases := []struct {
+		testName              string
+		optionStringSlice     []string
+		expectedResultOptions *traceeInputOptions
+		expectedError         error
+	}{
+		{
+			testName:              "no options specified",
+			optionStringSlice:     []string{},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("no tracee input options specified"),
+		},
+		{
+			testName:              "non-existant file specified",
+			optionStringSlice:     []string{"file:/iabxfdoabs22do2b"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid Tracee input file: /iabxfdoabs22do2b"),
+		},
+		{
+			testName:              "non-existant file specified",
+			optionStringSlice:     []string{"file:/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid Tracee input file: /AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+		},
+		{
+			testName:              "non-existant file specified",
+			optionStringSlice:     []string{"file:"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("empty key or value passed: key: >file< value: ><"),
+		},
+		{
+			testName:              "invalid file format specified",
+			optionStringSlice:     []string{"format:xml"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid tracee input format specified: XML"),
+		},
+		{
+			testName:              "invalid input option specified",
+			optionStringSlice:     []string{"shmoo:hallo"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid input-tracee option key: shmoo"),
+		},
+		{
+			testName:              "invalid input option specified",
+			optionStringSlice:     []string{":"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("empty key or value passed: key: >< value: ><"),
+		},
+		{
+			testName:              "invalid input option specified",
+			optionStringSlice:     []string{"A"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid input-tracee option: A"),
+		},
+		{
+			testName:              "invalid input option specified",
+			optionStringSlice:     []string{"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid input-tracee option: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+		},
+		{
+			testName:              "invalid input option specified",
+			optionStringSlice:     []string{"3O$B@4420**@!;;;go.fmt@!3h;^!#!@841083n1"},
+			expectedResultOptions: nil,
+			expectedError:         errors.New("invalid input-tracee option: 3O$B@4420**@!;;;go.fmt@!3h;^!#!@841083n1"),
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			opt, err := parseTraceeInputOptions(testcase.optionStringSlice)
+			assert.Equal(t, testcase.expectedError, err)
+			assert.Equal(t, testcase.expectedResultOptions, opt)
+		})
+	}
+}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -77,14 +77,6 @@ func main() {
 				Name:  "input-tracee",
 				Usage: "specify various key:value pairs for input options from tracee-ebpf, use '--input-tracee help' for more info",
 			},
-			&cli.StringFlag{
-				Name:  "tracee-file",
-				Usage: "path to Tracee Gob output file",
-			},
-			&cli.StringFlag{
-				Name:  "stdin-as",
-				Usage: "read events from stdin and treat them as JSON serialized events of the specified input source. this will override an already configured input source",
-			},
 		},
 	}
 	err := app.Run(os.Args)

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -17,8 +16,9 @@ func main() {
 		Name:  "tracee-rules",
 		Usage: "A rule engine for Runtime Security",
 		Action: func(c *cli.Context) error {
-			if c.NArg() == 0 && c.NumFlags() == 0 {
-				return errors.New("tracee-rules requires arguments, please use `tracee-rules --help`")
+			if c.NumFlags() == 0 {
+				cli.ShowAppHelp(c)
+				return nil
 			}
 			sigs, err := getSignatures(c.String("rules-dir"), c.StringSlice("rules"))
 			if err != nil {
@@ -37,6 +37,10 @@ func main() {
 			var inputs engine.EventSources
 			if c.IsSet("input-tracee") {
 				opts, err := parseTraceeInputOptions(c.StringSlice("input-tracee"))
+				if err == helpErr {
+					printHelp()
+					return nil
+				}
 				if err != nil {
 					return err
 				}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -16,6 +17,12 @@ func main() {
 		Name:  "tracee-rules",
 		Usage: "A rule engine for Runtime Security",
 		Action: func(c *cli.Context) error {
+
+			if c.NumFlags() == 0 {
+				cli.ShowAppHelp(c)
+				return errors.New("no flags specified")
+			}
+
 			sigs, err := getSignatures(c.String("rules-dir"), c.StringSlice("rules"))
 			if err != nil {
 				return err
@@ -76,7 +83,6 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:  "input-tracee",
 				Usage: "configure tracee-ebpf as input source. see '--input-tracee help' for more info",
-				Value: cli.NewStringSlice("file:stdin", "format:gob"),
 			},
 		},
 	}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -33,7 +33,7 @@ func main() {
 
 			var inputs engine.EventSources
 			opts, err := parseTraceeInputOptions(c.StringSlice("input-tracee"))
-			if err == helpErr {
+			if err == errHelp {
 				printHelp()
 				return nil
 			}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -16,10 +16,6 @@ func main() {
 		Name:  "tracee-rules",
 		Usage: "A rule engine for Runtime Security",
 		Action: func(c *cli.Context) error {
-			if c.NumFlags() == 0 {
-				cli.ShowAppHelp(c)
-				return nil
-			}
 			sigs, err := getSignatures(c.String("rules-dir"), c.StringSlice("rules"))
 			if err != nil {
 				return err
@@ -34,21 +30,21 @@ func main() {
 				}
 				return nil
 			}
+
 			var inputs engine.EventSources
-			if c.IsSet("input-tracee") {
-				opts, err := parseTraceeInputOptions(c.StringSlice("input-tracee"))
-				if err == helpErr {
-					printHelp()
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-				inputs.Tracee, err = setupInputSource(opts)
-				if err != nil {
-					return err
-				}
+			opts, err := parseTraceeInputOptions(c.StringSlice("input-tracee"))
+			if err == helpErr {
+				printHelp()
+				return nil
 			}
+			if err != nil {
+				return err
+			}
+			inputs.Tracee, err = setupInputSource(opts)
+			if err != nil {
+				return err
+			}
+
 			if inputs == (engine.EventSources{}) {
 				return err
 			}
@@ -79,7 +75,8 @@ func main() {
 			},
 			&cli.StringSliceFlag{
 				Name:  "input-tracee",
-				Usage: "specify various key:value pairs for input options from tracee-ebpf, use '--input-tracee help' for more info",
+				Usage: "configure tracee-ebpf as input source. see '--input-tracee help' for more info",
+				Value: cli.NewStringSlice("file:stdin", "format:gob"),
 			},
 		},
 	}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -40,7 +40,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			inputs.Tracee, err = setupInputSource(opts)
+			inputs.Tracee, err = setupTraceeInputSource(opts)
 			if err != nil {
 				return err
 			}

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -17,6 +17,7 @@ func setupOutput(webhook string) (chan types.Finding, error) {
 	go func() {
 		for res := range out {
 			fmt.Printf("%+v\n", res)
+			//FIXME: Don't do this check everytime there's a finding
 			if webhook != "" {
 				payload, err := prepareJSONPayload(res)
 				if err != nil {

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -17,7 +17,6 @@ func setupOutput(webhook string) (chan types.Finding, error) {
 	go func() {
 		for res := range out {
 			fmt.Printf("%+v\n", res)
-			//FIXME: Don't do this check everytime there's a finding
 			if webhook != "" {
 				payload, err := prepareJSONPayload(res)
 				if err != nil {


### PR DESCRIPTION
This addresses some of the points in #499. In particular:

1) Removes the `--trace-file`, and `--stdin-as` flags.
1) Adds a new flag called `--input-trace` that allows the user to specify the input file and input format for events to tracee-rules.

Still need to address:
1) ~Need to add unit tests for the above parsing logic~
1) What should the default options be?
1) ~https://github.com/aquasecurity/tracee/issues/499#issuecomment-771927000~

Signed-off-by: grantseltzer <grantseltzer@gmail.com>