### PR TITLE
Add check for empty bytes being written by file write channel 

### DIFF
--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -1280,6 +1280,9 @@ func (t *Tracee) processFileWrites() {
 	for {
 		select {
 		case dataRaw := <-t.fileWrChannel:
+			if len(dataRaw) == 0 {
+				continue
+			}
 			dataBuff := bytes.NewBuffer(dataRaw)
 			var meta chunkMeta
 			appendFile := false


### PR DESCRIPTION
This is to handle #690 

The "EOF" error is printed as a result of the File Write Channel sending empty raw data. I believe the reason for this has to do with allocating memory for []byte{} that'd be send over the file_write channel, but nothing ever being written, leading it to being drained in this way. 

This will skip over empty raw data that's been sent. Alternatively we can add a check for `err == io.EOF` and ignore it specifically.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>