### PR TITLE
Better help message for missing libbpf

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ The easiest way to get started is to just let Tracee build the eBPF program for 
 Alternatively, you can pre-compile the eBPF program, and provide it to Tracee. There are some benefits to this approach as you will not need clang and kernel headers at runtime anymore, as well as reduced risk of invoking an external program at runtime.
 
 You can build the eBPF program in the following ways:
-1. Clone the repo and `make bpf`.
+1. Clone the repo including submodules (`git clone --recursive https://github.com/aquasecurity/tracee.git`) and `make bpf`.
 2. `make bpf DOCKER=1` to build in a Docker container which includes all development tooling.
 
 Running this will produce a file called `tracee.bpf.$kernelversion.$traceeversion.o` under the `dist` directory.  

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -54,7 +54,7 @@ bpf_compile_tools = $(CMD_LLC) $(CMD_CLANG)
 $(bpf_compile_tools): % : check_%
 
 $(LIBBPF_SRC):
-	test -d $(LIBBPF_SRC) || (echo "missing libbpf source" ; false)
+	test -d $(LIBBPF_SRC) || (echo "missing libbpf source - maybe do 'git submodule init && git submodule update'" ; false)
 
 $(LIBBPF_HEADERS) $(LIBBPF_HEADERS)/bpf $(LIBBPF_HEADERS)/linux: | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC)
 	cd $(LIBBPF_SRC) && $(MAKE) install_headers install_uapi_headers DESTDIR=$(abspath $(OUT_DIR))/libbpf
@@ -148,7 +148,7 @@ clean:
 	-$(CMD_DOCKER) rmi $(file < $(docker_builder_file))
 	-rm -rf dist $(OUT_DIR)
 	$(MAKE) -C $(LIBBPF_SRC) clean
-	
+
 check_%:
 	@command -v $* >/dev/null || (echo "missing required tool $*" ; false)
 


### PR DESCRIPTION
Add the flag to add the submodules.

Suggest a way to get missing libbpf code if the original checkout
didn't specify the submodules.

Also remove extra tab character from Makefile.

Signed-off-by: Icarus Sparry <Icarus Sparry tracee@icarus.freeuk.com>