### PR TITLE
Fix eventsChannels race

### DIFF
--- a/libbpfgo/helpers/rwArray.go
+++ b/libbpfgo/helpers/rwArray.go
@@ -1,0 +1,74 @@
+package helpers
+
+import (
+	"sync"
+)
+
+type slot struct {
+	value interface{}
+	used  bool
+}
+
+// RWArray allows for multiple concurrent readers but
+// only a single writer. The writers lock a mutex while the readers
+// are lock free.
+// It is implemented as an array of slots where each slot holds a
+// value (of type interface{}) and a boolean marker to indicate if it's
+// in use or not. The insertion (Put) performs a linear probe
+// looking for an available slot as indicated by the in-use marker.
+// While probing, it is not touching the value itself, as it's
+// being read without a lock by the readers.
+type RWArray struct {
+	slots []slot
+	mux   sync.Mutex
+}
+
+func NewRWArray(capacity uint) RWArray {
+	return RWArray{
+		slots: make([]slot, capacity),
+	}
+}
+
+func (a *RWArray) Put(v interface{}) int {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	limit := len(a.slots)
+
+	for i := 0; i < limit; i++ {
+		if !a.slots[i].used {
+			a.slots[i].value = v
+			a.slots[i].used = true
+			return i
+		}
+	}
+
+	return -1
+}
+
+func (a *RWArray) Remove(index uint) {
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	if int(index) >= len(a.slots) {
+		return
+	}
+
+	a.slots[index].value = nil
+	a.slots[index].used = false
+}
+
+func (a *RWArray) Get(index uint) interface{} {
+	if int(index) >= len(a.slots) {
+		return nil
+	}
+
+	// N.B. If slot[index].used == false, this is technically
+	// a race since Put() might be putting the value in there
+	// at the same time.
+	return a.slots[index].value
+}
+
+func (a *RWArray) Capacity() uint {
+	return uint(len(a.slots))
+}

