### PR TITLE
fix: trace-ebpf flag output

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -30,7 +30,7 @@ DOCKER_BUILDER ?= tracee-builder
 # DOCKER_BUILDER_KERN_SRC(/BLD) is where the docker builder looks for kernel headers
 DOCKER_BUILDER_KERN_BLD ?= $(if $(shell readlink $(KERN_BLD_PATH)),$(shell readlink $(KERN_BLD_PATH)),$(KERN_BLD_PATH))
 DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink $(KERN_SRC_PATH)),$(shell readlink $(KERN_SRC_PATH)),$(KERN_SRC_PATH))
-# DOCKER_BUILDER_KERN_SRC_MNT is the kernel headers directory to mount into the docker builder container. DOCKER_BUILDER_KERN_SRC should usually be a decendent of this path.
+# DOCKER_BUILDER_KERN_SRC_MNT is the kernel headers directory to mount into the docker builder container. DOCKER_BUILDER_KERN_SRC should usually be a descendent of this path.
 DOCKER_BUILDER_KERN_SRC_MNT ?= $(dir $(DOCKER_BUILDER_KERN_SRC))
 
 $(OUT_DIR):

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -177,7 +177,7 @@ Use this flag multiple times to choose multiple capture options
 			res.Format = outputParts[0]
 			err := res.Validate()
 			if err != nil {
-				return res, fmt.Errorf("%s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.", err)
+				return res, err
 			}
 			outputParts = append(outputParts, outputParts[0])
 			outputParts[0] = "format"
@@ -188,7 +188,7 @@ Use this flag multiple times to choose multiple capture options
 			res.Format = outputParts[1]
 			err := res.Validate()
 			if err != nil {
-				return res, fmt.Errorf("%s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.", err)
+				return res, err
 			}
 		case "out-file":
 			res.OutPath = outputParts[1]

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -151,8 +151,8 @@ Control how and where output is printed.
 Possible options:
 
 [format:]{table,table-verbose,json,gob,gotemplate=/path/to/template}   output events in the specified format. for gotemplate, specify the mandatory template file
-out-file:/path/to/file                                                 write the output to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (deafult: stdout)
-err-file:/path/to/file                                                 write the errors to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (deafult: stderr)
+out-file:/path/to/file                                                 write the output to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (default: stdout)
+err-file:/path/to/file                                                 write the errors to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (default: stderr)
 option:{stack-addresses,detect-syscall,exec-env}                       augment output according to given options (default: none)
   stack-addresses                                                    include stack memory addresses for each event
   detect-syscall                                                     when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
@@ -174,16 +174,24 @@ Use this flag multiple times to choose multiple capture options
 		outputParts := strings.SplitN(o, ":", 2)
 		numParts := len(outputParts)
 		if numParts == 1 {
+			if !validateOutputFormatValue(outputParts[0]) {
+				return res, fmt.Errorf("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': %s. Use '--output help' for more info", outputParts[0])
+			}
 			outputParts = append(outputParts, outputParts[0])
 			outputParts[0] = "format"
 		}
-		if outputParts[0] == "format" {
+
+		switch outputParts[0] {
+		case "format":
+			if !validateOutputFormatValue(outputParts[1]) {
+				return res, fmt.Errorf("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': %s. Use '--output help' for more info", outputParts[0])
+			}
 			res.Format = outputParts[1]
-		} else if outputParts[0] == "out-file" {
+		case "out-file":
 			res.OutPath = outputParts[1]
-		} else if outputParts[0] == "err-file" {
+		case "err-file":
 			res.ErrPath = outputParts[1]
-		} else if outputParts[0] == "option" {
+		case "option":
 			switch outputParts[1] {
 			case "stack-addresses":
 				res.StackAddresses = true
@@ -192,14 +200,30 @@ Use this flag multiple times to choose multiple capture options
 			case "exec-env":
 				res.ExecEnv = true
 			default:
-				return res, fmt.Errorf("invalid output option: %s, use '--option help' for more info", outputParts[1])
+				return res, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}
+		default:
+			return res, fmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
 		}
 	}
+
 	if res.Format == "" {
 		res.Format = "table"
 	}
 	return res, nil
