### PR TITLE
update import paths after restructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,19 +61,13 @@ define release_docker_image
 	$(CMD_DOCKER) tag $(1) $(2) && $(CMD_DOCKER) push $(2) && echo '- `docker pull docker.io/$(2)`' >> $(release_notes);
 endef
 
-.PHONY: release
-# before running this rule ensure that git, gh, and docker are authorized to perform remote operations
-release:
-	test -n '$(RELEASE_TAG)' || (echo "missing required variable RELEASE_TAG" ; false)
-	$(CMD_GIT) tag $(RELEASE_TAG)
-	$(CMD_GIT) push origin $(RELEASE_TAG)
-	$(MAKE) release2
-
 release_notes := $(OUT_DIR)/release-notes.txt
 release_images_fat := $(PUSH_DOCKER_REPO):latest $(PUSH_DOCKER_REPO):$(PUSH_DOCKER_TAG)
 release_images_slim := $(PUSH_DOCKER_REPO):slim $(PUSH_DOCKER_REPO):slim-$(PUSH_DOCKER_TAG)
-.PHONY: release2
-release2: $(OUT_ARCHIVE) $(OUT_CHECKSUMS) docker docker-slim
+.PHONY: release
+# before running this rule, need to authenticate git, gh, and docker tools
+release: $(OUT_ARCHIVE) $(OUT_CHECKSUMS) | docker docker-slim $(check_release_tools)
+	test -n '$(RELEASE_TAG)' || (echo "missing required variable RELEASE_TAG" ; false)
 	-rm $(release_notes)
 	echo '## Changelog' > $(release_notes)
 	$(CMD_GIT) log --pretty=oneline --abbrev=commit --no-decorate --no-color tags/$(shell $(CMD_GIT) describe --tags --abbrev=0)..HEAD >> $(release_notes)
@@ -82,6 +76,8 @@ release2: $(OUT_ARCHIVE) $(OUT_CHECKSUMS) docker docker-slim
 	$(foreach img,$(release_images_fat),$(call release_docker_image,$(OUT_DOCKER):latest,$(img)))
 	$(foreach img,$(release_images_slim),$(call release_docker_image,$(OUT_DOCKER):slim,$(img)))
 	echo '' >>$(release_notes)
+	$(CMD_GIT) tag $(RELEASE_TAG)
+	$(CMD_GIT) push origin $(RELEASE_TAG)
 	$(CMD_GITHUB) release create $(RELEASE_TAG) $(OUT_ARCHIVE) $(OUT_CHECKSUMS) --title $(RELEASE_TAG) --notes-file $(release_notes)
 
 .PHONY: mostlyclean

--- a/tracee-ebpf/go.mod
+++ b/tracee-ebpf/go.mod
@@ -1,4 +1,4 @@
-module github.com/aquasecurity/tracee
+module github.com/aquasecurity/tracee/tracee-ebpf
 
 go 1.15
 

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aquasecurity/tracee/tracee"
+	"github.com/aquasecurity/tracee/tracee-ebpf/tracee"
 	"github.com/syndtr/gocapability/capability"
 	"github.com/urfave/cli/v2"
 )

--- a/tracee-ebpf/main_test.go
+++ b/tracee-ebpf/main_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/aquasecurity/tracee/tracee"
+	"github.com/aquasecurity/tracee/tracee-ebpf/tracee"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tracee-ebpf/test/gob/go.mod
+++ b/tracee-ebpf/test/gob/go.mod
@@ -1,3 +1,3 @@
-module github.com/aquasecurity/tracee/test/gob
+module github.com/aquasecurity/tracee/tracee-ebpf/test/gob
 
 go 1.15

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -3,7 +3,7 @@ package tracee
 import (
 	"math"
 
-	"github.com/aquasecurity/tracee/tracee/external"
+	"github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 )
 
 // bpfConfig is an enum that include various configurations that can be passed to bpf code

--- a/tracee-ebpf/tracee/pipeline.go
+++ b/tracee-ebpf/tracee/pipeline.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/aquasecurity/tracee/tracee/external"
+	"github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 )
 
 func (t *Tracee) runEventPipeline(done <-chan struct{}) error {

--- a/tracee-ebpf/tracee/printer.go
+++ b/tracee-ebpf/tracee/printer.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/aquasecurity/tracee/tracee/external"
+	"github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 )
 
 type eventPrinter interface {

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -16,7 +16,7 @@ import (
 	"syscall"
 
 	bpf "github.com/aquasecurity/tracee/libbpfgo"
-	"github.com/aquasecurity/tracee/tracee/external"
+	"github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 )
 
 // Config is a struct containing user defined configuration of tracee

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -4,8 +4,8 @@ import (
 	"io"
 	"log"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
 // Engine is a rule-engine that can process events coming from a set of input sources against a set of loaded signatures, and report the signatures' findings

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tracee-rules/go.mod
+++ b/tracee-rules/go.mod
@@ -3,8 +3,11 @@ module github.com/aquasecurity/tracee/tracee-rules
 go 1.15
 
 require (
-	github.com/aquasecurity/tracee v0.4.0
+	github.com/aquasecurity/tracee/tracee-ebpf v0.4.0
 	github.com/open-policy-agent/opa v0.25.2
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli/v2 v2.3.0
 )
+
+//TODO: remove this before release
+replace github.com/aquasecurity/tracee/tracee-ebpf => github.com/aquasecurity/tracee v0.4.0

--- a/tracee-rules/input.go
+++ b/tracee-rules/input.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"strings"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
 var errHelp = errors.New("user has requested help text")

--- a/tracee-rules/input_test.go
+++ b/tracee-rules/input_test.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	tracee "github.com/aquasecurity/tracee/tracee/external"
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
 func setupOutput(webhook string) (chan types.Finding, error) {

--- a/tracee-rules/signatures/golang/examples/example.go
+++ b/tracee-rules/signatures/golang/examples/example.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
 // counter is a simple demo signature that counts towards a target

--- a/tracee-rules/signatures/golang/helpers.go
+++ b/tracee-rules/signatures/golang/helpers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	tracee "github.com/aquasecurity/tracee/tracee/external"
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 )
 
 type connectAddrData struct {

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
 type stdioOverSocket struct {

--- a/tracee-rules/signatures/golang/stdio_over_socket_test.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	tracee "github.com/aquasecurity/tracee/tracee/external"
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"testing"
 
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"

--- a/tracee-rules/signatures/rego/regosig/traceerego.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 )

--- a/tracee-rules/signatures/rego/regosig/traceerego_test.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego_test.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
-	tracee "github.com/aquasecurity/tracee/tracee/external"
 )
 
 func TestGetMetadata(t *testing.T) {


### PR DESCRIPTION
closes: https://github.com/aquasecurity/tracee/issues/497
The restucture changed the paths in main but didn't
effect the Go import paths which looks for a given tag. This commit
updated the import paths in preparation for the release (which will
create the tag)