### PR TITLE
fix: move and document the signature helpers 

### DIFF
--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -52,7 +52,7 @@ Create a `.rego` file in the rules directory that has the following Rego Rules (
 2. `tracee_selected_events`: A *set* rule that defines the event selectors.
 3. `tracee_match`: A *boolean* or a *document* rule that defines the logic of the signature. If bool is "returned", a true evaluation will generate a Finding with no data if document is "returned", any non-empty evaluation will generate a Finding with the returned document as the Finding's "Data".
 
-See [example2.rego](/tracee-rules/signatures/rego/examples/example2.rego) and [example1.rego](/tracee-rules/signatures/rego/examples/example1.rego) for example Rego signatures.
+See [example2.rego](/tracee-rules/signatures/rego/examples/example2.rego) and [example1.rego](/tracee-rules/signatures/rego/examples/example1.rego) for example Rego signatures.  Helpers for writing rego rules are available in [tracee-rules/signatures/rego/helpers.rego](/tracee-rules/signatures/rego/helpers.rego).
 
 ### Go rules
 Tracee-Rules exports a `Signature` interface that you can implement. We use [Go Plugins](https://golang.org/pkg/plugin/) to load Go signatures.  
@@ -63,4 +63,4 @@ Tracee-Rules exports a `Signature` interface that you can implement. We use [Go 
 4. Compile using goplugins `go build -buildmode=plugin -o yourplugin.so yoursource.go`.
 5. Place the resulting compiled file in the rules directory and it will be automatically discovered by Tracee-Rules.
 
-See [example.go](/tracee-rules/signatures/golang/examples/example.go) for example Go signatures.
+See [example.go](/tracee-rules/signatures/golang/examples/example.go) for example Go signatures. Helpers for writing Go rules are available in [tracee-rules/signatures/helpers](/tracee-rules/signatures/helpers)

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
+	"github.com/aquasecurity/tracee/tracee-rules/signatures/helpers"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 )
 
@@ -51,7 +52,7 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 		return fmt.Errorf("invalid event")
 	}
 
-	var connectData connectAddrData
+	var connectData helpers.ConnectAddrData
 
 	pid := eventObj.ProcessID
 
@@ -59,19 +60,19 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 
 	case "connect":
 
-		sockfdArg, err := GetTraceeArgumentByName(eventObj, "sockfd")
+		sockfdArg, err := helpers.GetTraceeArgumentByName(eventObj, "sockfd")
 		if err != nil {
 			return err
 		}
 
 		sockfd := int(sockfdArg.Value.(int32))
 
-		addrArg, err := GetTraceeArgumentByName(eventObj, "addr")
+		addrArg, err := helpers.GetTraceeArgumentByName(eventObj, "addr")
 		if err != nil {
 			return err
 		}
 
-		err = GetAddrStructFromArg(addrArg, &connectData)
+		err = helpers.GetAddrStructFromArg(addrArg, &connectData)
 		if err != nil {
 			return err
 		}
@@ -103,7 +104,7 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return nil
 		}
 
-		oldFdArg, err := GetTraceeArgumentByName(eventObj, "oldfd")
+		oldFdArg, err := helpers.GetTraceeArgumentByName(eventObj, "oldfd")
 		if err != nil {
 			return err
 		}
@@ -125,14 +126,14 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 			return nil
 		}
 
-		oldFdArg, err := GetTraceeArgumentByName(eventObj, "oldfd")
+		oldFdArg, err := helpers.GetTraceeArgumentByName(eventObj, "oldfd")
 		if err != nil {
 			return err
 		}
 
 		srcFd := int(oldFdArg.Value.(int32))
 
-		newFdArg, err := GetTraceeArgumentByName(eventObj, "newfd")
+		newFdArg, err := helpers.GetTraceeArgumentByName(eventObj, "newfd")
 		if err != nil {
 			return err
 		}
@@ -146,7 +147,7 @@ func (sig *stdioOverSocket) OnEvent(e types.Event) error {
 
 	case "close":
 
-		currentFdArg, err := GetTraceeArgumentByName(eventObj, "fd")
+		currentFdArg, err := helpers.GetTraceeArgumentByName(eventObj, "fd")
 		if err != nil {
 			return err
 		}

--- a/tracee-rules/signatures/helpers/helpers.go
+++ b/tracee-rules/signatures/helpers/helpers.go
@@ -1,4 +1,4 @@
-package main
+package helpers
 
 import (
 	"encoding/json"
@@ -8,7 +8,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/tracee-ebpf/tracee/external"
 )
 
-type connectAddrData struct {
+type ConnectAddrData struct {
 	SaFamily string `json:"sa_family"`
 	SinPort  string `json:"sin_port"`
 	SinAddr  string `json:"sin_addr"`
@@ -33,7 +33,7 @@ func IsFileWrite(flags string) bool {
 	return false
 }
 
-func GetAddrStructFromArg(addrArg tracee.Argument, connectData *connectAddrData) error {
+func GetAddrStructFromArg(addrArg tracee.Argument, connectData *ConnectAddrData) error {
 	addrStr := strings.Replace(addrArg.Value.(string), "'", "\"", -1)
 	err := json.Unmarshal([]byte(addrStr), &connectData)
 	if err != nil {

--- a/tracee-rules/signatures/helpers/helpers.go
+++ b/tracee-rules/signatures/helpers/helpers.go
@@ -16,6 +16,7 @@ type ConnectAddrData struct {
 	SinAddr6 string `json:"sin6_addr"`
 }
 
+// GetTraceeArgumentByName fetches the argument in event with `Name` that matches argName
 func GetTraceeArgumentByName(event tracee.Event, argName string) (tracee.Argument, error) {
 	for _, arg := range event.Args {
 		if arg.Name == argName {
@@ -25,6 +26,8 @@ func GetTraceeArgumentByName(event tracee.Event, argName string) (tracee.Argumen
 	return tracee.Argument{}, fmt.Errorf("argument %s not found", argName)
 }
 
+// IsFileWrite returns whether or not the passed file permissions string contains
+// o_wronly or o_rdwr
 func IsFileWrite(flags string) bool {
 	flagsLow := strings.ToLower(flags)
 	if strings.Contains(flagsLow, "o_wronly") || strings.Contains(flagsLow, "o_rdwr") {
@@ -33,6 +36,7 @@ func IsFileWrite(flags string) bool {
 	return false
 }
 
+// GetAddrStructFromArg populates connectData with the value of the addrArg
 func GetAddrStructFromArg(addrArg tracee.Argument, connectData *ConnectAddrData) error {
 	addrStr := strings.Replace(addrArg.Value.(string), "'", "\"", -1)
 	err := json.Unmarshal([]byte(addrStr), &connectData)


### PR DESCRIPTION
This moves both the rego and go helper functions into their own package, updates usage and Makefile accordingly. (#599) 

It also adds notes in the README about them (#538).

Signed-off-by: grantseltzer <grantseltzer@gmail.com>