### PR TITLE
tracee-ebpf: add magic_write event

### DIFF
--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -152,6 +152,7 @@ const (
 	SchedProcessExitEventID
 	CommitCredsEventID
 	SwitchTaskNSEventID
+	MagicWriteEventID
 	MaxEventID
 )
 
@@ -523,6 +524,7 @@ var EventsIDToEvent = map[int32]EventConfig{
 	SchedProcessExitEventID:    {ID: SchedProcessExitEventID, ID32Bit: sys32undefined, Name: "sched_process_exit", Probes: []probe{{event: "sched:sched_process_exit", attach: rawTracepoint, fn: "tracepoint__sched__sched_process_exit"}}, EssentialEvent: true, Sets: []string{"default", "proc", "proc_life"}},
 	CommitCredsEventID:         {ID: CommitCredsEventID, ID32Bit: sys32undefined, Name: "commit_creds", Probes: []probe{{event: "commit_creds", attach: kprobe, fn: "trace_commit_creds"}}, Sets: []string{}},
 	SwitchTaskNSEventID:        {ID: SwitchTaskNSEventID, ID32Bit: sys32undefined, Name: "switch_task_ns", Probes: []probe{{event: "switch_task_namespaces", attach: kprobe, fn: "trace_switch_task_namespaces"}}, Sets: []string{}},
+	MagicWriteEventID:          {ID: MagicWriteEventID, ID32Bit: sys32undefined, Name: "magic_write", Probes: []probe{}, Sets: []string{}},
 }
 
 // EventsIDToParams is list of the parameters (name and type) used by the events
@@ -881,4 +883,5 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	SchedProcessExitEventID:    {},
 	CommitCredsEventID:         {{Type: "int", Name: "old_euid"}, {Type: "int", Name: "new_euid"}, {Type: "int", Name: "old_egid"}, {Type: "int", Name: "new_egid"}, {Type: "int", Name: "old_fsuid"}, {Type: "int", Name: "new_fsuid"}, {Type: "u64", Name: "old_cap_eff"}, {Type: "u64", Name: "new_cap_eff"}},
 	SwitchTaskNSEventID:        {{Type: "pid_t", Name: "pid"}, {Type: "u32", Name: "new_mnt"}, {Type: "u32", Name: "new_pid"}, {Type: "u32", Name: "new_uts"}, {Type: "u32", Name: "new_ipc"}, {Type: "u32", Name: "new_net"}, {Type: "u32", Name: "new_cgroup"}},
+	MagicWriteEventID:          {{Type: "const char*", Name: "pathname"}, {Type: "bytes", Name: "bytes"}},
 }

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -99,6 +99,7 @@ const (
 	strArrT
 	sockAddrT
 	alertT
+	bytesT
 )
 
 // argTag is an enum that encodes the argument types that the BPF program may write to the shared buffer

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -280,6 +280,11 @@ func New(cfg Config) (*Tracee, error) {
 		t.eventsToTrace[e] = true
 	}
 
+	if t.eventsToTrace[MagicWriteEventID] {
+		setEssential(VfsWriteEventID)
+		setEssential(VfsWritevEventID)
+	}
+
 	// Compile final list of events to trace including essential events
 	for id, event := range EventsIDToEvent {
 		// If an essential event was not requested by the user, set its map value to false


### PR DESCRIPTION
Adding a new event named magic_write. This event is triggered when a file header is written (currently set to the first 16 bytes).
This event can then be used to detect when a file of some given type is written (e.g. an ELF file).

To support the addition of this event, a new argument type is introduced: bytes.
When submitting an argument of this type, it is possible to transfer an arbitrary number of bytes as an argument