### PR TITLE
Fix stdio over socket

### DIFF
--- a/tracee-rules/signatures/golang/export.go
+++ b/tracee-rules/signatures/golang/export.go
@@ -5,5 +5,5 @@ import "github.com/aquasecurity/tracee/tracee-rules/types"
 // ExportedSignatures fulfills the goplugins contract required by the rule-engine
 // this is a list of signatures that this plugin exports
 var ExportedSignatures []types.Signature = []types.Signature{
-	&codeInjection{},
+	&stdioOverSocket{},
 }

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -61,7 +61,7 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return err
 		}
 
-		sockfd := sockfdArg.Value.(int)
+		sockfd := int(sockfdArg.Value.(int32))
 
 		addrArg, err := GetTraceeArgumentByName(eventObj, "addr")
 		if err != nil {
@@ -105,7 +105,7 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return err
 		}
 
-		srcFd := oldFdArg.Value.(int)
+		srcFd := int(oldFdArg.Value.(int32))
 
 		dstFd := eventObj.ReturnValue
 
@@ -127,14 +127,14 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return err
 		}
 
-		srcFd := oldFdArg.Value.(int)
+		srcFd := int(oldFdArg.Value.(int32))
 
 		newFdArg, err := GetTraceeArgumentByName(eventObj, "newfd")
 		if err != nil {
 			return err
 		}
 
-		dstFd := newFdArg.Value.(int)
+		dstFd := int(newFdArg.Value.(int32))
 
 		err = isStdioOverSocket(sig, eventObj, pidSocketMap, srcFd, dstFd)
 		if err != nil {
@@ -148,7 +148,7 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return err
 		}
 
-		currentFd := currentFdArg.Value.(int)
+		currentFd := int(currentFdArg.Value.(int32))
 
 		delete(sig.processSocketIp[pid], currentFd)
 

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -73,20 +73,24 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return err
 		}
 
-		ip := ""
-
 		if connectData.SaFamily == "AF_INET" {
-			ip = connectData.SinAddr
+
+			_, pidExists := sig.processSocketIp[pid]
+			if !pidExists {
+				sig.processSocketIp[pid] = make(map[int]string)
+			}
+
+			sig.processSocketIp[pid][sockfd] = connectData.SinAddr
+
 		} else if connectData.SaFamily == "AF_INET6" {
-			ip = connectData.SinAddr6
-		}
 
-		_, pidExists := sig.processSocketIp[pid]
-		if !pidExists {
-			sig.processSocketIp[pid] = make(map[int]string)
-		}
+			_, pidExists := sig.processSocketIp[pid]
+			if !pidExists {
+				sig.processSocketIp[pid] = make(map[int]string)
+			}
 
-		sig.processSocketIp[pid][sockfd] = ip
+			sig.processSocketIp[pid][sockfd] = connectData.SinAddr6
+		}
 
 	case "dup":
 

--- a/tracee-rules/signatures/golang/stdio_over_socket_test.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket_test.go
@@ -20,7 +20,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "sockfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -38,13 +38,13 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
 								Name: "newfd",
 							},
-							Value: 0,
+							Value: int32(0),
 						},
 					},
 				},
@@ -61,7 +61,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "sockfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -80,7 +80,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 					},
 				},
@@ -97,7 +97,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "sockfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -115,13 +115,13 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
 								Name: "newfd",
 							},
-							Value: 0,
+							Value: int32(0),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -144,13 +144,13 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
 								Name: "newfd",
 							},
-							Value: 0,
+							Value: int32(0),
 						},
 					},
 				},
@@ -167,7 +167,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "sockfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -185,7 +185,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "fd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 					},
 				},
@@ -197,13 +197,13 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
 								Name: "newfd",
 							},
-							Value: 0,
+							Value: int32(0),
 						},
 					},
 				},
@@ -220,7 +220,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "sockfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -238,13 +238,13 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
 								Name: "newfd",
 							},
-							Value: 0,
+							Value: int32(0),
 						},
 					},
 				},
@@ -261,7 +261,7 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "sockfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -279,13 +279,13 @@ func TestStdioOverSocket(t *testing.T) {
 							ArgMeta: tracee.ArgMeta{
 								Name: "oldfd",
 							},
-							Value: 5,
+							Value: int32(5),
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
 								Name: "newfd",
 							},
-							Value: 0,
+							Value: int32(0),
 						},
 					},
 				},


### PR DESCRIPTION
export the signature so it will be loaded by tracee-rules.

fix FD assignment to int32 rather than int, because it causes panic.