### PR TITLE
Add IDs to Signature Metadata

### DIFF
--- a/tracee-rules/signatures/golang/code_injection.go
+++ b/tracee-rules/signatures/golang/code_injection.go
@@ -27,6 +27,7 @@ func (sig *codeInjection) Init(cb types.SignatureHandler) error {
 
 func (sig *codeInjection) GetMetadata() (types.SignatureMetadata, error) {
 	return types.SignatureMetadata{
+		ID:          "TRC-1",
 		Name:        "Code injection",
 		Description: "Possible process injection detected during runtime",
 		Tags:        []string{"linux", "container"},

--- a/tracee-rules/signatures/golang/code_injection_test.go
+++ b/tracee-rules/signatures/golang/code_injection_test.go
@@ -3,12 +3,15 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
-func TestCodeInjection(t *testing.T) {
+func TestCodeInjection_OnEvent(t *testing.T) {
 	SigTests := []signaturestest.SigTest{
 		{
 			Events: []types.Event{
@@ -182,4 +185,20 @@ func TestCodeInjection(t *testing.T) {
 			t.Error("unexpected result", st)
 		}
 	}
+}
+
+func TestCodeInjection_GetMetadata(t *testing.T) {
+	sig := codeInjection{}
+	got, err := sig.GetMetadata()
+	require.NoError(t, err)
+	assert.Equal(t, types.SignatureMetadata{
+		ID:          "TRC-1",
+		Name:        "Code injection",
+		Description: "Possible process injection detected during runtime",
+		Tags:        []string{"linux", "container"},
+		Properties: map[string]interface{}{
+			"Severity":     3,
+			"MITRE ATT&CK": "Defense Evasion: Process Injection",
+		},
+	}, got)
 }

--- a/tracee-rules/signatures/golang/examples/example.go
+++ b/tracee-rules/signatures/golang/examples/example.go
@@ -26,6 +26,7 @@ func (sig *counter) Init(cb types.SignatureHandler) error {
 // GetMetadata implements the Signature interface by declaring information about the signature
 func (sig *counter) GetMetadata() (types.SignatureMetadata, error) {
 	return types.SignatureMetadata{
+		ID:   "TRC-12345",
 		Name: "count to " + strconv.Itoa(sig.target),
 	}, nil
 }

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+    "id": "TRC-1",
     "name": "detect self debugging using PTRACE_ME",
     "description": "Process uses anti-debugging technique to block debugger",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/examples/example1.rego
+++ b/tracee-rules/signatures/rego/examples/example1.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+    "id": "TRC-12345",
 	"name": "example1"
 }
 

--- a/tracee-rules/signatures/rego/examples/example2.rego
+++ b/tracee-rules/signatures/rego/examples/example2.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+    "id": "TRC-12345",
 	"name": "example2"
 }
 

--- a/tracee-rules/signatures/rego/regosig/traceerego_test.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego_test.go
@@ -5,6 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	tracee "github.com/aquasecurity/tracee/tracee/external"
@@ -15,6 +18,7 @@ func TestGetMetadata(t *testing.T) {
 package main
 
 __rego_metadoc__ := {
+	"id": "TRC-12345",
 	"name": "test name",
 	"description": "test description",
 	"tags": [ "tag1", "tag2" ],
@@ -26,10 +30,10 @@ __rego_metadoc__ := {
 }
 `
 	sig, err := NewRegoSignature(testRegoMeta)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+
 	expect := types.SignatureMetadata{
+		ID:          "TRC-12345",
 		Name:        "test name",
 		Description: "test description",
 		Tags:        []string{"tag1", "tag2"},
@@ -40,9 +44,8 @@ __rego_metadoc__ := {
 		},
 	}
 	meta, err := sig.GetMetadata()
-	if !reflect.DeepEqual(meta, expect) || err != nil {
-		t.Error(meta, expect, err)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, expect, meta)
 }
 
 func TestGetSelectedEvents(t *testing.T) {

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -17,6 +17,7 @@ type Signature interface {
 
 //SignatureMetadata represents information about the signature
 type SignatureMetadata struct {
+	ID          string
 	Name        string
 	Description string
 	Tags        []string


### PR DESCRIPTION
This PR introduces Signature IDs as part of their Metadata as discussed in https://github.com/aquasecurity/tracee/issues/515


Signed-off-by: Simarpreet Singh <simar@linux.com>

