### PR TITLE
Group of small fixes

### DIFF
--- a/libbpfgo/helpers/argumentParsers.go
+++ b/libbpfgo/helpers/argumentParsers.go
@@ -1,11 +1,8 @@
 package helpers
 
 import (
-	"bufio"
 	"encoding/binary"
-	"fmt"
 	"net"
-	"os"
 	"strconv"
 	"strings"
 )
@@ -603,30 +600,4 @@ func ParseBPFCmd(cmd int32) string {
 		res = strconv.Itoa(int(cmd))
 	}
 	return res
-}
-
-// TracePipeListen reads data from the trace pipe that bpf_trace_printk() writes to,
-// (/sys/kernel/debug/tracing/trace_pipe).
-// It writes the data to stdout. The pipe is global, so this function is not
-// associated with any BPF program. It is recommended to use bpf_trace_printk()
-// and this function for debug purposes only.
-// This is a blocking function intended to be called from a goroutine.
-func TracePipeListen() error {
-	f, err := os.Open("/sys/kernel/debug/tracing/trace_pipe")
-	if err != nil {
-		return fmt.Errorf("failed to open trace pipe: %v", err)
-	}
-	defer f.Close()
-
-	r := bufio.NewReader(f)
-	b := make([]byte, 1024)
-	for {
-		len, err := r.Read(b)
-		if err != nil {
-			return fmt.Errorf("failed to read from trace pipe: %v", err)
-		}
-
-		s := string(b[:len])
-		fmt.Println(s)
-	}
 }

--- a/libbpfgo/helpers/tracelisten.go
+++ b/libbpfgo/helpers/tracelisten.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// TracePipeListen reads data from the trace pipe that bpf_trace_printk() writes to,
+// (/sys/kernel/debug/tracing/trace_pipe).
+// It writes the data to stdout. The pipe is global, so this function is not
+// associated with any BPF program. It is recommended to use bpf_trace_printk()
+// and this function for debug purposes only.
+// This is a blocking function intended to be called from a goroutine.
+func TracePipeListen() error {
+	f, err := os.Open("/sys/kernel/debug/tracing/trace_pipe")
+	if err != nil {
+		return fmt.Errorf("failed to open trace pipe: %v", err)
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+	b := make([]byte, 1024)
+	for {
+		len, err := r.Read(b)
+		if err != nil {
+			return fmt.Errorf("failed to read from trace pipe: %v", err)
+		}
+
+		s := string(b[:len])
+		fmt.Println(s)
+	}
+}

--- a/libbpfgo/libbpfgo.go
+++ b/libbpfgo/libbpfgo.go
@@ -1,7 +1,7 @@
 package libbpfgo
 
 /*
-#cgo LDFLAGS: -lelf -lz
+#cgo LDFLAGS: -lelf -lz -lbpf
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
@@ -243,7 +243,7 @@ func bumpMemlockRlimit() error {
 	rLimit.Cur = 512 << 20 /* 512 MBs */
 	err := syscall.Setrlimit(C.RLIMIT_MEMLOCK, &rLimit)
 	if err != nil {
-		fmt.Errorf("error setting rlimit: %v", err)
+		return fmt.Errorf("error setting rlimit: %v", err)
 	}
 	return nil
 }
@@ -664,7 +664,7 @@ func (rb *RingBuffer) Stop() {
 		// goroutine will block in the callback.
 		eventChan := eventChannels[uintptr(rb.bpfMap.fd)]
 		go func() {
-			for _ = range eventChan {
+			for range eventChan {
 			}
 		}()
 
@@ -691,7 +691,7 @@ func (rb *RingBuffer) Close() {
 
 func (rb *RingBuffer) isStopped() bool {
 	select {
-	case _, _ = <-rb.stop:
+	case <-rb.stop:
 		return true
 	default:
 		return false
@@ -770,5 +770,4 @@ func (pb *PerfBuffer) poll() error {
 			}
 		}
 	}
-	return nil
 }

--- a/libbpfgo/selftest/ringbuffers/go.mod
+++ b/libbpfgo/selftest/ringbuffers/go.mod
@@ -1,7 +1,0 @@
-module github.com/aquasecurity/tracee/libbpfgo/selftests/5.8.15
-
-go 1.16
-
-replace github.com/aquasecurity/tracee/libbpfgo => ../../
-
-require github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b

--- a/libbpfgo/selftest/ringbuffers/go.sum
+++ b/libbpfgo/selftest/ringbuffers/go.sum
@@ -1,3 +1,0 @@
-github.com/aquasecurity/tracee v0.4.0 h1:fOfgeHWgjHSNK7vokaANNXOFljK9KOYSYriTxCfvMEU=
-github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b h1:KfjLxlXFVCRx0UDYzzTV7Tt80mEkfVmwl+F7SzfII30=
-github.com/aquasecurity/tracee/libbpfgo v0.0.0-20210204155428-0e61c188eb0b/go.mod h1:Ldem7RTRbX6bdTDxU2eYYvo7pPWYQbbc6rdGv0Ilyts=

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/aquasecurity/tracee/tracee-ebpf/tracee"
 	"github.com/syndtr/gocapability/capability"
-	"github.com/urfave/cli/v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 var debug bool

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 
 	"github.com/aquasecurity/tracee/tracee-rules/engine"
-	"github.com/urfave/cli/v2"
+	cli "github.com/urfave/cli/v2"
 )
 
 type Clock interface {


### PR DESCRIPTION
This PR handles the following small things (not associated with issues)

- moves the libbpfgo helpers function `TracePrintListen` into it's own file and renames the other helpers file.
- remove go.mod/go.sum file from the selftest package in libbpfgo, no need for them.
- fixes small linter errors in libbpfgo, and adds `-lbpf` to link libbpf (mostly just for gopls).
- fix importing of the `urfave/cli` package 