### PR TITLE
libbpfgo: Check for ERR_PTR return values

### DIFF
--- a/libbpfgo/Makefile
+++ b/libbpfgo/Makefile
@@ -1,0 +1,29 @@
+TARGET_BPF := test/test.bpf.o
+VMLINUX_H = test/vmlinux.h
+
+GO_SRC := $(shell find . -type f -name '*.go')
+BPF_SRC := $(shell find . -type f -name '*.bpf.c')
+PWD := $(shell pwd)
+
+LIBBPF_HEADERS := /usr/include/bpf
+LIBBPF := "-lbpf"
+
+.PHONY: all
+all: test
+
+$(VMLINUX_H):
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > test/vmlinux.h
+
+go_env := CC=gcc CGO_CFLAGS="-I $(LIBBPF_HEADERS)" CGO_LDFLAGS="$(LIBBPF)"
+.PHONY: test
+test: $(TARGET_BPF) $(GO_SRC)
+	$(go_env) go test -ldflags '-extldflags "-static"' .
+
+$(TARGET_BPF): $(BPF_SRC) $(VMLINUX_H)
+	clang \
+		-g -O2 -c -target bpf \
+		-o $@ $<
+
+.PHONY: clean
+clean: 
+	rm $(TARGET_BPF) $(VMLINUX_H)

--- a/libbpfgo/libbpfgo.go
+++ b/libbpfgo/libbpfgo.go
@@ -18,6 +18,24 @@ package libbpfgo
 #include <string.h>
 #include <unistd.h>
 
+#ifndef MAX_ERRNO
+#define MAX_ERRNO       4095
+
+#define IS_ERR_VALUE(x) ((x) >= (unsigned long)-MAX_ERRNO)
+
+static inline bool IS_ERR(const void *ptr) {
+	return IS_ERR_VALUE((unsigned long)ptr);
+}
+
+static inline bool IS_ERR_OR_NULL(const void *ptr) {
+	return !ptr || IS_ERR_VALUE((unsigned long)ptr);
+}
+
+static inline long PTR_ERR(const void *ptr) {
+	return (long) ptr;
+}
+#endif
+
 extern void perfCallback(void *ctx, int cpu, void *data, __u32 size);
 extern void perfLostCallback(void *ctx, int cpu, __u64 cnt);
 
@@ -261,14 +279,25 @@ func bumpMemlockRlimit() error {
 	return nil
 }
 
