### PR TITLE
fix tracee-ebpf dockerfile for go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE=fat
 
-FROM golang:alpine as builder
+FROM golang:1.16-alpine as builder
 RUN apk --no-cache update && apk --no-cache add git clang llvm make gcc libc6-compat coreutils linux-headers musl-dev elfutils-dev libelf-static zlib-static
 WORKDIR /tracee
 

--- a/tracee-ebpf/Dockerfile
+++ b/tracee-ebpf/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE=fat
 
-FROM golang:alpine as builder
+FROM golang:1.16-alpine as builder
 RUN apk --no-cache update && apk --no-cache add git clang llvm make gcc libc6-compat coreutils linux-headers musl-dev elfutils-dev libelf-static zlib-static
 WORKDIR /tracee
 


### PR DESCRIPTION
fix: #608

(a forced docker pull would have worked as well in this case but better to make the version explicit to avoid potential mistakes like this)