### PR TITLE
feat: Use //go:embed to bundle bpf code

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -43,7 +43,7 @@ go_env := GOOS=linux GOARCH=$(ARCH:x86_64=amd64) CC=$(CMD_CLANG) CGO_CFLAGS="-I 
 ifndef DOCKER
 $(OUT_BIN): $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(filter-out *_test.go,$(GO_SRC)) $(BPF_BUNDLE) | $(OUT_DIR)
 	$(go_env) go build -v -o $(OUT_BIN) \
-	-ldflags "-X main.bpfBundleInjected=$$(base64 -w 0 $(BPF_BUNDLE)) -X main.version=$(VERSION)"	
+	-ldflags "-X main.version=$(VERSION)"
 else 
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@ VERSION=$(VERSION))

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	_ "embed"
+
 	"archive/tar"
 	"compress/gzip"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,6 +27,7 @@ var traceeInstallPath string
 var buildPolicy string
 
 // These vars are supposed to be injected at build time
+//go:embed dist/tracee.bpf.tar.gz
 var bpfBundleInjected string
 var version string
 
@@ -978,13 +980,12 @@ func getBPFObject() (string, error) {
 	return bpfObjFilePath, nil
 }
 
-// unpackBPFBundle unpacks the bundle (tar(gzip(b64))) into the provided directory
+// unpackBPFBundle unpacks the bundle (tar(gzip)) into the provided directory
 func unpackBPFBundle(dir string) error {
 	if bpfBundleInjected == "" {
 		return fmt.Errorf("missing embedded data")
 	}
-	b64Reader := base64.NewDecoder(base64.RawStdEncoding, strings.NewReader(bpfBundleInjected))
-	gzReader, err := gzip.NewReader(b64Reader)
+	gzReader, err := gzip.NewReader(strings.NewReader(bpfBundleInjected))
 	if err != nil {
 		return err
 	}

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -1,3 +1,5 @@
+// +build go1.16
+
 package main
 
 import (

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -1,3 +1,5 @@
+// +build go1.16
+
 package main
 
 import (


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/tracee/issues/434

Requires go 1.16 or latest

Signed-off-by: Simarpreet Singh <simar@linux.com>