### PR TITLE
Tracee-Rules | JSON parser and container lifetime rego

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -18,7 +18,7 @@ VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags
 OUT_DIR ?= dist
 GO_SRC := $(shell find . -type f -name '*.go')
 OUT_BIN := $(OUT_DIR)/tracee-ebpf
-BPF_SRC := tracee/tracee.bpf.c 
+BPF_SRC := tracee/tracee.bpf.c
 OUT_BPF := $(OUT_DIR)/tracee.bpf.$(subst .,_,$(KERN_RELEASE)).$(subst .,_,$(VERSION)).o
 BPF_HEADERS := 3rdparty/include
 BPF_BUNDLE := $(OUT_DIR)/tracee.bpf.tar.gz
@@ -40,17 +40,23 @@ $(OUT_DIR):
 build: $(OUT_BIN)
 
 go_env := GOOS=linux GOARCH=$(ARCH:x86_64=amd64) CC=$(CMD_CLANG) CGO_CFLAGS="-I $(abspath $(LIBBPF_HEADERS))" CGO_LDFLAGS="$(abspath $(LIBBPF_OBJ))"
+
+LDF = -X main.version=$(VERSION)
+ifdef BUILD_STATIC
+	LDF += -extldflags=-static
+endif
+
 ifndef DOCKER
 $(OUT_BIN): $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(filter-out *_test.go,$(GO_SRC)) $(BPF_BUNDLE) | $(OUT_DIR)
 	$(go_env) go build -v -o $(OUT_BIN) \
-	-ldflags "-X main.version=$(VERSION)"
-else 
+	-ldflags "$(LDF)"
+else
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@ VERSION=$(VERSION))
 endif
 
 bpf_compile_tools = $(CMD_LLC) $(CMD_CLANG)
-.PHONY: $(bpf_compile_tools) 
+.PHONY: $(bpf_compile_tools)
 $(bpf_compile_tools): % : check_%
 
 $(LIBBPF_SRC):
@@ -59,8 +65,8 @@ $(LIBBPF_SRC):
 $(LIBBPF_HEADERS) $(LIBBPF_HEADERS)/bpf $(LIBBPF_HEADERS)/linux: | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC)
 	cd $(LIBBPF_SRC) && $(MAKE) install_headers install_uapi_headers DESTDIR=$(abspath $(OUT_DIR))/libbpf
 
-$(LIBBPF_OBJ): | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC) 
-	cd $(LIBBPF_SRC) && $(MAKE) OBJDIR=$(abspath $(OUT_DIR))/libbpf BUILD_STATIC_ONLY=1 
+$(LIBBPF_OBJ): | $(OUT_DIR) $(bpf_compile_tools) $(LIBBPF_SRC)
+	cd $(LIBBPF_SRC) && $(MAKE) OBJDIR=$(abspath $(OUT_DIR))/libbpf BUILD_STATIC_ONLY=1
 
 bpf_bundle_dir := $(OUT_DIR)/tracee.bpf
 $(BPF_BUNDLE): $(BPF_SRC) $(LIBBPF_HEADERS)/bpf $(BPF_HEADERS)
@@ -111,11 +117,11 @@ $(OUT_DIR)/tracee.bpf.%.o: $(BPF_SRC) $(LIBBPF_HEADERS) | $(OUT_DIR) $(bpf_compi
 	-$(CMD_LLVM_STRIP) -g $@
 	rm $(@:.o=.ll)
 else
-$(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR) 
+$(OUT_BPF): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@)
 endif
 
-.PHONY: test 
+.PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
 	$(go_env)	go test -v ./...

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -51,7 +51,7 @@ func main() {
 				}
 				loadedSigIDs = append(loadedSigIDs, m.ID)
 			}
-			fmt.Println("Loaded signature(s): ", loadedSigIDs)
+			fmt.Fprintln(os.Stderr, "Loaded signature(s): ", loadedSigIDs)
 
 			if c.Bool("list") {
 				return listSigs(os.Stdout, sigs)

--- a/tracee-rules/signatures/rego/container_start.rego
+++ b/tracee-rules/signatures/rego/container_start.rego
@@ -1,0 +1,31 @@
+
+package tracee.TRC_RUNTIME_CONTAINER_START
+
+import data.tracee.helpers
+
+__rego_metadoc__ := {
+    "id": "TRC-RUNTIME-CONTAINER-START",
+    "version": "0.1.0",
+    "name": "Identify Container Start",
+    "description": "Identify a container start event",
+    "tags": ["linux", "container"],
+    "properties": {}
+}
+
+eventSelectors := [
+    {
+        "source": "tracee",
+        "name": "execve"
+    }
+]
+
+tracee_selected_events[eventSelector] {
+	eventSelector := eventSelectors[_]
+}
+
+
+tracee_match {
+    input.eventName == "execve"
+    input.processId == 1
+    input.processName == "runc:[2:INIT]"
+}

--- a/tracee-rules/signatures/rego/container_stop.rego
+++ b/tracee-rules/signatures/rego/container_stop.rego
@@ -1,0 +1,30 @@
+
+package tracee.TRC_RUNTIME_CONTAINER_STOP
+
+import data.tracee.helpers
+
+__rego_metadoc__ := {
+    "id": "TRC-RUNTIME-CONTAINER-STOP",
+    "version": "0.1.0",
+    "name": "Identify Container Stop",
+    "description": "Identify a container stop event",
+    "tags": ["linux", "container"],
+    "properties": {}
+}
+
+eventSelectors := [
+    {
+        "source": "tracee",
+        "name": "sched_process_exit"
+    }
+]
+
+tracee_selected_events[eventSelector] {
+	eventSelector := eventSelectors[_]
+}
+
+tracee_match {
+    input.eventName == "sched_process_exit"
+    input.processId == 1
+    input.processName != "runc:[2:INIT]"
+}

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -17,12 +17,12 @@ type Signature interface {
 
 //SignatureMetadata represents information about the signature
 type SignatureMetadata struct {
-	ID          string
-	Version     string
-	Name        string
-	Description string
-	Tags        []string
-	Properties  map[string]interface{}
+	ID          string                 `json:ID`
+	Version     string                 `json:Version`
+	Name        string                 `json:Name`
+	Description string                 `json:Description`
+	Tags        []string               `json:Tags`
+	Properties  map[string]interface{} `json:Properties`
 }
 
 //SignatureEventSelector represents events the signature is subscribed to
@@ -45,7 +45,7 @@ type SignalSourceComplete string
 
 //Finding is the main output of a signature. It represents a match result for the signature business logic
 type Finding struct {
-	Data        map[string]interface{}
-	Context     Event
-	SigMetadata SignatureMetadata
+	Data        map[string]interface{} `json:Data`
+	Context     Event                  `json:Context`
+	SigMetadata SignatureMetadata      `json:SigMetadata`
 }


### PR DESCRIPTION
This commit contains the following modifications:
1. Add JSON parser as a tracee-rules output method.
2. Rego files for container start and stop events.