### PR TITLE
Add Resize() and GetMaxEntries() to BPFMap

### DIFF
--- a/libbpfgo/selftest/ringbuffers/Makefile
+++ b/libbpfgo/selftest/ringbuffers/Makefile
@@ -7,7 +7,7 @@ BPF_SRC := $(shell find . -type f -name '*.bpf.c')
 PWD := $(shell pwd)
 
 LIBBPF_HEADERS := /usr/include/bpf
-LIBBPF_OBJ := /usr/lib64/libbpf.a
+LIBBPF_OBJ := -lbpf
 
 .PHONY: all
 all: vmlinux.h $(TARGET) $(TARGET_BPF)


### PR DESCRIPTION
While it's convenient to specify map sizes in BPF C file,
sometimes the right size is only known at runtime.

With Resize(), it's possible to instantiate the module
and resize the maps before they're loaded into the kernel.

Fixes #655 