### PR TITLE
add external package as a module

### DIFF
--- a/tracee-ebpf/external/external.go
+++ b/tracee-ebpf/external/external.go
@@ -1,0 +1,115 @@
+package external
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Event is a user facing data structure representing a single event
+type Event struct {
+	Timestamp           float64    `json:"timestamp"`
+	ProcessID           int        `json:"processId"`
+	ThreadID            int        `json:"threadId"`
+	ParentProcessID     int        `json:"parentProcessId"`
+	HostProcessID       int        `json:"hostProcessId"`
+	HostThreadID        int        `json:"hostThreadId"`
+	HostParentProcessID int        `json:"hostParentProcessId"`
+	UserID              int        `json:"userId"`
+	MountNS             int        `json:"mountNamespace"`
+	PIDNS               int        `json:"pidNamespace"`
+	ProcessName         string     `json:"processName"`
+	HostName            string     `json:"hostName"`
+	ContainerID         string     `json:"containerId`
+	EventID             int        `json:"eventId,string"`
+	EventName           string     `json:"eventName"`
+	ArgsNum             int        `json:"argsNum"`
+	ReturnValue         int        `json:"returnValue"`
+	StackAddresses      []uint64   `json:"stackAddresses"`
+	Args                []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
+}
+
+// Argument holds the information for one argument
+type Argument struct {
+	ArgMeta
+	Value interface{} `json:"value"`
+}
+
+// ArgMeta describes an argument
+type ArgMeta struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// UnmarshalJSON implements the encoding/json.Unmershaler interface
+func (arg *Argument) UnmarshalJSON(b []byte) error {
+	type argument Argument //alias Argument so we can unmarshal it within the unmarshaler implementation
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	if err := d.Decode((*argument)(arg)); err != nil {
+		return err
+	}
+	if num, isNum := arg.Value.(json.Number); isNum {
+		switch arg.Type {
+		case "int", "pid_t", "uid_t", "gid_t", "mqd_t", "clockid_t", "const clockid_t", "key_t", "key_serial_t", "timer_t":
+			tmp, err := strconv.ParseInt(num.String(), 10, 32)
+			if err != nil {
+				return err
+			}
+			arg.Value = int32(tmp)
+		case "long":
+			tmp, err := num.Int64()
+			if err != nil {
+				return err
+			}
+			arg.Value = tmp
+		case "unsigned int", "u32", "mode_t", "dev_t":
+			tmp, err := strconv.ParseUint(num.String(), 10, 32)
+			if err != nil {
+				return err
+			}
+			arg.Value = uint32(tmp)
+		case "unsigned long", "u64", "off_t", "size_t", "void*", "const void*":
+			tmp, err := strconv.ParseUint(num.String(), 10, 64)
+			if err != nil {
+				return err
+			}
+			arg.Value = uint64(tmp)
+		case "float":
+			tmp, err := strconv.ParseFloat(num.String(), 32)
+			if err != nil {
+				return err
+			}
+			arg.Value = float32(tmp)
+		case "float64":
+			tmp, err := num.Float64()
+			if err != nil {
+				return err
+			}
+			arg.Value = tmp
+		default:
+			return fmt.Errorf("unrecognized argument type")
+		}
+	}
+
+	return nil
+}
+
+// SlimCred struct is a slim version of the kernel's cred struct
+// it is used to unmarshal binary data and therefore should match (bit by bit) to the `slim_cred_t` struct in the ebpf code.
+type SlimCred struct {
+	Uid            uint32 /* real UID of the task */
+	Gid            uint32 /* real GID of the task */
+	Suid           uint32 /* saved UID of the task */
+	Sgid           uint32 /* saved GID of the task */
+	Euid           uint32 /* effective UID of the task */
+	Egid           uint32 /* effective GID of the task */
+	Fsuid          uint32 /* UID for VFS ops */
+	Fsgid          uint32 /* GID for VFS ops */
+	CapInheritable uint64 /* caps our children can inherit */
+	CapPermitted   uint64 /* caps we're permitted */
+	CapEffective   uint64 /* caps we can actually use */
+	CapBounding    uint64 /* capability bounding set */
+	CapAmbient     uint64 /* Ambient capability set */
+}

