### PR TITLE
types.Finding interface update

### DIFF
--- a/tracee-rules/output.go
+++ b/tracee-rules/output.go
@@ -66,7 +66,8 @@ func setupOutput(w io.Writer, webhook string, webhookTemplate string, contentTyp
 
 			switch res.Context.(type) {
 			case tracee.Event:
-				if err := tOutput.Execute(w, types.FindingWithMetadata{Finding: res, SignatureMetadata: sigMetadata}); err != nil {
+				res.SigMetadata = sigMetadata
+				if err := tOutput.Execute(w, res); err != nil {
 					log.Println("error writing to output: ", err)
 				}
 			default:

--- a/tracee-rules/signatures/golang/examples/example.go
+++ b/tracee-rules/signatures/golang/examples/example.go
@@ -50,13 +50,14 @@ func (sig *counter) OnEvent(e types.Event) error {
 		sig.count++
 	}
 	if sig.count == sig.target {
+		m, _ := sig.GetMetadata()
 		sig.cb(types.Finding{
 			Data: map[string]interface{}{
 				"count":    sig.count,
 				"severity": "HIGH",
 			},
-			Context:   e,
-			Signature: sig,
+			Context:     e,
+			SigMetadata: m,
 		})
 		sig.count = 0
 	}

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -170,16 +170,15 @@ func (sig *stdioOverSocket) OnSignal(s types.Signal) error {
 }
 
 func isStdioOverSocket(sig *stdioOverSocket, eventObj tracee.Event, pidSocketMap map[int]string, srcFd int, dstFd int) error {
-
 	stdAll := []int{0, 1, 2}
-
 	ip, socketfdExists := pidSocketMap[srcFd]
 
 	// this means that a socket FD is duplicated into one of the standard FDs
 	if socketfdExists && intInSlice(dstFd, stdAll) {
+		m, _ := sig.GetMetadata()
 		sig.cb(types.Finding{
-			Signature: sig,
-			Context:   eventObj,
+			SigMetadata: m,
+			Context:     eventObj,
 			Data: map[string]interface{}{
 				"ip": ip,
 			},

--- a/tracee-rules/signatures/rego/regosig/traceerego.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego.go
@@ -147,16 +147,16 @@ func (sig *RegoSignature) OnEvent(e types.Event) error {
 		case bool:
 			if v {
 				sig.cb(types.Finding{
-					Data:      nil,
-					Context:   ee,
-					Signature: sig,
+					Data:        nil,
+					Context:     ee,
+					SigMetadata: sig.metadata,
 				})
 			}
 		case map[string]interface{}:
 			sig.cb(types.Finding{
-				Data:      v,
-				Context:   ee,
-				Signature: sig,
+				Data:        v,
+				Context:     ee,
+				SigMetadata: sig.metadata,
 			})
 		}
 	}

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -47,6 +47,5 @@ type SignalSourceComplete string
 type Finding struct {
 	Data        map[string]interface{}
 	Context     Event
-	Signature   Signature
 	SigMetadata SignatureMetadata
 }

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -45,12 +45,8 @@ type SignalSourceComplete string
 
 //Finding is the main output of a signature. It represents a match result for the signature business logic
 type Finding struct {
-	Data      map[string]interface{}
-	Context   Event
-	Signature Signature
-}
-
-type FindingWithMetadata struct {
-	Finding
-	SignatureMetadata
+	Data        map[string]interface{}
+	Context     Event
+	Signature   Signature
+	SigMetadata SignatureMetadata
 }


### PR DESCRIPTION
This PR changes the `types.Finding` struct to use SignatureMetadata field instead of Signature field.

Signed-off-by: Simarpreet Singh <simar@linux.com>
