### PR TITLE
feat: Add OPA tests to Github Actions

### DIFF
--- a/.github/workflows/pr-rules.yaml
+++ b/.github/workflows/pr-rules.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: Build signatures
         run: make rules
       - name: Run Tests
-        run: make test
+        run: make test DOCKER=1

--- a/.github/workflows/pr-rules.yaml
+++ b/.github/workflows/pr-rules.yaml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.15
+      - name: Setup OPA
+        run: make setup-opa
       - name: Lint
         run: |
           if test -z "$(gofmt -l .)"; then
@@ -29,10 +31,5 @@ jobs:
         run: make build
       - name: Build signatures
         run: make rules
-      - name: Run Unit Tests
+      - name: Run Tests
         run: make test
-      - name: Run OPA Tests
-        uses: petroprotsakh/opa-test-action@v2.1
-        with:
-          tests: "tracee-rules/"
-          options: "--verbose --ignore='examples'"

--- a/.github/workflows/pr-rules.yaml
+++ b/.github/workflows/pr-rules.yaml
@@ -16,8 +16,6 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.15
-      - name: Setup OPA
-        run: make setup-opa
       - name: Lint
         run: |
           if test -z "$(gofmt -l .)"; then

--- a/.github/workflows/pr-rules.yaml
+++ b/.github/workflows/pr-rules.yaml
@@ -29,5 +29,10 @@ jobs:
         run: make build
       - name: Build signatures
         run: make rules
-      - name: Test
+      - name: Run Unit Tests
         run: make test
+      - name: Run OPA Tests
+        uses: petroprotsakh/opa-test-action@v2.1
+        with:
+          tests: "tracee-rules/"
+          options: "--verbose --ignore='examples'"

--- a/tracee-ebpf/Dockerfile.builder
+++ b/tracee-ebpf/Dockerfile.builder
@@ -1,5 +1,5 @@
 FROM golang:1.15-buster as builder
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
-    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 curl && \
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 && \
     (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
 WORKDIR /tracee

--- a/tracee-ebpf/Dockerfile.builder
+++ b/tracee-ebpf/Dockerfile.builder
@@ -1,6 +1,5 @@
 FROM golang:1.15-buster as builder
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
     DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 curl && \
-    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done) && \
-    curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 755 /usr/bin/opa
+    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
 WORKDIR /tracee

--- a/tracee-ebpf/Dockerfile.builder
+++ b/tracee-ebpf/Dockerfile.builder
@@ -1,5 +1,6 @@
 FROM golang:1.15-buster as builder
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
-    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 && \
-    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done)
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 curl && \
+    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done) && \
+    curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 755 /usr/bin/opa
 WORKDIR /tracee

--- a/tracee-rules/Dockerfile.builder
+++ b/tracee-rules/Dockerfile.builder
@@ -1,5 +1,5 @@
 FROM golang:1.15-buster as builder
-RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+RUN apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
     DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends curl && \
     curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 755 /usr/bin/opa
 WORKDIR /tracee

--- a/tracee-rules/Dockerfile.builder
+++ b/tracee-rules/Dockerfile.builder
@@ -1,5 +1,4 @@
 FROM golang:1.15-buster as builder
-RUN apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
-    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends curl && \
-    curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 755 /usr/bin/opa
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends curl && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.26.0/opa_linux_amd64 && chmod 755 /usr/bin/opa
 WORKDIR /tracee

--- a/tracee-rules/Dockerfile.builder
+++ b/tracee-rules/Dockerfile.builder
@@ -1,0 +1,6 @@
+FROM golang:1.15-buster as builder
+RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 curl && \
+    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done) && \
+    curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 755 /usr/bin/opa
+WORKDIR /tracee

