### PR TITLE
feat: Add IDs to Signature Metadata.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ Name | Description | Tags
 Standard Input/Output Over Socket | Redirection of process's standard input/output to socket | "linux", "container"
 Anti-Debugging | Process uses anti-debugging technique to block debugger | "linux", "container"
 Code injection | Possible code injection into another process | "linux", "container"
-Dynamic Code Loading | writing to executable allocated memory region | "linux", "container"
+Dynamic Code Loading | Writing to executable allocated memory region | "linux", "container"
 Fileless Execution | Executing a precess from memory, without a file in the disk | "linux", "container"
 kernel module loading | Attempt to load a kernel module detection | "linux", "container"
 LD_PRELOAD | Usage of LD_PRELOAD to allow hooks on process | "linux", "container"

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -28,13 +28,13 @@ func main() {
 				return err
 			}
 			if c.Bool("list") {
-				fmt.Printf("%-10s %s\n", "RULE ID", "DESCRIPTION")
+				fmt.Printf("%-10s %-35s %s\n", "ID", "NAME", "DESCRIPTION")
 				for _, sig := range sigs {
 					meta, err := sig.GetMetadata()
 					if err != nil {
 						continue
 					}
-					fmt.Printf("%-10s %s\n", meta.ID, meta.Description)
+					fmt.Printf("%-10s %-35s %s\n", meta.ID, meta.Name, meta.Description)
 				}
 				return nil
 			}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -28,13 +28,13 @@ func main() {
 				return err
 			}
 			if c.Bool("list") {
-				fmt.Printf("%-30s %s\n", "RULE NAME", "DESCRIPTION")
+				fmt.Printf("%-10s %s\n", "RULE ID", "DESCRIPTION")
 				for _, sig := range sigs {
 					meta, err := sig.GetMetadata()
 					if err != nil {
 						continue
 					}
-					fmt.Printf("%-30s %s\n", meta.Name, meta.Description)
+					fmt.Printf("%-10s %s\n", meta.ID, meta.Description)
 				}
 				return nil
 			}

