### PR TITLE
implemented broker and consume API for tracee-ebpf

### DIFF
--- a/tracee-ebpf/tracee/pipeline.go
+++ b/tracee-ebpf/tracee/pipeline.go
@@ -200,8 +200,12 @@ func (t *Tracee) printEvent(done <-chan struct{}, in <-chan external.Event) (<-c
 	go func() {
 		defer close(errc)
 		for printEvent := range in {
-			t.stats.eventCounter.Increment()
-			t.printer.Print(printEvent)
+			if t.config.ChanEvents != nil {
+				t.config.ChanEvents <- printEvent
+			} else {
+				t.stats.eventCounter.Increment()
+				t.printer.Print(printEvent)
+			}
 		}
 	}()
 	return errc, nil

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -33,6 +33,7 @@ type Config struct {
 	SecurityAlerts     bool
 	maxPidsCache       int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
 	BPFObjPath         string
+	ChanEvents         chan external.Event
 }
 
 type Filter struct {


### PR DESCRIPTION
This commit includes: 
- a Broker API with the Streamer interface and implementation of IOStreamer (aka printer).
- the creation of Consume() API exposed by Tracee.