### PR TITLE
fix: Use a proper macro to handle libbpf error returns

### DIFF
--- a/libbpfgo/libbpfgo.go
+++ b/libbpfgo/libbpfgo.go
@@ -12,6 +12,7 @@ package libbpfgo
 
 #include <asm-generic/unistd.h>
 #include <errno.h>
+#include <err.h>
 #include <fcntl.h>
 #include <linux/perf_event.h>
 #include <linux/unistd.h>
@@ -38,7 +39,7 @@ void set_print_fn() {
 struct ring_buffer * init_ring_buf(int map_fd, uintptr_t ctx) {
     struct ring_buffer *rb = NULL;
     rb = ring_buffer__new(map_fd, ringbufferCallback, (void*)ctx, NULL);
-    if (!rb) {
+    if IS_ERR(rb) {
         fprintf(stderr, "Failed to initialize ring buffer\n");
         return NULL;
     }
@@ -52,7 +53,7 @@ struct perf_buffer * init_perf_buf(int map_fd, int page_cnt, uintptr_t ctx) {
     pb_opts.lost_cb = perfLostCallback;
     pb_opts.ctx = (void*)ctx;
     pb = perf_buffer__new(map_fd, page_cnt, &pb_opts);
-    if (pb < 0) {
+    if IS_ERR(pb) {
         fprintf(stderr, "Failed to initialize perf buffer!\n");
         return NULL;
     }


### PR DESCRIPTION
Fixes: https://github.com/aquasecurity/tracee/issues/691

Signed-off-by: Simarpreet Singh <simar@linux.com>