### PR TITLE
fix: trace-ebpf: Fix typo in clang option

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -96,7 +96,7 @@ $(OUT_DIR)/tracee.bpf.%.o: $(BPF_SRC) $(LIBBPF_HEADERS) | $(OUT_DIR) $(bpf_compi
 		-Wno-deprecated-declarations \
 		-Wno-gnu-variable-sized-type-not-at-end \
 		-Wno-pointer-sign \
-		-Wno-pragma-once-outside-heade \
+		-Wno-pragma-once-outside-header \
 		-Wno-unknown-warning-option \
 		-Wno-unused-value \
 		-Wunused \


### PR DESCRIPTION
Small PR to fix a clang option

Fixes https://github.com/aquasecurity/tracee/issues/504

Signed-off-by: Simarpreet Singh <simar@linux.com>