### PR TITLE
Update Prerequisites Link in READMe

### DIFF
--- a/tracee-ebpf/Readme.md
+++ b/tracee-ebpf/Readme.md
@@ -10,7 +10,7 @@ The full documentation of Tracee's eBPF tracing is available at [https://aquasec
 
 ## Quickstart
 
-Before you proceed, make sure you follow the [minimum requirements for running Tracee](https://aquasecurity.github.io/tracee/dev/install/prerequisites.md).
+Before you proceed, make sure you follow the [minimum requirements for running Tracee](https://aquasecurity.github.io/tracee/dev/install/prerequisites/).
 
 ```bash
 docker run --name tracee --rm --privileged -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest trace


### PR DESCRIPTION
The link was coming up as 404 for me, modified to use the link from the docs site, which seems to be working ok.