+}
+
+func validateOutputFormatValue(option string) bool {
+	if strings.HasPrefix(option, "gotemplate=") {
+		return true
+	}
+	options := []string{"table", "table-verbose", "json", "gob"}
+	for _, item := range options {
+		if item == option {
+			return true
+		}
+	}
+	return false
 }
 
 func prepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -174,8 +174,10 @@ Use this flag multiple times to choose multiple capture options
 		outputParts := strings.SplitN(o, ":", 2)
 		numParts := len(outputParts)
 		if numParts == 1 {
-			if !validateOutputFormatValue(outputParts[0]) {
-				return res, fmt.Errorf("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': %s. Use '--output help' for more info", outputParts[0])
+			res.Format = outputParts[0]
+			err := res.Validate()
+			if err != nil {
+				return res, fmt.Errorf("%s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.", err)
 			}
 			outputParts = append(outputParts, outputParts[0])
 			outputParts[0] = "format"
@@ -183,10 +185,11 @@ Use this flag multiple times to choose multiple capture options
 
 		switch outputParts[0] {
 		case "format":
-			if !validateOutputFormatValue(outputParts[1]) {
-				return res, fmt.Errorf("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': %s. Use '--output help' for more info", outputParts[0])
-			}
 			res.Format = outputParts[1]
+			err := res.Validate()
+			if err != nil {
+				return res, fmt.Errorf("%s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.", err)
+			}
 		case "out-file":
 			res.OutPath = outputParts[1]
 		case "err-file":
@@ -211,19 +214,6 @@ Use this flag multiple times to choose multiple capture options
 		res.Format = "table"
 	}
 	return res, nil
-}
-
-func validateOutputFormatValue(option string) bool {
-	if strings.HasPrefix(option, "gotemplate=") {
-		return true
-	}
-	options := []string{"table", "table-verbose", "json", "gob"}
-	for _, item := range options {
-		if item == option {
-			return true
-		}
-	}
-	return false
 }
 
 func prepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {

--- a/tracee-ebpf/main_test.go
+++ b/tracee-ebpf/main_test.go
@@ -1162,7 +1162,7 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: tracee.OutputConfig{
 				Format: "foo",
 			},
-			expectedError: errors.New("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': foo. Use '--output help' for more info"),
+			expectedError: errors.New("unrecognized output format: foo. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info."),
 		},
 		{
 			testName:       "invalid output option",
@@ -1215,7 +1215,7 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: tracee.OutputConfig{
 				Format: "out-file",
 			},
-			expectedError: errors.New("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': out-file. Use '--output help' for more info"),
+			expectedError: errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info."),
 		},
 		{
 			testName:    "err",

--- a/tracee-ebpf/main_test.go
+++ b/tracee-ebpf/main_test.go
@@ -1162,19 +1162,19 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: tracee.OutputConfig{
 				Format: "foo",
 			},
-			expectedError: nil,
+			expectedError: errors.New("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': foo. Use '--output help' for more info"),
 		},
 		{
 			testName:       "invalid output option",
 			outputSlice:    []string{"option:"},
 			expectedOutput: tracee.OutputConfig{},
-			expectedError:  errors.New("invalid output option: , use '--option help' for more info"),
+			expectedError:  errors.New("invalid output option: , use '--output help' for more info"),
 		},
 		{
 			testName:       "invalid output option 2",
 			outputSlice:    []string{"option:foo"},
 			expectedOutput: tracee.OutputConfig{},
-			expectedError:  errors.New("invalid output option: foo, use '--option help' for more info"),
+			expectedError:  errors.New("invalid output option: foo, use '--output help' for more info"),
 		},
 		{
 			testName:    "format explicit",
@@ -1215,7 +1215,7 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: tracee.OutputConfig{
 				Format: "out-file",
 			},
-			expectedError: nil,
+			expectedError: errors.New("invalid format value not match 'table', 'table-verbose', 'json', 'gob' or 'gotemplate=': out-file. Use '--output help' for more info"),
 		},
 		{
 			testName:    "err",

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -112,7 +112,7 @@ type OutputConfig struct {
 // Validate does static validation of the configuration
 func (cfg OutputConfig) Validate() error {
 	if cfg.Format != "table" && cfg.Format != "table-verbose" && cfg.Format != "json" && cfg.Format != "gob" && !strings.HasPrefix(cfg.Format, "gotemplate=") {
-		return fmt.Errorf("unrecognized output format: %s", cfg.Format)
+		return fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.", cfg.Format)
 	}
 	return nil
 }


### PR DESCRIPTION
Related issue https://github.com/aquasecurity/tracee/issues/560
- Using switch and validateOutputFormatValue method to validate the default output format values("table", "table-verbose", "json", "gob","gotemplate=").

 