### PR TITLE
Adding version string to --list output

### DIFF
--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -109,13 +109,13 @@ func main() {
 }
 
 func listSigs(w io.Writer, sigs []types.Signature) error {
-	fmt.Fprintf(w, "%-10s %-35s %s\n", "ID", "NAME", "DESCRIPTION")
+	fmt.Fprintf(w, "%-10s %-35s %s %s\n", "ID", "NAME", "VERSION", "DESCRIPTION")
 	for _, sig := range sigs {
 		meta, err := sig.GetMetadata()
 		if err != nil {
 			continue
 		}
-		fmt.Fprintf(w, "%-10s %-35s %s\n", meta.ID, meta.Name, meta.Description)
+		fmt.Fprintf(w, "%-10s %-35s %-7s %s\n", meta.ID, meta.Name, meta.Version, meta.Description)
 	}
 	return nil
 }

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/aquasecurity/tracee/tracee-rules/types"
 
 	"github.com/aquasecurity/tracee/tracee-rules/engine"
 	"github.com/urfave/cli/v2"
@@ -40,15 +43,7 @@ func main() {
 				return err
 			}
 			if c.Bool("list") {
-				fmt.Printf("%-10s %-35s %s\n", "ID", "NAME", "DESCRIPTION")
-				for _, sig := range sigs {
-					meta, err := sig.GetMetadata()
-					if err != nil {
-						continue
-					}
-					fmt.Printf("%-10s %-35s %s\n", meta.ID, meta.Name, meta.Description)
-				}
-				return nil
+				return listSigs(os.Stdout, sigs)
 			}
 
 			var inputs engine.EventSources
@@ -111,6 +106,18 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func listSigs(w io.Writer, sigs []types.Signature) error {
+	fmt.Fprintf(w, "%-10s %-35s %s\n", "ID", "NAME", "DESCRIPTION")
+	for _, sig := range sigs {
+		meta, err := sig.GetMetadata()
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(w, "%-10s %-35s %s\n", meta.ID, meta.Name, meta.Description)
+	}
+	return nil
 }
 
 func sigHandler() chan bool {

--- a/tracee-rules/main_test.go
+++ b/tracee-rules/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/tracee/tracee-rules/types"
+)
+
+func Test_listSigs(t *testing.T) {
+	fakeSigs := []fakeSignature{
+		{
+			getMetadata: func() (types.SignatureMetadata, error) {
+				return types.SignatureMetadata{
+					ID:          "FOO-1",
+					Version:     "1.2.3",
+					Name:        "foo signature",
+					Description: "foo signature helps with foo",
+				}, nil
+			},
+		},
+		{
+			getMetadata: func() (types.SignatureMetadata, error) {
+				return types.SignatureMetadata{
+					ID:          "BAR-1",
+					Version:     "4.5.6",
+					Name:        "bar signature",
+					Description: "bar signature helps with bar",
+				}, nil
+			},
+		},
+		{
+			getMetadata: func() (types.SignatureMetadata, error) {
+				return types.SignatureMetadata{}, errors.New("baz failed")
+			},
+		},
+	}
+
+	var inputSigs []types.Signature
+	for _, fs := range fakeSigs {
+		inputSigs = append(inputSigs, fs)
+	}
+
+	buf := bytes.Buffer{}
+	assert.NoError(t, listSigs(&buf, inputSigs))
+	assert.Equal(t, `ID         NAME                                DESCRIPTION
+FOO-1      foo signature                       foo signature helps with foo
+BAR-1      bar signature                       bar signature helps with bar
+`, buf.String())
+}

--- a/tracee-rules/main_test.go
+++ b/tracee-rules/main_test.go
@@ -46,8 +46,8 @@ func Test_listSigs(t *testing.T) {
 
 	buf := bytes.Buffer{}
 	assert.NoError(t, listSigs(&buf, inputSigs))
-	assert.Equal(t, `ID         NAME                                DESCRIPTION
-FOO-1      foo signature                       foo signature helps with foo
-BAR-1      bar signature                       bar signature helps with bar
+	assert.Equal(t, `ID         NAME                                VERSION DESCRIPTION
+FOO-1      foo signature                       1.2.3   foo signature helps with foo
+BAR-1      bar signature                       4.5.6   bar signature helps with bar
 `, buf.String())
 }


### PR DESCRIPTION
```
ID         NAME                                VERSION DESCRIPTION
TRC-1      Standard Input/Output Over Socket   0.1.0   Redirection of process's standard input/output to socket
TRC-2      Anti-Debugging                      0.1.0   Process uses anti-debugging technique to block debugger
TRC-3      Code injection                      0.1.0   Possible code injection into another process
TRC-4      Dynamic Code Loading                0.1.0   Writing to executable allocated memory region
TRC-5      Fileless Execution                  0.1.0   Executing a precess from memory, without a file in the disk
TRC-6      kernel module loading               0.1.0   Attempt to load a kernel module detection
TRC-7      LD_PRELOAD                          0.1.0   Usage of LD_PRELOAD to allow hooks on process
```

Signed-off-by: Simarpreet Singh <simar@linux.com>