--- a/tracee-ebpf/external/external_test.go
+++ b/tracee-ebpf/external/external_test.go
@@ -1,0 +1,105 @@
+package external
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestEventUnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		json        string
+		expect      Event
+		expectError bool
+	}
+
+	testCases := []testCase{
+		{
+			json: `{"timestamp":260182.49532,"processId":12434,"threadId":12434,"parentprocessid":23921,
+			"hostprocessid":12434,"hostthreadid":12434,"hostparentprocessid":23921,"userid":1000,"mountnamespace":4026531840,
+			"pidnamespace":4026531836,"processname":"strace","hostname":"ubuntu","eventid":"101","eventname":"ptrace",
+			"argsnum":4,"returnvalue":0,"args":[{"name":"request","type":"long","value":"ptrace_seize"},
+			{"name":"pid","type":"pid_t","value":12435},{"name":"addr","type":"void*","value":"0x0"},{"name":"data","type":"void*","value":"0x7f6f1eb44b83"}]}`,
+			expect: Event{Timestamp: float64(260182.49532), ProcessID: 12434, ThreadID: 12434, ParentProcessID: 23921, HostProcessID: 12434, HostThreadID: 12434, HostParentProcessID: 23921, UserID: 1000, MountNS: 4026531840, PIDNS: 4026531836, ProcessName: "strace", HostName: "ubuntu", EventID: 101, EventName: "ptrace", ArgsNum: 4, ReturnValue: 0, Args: []Argument{{ArgMeta: ArgMeta{Name: "request", Type: "long"}, Value: "ptrace_seize"}, {ArgMeta: ArgMeta{Name: "pid", Type: "pid_t"}, Value: int32(12435)}, {ArgMeta: ArgMeta{Name: "addr", Type: "void*"}, Value: "0x0"}, {ArgMeta: ArgMeta{Name: "data", Type: "void*"}, Value: "0x7f6f1eb44b83"}}},
+		},
+	}
+	for _, tc := range testCases {
+		var res Event
+		err := json.Unmarshal([]byte(tc.json), &res)
+		if err != nil {
+			if !tc.expectError {
+				t.Error(err)
+			} else {
+				continue
+			}
+		}
+		if !reflect.DeepEqual(tc.expect, res) {
+			for _, arg := range res.Args {
+				fmt.Printf("%v (%T)", arg, arg.Value)
+			}
+			t.Errorf("want %v\n have %v", tc.expect, res)
+		}
+	}
+}
+
+func TestArgumentUnmarshalJSON(t *testing.T) {
+	type testCase struct {
+		json        string
+		expect      Argument
+		expectError bool
+	}
+
+	var maxInt32JSON, maxUint32JSON, maxInt64JSON, maxUint64JSON, maxFloat32JSON, maxFloat64JSON []byte
+	maxInt32JSON, _ = json.Marshal(int32(math.MaxInt32))
+	maxUint32JSON, _ = json.Marshal(uint32(math.MaxUint32))
+	maxInt64JSON, _ = json.Marshal(int64(math.MaxInt64))
+	maxUint64JSON, _ = json.Marshal(uint64(math.MaxUint64))
+	maxFloat32JSON, _ = json.Marshal(float32(math.MaxFloat32))
+	maxFloat64JSON, _ = json.Marshal(float64(math.MaxFloat64))
+	testCases := []testCase{
+		{
+			json:   `{ "name":"test", "type":"int", "value": ` + string(maxInt32JSON) + `}`,
+			expect: Argument{ArgMeta: ArgMeta{Name: "test", Type: "int"}, Value: int32(math.MaxInt32)},
+		},
+		{
+			json:   `{ "name":"test", "type":"unsigned int", "value": ` + string(maxUint32JSON) + `}`,
+			expect: Argument{ArgMeta: ArgMeta{Name: "test", Type: "unsigned int"}, Value: uint32(math.MaxUint32)},
+		},
+		{
+			json:   `{ "name":"test", "type":"long", "value": ` + string(maxInt64JSON) + `}`,
+			expect: Argument{ArgMeta: ArgMeta{Name: "test", Type: "long"}, Value: int64(math.MaxInt64)},
+		},
+		{
+			json:   `{ "name":"test", "type":"unsigned long", "value": ` + string(maxUint64JSON) + `}`,
+			expect: Argument{ArgMeta: ArgMeta{Name: "test", Type: "unsigned long"}, Value: uint64(math.MaxUint64)},
+		},
+		{
+			json:   `{ "name":"test", "type":"float", "value": ` + string(maxFloat32JSON) + `}`,
+			expect: Argument{ArgMeta: ArgMeta{Name: "test", Type: "float"}, Value: float32(math.MaxFloat32)},
+		},
+		{
+			json:   `{ "name":"test", "type":"float64", "value": ` + string(maxFloat64JSON) + `}`,
+			expect: Argument{ArgMeta: ArgMeta{Name: "test", Type: "float64"}, Value: float64(math.MaxFloat64)},
+		},
+		{
+			json:        `{ "name":"test", "type":"err", "value": 0}`,
+			expectError: true,
+		},
+	}
+	for _, tc := range testCases {
+		var res Argument
+		err := json.Unmarshal([]byte(tc.json), &res)
+		if err != nil {
+			if !tc.expectError {
+				t.Error(err)
+			} else {
+				continue
+			}
+		}
+		if !reflect.DeepEqual(tc.expect, res) {
+			t.Errorf("want %v (Value type %T), have %v (Value type %T)", tc.expect, tc.expect.Value, res, res.Value)
+		}
+	}
+}

--- a/tracee-ebpf/external/go.mod
+++ b/tracee-ebpf/external/go.mod
@@ -1,0 +1,3 @@
+module github.com/aquasecurity/tracee/tracee-ebpf/external
+
+go 1.16


### PR DESCRIPTION
the external package was originally created for consuming tracee-ebpf events without having to import and build entire tracee-ebpf project, but since it was under the same module that defeated the purpose of a separate package. this commit is a preperation for a future commit which will import external package as a go module from this commit (after which we can remove the old external package).