+func errptrError(ptr unsafe.Pointer, format string, args... interface{}) error {
+	negErrno := C.PTR_ERR(ptr)
+	errno := syscall.Errno(-int64(negErrno))
+	if errno == 0 {
+		return fmt.Errorf(format, args...)
+	}
+
+	args = append(args, errno.Error())
+	return fmt.Errorf(format + ": %v", args...)
+}
+
 func NewModuleFromFile(bpfObjFile string) (*Module, error) {
 	C.set_print_fn()
 	bumpMemlockRlimit()
 	cs := C.CString(bpfObjFile)
 	obj := C.bpf_object__open(cs)
 	C.free(unsafe.Pointer(cs))
-	if obj == nil {
-		return nil, fmt.Errorf("failed to open BPF object %s", bpfObjFile)
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(obj)) {
+		return nil, errptrError(unsafe.Pointer(obj), "failed to open BPF object %s", bpfObjFile)
 	}
 
 	return &Module{
@@ -285,8 +314,8 @@ func NewModuleFromBuffer(bpfObjBuff []byte, bpfObjName string) (*Module, error) 
 	obj := C.bpf_object__open_buffer(buffPtr, buffSize, name)
 	C.free(unsafe.Pointer(name))
 	C.free(unsafe.Pointer(buffPtr))
-	if obj == nil {
-		return nil, fmt.Errorf("failed to open BPF object %s: %v", bpfObjName, bpfObjBuff[:20])
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(obj)) {
+		return nil, errptrError(unsafe.Pointer(obj), "failed to open BPF object %s: %v", bpfObjName, bpfObjBuff[:20])
 	}
 
 	return &Module{
@@ -556,13 +585,16 @@ func (p *BPFProg) SetTracepoint() error {
 
 func (p *BPFProg) AttachTracepoint(tp string) (*BPFLink, error) {
 	tpEvent := strings.Split(tp, ":")
+	if len(tpEvent) != 2 {
+		return nil, fmt.Errorf("tracepoint must be in 'category:name' format")
+	}
 	tpCategory := C.CString(tpEvent[0])
 	tpName := C.CString(tpEvent[1])
 	link := C.bpf_program__attach_tracepoint(p.prog, tpCategory, tpName)
 	C.free(unsafe.Pointer(tpCategory))
 	C.free(unsafe.Pointer(tpName))
-	if link == nil {
-		return nil, fmt.Errorf("failed to attach tracepoint %s to program %s", tp, p.name)
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(link)) {
+		return nil, errptrError(unsafe.Pointer(link), "failed to attach tracepoint %s to program %s", tp, p.name)
 	}
 
 	bpfLink := &BPFLink{
@@ -579,8 +611,8 @@ func (p *BPFProg) AttachRawTracepoint(tpEvent string) (*BPFLink, error) {
 	cs := C.CString(tpEvent)
 	link := C.bpf_program__attach_raw_tracepoint(p.prog, cs)
 	C.free(unsafe.Pointer(cs))
-	if link == nil {
-		return nil, fmt.Errorf("failed to attach raw tracepoint %s to program %s", tpEvent, p.name)
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(link)) {
+		return nil, errptrError(unsafe.Pointer(link), "failed to attach raw tracepoint %s to program %s", tpEvent, p.name)
 	}
 
 	bpfLink := &BPFLink{
@@ -605,8 +637,8 @@ func (p *BPFProg) AttachKretprobe(kp string) (*BPFLink, error) {
 
 func (p *BPFProg) AttachLSM() (*BPFLink, error) {
 	link := C.bpf_program__attach_lsm(p.prog)
-	if link == nil {
-		return nil, fmt.Errorf("failed to attach lsm to program %s", p.name)
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(link)) {
+		return nil, errptrError(unsafe.Pointer(link), "failed to attach lsm to program %s", p.name)
 	}
 
 	bpfLink := &BPFLink{
@@ -623,8 +655,8 @@ func doAttachKprobe(prog *BPFProg, kp string, isKretprobe bool) (*BPFLink, error
 	cbool := C.bool(isKretprobe)
 	link := C.bpf_program__attach_kprobe(prog.prog, cbool, cs)
 	C.free(unsafe.Pointer(cs))
-	if link == nil {
-		return nil, fmt.Errorf("failed to attach %s k(ret)probe to program %s", kp, prog.name)
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(link)) {
+		return nil, errptrError(unsafe.Pointer(link), "failed to attach %s k(ret)probe to program %s", kp, prog.name)
 	}
 
 	kpType := Kprobe
@@ -655,8 +687,8 @@ func doAttachKprobeLegacy(prog *BPFProg, kp string, isKretprobe bool) (*BPFLink,
 	cbool := C.bool(isKretprobe)
 	link := C.attach_kprobe_legacy(prog.prog, cs, cbool)
 	C.free(unsafe.Pointer(cs))
-	if link == nil {
-		return nil, fmt.Errorf("failed to attach %s k(ret)probe using legacy debugfs API", kp)
+	if C.IS_ERR_OR_NULL(unsafe.Pointer(link)) {
+		return nil, errptrError(unsafe.Pointer(link), "failed to attach %s k(ret)probe using legacy debugfs API", kp)
 	}
 
 	kpType := KprobeLegacy

--- a/libbpfgo/libbpfgo_test.go
+++ b/libbpfgo/libbpfgo_test.go
@@ -1,6 +1,3 @@
-//go:generate /bin/sh -c "bpftool btf dump file /sys/kernel/btf/vmlinux format c > test/vmlinux.h"
-//go:generate clang -g -O2 -c -target bpf -o test/test.bpf.o test/test.bpf.c
-
 package libbpfgo
 
 import (

--- a/libbpfgo/libbpfgo_test.go
+++ b/libbpfgo/libbpfgo_test.go
@@ -1,0 +1,110 @@
+//go:generate /bin/sh -c "bpftool btf dump file /sys/kernel/btf/vmlinux format c > test/vmlinux.h"
+//go:generate clang -g -O2 -c -target bpf -o test/test.bpf.o test/test.bpf.c
+
+package libbpfgo
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_LoadAndAttach(t *testing.T) {
+	// load non exisiting file, should fail
+	module, err := NewModuleFromFile("test/foo.bpf.o")
+	if err == nil {
+		t.Errorf("NewModuleFromFile returned nil error on non-existing file")
+	}
+
+	module, err = NewModuleFromFile("test/test.bpf.o")
+	if err != nil {
+		t.Fatalf("NewModuleFromFile failed: %v", err)
+	}
+	defer module.Close()
+
+	// load non exisiting program, should fail
+	if err = module.BPFLoadObject(); err != nil {
+		t.Fatalf("BPFLoadObject failed: %v", err)
+	}
+
+	// get non exisiting program, should fail
+	_, err = module.GetProgram("foo")
+	if err == nil {
+		t.Errorf("GetProgram returned nil error on non-existing program")
+	}
+
+	attachTests := []struct {
+		prog      string
+		attachArg string
+		attachFn  func(*BPFProg, string) (*BPFLink, error)
+	}{
+		{
+			prog:      "tracepoint__sys_enter_dup",
+			attachArg: "syscalls:sys_enter_dup",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				return prog.AttachTracepoint(name)
+			},
+		},
+		{
+			prog:      "raw_tracepoint__sched_switch",
+			attachArg: "sched_switch",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				return prog.AttachRawTracepoint(name)
+			},
+		},
+		{
+			prog:      "kprobe__get_task_pid",
+			attachArg: "get_task_pid",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				return prog.AttachKprobe(name)
+			},
+		},
+		{
+			prog:      "kretprobe__get_task_pid",
+			attachArg: "get_task_pid",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				return prog.AttachKretprobe(name)
+			},
+		},
+		{
+			prog:      "kprobe__get_task_pid",
+			attachArg: "get_task_pid",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				return prog.AttachKprobeLegacy(name)
+			},
+		},
+		{
+			prog:      "kretprobe__get_task_pid",
+			attachArg: "get_task_pid",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				return prog.AttachKretprobeLegacy(name)
+			},
+		},
+		{
+			prog: "socket_connect",
+			attachFn: func(prog *BPFProg, name string) (*BPFLink, error) {
+				if name != "" {
+					// to make the check for attaching with "foo" happy
+					return nil, fmt.Errorf("name not empty")
+				}
+				return prog.AttachLSM()
+			},
+		},
+	}
+
+	for i, test := range attachTests {
+		prog, err := module.GetProgram(test.prog)
+		if err != nil {
+			t.Errorf("test %v: GetProgram(%q) failed: %v", i, test.prog, err)
+			continue
+		}
+
+		// make sure it handles errors ok
+		if _, err = test.attachFn(prog, "foo"); err == nil {
+			t.Errorf("test %v: failure to attach expected", i)
+		}
+
+		if _, err = test.attachFn(prog, test.attachArg); err != nil {
+			t.Errorf("test %v: attach failed: %v", i, err)
+		}
+	}
+}

--- a/libbpfgo/selftest/perfbuffers/main.go
+++ b/libbpfgo/selftest/perfbuffers/main.go
@@ -32,22 +32,26 @@ func main() {
 
 	bpfModule, err := bpf.NewModuleFromFile("self.bpf.o")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 	defer bpfModule.Close()
 
 	if err = resizeMap(bpfModule, "events", 8192); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 
 	bpfModule.BPFLoadObject()
 	prog, err := bpfModule.GetProgram("kprobe__sys_mmap")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 
 	_, err = prog.AttachKprobe("__x64_sys_mmap")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 
@@ -55,6 +59,7 @@ func main() {
 	lostChannel := make(chan uint64)
 	pb, err := bpfModule.InitPerfBuf("events", eventsChannel, lostChannel, 1)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 

--- a/libbpfgo/selftest/ringbuffers/main.go
+++ b/libbpfgo/selftest/ringbuffers/main.go
@@ -32,28 +32,33 @@ func main() {
 
 	bpfModule, err := bpf.NewModuleFromFile("self.bpf.o")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 	defer bpfModule.Close()
 
 	if err = resizeMap(bpfModule, "events", 8192); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 
 	bpfModule.BPFLoadObject()
 	prog, err := bpfModule.GetProgram("kprobe__sys_mmap")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 
 	_, err = prog.AttachKprobe("__x64_sys_mmap")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 
 	eventsChannel := make(chan []byte)
 	rb, err := bpfModule.InitRingBuf("events", eventsChannel)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(-1)
 	}
 

--- a/libbpfgo/selftest/run.sh
+++ b/libbpfgo/selftest/run.sh
@@ -4,7 +4,9 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m' 
 
-for d in */
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+for d in ${DIR}/*/
 do
     echo -e "${GREEN}[*] RUNNING $d ${NC}"
     ( cd $d && bash "run.sh" )

--- a/libbpfgo/test/.gitignore
+++ b/libbpfgo/test/.gitignore
@@ -1,0 +1,2 @@
+vmlinux.h
+test.bpf.o

--- a/libbpfgo/test/test.bpf.c
+++ b/libbpfgo/test/test.bpf.c
@@ -1,0 +1,31 @@
+//+build ignore
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";
+
+SEC("tp/syscalls/sys_enter_dup")
+int tracepoint__sys_enter_dup(struct trace_event_raw_sys_enter *args) {
+	return 0;
+}
+
+SEC("raw_tp/sched_switch")
+int raw_tracepoint__sched_switch(struct bpf_raw_tracepoint_args *args) {
+	return 0;
+}
+
+SEC("kprobe/get_task_pid")
+int kprobe__get_task_pid(struct pt_regs *ctx) {
+	return 0;
+}
+
+SEC("kretprobe/get_task_pid")
+int kretprobe__get_task_pid(struct pt_regs *ctx) {
+	return 0;
+}
+
+SEC("lsm/socket_connect")
+int BPF_PROG(socket_connect, struct socket *sock, struct sockaddr *address, int addrlen) {
+	return 0;
+}


### PR DESCRIPTION
Some libbpf functions fail and return an -errno
encoded inside the pointer. Therefore checking
for NULL is not enough.

Checks the returned pointers for NULL or ERR_PTR
encoding and converts the errno (if available)
to an error message.

Fixes #708 
Fixes #691 