### PR TITLE
Add sockfd arg to network lsm hooks

### DIFF
--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -896,8 +896,8 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	SwitchTaskNSEventID:          {{Type: "pid_t", Name: "pid"}, {Type: "u32", Name: "new_mnt"}, {Type: "u32", Name: "new_pid"}, {Type: "u32", Name: "new_uts"}, {Type: "u32", Name: "new_ipc"}, {Type: "u32", Name: "new_net"}, {Type: "u32", Name: "new_cgroup"}},
 	MagicWriteEventID:            {{Type: "const char*", Name: "pathname"}, {Type: "bytes", Name: "bytes"}},
 	SecuritySocketCreateEventID:  {{Type: "int", Name: "family"}, {Type: "int", Name: "type"}, {Type: "int", Name: "protocol"}, {Type: "int", Name: "kern"}},
-	SecuritySocketListenEventID:  {{Type: "struct sockaddr*", Name: "local_addr"}, {Type: "int", Name: "backlog"}},
-	SecuritySocketConnectEventID: {{Type: "struct sockaddr*", Name: "remote_addr"}},
-	SecuritySocketAcceptEventID:  {{Type: "struct sockaddr*", Name: "local_addr"}},
-	SecuritySocketBindEventID:    {{Type: "struct sockaddr*", Name: "local_addr"}},
+	SecuritySocketListenEventID:  {{Type: "int", Name: "sockfd"}, {Type: "struct sockaddr*", Name: "local_addr"}, {Type: "int", Name: "backlog"}},
+	SecuritySocketConnectEventID: {{Type: "int", Name: "sockfd"}, {Type: "struct sockaddr*", Name: "remote_addr"}},
+	SecuritySocketAcceptEventID:  {{Type: "int", Name: "sockfd"}, {Type: "struct sockaddr*", Name: "local_addr"}},
+	SecuritySocketBindEventID:    {{Type: "int", Name: "sockfd"}, {Type: "struct sockaddr*", Name: "local_addr"}},
 }

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -353,7 +353,7 @@ BPF_HASH(bin_args_map, u64, bin_args_t);                // Persist args for send
 BPF_HASH(sys_32_to_64_map, u32, u32);                   // Map 32bit syscalls numbers to 64bit syscalls numbers
 BPF_HASH(params_types_map, u32, u64);                   // Encoded parameters types for event
 BPF_HASH(params_names_map, u32, u64);                   // Encoded parameters names for event
-BPF_HASH(sockfd_map, u64, u32);                            // Persist return value to be used in tail calls
+BPF_HASH(sockfd_map, u64, u32);                         // Persist sockfd from syscalls to be used in the corresponding lsm hooks
 BPF_ARRAY(file_filter, path_filter_t, 3);               // Used to filter vfs_write events
 BPF_ARRAY(string_store, path_filter_t, 1);              // Store strings from userspace
 BPF_PERCPU_ARRAY(bufs, buf_t, MAX_BUFFERS);             // Percpu global buffer variables

