### PR TITLE
fix(benchmark): Unprotected global variable processMemFileRegexp in golang.codeInjection.Init()

### DIFF
--- a/tracee-rules/benchmark/README.md
+++ b/tracee-rules/benchmark/README.md
@@ -1,14 +1,15 @@
 # Benchmark
 
 ```
+git clone https://github.com/aquasecurity/tracee.git
 cd tracee-rules/benchmark
 ```
 
 ```
 # Run all benchmark tests in the current directory
-go test -bench=. -benchmem
-# Run all benchmark tests in the current directory and spcify b.N to equal 100
-go test -bench=. -benchtime=100x -benchmem
-# Run just BenchmarkEngineWithCodeInjecionRuleGp test
-go test -bench=EngineWithCodeInjectionRuleGo -benchmem
+go test -tags=opa_wasm -bench=. -benchmem
+# Run all benchmark tests in the current directory and specify b.N to equal 100
+go test -tags=opa_wasm -bench=. -benchtime=100x -benchmem
+# Run just BenchmarkEngineWithCodeInjecion signature implemented in Go with data race detector enabled
+go test -race -bench=EngineWithCodeInjection/golang -benchmem
 ```


### PR DESCRIPTION
```console
$ go test -race -bench=EngineWithCodeInjection/golang -benchmem
goos: darwin
goarch: amd64
pkg: github.com/aquasecurity/tracee/tracee-rules/benchmark
cpu: Intel(R) Core(TM) i5-6360U CPU @ 2.00GHz
BenchmarkEngineWithCodeInjection/golang-4         	==================
WARNING: DATA RACE
Write at 0x000001f61f40 by goroutine 20:
  github.com/aquasecurity/tracee/tracee-rules/benchmark/signature/golang.(*codeInjection).Init()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/benchmark/signature/golang/code_injection.go:36 +0xb8
  github.com/aquasecurity/tracee/tracee-rules/engine.NewEngine()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/engine/engine.go:56 +0x738
  github.com/aquasecurity/tracee/tracee-rules/benchmark.BenchmarkEngineWithCodeInjection.func1()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/benchmark/benchmark_test.go:86 +0x508
  testing.(*B).runN()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:192 +0x1c5
  testing.(*B).launch()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:325 +0x165

Previous read at 0x000001f61f40 by goroutine 56:
  github.com/aquasecurity/tracee/tracee-rules/benchmark/signature/golang.(*codeInjection).OnEvent()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/benchmark/signature/golang/code_injection.go:76 +0x5f3
  github.com/aquasecurity/tracee/tracee-rules/engine.(*Engine).Start.func1()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/engine/engine.go:74 +0xb7

Goroutine 20 (running) created at:
  testing.(*B).doBench()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:280 +0x64
  testing.(*benchContext).processBench()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:580 +0x513
  testing.(*B).run()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:272 +0xbe
  testing.(*B).Run()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:668 +0x7db
  github.com/aquasecurity/tracee/tracee-rules/benchmark.BenchmarkEngineWithCodeInjection()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/benchmark/benchmark_test.go:75 +0x22b
  testing.(*B).runN()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:192 +0x1c5
  testing.(*B).run1.func1()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:232 +0x75

Goroutine 56 (finished) created at:
  github.com/aquasecurity/tracee/tracee-rules/engine.(*Engine).Start()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/engine/engine.go:72 +0xe9
  github.com/aquasecurity/tracee/tracee-rules/benchmark.BenchmarkEngineWithCodeInjection.func1()
      /Users/dpacak/go/src/github.com/aquasecurity/tracee/tracee-rules/benchmark/benchmark_test.go:90 +0x544
  testing.(*B).runN()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:192 +0x1c5
  testing.(*B).launch()
      /usr/local/Cellar/go/1.16.4/libexec/src/testing/benchmark.go:325 +0x165
==================
--- FAIL: BenchmarkEngineWithCodeInjection/golang-4
    benchmark_test.go:92: Test is done with 339 findings
    benchmark_test.go:92: Test is done with 313 findings
    benchmark_test.go:92: Test is done with 332 findings
    benchmark_test.go:92: Test is done with 339 findings
    benchmark_test.go:92: Test is done with 357 findings
    benchmark_test.go:92: Test is done with 327 findings
    benchmark_test.go:92: Test is done with 343 findings
    benchmark_test.go:92: Test is done with 342 findings
    benchmark_test.go:92: Test is done with 329 findings
    benchmark_test.go:92: Test is done with 326 findings
    benchmark_test.go:92: Test is done with 331 findings
    benchmark_test.go:92: Test is done with 323 findings
    benchmark_test.go:92: Test is done with 337 findings
    benchmark_test.go:92: Test is done with 338 findings
    benchmark_test.go:92: Test is done with 334 findings
    benchmark_test.go:92: Test is done with 345 findings
    benchmark_test.go:92: Test is done with 314 findings
    benchmark_test.go:92: Test is done with 343 findings
    benchmark_test.go:92: Test is done with 351 findings
    benchmark_test.go:92: Test is done with 338 findings
    benchmark_test.go:92: Test is done with 338 findings
    benchmark_test.go:92: Test is done with 336 findings
    benchmark_test.go:92: Test is done with 366 findings
    benchmark_test.go:92: Test is done with 321 findings
    benchmark_test.go:92: Test is done with 356 findings
    benchmark_test.go:92: Test is done with 305 findings
    benchmark_test.go:92: Test is done with 337 findings
    benchmark_test.go:92: Test is done with 367 findings
    benchmark_test.go:92: Test is done with 311 findings
    benchmark_test.go:92: Test is done with 328 findings
    benchmark_test.go:92: Test is done with 376 findings
    benchmark_test.go:92: Test is done with 324 findings
    benchmark_test.go:92: Test is done with 327 findings
    benchmark_test.go:92: Test is done with 341 findings
    benchmark_test.go:92: Test is done with 347 findings
    benchmark_test.go:92: Test is done with 332 findings
    benchmark_test.go:92: Test is done with 334 findings
    benchmark_test.go:92: Test is done with 336 findings
    benchmark_test.go:92: Test is done with 333 findings
    benchmark_test.go:92: Test is done with 351 findings
    benchmark_test.go:92: Test is done with 316 findings
    benchmark_test.go:92: Test is done with 355 findings
    benchmark_test.go:92: Test is done with 336 findings
    benchmark_test.go:92: Test is done with 334 findings
    benchmark_test.go:92: Test is done with 344 findings
    benchmark_test.go:92: Test is done with 344 findings
    benchmark_test.go:92: Test is done with 347 findings
    benchmark_test.go:92: Test is done with 333 findings
    benchmark_test.go:92: Test is done with 352 findings
    benchmark_test.go:92: Test is done with 327 findings
    benchmark_test.go:92: Test is done with 310 findings
    benchmark_test.go:92: Test is done with 319 findings
    benchmark_test.go:92: Test is done with 315 findings
    benchmark_test.go:92: Test is done with 364 findings
    benchmark_test.go:92: Test is done with 349 findings
    benchmark_test.go:92: Test is done with 340 findings
    benchmark_test.go:92: Test is done with 348 findings
    benchmark_test.go:92: Test is done with 314 findings
    benchmark_test.go:92: Test is done with 315 findings
    benchmark_test.go:92: Test is done with 361 findings
    benchmark_test.go:92: Test is done with 331 findings
    benchmark_test.go:92: Test is done with 322 findings
    benchmark_test.go:92: Test is done with 336 findings
    benchmark_test.go:92: Test is done with 338 findings
    benchmark_test.go:92: Test is done with 317 findings
    benchmark_test.go:92: Test is done with 347 findings
    benchmark_test.go:92: Test is done with 343 findings
    benchmark_test.go:92: Test is done with 320 findings
    benchmark_test.go:92: Test is done with 356 findings
    benchmark_test.go:92: Test is done with 343 findings
    benchmark_test.go:92: Test is done with 326 findings
    benchmark_test.go:92: Test is done with 325 findings
    benchmark_test.go:92: Test is done with 336 findings
    benchmark_test.go:92: Test is done with 333 findings
    benchmark_test.go:92: Test is done with 311 findings
    benchmark_test.go:92: Test is done with 339 findings
    benchmark_test.go:92: Test is done with 338 findings
    benchmark_test.go:92: Test is done with 312 findings
    benchmark_test.go:92: Test is done with 320 findings
    benchmark_test.go:92: Test is done with 341 findings
    benchmark_test.go:92: Test is done with 318 findings
    benchmark_test.go:92: Test is done with 360 findings
    benchmark_test.go:92: Test is done with 314 findings
    benchmark_test.go:92: Test is done with 313 findings
    benchmark_test.go:92: Test is done with 351 findings
    benchmark.go:198: race detected during execution of benchmark
--- FAIL: BenchmarkEngineWithCodeInjection
    benchmark.go:198: race detected during execution of benchmark
FAIL
exit status 1
FAIL	github.com/aquasecurity/tracee/tracee-rules/benchmark	1.604s
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>