### PR TITLE
fix error handling

### DIFF
--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -73,7 +73,6 @@ func main() {
 			}
 			t, err := tracee.New(cfg)
 			if err != nil {
-				// t is being closed internally
 				return fmt.Errorf("error creating Tracee: %v", err)
 			}
 			return t.Run()

--- a/tracee-ebpf/tracee/printer.go
+++ b/tracee-ebpf/tracee/printer.go
@@ -163,8 +163,6 @@ func (p tableEventPrinter) Epilogue(stats statsStore) {
 }
 
 func (p tableEventPrinter) Close() {
-	p.out.Close()
-	p.err.Close()
 }
 
 type templateEventPrinter struct {
@@ -210,8 +208,6 @@ func (p templateEventPrinter) Print(event external.Event) {
 func (p templateEventPrinter) Epilogue(stats statsStore) {}
 
 func (p templateEventPrinter) Close() {
-	p.out.Close()
-	p.err.Close()
 }
 
 type jsonEventPrinter struct {
@@ -242,8 +238,6 @@ func (p jsonEventPrinter) Error(e error) {
 func (p jsonEventPrinter) Epilogue(stats statsStore) {}
 
 func (p jsonEventPrinter) Close() {
-	p.out.Close()
-	p.err.Close()
 }
 
 // gobEventPrinter is printing events using golang's builtin Gob serializer
@@ -276,6 +270,4 @@ func (p *gobEventPrinter) Error(e error) {
 func (p *gobEventPrinter) Epilogue(stats statsStore) {}
 
 func (p gobEventPrinter) Close() {
-	p.out.Close()
-	p.err.Close()
 }


### PR DESCRIPTION
fix: #618 

printers were closing their stdout/stderr although they didn't create
those. this caused initBPF errors for example to get unseen