--- a/libbpfgo/helpers/rwArray_test.go
+++ b/libbpfgo/helpers/rwArray_test.go
@@ -1,0 +1,138 @@
+package helpers
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestRWArrayWrite(t *testing.T) {
+	a := NewRWArray(1024)
+
+	last := 0
+
+	for i := 0; i < 1000; i++ {
+		slot1 := a.Put(&i)
+		if slot1 < 0 {
+			t.Errorf("failed to put")
+		}
+
+		if last != slot1 {
+			t.Fatalf("Put didn't occupy first available; expected=%v, got=%v", last, slot1)
+		}
+
+		slot2 := a.Put(&i)
+		if slot2 < 0 {
+			t.Fatalf("failed to put")
+		}
+
+		if slot1 >= slot2 {
+			t.Fatalf("slot1 (%v) < slot2 (%v)", slot1, slot2)
+		}
+
+		a.Remove(uint(slot2))
+
+		last = slot2
+	}
+}
+
+func TestRWArrayExhaust(t *testing.T) {
+	a := NewRWArray(1024)
+
+	last := -1
+
+	for {
+		v := 123
+		slot := a.Put(&v)
+
+		if slot < 0 {
+			if uint(last) != a.Capacity()-1 {
+				t.Fatalf("failed to put, last=%v", last)
+			}
+			return
+		}
+
+		if slot != last+1 {
+			t.Fatalf("Put returned non-sequential slot; expected=%v, got=%v", last+1, slot)
+		}
+
+		last = slot
+	}
+}
+
+func TestRWArrayRead(t *testing.T) {
+	a := NewRWArray(1024)
+
+	for i := 0; i < 1000; i++ {
+		v := i
+		slot := a.Put(&v)
+		if slot != i {
+			t.Errorf("Put returned non-sequential slot; expected=%v, got=%v", i, slot)
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		v := a.Get(uint(i)).(*int)
+		if *v != i {
+			t.Errorf("Get returned wrong valuue; expected=%v, got=%v", i, *v)
+		}
+	}
+}
+
+// Designed to be run under race detector
+func TestRWArrayConcurrent(t *testing.T) {
+	a := NewRWArray(16 * 1024)
+	capacity := a.Capacity()
+
+	stop := make(chan struct{})
+	wg := sync.WaitGroup{}
+
+	// Populate every other slot
+	v := 123
+	for i := uint(0); i < capacity; i++ {
+		a.Put(&v)
+	}
+	for i := uint(1); i < capacity; i += 2 {
+		a.Remove(i)
+	}
+
+	writer := func() {
+		for {
+			// fill the holes
+			for i := uint(0); i < capacity/2; i++ {
+				a.Put(&v)
+			}
+
+			// make some holes
+			for i := uint(1); i < capacity; i += 2 {
+				a.Remove(i)
+			}
+
+			// time to exit?
+			select {
+			case _, _ = <-stop:
+				return
+			default:
+			}
+		}
+	}
+
+	reader := func() {
+		for rounds := 0; rounds < 10; rounds++ {
+			for i := uint(0); i < capacity; i += 2 {
+				a.Get(i)
+			}
+		}
+
+		wg.Done()
+	}
+
+	go writer()
+
+	wg.Add(3)
+	go reader()
+	go reader()
+	go reader()
+
+	wg.Wait()
+	close(stop)
+}

--- a/libbpfgo/libbpfgo.go
+++ b/libbpfgo/libbpfgo.go
@@ -5,6 +5,7 @@ package libbpfgo
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/resource.h>
@@ -34,9 +35,8 @@ void set_print_fn() {
     libbpf_set_print(libbpf_print_fn);
 }
 
-struct ring_buffer * init_ring_buf(int map_fd) {
+struct ring_buffer * init_ring_buf(int map_fd, uintptr_t ctx) {
     struct ring_buffer *rb = NULL;
-    __u64 ctx = map_fd;
     rb = ring_buffer__new(map_fd, ringbufferCallback, (void*)ctx, NULL);
     if (!rb) {
         fprintf(stderr, "Failed to initialize ring buffer\n");
@@ -45,12 +45,11 @@ struct ring_buffer * init_ring_buf(int map_fd) {
     return rb;
 }
 
-struct perf_buffer * init_perf_buf(int map_fd, int page_cnt) {
+struct perf_buffer * init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx) {
     struct perf_buffer_opts pb_opts = {};
     struct perf_buffer *pb = NULL;
     pb_opts.sample_cb = perfCallback;
     pb_opts.lost_cb = perfLostCallback;
-    __u64 ctx = map_fd;
     pb_opts.ctx = (void*)ctx;
     pb = perf_buffer__new(map_fd, page_cnt, &pb_opts);
     if (pb < 0) {
@@ -182,6 +181,13 @@ import (
 	"sync"
 	"syscall"
 	"unsafe"
+
+	"github.com/aquasecurity/tracee/libbpfgo/helpers"
+)
+
+const (
+	// Maximum number of channels (RingBuffers + PerfBuffers) supported
+	maxEventChannels = 512
 )
 
 type Module struct {
@@ -222,16 +228,20 @@ type BPFLink struct {
 }
 
 type PerfBuffer struct {
-	pb     *C.struct_perf_buffer
-	bpfMap *BPFMap
-	stop   chan struct{}
-	closed bool
-	wg     sync.WaitGroup
+	pb         *C.struct_perf_buffer
+	bpfMap     *BPFMap
+	slot       uint
+	eventsChan chan []byte
+	lostChan   chan uint64
+	stop       chan struct{}
+	closed     bool
+	wg         sync.WaitGroup
 }
 
 type RingBuffer struct {
 	rb     *C.struct_ring_buffer
 	bpfMap *BPFMap
+	slot   uint
 	stop   chan struct{}
 	closed bool
 	wg     sync.WaitGroup
@@ -621,8 +631,7 @@ func doAttachKprobeLegacy(prog *BPFProg, kp string, isKretprobe bool) (*BPFLink,
 	return bpfLink, nil
 }
 
-var eventChannels = make(map[uintptr]chan []byte)
-var lostChannels = make(map[uintptr]chan uint64)
+var eventChannels = helpers.NewRWArray(maxEventChannels)
 
 func (m *Module) InitRingBuf(mapName string, eventsChan chan []byte) (*RingBuffer, error) {
 	bpfMap, err := m.GetMap(mapName)
@@ -630,20 +639,24 @@ func (m *Module) InitRingBuf(mapName string, eventsChan chan []byte) (*RingBuffe
 		return nil, err
 	}
 
-	ctx := uintptr(bpfMap.fd)
 	if eventsChan == nil {
 		return nil, fmt.Errorf("events channel can not be nil")
 	}
-	eventChannels[ctx] = eventsChan
 
-	rb := C.init_ring_buf(bpfMap.fd)
+	slot := eventChannels.Put(eventsChan)
+	if slot == -1 {
+		return nil, fmt.Errorf("max ring buffers reached")
+	}
+
+	rb := C.init_ring_buf(bpfMap.fd, C.uintptr_t(slot))
 	if rb == nil {
-		return nil, fmt.Errorf("")
+		return nil, fmt.Errorf("failed to initialize ring buffer")
 	}
 
 	ringBuf := &RingBuffer{
 		rb:     rb,
 		bpfMap: bpfMap,
+		slot:   uint(slot),
 	}
 	m.ringBufs = append(m.ringBufs, ringBuf)
 	return ringBuf, nil
@@ -664,7 +677,7 @@ func (rb *RingBuffer) Stop() {
 		// may have stopped at this point. Failure to drain it will
 		// result in a deadlock: the channel will fill up and the poll
 		// goroutine will block in the callback.
-		eventChan := eventChannels[uintptr(rb.bpfMap.fd)]
+		eventChan := eventChannels.Get(rb.slot).(chan []byte)
 		go func() {
 			for range eventChan {
 			}
@@ -688,6 +701,7 @@ func (rb *RingBuffer) Close() {
 	}
 	rb.Stop()
 	C.ring_buffer__free(rb.rb)
+	eventChannels.Remove(rb.slot)
 	rb.closed = true
 }
 
@@ -724,21 +738,30 @@ func (m *Module) InitPerfBuf(mapName string, eventsChan chan []byte, lostChan ch
 	if err != nil {
 		return nil, fmt.Errorf("failed to init perf buffer: %v", err)
 	}
-	ctx := uintptr(bpfMap.fd)
 	if eventsChan == nil {
 		return nil, fmt.Errorf("failed to init perf buffer: events channel can not be nil")
 	}
-	eventChannels[ctx] = eventsChan
-	lostChannels[ctx] = lostChan
-	pb := C.init_perf_buf(bpfMap.fd, C.int(pageCnt))
+
+	perfBuf := &PerfBuffer{
+		bpfMap:     bpfMap,
+		eventsChan: eventsChan,
+		lostChan:   lostChan,
+	}
+
+	slot := eventChannels.Put(perfBuf)
+	if slot == -1 {
+		return nil, fmt.Errorf("max number of ring/perf buffers reached")
+	}
+
+	pb := C.init_perf_buf(bpfMap.fd, C.int(pageCnt), C.uintptr_t(slot))
 	if pb == nil {
+		eventChannels.Remove(uint(slot))
 		return nil, fmt.Errorf("failed to initialize perf buffer")
 	}
 
-	perfBuf := &PerfBuffer{
-		pb:     pb,
-		bpfMap: bpfMap,
-	}
+	perfBuf.pb = pb
+	perfBuf.slot = uint(slot)
+
 	m.perfBufs = append(m.perfBufs, perfBuf)
 	return perfBuf, nil
 }
@@ -754,19 +777,16 @@ func (pb *PerfBuffer) Stop() {
 		// Tell the poll goroutine that it's time to exit
 		close(pb.stop)
 
-		eventsChan := eventChannels[uintptr(pb.bpfMap.fd)]
-		lostChan := lostChannels[uintptr(pb.bpfMap.fd)]
-
 		// The event and lost channels should be drained here since the consumer
 		// may have stopped at this point. Failure to drain it will
 		// result in a deadlock: the channel will fill up and the poll
 		// goroutine will block in the callback.
 		go func() {
-			for range eventsChan {
+			for range pb.eventsChan {
 			}
 
-			if lostChan != nil {
-				for range lostChan {
+			if pb.lostChan != nil {
+				for range pb.lostChan {
 				}
 			}
 		}()
@@ -776,8 +796,8 @@ func (pb *PerfBuffer) Stop() {
 
 		// Close the channel -- this is useful for the consumer but
 		// also to terminate the drain goroutine above.
-		close(eventsChan)
-		close(lostChan)
+		close(pb.eventsChan)
+		close(pb.lostChan)
 
 		// This allows Stop() to be called multiple times safely
 		pb.stop = nil
@@ -790,6 +810,7 @@ func (pb *PerfBuffer) Close() {
 	}
 	pb.Stop()
 	C.perf_buffer__free(pb.pb)
+	eventChannels.Remove(pb.slot)
 	pb.closed = true
 }
 


### PR DESCRIPTION
Fixes eventsChannels and lostChannels accesses
- Both were accessed without a mutex
- The acceeses in polling goroutine are frequent,
  locks are undesired in this path
- Use a sparse array (implemented as a two level tree)
  to provide lock-free read-only access.

Fixes #648 