### PR TITLE
Rename signatures and add spacing to printing of them with --list flag

### DIFF
--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -28,12 +28,13 @@ func main() {
 				return err
 			}
 			if c.Bool("list") {
+				fmt.Printf("%-30s %s\n", "RULE NAME", "DESCRIPTION")
 				for _, sig := range sigs {
 					meta, err := sig.GetMetadata()
 					if err != nil {
 						continue
 					}
-					fmt.Printf("%s: %s\n", meta.Name, meta.Description)
+					fmt.Printf("%-30s %s\n", meta.Name, meta.Description)
 				}
 				return nil
 			}


### PR DESCRIPTION
Small change but this will make output look like this:

<img width="642" alt="Screen Shot 2021-02-09 at 2 55 39 PM" src="https://user-images.githubusercontent.com/10857349/107420568-06435e00-6ae7-11eb-809c-378a30d0ca85.png">
