### PR TITLE
Webhook message formatting using go templates

### DIFF
--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -33,7 +33,11 @@ This will:
 
 When a detection is made by any of the signatures, it will be printed to stdout. Using the `--webhook` flag you can post detections into an HTTP endpoint that can further relay the detection.
 
-You can also use a custom template (or use a pre-supplied one) to further tune your webhook detection output. This can be passed in via the `--webhook-template` flag.
+You can also use a custom template (or use a pre-supplied one) to further tune your webhook detection output. Templates are written in the Go templating language. 
+
+When supplying a custom template, fields of the `types.Finding` event type can be used as output fields. These are available [here](https://github.com/aquasecurity/tracee/blob/28fbc66be8c9f3efa53f617a654cafe7421e8c70/tracee-rules/types/types.go#L46-L50). Some examples of custom templates are documented [here](templates/).
+ 
+ Custom templates can be passed in via the `--webhook-template` flag.
 
 # Rules
 Rules are discovered from the local `rules` directory (unless changed by the `--rules-dir` flag). By default, all discovered rules will be loaded unless specific rules are selected using the `--rules` flag.

--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -31,13 +31,13 @@ This will:
 
 # Integrations
 
-When a detection is made by any of the signatures, it will be printed to stdout. Using the `--webhook` flag you can post detections into an HTTP endpoint that can further relay the detection.
+When a detection is made by any of the signatures, it will be printed to stdout. Using the `--webhook` flag you can post detections into an HTTP endpoint that can further relay the detection. By default, payloads are sent as JSON to the webhook.
 
 You can also use a custom template (or use a pre-supplied one) to further tune your webhook detection output. Templates are written in the Go templating language. 
 
 When supplying a custom template, fields of the `types.Finding` event type can be used as output fields. These are available [here](https://github.com/aquasecurity/tracee/blob/28fbc66be8c9f3efa53f617a654cafe7421e8c70/tracee-rules/types/types.go#L46-L50). Some examples of custom templates are documented [here](templates/).
  
- Custom templates can be passed in via the `--webhook-template` flag.
+ Custom templates can be passed in via the `--webhook-template` flag. Payload Content-Type must be specified when using a custom template with the `--content-type` flag.
 
 # Rules
 Rules are discovered from the local `rules` directory (unless changed by the `--rules-dir` flag). By default, all discovered rules will be loaded unless specific rules are selected using the `--rules` flag.

--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -33,6 +33,8 @@ This will:
 
 When a detection is made by any of the signatures, it will be printed to stdout. Using the `--webhook` flag you can post detections into an HTTP endpoint that can further relay the detection.
 
+You can also use a custom template (or use a pre-supplied one) to further tune your webhook detection output. This can be passed in via the `--webhook-template` flag.
+
 # Rules
 Rules are discovered from the local `rules` directory (unless changed by the `--rules-dir` flag). By default, all discovered rules will be loaded unless specific rules are selected using the `--rules` flag.
 

--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -37,7 +37,7 @@ You can also use a custom template (or use a pre-supplied one) to further tune y
 
 When supplying a custom template, fields of the `types.Finding` event type can be used as output fields. These are available [here](https://github.com/aquasecurity/tracee/blob/28fbc66be8c9f3efa53f617a654cafe7421e8c70/tracee-rules/types/types.go#L46-L50). Some examples of custom templates are documented [here](templates/).
  
- Custom templates can be passed in via the `--webhook-template` flag. Payload Content-Type must be specified when using a custom template with the `--content-type` flag.
+ Custom templates can be passed in via the `--webhook-template` flag. Payload Content-Type can be specified (and is recommended) when using a custom template with the `--webhook-content-type` flag.
 
 # Rules
 Rules are discovered from the local `rules` directory (unless changed by the `--rules-dir` flag). By default, all discovered rules will be loaded unless specific rules are selected using the `--rules` flag.

--- a/tracee-rules/goldens/broken.tmpl
+++ b/tracee-rules/goldens/broken.tmpl
@@ -1,0 +1,1 @@
+{{ .InvalidField }}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -68,7 +68,7 @@ func main() {
 			if inputs == (engine.EventSources{}) {
 				return err
 			}
-			output, err := setupOutput(os.Stdout, realClock{}, c.String("webhook"))
+			output, err := setupOutput(os.Stdout, realClock{}, c.String("webhook"), c.String("webhook-template"))
 			if err != nil {
 				return err
 			}
@@ -92,6 +92,10 @@ func main() {
 			&cli.StringFlag{
 				Name:  "webhook",
 				Usage: "HTTP endpoint to call for every match",
+			},
+			&cli.StringFlag{
+				Name:  "webhook-template",
+				Usage: "path to a gotemplate for formatting webhook output",
 			},
 			&cli.StringSliceFlag{
 				Name:  "input-tracee",

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -68,7 +68,7 @@ func main() {
 			if inputs == (engine.EventSources{}) {
 				return err
 			}
-			output, err := setupOutput(os.Stdout, realClock{}, c.String("webhook"), c.String("webhook-template"), c.String("content-type"))
+			output, err := setupOutput(os.Stdout, realClock{}, c.String("webhook"), c.String("webhook-template"), c.String("webhook-content-type"))
 			if err != nil {
 				return err
 			}
@@ -98,8 +98,8 @@ func main() {
 				Usage: "path to a gotemplate for formatting webhook output",
 			},
 			&cli.StringFlag{
-				Name:  "content-type",
-				Usage: "content type of the template in use. Required if using --webhook-template",
+				Name:  "webhook-content-type",
+				Usage: "content type of the template in use. Recommended if using --webhook-template",
 			},
 			&cli.StringSliceFlag{
 				Name:  "input-tracee",

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -68,7 +68,7 @@ func main() {
 			if inputs == (engine.EventSources{}) {
 				return err
 			}
-			output, err := setupOutput(os.Stdout, realClock{}, c.String("webhook"), c.String("webhook-template"))
+			output, err := setupOutput(os.Stdout, realClock{}, c.String("webhook"), c.String("webhook-template"), c.String("content-type"))
 			if err != nil {
 				return err
 			}
@@ -96,6 +96,10 @@ func main() {
 			&cli.StringFlag{
 				Name:  "webhook-template",
 				Usage: "path to a gotemplate for formatting webhook output",
+			},
+			&cli.StringFlag{
+				Name:  "content-type",
+				Usage: "content type of the template in use. Required if using --webhook-template",
 			},
 			&cli.StringSliceFlag{
 				Name:  "input-tracee",

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -29,7 +29,7 @@ Hostname: %s
 func setupOutput(resultWriter io.Writer, clock Clock, webhook string, webhookTemplate string, contentType string) (chan types.Finding, error) {
 	out := make(chan types.Finding)
 
-	t, err := setupTemplate(webhookTemplate)
+	t, err := setupTemplate(webhookTemplate, realClock{})
 	if err != nil && webhookTemplate != "" {
 		return nil, fmt.Errorf("error preparing webhook template: %v", err)
 	}
@@ -62,11 +62,11 @@ func setupOutput(resultWriter io.Writer, clock Clock, webhook string, webhookTem
 	return out, nil
 }
 
-func setupTemplate(webhookTemplate string) (*template.Template, error) {
+func setupTemplate(webhookTemplate string, clock Clock) (*template.Template, error) {
 	return template.New(filepath.Base(webhookTemplate)).
 		Funcs(map[string]interface{}{
-			"unixToRFC3339": func(unixTs float64) string {
-				return time.Unix(int64(unixTs), 0).UTC().Format("2006-01-02T15:04:05Z")
+			"timeNow": func(unixTs float64) string {
+				return clock.Now().UTC().Format("2006-01-02T15:04:05Z")
 			},
 		}).ParseFiles(webhookTemplate)
 }

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -80,7 +80,7 @@ func sendToWebhook(t *template.Template, res types.Finding, webhook string, webh
 			return fmt.Errorf("error writing to template: template not initialized")
 		}
 		if contentType == "" {
-			return fmt.Errorf("--content-type flag needs to be defined for custom templates")
+			log.Println("content-type was not set for the custom template: ", webhookTemplate)
 		}
 		buf := bytes.Buffer{}
 		if err := t.Execute(&buf, res); err != nil {

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -68,7 +68,7 @@ func sendToWebhook(res types.Finding, webhook string, webhookTemplate string, cl
 				},
 			}).ParseFiles(webhookTemplate)
 		if err != nil {
-			return fmt.Errorf("error preparing webhook template %v", err)
+			return fmt.Errorf("error preparing webhook template: %v", err)
 		}
 
 		buf := bytes.Buffer{}
@@ -81,15 +81,15 @@ func sendToWebhook(res types.Finding, webhook string, webhookTemplate string, cl
 		var err error
 		payload, err = prepareJSONPayload(res, clock)
 		if err != nil {
-			return fmt.Errorf("error preparing json payload for %v: %v", res, err)
+			return fmt.Errorf("error preparing json payload: %v", err)
 		}
 	}
 
 	resp, err := http.Post(webhook, "application/json", strings.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("error calling webhook for %v: %v", res, err)
+		return fmt.Errorf("error calling webhook %v", err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	return nil
 }
 

--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -114,7 +114,7 @@ func prepareJSONPayload(res types.Finding, clock Clock) (string, error) {
 	payload := Payload{
 		Output:       fmt.Sprintf("Rule \"%s\" detection:\n %v", sigmeta.Name, res.Data),
 		Rule:         sigmeta.Name,
-		Time:         clock.Now(),
+		Time:         clock.Now().UTC(),
 		OutputFields: fields,
 	}
 	payloadJSON, err := json.Marshal(payload)

--- a/tracee-rules/output_test.go
+++ b/tracee-rules/output_test.go
@@ -103,7 +103,7 @@ func Test_sendToWebhook(t *testing.T) {
 	}{
 		{
 			name:           "happy path, no template JSON output",
-			expectedOutput: `{"output":"Rule \"foo bar signature\" detection:\n map[foo1:bar1, baz1 foo2:[bar2 baz2]]","rule":"foo bar signature","time":"2021-02-22T17:54:57-08:00","output_fields":{"value":0}}`,
+			expectedOutput: `{"output":"Rule \"foo bar signature\" detection:\n map[foo1:bar1, baz1 foo2:[bar2 baz2]]","rule":"foo bar signature","time":"2021-02-23T01:54:57Z","output_fields":{"value":0}}`,
 		},
 		{
 			name: "happy path, with simple template",

--- a/tracee-rules/output_test.go
+++ b/tracee-rules/output_test.go
@@ -145,7 +145,7 @@ HostName: foobar.local
 		{
 			name:              "sad path, with missing template",
 			inputTemplateFile: "invalid/template",
-			expectedError:     `error preparing webhook template: open invalid/template: no such file or directory`,
+			expectedError:     `error writing to template: template not initialized`,
 		},
 		{
 			name:              "sad path, with an invalid template",
@@ -166,7 +166,9 @@ HostName: foobar.local
 				ts.URL = tc.inputTestServerURL
 			}
 
-			actualError := sendToWebhook(types.Finding{
+			inputTemplate, _ := setupTemplate(tc.inputTemplateFile)
+
+			actualError := sendToWebhook(inputTemplate, types.Finding{
 				Data: map[string]interface{}{
 					"foo1": "bar1, baz1",
 					"foo2": []string{"bar2", "baz2"},

--- a/tracee-rules/output_test.go
+++ b/tracee-rules/output_test.go
@@ -120,6 +120,15 @@ HostName: foobar.local
 			inputTemplateFile: "templates/csv.tmpl",
 		},
 		{
+			name: "happy path, with XML template",
+			expectedOutput: `<?xml version="1.0" encoding="UTF-8" ?>
+ <detection timestamp="2021-02-27T07:19:07Z">
+    <processname>foobar.exe</processname>
+    <hostname>foobar.local</hostname>
+ </detection>`,
+			inputTemplateFile: "templates/xml.tmpl",
+		},
+		{
 			name: "sad path, with failing GetMetadata func for sig",
 			inputSignature: fakeSignature{
 				getMetadata: func() (types.SignatureMetadata, error) {

--- a/tracee-rules/output_test.go
+++ b/tracee-rules/output_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -25,9 +26,14 @@ func (fakeClock) Now() time.Time {
 
 type fakeSignature struct {
 	types.Signature
+	getMetadata func() (types.SignatureMetadata, error)
 }
 
 func (f fakeSignature) GetMetadata() (types.SignatureMetadata, error) {
+	if f.getMetadata != nil {
+		return f.getMetadata()
+	}
+
 	return types.SignatureMetadata{
 		ID:          "FOO-666",
 		Name:        "foo bar signature",
@@ -88,9 +94,12 @@ Hostname: foobar.local
 
 func Test_sendToWebhook(t *testing.T) {
 	var testCases = []struct {
-		name           string
-		inputTemplate  string
-		expectedOutput string
+		name               string
+		inputTemplateFile  string
+		inputSignature     fakeSignature
+		inputTestServerURL string
+		expectedOutput     string
+		expectedError      string
 	}{
 		{
 			name:           "happy path, no template JSON output",
@@ -103,7 +112,31 @@ Timestamp: 2021-02-27T07:19:07Z
 ProcessName: foobar.exe
 HostName: foobar.local
 `,
-			inputTemplate: "templates/simple.tmpl",
+			inputTemplateFile: "templates/simple.tmpl",
+		},
+		{
+			name: "sad path, with failing GetMetadata func for sig",
+			inputSignature: fakeSignature{
+				getMetadata: func() (types.SignatureMetadata, error) {
+					return types.SignatureMetadata{}, errors.New("getMetadata failed")
+				},
+			},
+			expectedError: "error preparing json payload: getMetadata failed",
+		},
+		{
+			name:               "sad path, error reaching webhook",
+			inputTestServerURL: "foo://bad.host",
+			expectedError:      `error calling webhook Post "foo://bad.host": unsupported protocol scheme "foo"`,
+		},
+		{
+			name:              "sad path, with missing template",
+			inputTemplateFile: "invalid/template",
+			expectedError:     `error preparing webhook template: open invalid/template: no such file or directory`,
+		},
+		{
+			name:              "sad path, with an invalid template",
+			inputTemplateFile: "goldens/broken.tmpl",
+			expectedError:     `error writing to the template: template: broken.tmpl:1:3: executing "broken.tmpl" at <.InvalidField>: can't evaluate field InvalidField in type types.Finding`,
 		},
 	}
 
@@ -115,7 +148,11 @@ HostName: foobar.local
 			}))
 			defer ts.Close()
 
-			assert.NoError(t, sendToWebhook(types.Finding{
+			if tc.inputTestServerURL != "" {
+				ts.URL = tc.inputTestServerURL
+			}
+
+			actualError := sendToWebhook(types.Finding{
 				Data: map[string]interface{}{
 					"foo1": "bar1, baz1",
 					"foo2": []string{"bar2", "baz2"},
@@ -125,8 +162,16 @@ HostName: foobar.local
 					ProcessName: "foobar.exe",
 					HostName:    "foobar.local",
 				},
-				Signature: fakeSignature{},
-			}, ts.URL, tc.inputTemplate, fakeClock{}), tc.name)
+				Signature: tc.inputSignature,
+			}, ts.URL, tc.inputTemplateFile, fakeClock{})
+
+			switch {
+			case tc.expectedError != "":
+				assert.EqualError(t, actualError, tc.expectedError, tc.name)
+			default:
+				assert.NoError(t, actualError, tc.name)
+			}
 		})
+
 	}
 }

--- a/tracee-rules/output_test.go
+++ b/tracee-rules/output_test.go
@@ -115,6 +115,11 @@ HostName: foobar.local
 			inputTemplateFile: "templates/simple.tmpl",
 		},
 		{
+			name:              "happy path, with CSV template",
+			expectedOutput:    `2021-02-27T07:19:07Z,foobar.exe,foobar.local`,
+			inputTemplateFile: "templates/csv.tmpl",
+		},
+		{
 			name: "sad path, with failing GetMetadata func for sig",
 			inputSignature: fakeSignature{
 				getMetadata: func() (types.SignatureMetadata, error) {

--- a/tracee-rules/output_test.go
+++ b/tracee-rules/output_test.go
@@ -50,7 +50,6 @@ func Test_setupOutput(t *testing.T) {
 		{
 			name: "happy path with tracee event",
 			inputContext: external.Event{
-				Timestamp:   12345678,
 				ProcessName: "foobar.exe",
 				HostName:    "foobar.local",
 			},
@@ -111,7 +110,7 @@ func Test_sendToWebhook(t *testing.T) {
 			name:        "happy path, with simple template",
 			contentType: "text/plain",
 			expectedOutput: `*** Detection ***
-Timestamp: 2021-02-27T07:19:07Z
+Timestamp: 2021-02-23T01:54:57Z
 ProcessName: foobar.exe
 HostName: foobar.local
 `,
@@ -120,14 +119,14 @@ HostName: foobar.local
 		{
 			name:              "happy path, with CSV template",
 			contentType:       "text/csv",
-			expectedOutput:    `2021-02-27T07:19:07Z,foobar.exe,foobar.local`,
+			expectedOutput:    `2021-02-23T01:54:57Z,foobar.exe,foobar.local`,
 			inputTemplateFile: "templates/csv.tmpl",
 		},
 		{
 			name:        "happy path, with XML template",
 			contentType: "application/xml",
 			expectedOutput: `<?xml version="1.0" encoding="UTF-8" ?>
- <detection timestamp="2021-02-27T07:19:07Z">
+ <detection timestamp="2021-02-23T01:54:57Z">
     <processname>foobar.exe</processname>
     <hostname>foobar.local</hostname>
  </detection>`,
@@ -173,7 +172,7 @@ HostName: foobar.local
 				ts.URL = tc.inputTestServerURL
 			}
 
-			inputTemplate, _ := setupTemplate(tc.inputTemplateFile)
+			inputTemplate, _ := setupTemplate(tc.inputTemplateFile, fakeClock{})
 
 			actualError := sendToWebhook(inputTemplate, types.Finding{
 				Data: map[string]interface{}{
@@ -181,7 +180,6 @@ HostName: foobar.local
 					"foo2": []string{"bar2", "baz2"},
 				},
 				Context: external.Event{
-					Timestamp:   1614410347,
 					ProcessName: "foobar.exe",
 					HostName:    "foobar.local",
 				},

--- a/tracee-rules/templates/csv.tmpl
+++ b/tracee-rules/templates/csv.tmpl
@@ -1,0 +1,1 @@
+{{ .Context.Timestamp | unixToRFC3339 }},{{ .Context.ProcessName }},{{ .Context.HostName }}

--- a/tracee-rules/templates/csv.tmpl
+++ b/tracee-rules/templates/csv.tmpl
@@ -1,1 +1,1 @@
-{{ .Context.Timestamp | unixToRFC3339 }},{{ .Context.ProcessName }},{{ .Context.HostName }}
+{{ .Context.Timestamp | timeNow }},{{ .Context.ProcessName }},{{ .Context.HostName }}

--- a/tracee-rules/templates/simple.tmpl
+++ b/tracee-rules/templates/simple.tmpl
@@ -1,4 +1,4 @@
 *** Detection ***
-Timestamp: {{ .Context.Timestamp | unixToRFC3339 }}
+Timestamp: {{ .Context.Timestamp | timeNow }}
 ProcessName: {{ .Context.ProcessName }}
 HostName: {{ .Context.HostName }}

--- a/tracee-rules/templates/simple.tmpl
+++ b/tracee-rules/templates/simple.tmpl
@@ -1,0 +1,4 @@
+*** Detection ***
+Timestamp: {{ .Context.Timestamp | unixToRFC3339 }}
+ProcessName: {{ .Context.ProcessName }}
+HostName: {{ .Context.HostName }}

--- a/tracee-rules/templates/xml.tmpl
+++ b/tracee-rules/templates/xml.tmpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
- <detection timestamp="{{.Context.Timestamp | unixToRFC3339 }}">
+ <detection timestamp="{{.Context.Timestamp | timeNow }}">
     <processname>{{ .Context.ProcessName }}</processname>
     <hostname>{{ .Context.HostName }}</hostname>
  </detection>

--- a/tracee-rules/templates/xml.tmpl
+++ b/tracee-rules/templates/xml.tmpl
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+ <detection timestamp="{{.Context.Timestamp | unixToRFC3339 }}">
+    <processname>{{ .Context.ProcessName }}</processname>
+    <hostname>{{ .Context.HostName }}</hostname>
+ </detection>


### PR DESCRIPTION
This PR aims to add the following:

- Formatting webhook payloads with supplied templates
- Using a user supplied template for formatting payload
- Additional refactoring & testing

Fixes: https://github.com/aquasecurity/tracee/issues/539


Sample usage:
```
tracee-rules --input-tracee format:json --webhook="http://foo.local" --webhook-template="templates/simple.tmpl" --content-type="application/json"
```

Signed-off-by: Simarpreet Singh <simar@linux.com>