### PR TITLE
Remove debugfs mount

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,9 @@
 #!/bin/sh
 
 TRACEE_EBPF_EXE=${TRACEE_EBPF_EXE:="/tracee/tracee-ebpf"}
-TRACEE_MOUNT_EXE=${TRACEE_MOUNT_EXE:="mount"}
 TRACEE_WEBHOOK_CONFIG=${TRACEE_WEBHOOK_CONFIG:="/tmp/tracee/integrations-config.yaml"}
 TRACEE_WEBHOOK_EXE=${TRACEE_WEBHOOK_EXE:="/tracee/falcosidekick"}
 TRACEE_RULES_EXE=${TRACEE_RULES_EXE:="/tracee/tracee-rules"}
-
-if ! $TRACEE_MOUNT_EXE | grep -q 'debugfs on /sys/kernel/debug'; then
-  $TRACEE_MOUNT_EXE -t debugfs debugfs /sys/kernel/debug/
-fi
 
 if [ "$1" = "trace" ]; then
 	shift

--- a/entrypoint_test.bats
+++ b/entrypoint_test.bats
@@ -10,24 +10,10 @@ setup() {
     export TRACEE_RULES_EXE="tracee-rules"
     export TRACEE_WEBHOOK_EXE="falco-sidekick"
     export TRACEE_WEBHOOK_CONFIG="$0" #some existing file
-    export TRACEE_MOUNT_EXE="mount"
 }
 
 teardown() {
     rm $log
-}
-
-@test "mount debugfs" {
-    run ./entrypoint.sh
-    assert_success
-    assert_contains 'mounted'
-}
-
-@test "don't mount debugfs" {
-    export MOCK_MOUNT_EXISTS=true
-    run ./entrypoint.sh
-    assert_success
-    assert_absent 'mounted'
 }
 
 @test "trace" {

--- a/test/mocks/mock
+++ b/test/mocks/mock
@@ -1,18 +1,5 @@
 #!/usr/bin/env bash
 
-mock_mount() {
-    if [ $# -eq 0 ]; then
-      if [ "$MOCK_MOUNT_EXISTS" ]; then
-        echo 'debugfs on /sys/kernel/debug type debugfs (rw,nosuid,nodev,noexec,relatime)'
-      fi
-      exit
-    fi
-    if [ $1 = '-t' ]; then
-      echo "mounted"
-      exit
-    fi
-}
-
 mock_tracee_ebpf() {
   echo 'event1'
 }
@@ -32,9 +19,6 @@ mock_tracee_rules() {
 cmd=$(basename $0)
 [ "$MOCK_LOG" ] && echo "$cmd $@" >> "$MOCK_LOG"
 case "$cmd" in 
-  'mount')
-    mock_mount $@
-    ;;
   'tracee-ebpf')
     mock_tracee_ebpf $@
     ;;

--- a/tracee-ebpf/Dockerfile
+++ b/tracee-ebpf/Dockerfile
@@ -21,5 +21,5 @@ RUN apk --no-cache update && apk --no-cache add libc6-compat elfutils-dev
 # docker run --name tracee --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee aquasec/tracee
 FROM $BASE
 WORKDIR /tracee
-COPY --from=build /tracee/dist/tracee-ebpf /tracee/entrypoint.sh ./
-ENTRYPOINT ["./entrypoint.sh", "./tracee-ebpf"]
+COPY --from=build /tracee/dist/tracee-ebpf ./
+ENTRYPOINT ["./tracee-ebpf"]

--- a/tracee-ebpf/entrypoint.sh
+++ b/tracee-ebpf/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -e
-mount -t debugfs debugfs /sys/kernel/debug/
-exec "$@"


### PR DESCRIPTION
Since we now moved to perf based kprobes instead of the legacy debugfs probes, we can remove the mount of debugfs