### PR TITLE
Fix PerfBuffer shutdown

### DIFF
--- a/libbpfgo/selftest/perfbuffers/.gitignore
+++ b/libbpfgo/selftest/perfbuffers/.gitignore
@@ -1,0 +1,3 @@
+vmlinux.h
+self
+self.bpf.o

--- a/libbpfgo/selftest/perfbuffers/Makefile
+++ b/libbpfgo/selftest/perfbuffers/Makefile
@@ -1,0 +1,29 @@
+TARGET := self
+TARGET_BPF := $(TARGET).bpf.o
+
+GO_SRC := $(shell find . -type f -name '*.go')
+LIBBPFGO_SRC := $(shell find ../.. -type f -name '*.go')
+BPF_SRC := $(shell find . -type f -name '*.bpf.c')
+PWD := $(shell pwd)
+
+LIBBPF_HEADERS := /usr/include/bpf
+LIBBPF_OBJ := /usr/lib64/libbpf.a
+
+.PHONY: all
+all: vmlinux.h $(TARGET) $(TARGET_BPF)
+
+vmlinux.h:
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+
+go_env := CC=gcc CGO_CFLAGS="-I $(LIBBPF_HEADERS)" CGO_LDFLAGS="$(LIBBPF_OBJ)"
+$(TARGET): $(GO_SRC) $(LIBBPFGO_SRC)
+	$(go_env) go build -ldflags '-extldflags "-static"' -o $(TARGET) 
+
+$(TARGET_BPF): $(BPF_SRC)
+	clang \
+		-g -O2 -c -target bpf \
+		-o $@ $<
+
+.PHONY: clean
+clean: 
+	rm $(TARGET) $(TARGET_BPF) vmlinux.h

--- a/libbpfgo/selftest/perfbuffers/go.mod
+++ b/libbpfgo/selftest/perfbuffers/go.mod
@@ -1,0 +1,7 @@
+module github.com/aquasecurity/tracee/libbpfgo/selftests/5.8.15
+
+go 1.16
+
+replace github.com/aquasecurity/tracee/libbpfgo => ../../
+
+require github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b

--- a/libbpfgo/selftest/perfbuffers/go.sum
+++ b/libbpfgo/selftest/perfbuffers/go.sum
@@ -1,0 +1,3 @@
+github.com/aquasecurity/tracee v0.4.0 h1:fOfgeHWgjHSNK7vokaANNXOFljK9KOYSYriTxCfvMEU=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b h1:KfjLxlXFVCRx0UDYzzTV7Tt80mEkfVmwl+F7SzfII30=
+github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=

--- a/libbpfgo/selftest/perfbuffers/main.go
+++ b/libbpfgo/selftest/perfbuffers/main.go
@@ -1,0 +1,63 @@
+package main
+
+import "C"
+
+import (
+	"os"
+
+	"encoding/binary"
+	"fmt"
+
+	bpf "github.com/aquasecurity/tracee/libbpfgo"
+)
+
+func main() {
+
+	bpfModule, err := bpf.NewModuleFromFile("self.bpf.o")
+	if err != nil {
+		os.Exit(-1)
+	}
+	defer bpfModule.Close()
+
+	bpfModule.BPFLoadObject()
+	prog, err := bpfModule.GetProgram("kprobe__sys_mmap")
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	_, err = prog.AttachKprobe("__x64_sys_mmap")
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	eventsChannel := make(chan []byte)
+	lostChannel := make(chan uint64)
+	pb, err := bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 1)
+	if err != nil {
+		os.Exit(-1)
+	}
+
+	pb.Start()
+
+	numberOfEventsReceived := 0
+
+recvLoop:
+	for {
+		b := <-eventsChannel
+		if binary.LittleEndian.Uint32(b) != 2021 {
+			fmt.Fprintf(os.Stderr, "invalid data retrieved\n")
+			os.Exit(-1)
+		}
+		numberOfEventsReceived++
+		if numberOfEventsReceived > 5 {
+			break recvLoop
+		}
+	}
+
+	// Test that it won't cause a panic or block if Stop or Close called multiple times
+	pb.Stop()
+	pb.Stop()
+	pb.Close()
+	pb.Close()
+	pb.Stop()
+}

--- a/libbpfgo/selftest/perfbuffers/run.sh
+++ b/libbpfgo/selftest/perfbuffers/run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+GREEN='    \033[0;32m'
+RED='    \033[0;31m'
+NC='\033[0m' 
+
+VERSION_LIMIT=4.3
+CURRENT_VERSION=$(uname -r | cut -d '.' -f1-2)
+
+# Check that kernel version is big enough
+if [ $(echo "$CURRENT_VERSION"$'\n'"$VERSION_LIMIT" | sort -V | head -n1) != "$VERSION_LIMIT" ]; then
+    echo -e "${RED}[*] OUTDATED KERNEL VERSION${NC}"
+    exit 1
+fi
+
+make -f $PWD/Makefile
+if [ $? -ne 0 ]; then
+    echo -e "${RED}[*] MAKE FAILED"
+    exit 2
+else
+    echo -e "${GREEN}[*] MAKE RAN SUCCESFULLY${NC}"
+fi
+
+timeout 5 $PWD/self
+RETURN_CODE=$?
+if [ $RETURN_CODE -eq 124 ]; then
+    echo -e "${RED}[*] SELFTEST TIMEDOUT${NC}"
+    exit 3
+fi
+
+if [ $RETURN_CODE -ne 0 ]; then
+    echo -e "${RED}[*] ERROR IN SELFTEST${NC}"
+    exit 4
+fi
+
+echo -e "${GREEN}[*] SUCCESS${NC}"
+exit 0

--- a/libbpfgo/selftest/perfbuffers/self.bpf.c
+++ b/libbpfgo/selftest/perfbuffers/self.bpf.c
@@ -1,0 +1,25 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+} events SEC(".maps");
+
+SEC("kprobe/sys_mmap")
+int kprobe__sys_mmap(struct pt_regs *ctx)
+{
+    int process = 2021;
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &process, sizeof(int));
+
+    return 0;
+}


### PR DESCRIPTION
This is anlogous to 09b2b47c (which fixed RingBuffer).
It does a clean PerfBuffer stop by waiting for the
polling goroutine to finish its work.

Fixes #640 