--- a/tracee-rules/signatures/golang/stdio_over_socket_test.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket_test.go
@@ -18,6 +18,12 @@ func TestStdioOverSocket(t *testing.T) {
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
+								Name: "sockfd",
+							},
+							Value: int32(5),
+						},
+						{
+							ArgMeta: tracee.ArgMeta{
 								Name: "remote_addr",
 							},
 							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
@@ -26,7 +32,30 @@ func TestStdioOverSocket(t *testing.T) {
 				},
 				tracee.Event{
 					ProcessID: 45,
-					EventName: "connect",
+					EventName: "dup2",
+					Args: []tracee.Argument{
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "oldfd",
+							},
+							Value: int32(5),
+						},
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "newfd",
+							},
+							Value: int32(0),
+						},
+					},
+				},
+			},
+			Expect: true,
+		},
+		{
+			Events: []types.Event{
+				tracee.Event{
+					ProcessID: 45,
+					EventName: "security_socket_connect",
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -36,7 +65,7 @@ func TestStdioOverSocket(t *testing.T) {
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
+								Name: "remote_addr",
 							},
 							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
 						},
@@ -67,7 +96,7 @@ func TestStdioOverSocket(t *testing.T) {
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
-					EventName: "connect",
+					EventName: "security_socket_connect",
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -77,48 +106,7 @@ func TestStdioOverSocket(t *testing.T) {
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
-							},
-							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
-						},
-					},
-				},
-				tracee.Event{
-					ProcessID: 45,
-					EventName: "dup2",
-					Args: []tracee.Argument{
-						{
-							ArgMeta: tracee.ArgMeta{
-								Name: "oldfd",
-							},
-							Value: int32(5),
-						},
-						{
-							ArgMeta: tracee.ArgMeta{
-								Name: "newfd",
-							},
-							Value: int32(0),
-						},
-					},
-				},
-			},
-			Expect: true,
-		},
-		{
-			Events: []types.Event{
-				tracee.Event{
-					ProcessID: 45,
-					EventName: "connect",
-					Args: []tracee.Argument{
-						{
-							ArgMeta: tracee.ArgMeta{
-								Name: "sockfd",
-							},
-							Value: int32(5),
-						},
-						{
-							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
+								Name: "remote_addr",
 							},
 							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
 						},
@@ -144,7 +132,7 @@ func TestStdioOverSocket(t *testing.T) {
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
-					EventName: "connect",
+					EventName: "security_socket_connect",
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -154,7 +142,7 @@ func TestStdioOverSocket(t *testing.T) {
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
+								Name: "remote_addr",
 							},
 							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
 						},
@@ -214,7 +202,7 @@ func TestStdioOverSocket(t *testing.T) {
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
-					EventName: "connect",
+					EventName: "security_socket_connect",
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -224,7 +212,7 @@ func TestStdioOverSocket(t *testing.T) {
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
+								Name: "remote_addr",
 							},
 							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
 						},
@@ -267,7 +255,7 @@ func TestStdioOverSocket(t *testing.T) {
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
-					EventName: "connect",
+					EventName: "security_socket_connect",
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -277,7 +265,7 @@ func TestStdioOverSocket(t *testing.T) {
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
+								Name: "remote_addr",
 							},
 							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
 						},
@@ -308,7 +296,7 @@ func TestStdioOverSocket(t *testing.T) {
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
-					EventName: "connect",
+					EventName: "security_socket_connect",
 					Args: []tracee.Argument{
 						{
 							ArgMeta: tracee.ArgMeta{
@@ -318,7 +306,7 @@ func TestStdioOverSocket(t *testing.T) {
 						},
 						{
 							ArgMeta: tracee.ArgMeta{
-								Name: "addr",
+								Name: "remote_addr",
 							},
 							Value: "{'sin6_scopeid': '0','sa_family': 'AF_INET6','sin6_port': '443','sin6_flowinfo': '0','sin6_addr': '2001:67c:1360:8001::2f'}",
 						},

--- a/tracee-rules/signatures/golang/stdio_over_socket_test.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket_test.go
@@ -14,6 +14,59 @@ func TestStdioOverSocket(t *testing.T) {
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
+					EventName: "security_socket_connect",
+					Args: []tracee.Argument{
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "remote_addr",
+							},
+							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
+						},
+					},
+				},
+				tracee.Event{
+					ProcessID: 45,
+					EventName: "connect",
+					Args: []tracee.Argument{
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "sockfd",
+							},
+							Value: int32(5),
+						},
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "addr",
+							},
+							Value: "{'sa_family': 'AF_INET','sin_port': '53','sin_addr': '10.225.0.2'}",
+						},
+					},
+				},
+				tracee.Event{
+					ProcessID: 45,
+					EventName: "dup2",
+					Args: []tracee.Argument{
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "oldfd",
+							},
+							Value: int32(5),
+						},
+						{
+							ArgMeta: tracee.ArgMeta{
+								Name: "newfd",
+							},
+							Value: int32(0),
+						},
+					},
+				},
+			},
+			Expect: true,
+		},
+		{
+			Events: []types.Event{
+				tracee.Event{
+					ProcessID: 45,
 					EventName: "connect",
 					Args: []tracee.Argument{
 						{


### PR DESCRIPTION
add the sockfd arg to:
- security_socket_bind
- security_socket_listen
- security_socket_connect
- security_socket_accept

in stdio_over_socket.go signature: 
- instead of 'connect' use 'security_socket_connect' with new sockfd arg.
- also detect connection directly on stdio (if dup happened before connect).
- add port and FD to detection data
