### PR TITLE
feat: add testing envrionment matrix that includes self hosted runner

### DIFF
--- a/.github/workflows/pr-ebpf.yaml
+++ b/.github/workflows/pr-ebpf.yaml
@@ -5,7 +5,10 @@ on:
       - "tracee-ebpf/**"
 jobs:
   build-test:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-20.04, centos-8.2-linux-4.18]
     defaults:
       run:
         working-directory: tracee-ebpf


### PR DESCRIPTION
I hosted a VM in azure where i'm running a github actions runner

#685

```
[*] uname -a
Linux gh-action-tracee-centos-8.2 4.18.0-193.28.1.el8_2.x86_64 #1 SMP Thu Oct 22 00:20:22 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux
```

Signed-off-by: grantseltzer <grantseltzer@gmail.com>