### PR TITLE
Added information how to run Tracee on Docker Mac

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,6 +103,7 @@ Alternatively, running as `root` or with the `--privileged` flag of Docker, is a
 
 In order to compile the eBPF program, Tracee needs some of the Linux kernel headers. Depending on your Linux distribution, there may be different ways to obtain them.  
 
+- On Docker for MAC follow the [following guidelines](docker-mac.md).
 - On Ubuntu/Debian/Arch/Manjaro install the `linux-headers` package.
 - On CentOS/Fedora install the `kernel-headers` and `kernel-devel` packages.
 

--- a/docker-mac.md
+++ b/docker-mac.md
@@ -1,0 +1,28 @@
+Docker for Mac does not come with Kernel headers.
+You need to do the following to make Tracee work:
+
+1. Identify your docker version: 
+```
+dockerver=$(docker version | grep  Version | head -n 1 | cut -d ':' -f 2 | xargs)
+```
+
+2. Run a container with Docker CLI, while mounting to the host path:
+```
+  docker run -it -v /:/host -v /var/run/docker.sock:/var/run/docker.sock docker:$dockerver /bin/sh
+```
+
+3. Get the Kernel Header files from the linuxkit Docker image and copy it to the host /usr/src path:
+
+```
+   mkdir /host/kheader
+   cd /host/kheader
+   linux_version="${VERSION:-$(uname -r | cut -d - -f 1)}"
+   docker pull "linuxkit/kernel:$linux_version"
+   docker save "linuxkit/kernel:$linux_version" > "linuxkit.tar"
+   tar -xf "linuxkit.tar"
+   layertar=$(find . -name layer.tar)
+   tar -xf "$layertar"
+   tar -xf "kernel-dev.tar" --directory /host/
+```
+
+4. You can now run Tracee on your Docker for Mac


### PR DESCRIPTION
Added information how to run Tracee on Docker for Mac (which does not come with Kernel headers).

This fixes issue #570 