### PR TITLE
Fix some of the toplevel "make clean" errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ $(OUT_DIR)/tracee.bpf.%.o: bpf ;
 bpf: tracee-ebpf | $(OUT_DIR)
 		$(MAKE) -C $< mostlyclean $@ OUT_DIR=dist && $(CMD_CP) $</dist/tracee.bpf.*.o $(OUT_DIR)
 
+# Use Gnu Make 4.3 "grouped targets" to make both $(OUT_ARCHIVE)
+# and $(OUT_CHECKSUMS) with one command.
 $(OUT_ARCHIVE) $(OUT_CHECKSUMS) &: $(RELEASE_FILES) | $(OUT_DIR)
 	$(CMD_TAR) -czf $(OUT_ARCHIVE) $(RELEASE_FILES)
 	$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
@@ -98,8 +100,8 @@ mostlyclean:
 .PHONY: clean
 clean:
 	-$(CMD_DOCKER) rmi $(OUT_DOCKER) $(release_images_fat) $(release_images_slim)
-	-$(MAKE) -c tracee-ebpf clean
-	-$(MAKE) -c tracee-rules clean
+	-$(MAKE) -C tracee-ebpf clean
+	-$(MAKE) -C tracee-rules clean
 
 .PHONY: test-entrypoint
 test-entrypoint: entrypoint.sh entrypoint_test.bats test/mocks/* test/bats-helpers.bash

--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,9 @@ Tracee is composed of the following sub-projects:
 - Linux kernel version >= 4.18
 - Relevant kernel headers available under conventional location (see [Linux Headers](#Linux-Headers) section for info)
 - libc, and the libraries: libelf and zlib
+- Gnu Make >= 4.3, needed for "group targets" support.
 - clang >= 9
+- go >= 1.16, needed for embedded support.
 
 Exceptions:
 

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -145,10 +145,13 @@ mostlyclean:
 
 .PHONY: clean
 clean:
-	-$(CMD_DOCKER) rmi $(file < $(docker_builder_file))
+	-FILE="$(docker_builder_file)" ; \
+	if [ -r "$$FILE" ] ; then \
+		$(CMD_DOCKER) rmi "$$(< $$FILE)" ; \
+	fi
 	-rm -rf dist $(OUT_DIR)
 	$(MAKE) -C $(LIBBPF_SRC) clean
-	
+
 check_%:
 	@command -v $* >/dev/null || (echo "missing required tool $*" ; false)
 

--- a/tracee-ebpf/Readme.md
+++ b/tracee-ebpf/Readme.md
@@ -13,7 +13,9 @@ Tracee-eBPF is a lightweight and easy to use tracing tool for Linux, which is fo
 - Linux kernel version >= 4.18
 - Relevant kernel headers available under conventional location (see [Linux Headers](#Linux-Headers) section for info)
 - libc, and the libraries: libelf and zlib
+- Gnu Make >= 4.3, needed for "group targets" support.
 - clang >= 9
+- go >= 1.16, needed for embedded support.
 
 Exceptions:
 

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -51,7 +51,10 @@ endif
 
 .PHONY: clean mostlyclean
 clean mostlyclean:
-	-$(CMD_DOCKER) rmi $(file < $(docker_builder_file))
+	-FILE="$(docker_builder_file)" ; \
+	if [ -r "$$FILE" ] ; then \
+		$(CMD_DOCKER) rmi "$$(< $$FILE)" ; \
+	fi
 	-rm -rf $(OUT_DIR)
 
 # docker_builder_make runs a make command in the tracee-builder container


### PR DESCRIPTION
Fix "make clean".
 - Use '-C' rather than '-c' to enter subdirectory
 - Check for existence of files before reading from them, fixes empty
 args to docker rmi.

Document Gnu Make 4.3 or better is required, Makefiles uses grouped targets.

Signed-off-by: Icarus Sparry <Icarus Sparry tracee@icarus.freeuk.com>