### PR TITLE
tracee-ebpf: update minimal kernel version to 4.18

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ Tracee is composed of the following sub-projects:
 
 ### Prerequisites
 
-- Linux kernel version >= 4.14
+- Linux kernel version >= 4.18
 - Relevant kernel headers available under conventional location (see [Linux Headers](#Linux-Headers) section for info)
 - libc, and the libraries: libelf and zlib
 - clang >= 9

--- a/tracee-ebpf/Readme.md
+++ b/tracee-ebpf/Readme.md
@@ -10,7 +10,7 @@ Tracee-eBPF is a lightweight and easy to use tracing tool for Linux, which is fo
 
 ### Prerequisites
 
-- Linux kernel version >= 4.14
+- Linux kernel version >= 4.18
 - Relevant kernel headers available under conventional location (see [Linux Headers](#Linux-Headers) section for info)
 - libc, and the libraries: libelf and zlib
 - clang >= 9


### PR DESCRIPTION
As described in #452 , there are many things that were changed between kernel version 4.14 to 4.18, and keeping support for kernels <4.18 will force us to keep too many compilation flags and kernel version checks.
These changes include the following:

1. bpf_get_current_cgroup_id() helper function that was added in 4.18 will allow us to better distinguish between different containers (we currently use pid namespace for that, which is far from ideal)
2. raw tracepoints vs "regular" tracepoint - today we support both, but there is no good reason to use the "regular" tracepoints.
3. attach_Xprobe() vs attach_legacyXprobe() - X={u,k}
4. syscall arguments passing was changed in 4.17, and now it is save in pt_regs struct indirectly. We already support both in the code, but it makes the code less readable.
5. btf support was added in kernel 4.18 (although requires CONFIG_BTF to be enabled)

Hopefully, this will be the only time that we will need to update the kernel version.

Close #452 