--- a/tracee-rules/Dockerfile.builder
+++ b/tracee-rules/Dockerfile.builder
@@ -1,6 +1,5 @@
 FROM golang:1.15-buster as builder
 RUN echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-9 main" >> /etc/apt/sources.list && apt-key adv --keyserver hkps://keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421 && \
-    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends libelf-dev llvm-9-dev clang-9 curl && \
-    (for tool in "clang" "llc" "llvm-strip"; do path=$(which $tool-9) && ln -s $path ${path%-*}; done) && \
+    DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends curl && \
     curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 755 /usr/bin/opa
 WORKDIR /tracee

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -13,7 +13,7 @@ GOSIGNATURES_SRC := $(shell find $(GOSIGNATURES_DIR) -type f -name '*.go' ! -nam
 OUT_GOSIGNATURES := $(OUT_RULES)/builtin.so
 REGO_SIGNATURES_DIR ?= signatures/rego
 REGO_SIGNATURES_SRC := $(shell find $(REGO_SIGNATURES_DIR) -type f -name '*.rego' ! -name '*_test.rego' ! -path '$(REGO_SIGNATURES_DIR)/examples/*')
-DOCKER_BUILDER ?= tracee-rules
+DOCKER_BUILDER ?= tracee-rules-builder
 
 $(OUT_DIR):
 	mkdir -p $@
@@ -51,6 +51,7 @@ endif
 
 .PHONY: clean mostlyclean
 clean mostlyclean:
+	-$(CMD_DOCKER) rmi $(file < $(docker_builder_file))
 	-rm -rf $(OUT_DIR)
 
 # docker_builder_make runs a make command in the tracee-builder container

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -61,7 +61,6 @@ define docker_builder_make
 	--entrypoint make $(DOCKER_BUILDER) $(1)
 endef
 
-# record built image id to prevent unnecessary building and for cleanup
 docker_builder_file := $(OUT_DIR)/$(DOCKER_BUILDER)
 .PHONY: $(DOCKER_BUILDER)
 $(DOCKER_BUILDER) $(docker_builder_file) &: Dockerfile.builder | $(OUT_DIR) check_$(CMD_DOCKER)

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -1,6 +1,8 @@
 .PHONY: all
 all: build rules
 
+CMD_GO ?= go
+CMD_OPA ?= opa
 OUT_DIR ?= dist
 OUT_BIN := $(OUT_DIR)/tracee-rules
 OUT_RULES := $(OUT_DIR)/rules
@@ -28,16 +30,17 @@ $(OUT_RULES): $(GOSIGNATURES_DIR) $(REGO_SIGNATURES_SRC) | $(OUT_DIR)
 	go build -buildmode=plugin -o $(OUT_GOSIGNATURES) $(GOSIGNATURES_SRC)
 	cp $(REGO_SIGNATURES_SRC) $(OUT_RULES)
 
-.PHONY: setup-opa
-setup-opa:
-	curl -L -o ~/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
-	chmod 755 ~/opa
-	~/opa version
+check_%:
+	@command -v $* >/dev/null || (echo "missing required tool $*" ; false)
+
+tools = $(CMD_OPA) $(CMD_GO)
+.PHONY: $(tools)
+$(tools): % : check_%
 
 .PHONY: test
-test: $(GO_SRC)
+test: $(GO_SRC) $(tools)
 	go test -v ./...
-	~/opa test . --verbose --ignore="examples" --ignore="dist"
+	opa test . --verbose --ignore="examples" --ignore="dist"
 
 .PHONY: clean mostlyclean
 clean mostlyclean:

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -27,10 +27,17 @@ $(OUT_RULES): $(GOSIGNATURES_DIR) $(REGO_SIGNATURES_SRC) | $(OUT_DIR)
 	mkdir -p $(OUT_RULES)
 	go build -buildmode=plugin -o $(OUT_GOSIGNATURES) $(GOSIGNATURES_SRC)
 	cp $(REGO_SIGNATURES_SRC) $(OUT_RULES)
-	
+
+.PHONY: setup-opa
+setup-opa:
+	curl -L -o ~/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+	chmod 755 ~/opa
+	~/opa version
+
 .PHONY: test
 test: $(GO_SRC)
 	go test -v ./...
+	~/opa test . --verbose --ignore="examples" --ignore="dist"
 
 .PHONY: clean mostlyclean
 clean mostlyclean:

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all
 all: build rules
 
+CMD_DOCKER ?= docker
 CMD_GO ?= go
 CMD_OPA ?= opa
 OUT_DIR ?= dist
@@ -12,6 +13,7 @@ GOSIGNATURES_SRC := $(shell find $(GOSIGNATURES_DIR) -type f -name '*.go' ! -nam
 OUT_GOSIGNATURES := $(OUT_RULES)/builtin.so
 REGO_SIGNATURES_DIR ?= signatures/rego
 REGO_SIGNATURES_SRC := $(shell find $(REGO_SIGNATURES_DIR) -type f -name '*.rego' ! -name '*_test.rego' ! -path '$(REGO_SIGNATURES_DIR)/examples/*')
+DOCKER_BUILDER ?= tracee-rules
 
 $(OUT_DIR):
 	mkdir -p $@
@@ -38,10 +40,29 @@ tools = $(CMD_OPA) $(CMD_GO)
 $(tools): % : check_%
 
 .PHONY: test
+ifndef DOCKER
 test: $(GO_SRC) $(tools)
 	go test -v ./...
 	opa test . --verbose --ignore="examples" --ignore="dist"
+else
+test: $(DOCKER_BUILDER)
+	$(call docker_builder_make,$@)
+endif
 
 .PHONY: clean mostlyclean
 clean mostlyclean:
 	-rm -rf $(OUT_DIR)
+
+# docker_builder_make runs a make command in the tracee-builder container
+define docker_builder_make
+	$(CMD_DOCKER) run --rm \
+	-v $(abspath .):/tracee/tracee-rules \
+	-w /tracee/tracee-rules \
+	--entrypoint make $(DOCKER_BUILDER) $(1)
+endef
+
+# record built image id to prevent unnecessary building and for cleanup
+docker_builder_file := $(OUT_DIR)/$(DOCKER_BUILDER)
+.PHONY: $(DOCKER_BUILDER)
+$(DOCKER_BUILDER) $(docker_builder_file) &: Dockerfile.builder | $(OUT_DIR) check_$(CMD_DOCKER)
+	$(CMD_DOCKER) build -t $(DOCKER_BUILDER) --iidfile $(docker_builder_file) - < $<


### PR DESCRIPTION
There aren't docs around to use this action but looking at the yaml, I was able to understand it. https://github.com/petroprotsakh/opa-test-action/blob/master/action.yml

Saves us the hassle from building our own setup each time (clone OPA binary, etc.)

In theory it should run this (from the tracee-rules dir):
```
$ opa test . --verbose --ignore="examples"
data.main.test_match_1: PASS (3.399054ms)
data.main.test_match_wrong_request: PASS (114.405µs)
--------------------------------------------------------------------------------
PASS: 2/2
```

Fixes https://github.com/aquasecurity/tracee/issues/491

Requires: https://github.com/aquasecurity/tracee/pull/567

Signed-off-by: Simarpreet Singh <simar@linux.com>