--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -35,7 +35,7 @@ func getSignatures(rulesDir string, rules []string) ([]types.Signature, error) {
 	} else {
 		for _, s := range sigs {
 			for _, r := range rules {
-				if m, err := s.GetMetadata(); err == nil && m.Name == r {
+				if m, err := s.GetMetadata(); err == nil && m.ID == r {
 					res = append(res, s)
 				}
 			}

--- a/tracee-rules/signature_test.go
+++ b/tracee-rules/signature_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aquasecurity/tracee/tracee-rules/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getSignatures(t *testing.T) {
+	sigs, err := getSignatures("signatures/rego", []string{"TRC-2"})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sigs))
+
+	gotMetadata, err := sigs[0].GetMetadata()
+	assert.Equal(t, types.SignatureMetadata{
+		ID:          "TRC-2",
+		Name:        "Anti-Debugging",
+		Description: "Process uses anti-debugging technique to block debugger",
+		Tags:        []string{"linux", "container"},
+		Properties: map[string]interface{}{
+			"MITRE ATT&CK": "Defense Evasion: Execution Guardrails",
+			"Severity":     json.Number("3"),
+		},
+	}, gotMetadata)
+}

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 )
@@ -20,6 +21,7 @@ func (sig *stdioOverSocket) Init(cb types.SignatureHandler) error {
 
 func (sig *stdioOverSocket) GetMetadata() (types.SignatureMetadata, error) {
 	return types.SignatureMetadata{
+		ID:          "TRC-1",
 		Name:        "Standard Input/Output Over Socket",
 		Description: "Redirection of process's standard input/output to socket",
 		Tags:        []string{"linux", "container"},

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+    "id": "TRC-2",
     "name": "Anti-Debugging",
     "description": "Process uses anti-debugging technique to block debugger",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
@@ -1,4 +1,4 @@
-package main
+package anti_debugging_ptraceme
 
 __rego_metadoc__ := {
     "id": "TRC-2",

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
@@ -1,4 +1,4 @@
-package anti_debugging_ptraceme
+package tracee.TRC_2
 
 __rego_metadoc__ := {
     "id": "TRC-2",

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme_test.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme_test.rego
@@ -1,4 +1,4 @@
-package main
+package anti_debugging_ptraceme
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme_test.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme_test.rego
@@ -1,4 +1,4 @@
-package tracee.TRC_3
+package tracee.TRC_2
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme_test.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme_test.rego
@@ -1,4 +1,4 @@
-package anti_debugging_ptraceme
+package tracee.TRC_3
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/code_injection.rego
+++ b/tracee-rules/signatures/rego/code_injection.rego
@@ -1,4 +1,4 @@
-package code_injection
+package tracee.TRC_3
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/code_injection.rego
+++ b/tracee-rules/signatures/rego/code_injection.rego
@@ -1,4 +1,4 @@
-package main
+package code_injection
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/code_injection.rego
+++ b/tracee-rules/signatures/rego/code_injection.rego
@@ -3,6 +3,7 @@ package main
 import data.tracee.helpers
 
 __rego_metadoc__ := {
+    "id": "TRC-3",
     "name": "Code injection",
     "description": "Possible code injection into another process",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/code_injection_test.rego
+++ b/tracee-rules/signatures/rego/code_injection_test.rego
@@ -1,4 +1,4 @@
-package main
+package code_injection
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/code_injection_test.rego
+++ b/tracee-rules/signatures/rego/code_injection_test.rego
@@ -1,4 +1,4 @@
-package code_injection
+package tracee.TRC_3
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/dynamic_code_loading.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading.rego
@@ -3,6 +3,7 @@ package main
 import data.tracee.helpers
 
 __rego_metadoc__ := {
+    "id": "TRC-4",
     "name": "Dynamic Code Loading",
     "description": "writing to executable allocated memory region",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/dynamic_code_loading.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading.rego
@@ -1,4 +1,4 @@
-package main
+package dynamic_code_loading
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/dynamic_code_loading.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading.rego
@@ -1,4 +1,4 @@
-package dynamic_code_loading
+package tracee.TRC_4
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/dynamic_code_loading.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading.rego
@@ -5,7 +5,7 @@ import data.tracee.helpers
 __rego_metadoc__ := {
     "id": "TRC-4",
     "name": "Dynamic Code Loading",
-    "description": "writing to executable allocated memory region",
+    "description": "Writing to executable allocated memory region",
     "tags": ["linux", "container"],
     "properties": {
         "Severity": 2,

--- a/tracee-rules/signatures/rego/dynamic_code_loading_test.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading_test.rego
@@ -1,4 +1,4 @@
-package dynamic_code_loading
+package tracee.TRC_4
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/dynamic_code_loading_test.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading_test.rego
@@ -1,4 +1,4 @@
-package main
+package dynamic_code_loading
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/examples/example1.rego
+++ b/tracee-rules/signatures/rego/examples/example1.rego
@@ -1,4 +1,4 @@
-package main
+package example1
 
 __rego_metadoc__ := {
 	"id": "FOO-1",

--- a/tracee-rules/signatures/rego/examples/example1.rego
+++ b/tracee-rules/signatures/rego/examples/example1.rego
@@ -1,4 +1,4 @@
-package example1
+package FOO_1
 
 __rego_metadoc__ := {
 	"id": "FOO-1",

--- a/tracee-rules/signatures/rego/examples/example1.rego
+++ b/tracee-rules/signatures/rego/examples/example1.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+	"id": "FOO-1",
 	"name": "example1"
 }
 

--- a/tracee-rules/signatures/rego/examples/example1_test.rego
+++ b/tracee-rules/signatures/rego/examples/example1_test.rego
@@ -1,4 +1,4 @@
-package example1
+package FOO_1
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/examples/example1_test.rego
+++ b/tracee-rules/signatures/rego/examples/example1_test.rego
@@ -1,4 +1,4 @@
-package main
+package example1
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/examples/example2.rego
+++ b/tracee-rules/signatures/rego/examples/example2.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+	"id": "FOO-2",
 	"name": "example2"
 }
 

--- a/tracee-rules/signatures/rego/examples/example2.rego
+++ b/tracee-rules/signatures/rego/examples/example2.rego
@@ -1,4 +1,4 @@
-package main
+package example2
 
 __rego_metadoc__ := {
 	"id": "FOO-2",

--- a/tracee-rules/signatures/rego/examples/example2.rego
+++ b/tracee-rules/signatures/rego/examples/example2.rego
@@ -1,4 +1,4 @@
-package example2
+package FOO_2
 
 __rego_metadoc__ := {
 	"id": "FOO-2",

--- a/tracee-rules/signatures/rego/examples/example2_test.rego
+++ b/tracee-rules/signatures/rego/examples/example2_test.rego
@@ -1,4 +1,4 @@
-package main
+package example2
 
 test_match_1 {
     tracee_match == { "Severity": 1 } with input as {

--- a/tracee-rules/signatures/rego/examples/example2_test.rego
+++ b/tracee-rules/signatures/rego/examples/example2_test.rego
@@ -1,4 +1,4 @@
-package example2
+package FOO_2
 
 test_match_1 {
     tracee_match == { "Severity": 1 } with input as {

--- a/tracee-rules/signatures/rego/fileless_execution.rego
+++ b/tracee-rules/signatures/rego/fileless_execution.rego
@@ -1,4 +1,4 @@
-package fileless_execution
+package tracee.TRC_5
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/fileless_execution.rego
+++ b/tracee-rules/signatures/rego/fileless_execution.rego
@@ -1,4 +1,4 @@
-package main
+package fileless_execution
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/fileless_execution.rego
+++ b/tracee-rules/signatures/rego/fileless_execution.rego
@@ -3,6 +3,7 @@ package main
 import data.tracee.helpers
 
 __rego_metadoc__ := {
+    "id": "TRC-5",
     "name": "Fileless Execution",
     "description": "Executing a precess from memory, without a file in the disk",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/fileless_execution_test.rego
+++ b/tracee-rules/signatures/rego/fileless_execution_test.rego
@@ -1,4 +1,4 @@
-package fileless_execution
+package tracee.TRC_5
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/fileless_execution_test.rego
+++ b/tracee-rules/signatures/rego/fileless_execution_test.rego
@@ -1,4 +1,4 @@
-package main
+package fileless_execution
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/kernel_module_loading.rego
+++ b/tracee-rules/signatures/rego/kernel_module_loading.rego
@@ -1,4 +1,4 @@
-package main
+package kernel_module_loading
 
 __rego_metadoc__ := {
     "id": "TRC-6",

--- a/tracee-rules/signatures/rego/kernel_module_loading.rego
+++ b/tracee-rules/signatures/rego/kernel_module_loading.rego
@@ -1,4 +1,4 @@
-package kernel_module_loading
+package tracee.TRC_6
 
 __rego_metadoc__ := {
     "id": "TRC-6",

--- a/tracee-rules/signatures/rego/kernel_module_loading.rego
+++ b/tracee-rules/signatures/rego/kernel_module_loading.rego
@@ -1,6 +1,7 @@
 package main
 
 __rego_metadoc__ := {
+    "id": "TRC-6",
     "name": "kernel module loading",
     "description": "Attempt to load a kernel module detection",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/kernel_module_loading_test.rego
+++ b/tracee-rules/signatures/rego/kernel_module_loading_test.rego
@@ -1,4 +1,4 @@
-package main
+package kernel_module_loading
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/kernel_module_loading_test.rego
+++ b/tracee-rules/signatures/rego/kernel_module_loading_test.rego
@@ -1,4 +1,4 @@
-package kernel_module_loading
+package tracee.TRC_6
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/ld_preload.rego
+++ b/tracee-rules/signatures/rego/ld_preload.rego
@@ -1,4 +1,4 @@
-package main
+package ld_preload
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/ld_preload.rego
+++ b/tracee-rules/signatures/rego/ld_preload.rego
@@ -3,6 +3,7 @@ package main
 import data.tracee.helpers
 
 __rego_metadoc__ := {
+    "id": "TRC-7",
     "name": "LD_PRELOAD",
     "description": "Usage of LD_PRELOAD to allow hooks on process",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/ld_preload.rego
+++ b/tracee-rules/signatures/rego/ld_preload.rego
@@ -1,4 +1,4 @@
-package ld_preload
+package tracee.TRC_7
 
 import data.tracee.helpers
 

--- a/tracee-rules/signatures/rego/ld_preload_test.rego
+++ b/tracee-rules/signatures/rego/ld_preload_test.rego
@@ -1,4 +1,4 @@
-package main
+package ld_preload
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/signatures/rego/ld_preload_test.rego
+++ b/tracee-rules/signatures/rego/ld_preload_test.rego
@@ -1,4 +1,4 @@
-package ld_preload
+package tracee.TRC_7
 
 test_match_1 {
     tracee_match with input as {

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -17,6 +17,7 @@ type Signature interface {
 
 //SignatureMetadata represents information about the signature
 type SignatureMetadata struct {
+	ID          string
 	Name        string
 	Description string
 	Tags        []string


### PR DESCRIPTION
This PR intends to introduces the following:

- [x] Signature IDs as part of their Metadata as discussed in #515
- [x] Namespaces the rego signatures appropriately.
- [x] Logic to handle new namespaced rego signatures

Signed-off-by: Simarpreet Singh <simar@linux.com>