### PR TITLE
perf: Improve Rego sig performance with Engine Unification

### DIFF
--- a/tracee-rules/benchmark/signature/rego/aio.rego
+++ b/tracee-rules/benchmark/signature/rego/aio.rego
@@ -1,0 +1,79 @@
+package tracee.aio
+
+import data.tracee.helpers
+
+__rego_metadoc__ := {
+    "id": "TRC-AIO",
+    "version": "0.1.0",
+    "name": "All in one Tracee signature",
+    "description": "Combines Anti-Debugging and Code-injection",
+    "tags": ["linux", "container"],
+    "properties": {
+        "Severity": 3,
+        "MITRE ATT&CK": "Defense Evasion: Execution Guardrails",
+    }
+}
+
+# anti_debugging
+tracee_anti_debugging_tracee_selected_events[eventSelector] {
+	eventSelector := {
+		"source": "tracee",
+		"name": "ptrace"
+	}
+}
+
+tracee_anti_debugging_tracee_match {
+    input.eventName == "ptrace"
+    arg := input.args[_]
+    arg.name == "request"
+    arg.value == "PTRACE_TRACEME"
+}
+
+# code_injection
+tracee_code_injection_eventSelectors := [
+    {
+        "source": "tracee",
+        "name": "ptrace"
+    },
+    {
+        "source": "tracee",
+        "name": "security_file_open"
+    },
+    {
+        "source": "tracee",
+        "name": "process_vm_writev"
+    }
+]
+
+tracee_code_injection_tracee_selected_events[eventSelector] {
+	eventSelector := tracee_code_injection_eventSelectors[_]
+}
+
+
+tracee_code_injection_tracee_match {
+    input.eventName == "ptrace"
+    arg_value = helpers.get_tracee_argument("request")
+    arg_value == "PTRACE_POKETEXT"
+}
+
+tracee_code_injection_tracee_match = res {
+    input.eventName == "security_file_open"
+    flags = helpers.get_tracee_argument("flags")
+
+    helpers.is_file_write(flags)
+
+    pathname := helpers.get_tracee_argument("pathname")
+
+    regex.match(`/proc/(?:\d.+|self)/mem`, pathname)
+
+    res := {
+        "file flags": flags,
+        "file path": pathname,
+    }
+}
+
+tracee_code_injection_tracee_match {
+    input.eventName == "process_vm_writev"
+    dst_pid = helpers.get_tracee_argument("pid")
+    dst_pid != input.processId
+}

--- a/tracee-rules/benchmark/signature/rego/aio.rego
+++ b/tracee-rules/benchmark/signature/rego/aio.rego
@@ -1,12 +1,12 @@
 package tracee.aio
+ import data.tracee.helpers
 
-import data.tracee.helpers
 
-__rego_metadoc__ := {
-    "id": "TRC-AIO",
+__rego_metadoc__tracee.TRC_2 := {
+    "id": "TRC-2",
     "version": "0.1.0",
-    "name": "All in one Tracee signature",
-    "description": "Combines Anti-Debugging and Code-injection",
+    "name": "Anti-Debugging",
+    "description": "Process uses anti-debugging technique to block debugger",
     "tags": ["linux", "container"],
     "properties": {
         "Severity": 3,
@@ -14,23 +14,36 @@ __rego_metadoc__ := {
     }
 }
 
-# anti_debugging
-tracee_anti_debugging_tracee_selected_events[eventSelector] {
-	eventSelector := {
-		"source": "tracee",
-		"name": "ptrace"
-	}
+tracee_selected_events[eventSelector] {
+        eventSelector := {
+                "source": "tracee",
+                "name": "ptrace"
+        }
 }
 
-tracee_anti_debugging_tracee_match {
+tracee_match {
     input.eventName == "ptrace"
     arg := input.args[_]
     arg.name == "request"
     arg.value == "PTRACE_TRACEME"
 }
 
-# code_injection
-tracee_code_injection_eventSelectors := [
+
+
+
+__rego_metadoc__tracee.TRC_3 := {
+    "id": "TRC-3",
+    "version": "0.1.0",
+    "name": "Code injection",
+    "description": "Possible code injection into another process",
+    "tags": ["linux", "container"],
+    "properties": {
+        "Severity": 3,
+        "MITRE ATT&CK": "Defense Evasion: Process Injection",
+    }
+}
+
+eventSelectors_1 := [
     {
         "source": "tracee",
         "name": "ptrace"
@@ -45,18 +58,18 @@ tracee_code_injection_eventSelectors := [
     }
 ]
 
-tracee_code_injection_tracee_selected_events[eventSelector] {
-	eventSelector := tracee_code_injection_eventSelectors[_]
+tracee_selected_events[eventSelector] {
+        eventSelector := eventSelectors_1[_]
 }
 
 
-tracee_code_injection_tracee_match {
+tracee_match {
     input.eventName == "ptrace"
     arg_value = helpers.get_tracee_argument("request")
     arg_value == "PTRACE_POKETEXT"
 }
 
-tracee_code_injection_tracee_match = res {
+tracee_match = res {
     input.eventName == "security_file_open"
     flags = helpers.get_tracee_argument("flags")
 
@@ -72,8 +85,176 @@ tracee_code_injection_tracee_match = res {
     }
 }
 
-tracee_code_injection_tracee_match {
+tracee_match {
     input.eventName == "process_vm_writev"
     dst_pid = helpers.get_tracee_argument("pid")
     dst_pid != input.processId
 }
+
+
+
+
+__rego_metadoc__tracee.TRC_4 := {
+    "id": "TRC-4",
+    "version": "0.1.0",
+    "name": "Dynamic Code Loading",
+    "description": "Writing to executable allocated memory region",
+    "tags": ["linux", "container"],
+    "properties": {
+        "Severity": 2,
+        "MITRE ATT&CK": "Defense Evasion: Obfuscated Files or Information",
+    }
+}
+
+eventSelectors_2 := [
+    {
+        "source": "tracee",
+        "name": "mem_prot_alert"
+    }
+]
+
+tracee_selected_events[eventSelector] {
+        eventSelector := eventSelectors_2[_]
+}
+
+
+tracee_match {
+    input.eventName == "mem_prot_alert"
+    message := helpers.get_tracee_argument("alert")
+    message == "Protection changed from W+E to E!"
+}
+
+
+
+
+__rego_metadoc__tracee.TRC_5 := {
+    "id": "TRC-5",
+    "version": "0.1.0",
+    "name": "Fileless Execution",
+    "description": "Executing a process from memory, without a file in the disk",
+    "tags": ["linux", "container"],
+    "properties": {
+        "Severity": 2,
+        "MITRE ATT&CK": "Defense Evasion: Obfuscated Files or Information",
+    }
+}
+
+eventSelectors_3 := [
+    {
+        "source": "tracee",
+        "name": "security_bprm_check"
+    }
+]
+
+tracee_selected_events[eventSelector] {
+        eventSelector := eventSelectors_3[_]
+}
+
+
+tracee_match {
+    input.eventName == "security_bprm_check"
+    pathname = helpers.get_tracee_argument("pathname")
+    startswith(pathname, "memfd:")
+}
+
+tracee_match {
+    input.eventName == "security_bprm_check"
+    pathname = helpers.get_tracee_argument("pathname")
+    startswith(pathname, "/dev/shm")
+}
+
+
+__rego_metadoc__tracee.TRC_6 := {
+    "id": "TRC-6",
+    "version": "0.1.0",
+    "name": "kernel module loading",
+    "description": "Attempt to load a kernel module detection",
+    "tags": ["linux", "container"],
+    "properties": {
+        "Severity": 3,
+        "MITRE ATT&CK": "Persistence: Kernel Modules and Extensions",
+    }
+}
+
+eventSelectors_4 := [
+    {
+        "source": "tracee",
+        "name": "init_module"
+    },
+    {
+        "source": "tracee",
+        "name": "finit_module"
+    }
+]
+
+tracee_selected_events[eventSelector] {
+        eventSelector := eventSelectors_4[_]
+}
+
+
+tracee_match {
+    input.eventName == "init_module"
+}
+
+tracee_match {
+    input.eventName == "finit_module"
+}
+
+
+
+
+__rego_metadoc__tracee.TRC_7 := {
+    "id": "TRC-7",
+    "version": "0.1.0",
+    "name": "LD_PRELOAD",
+    "description": "Usage of LD_PRELOAD to allow hooks on process",
+    "tags": ["linux", "container"],
+    "properties": {
+        "Severity": 2,
+        "MITRE ATT&CK": "Persistence: Hijack Execution Flow",
+    }
+}
+
+eventSelectors_5 := [
+    {
+        "source": "tracee",
+        "name": "execve"
+    },
+    {
+     "source": "tracee",
+     "name": "security_file_open"
+    }
+]
+
+tracee_selected_events[eventSelector] {
+        eventSelector := eventSelectors_5[_]
+}
+
+
+tracee_match {
+    input.eventName == "execve"
+    envp = helpers.get_tracee_argument("envp")
+
+    envvar := envp[_]
+    startswith(envvar, "LD_PRELOAD")
+}
+
+tracee_match {
+    input.eventName == "execve"
+    envp = helpers.get_tracee_argument("envp")
+
+    envvar := envp[_]
+    startswith(envvar, "LD_LIBRARY_PATH")
+}
+
+tracee_match {
+    input.eventName == "security_file_open"
+    flags = helpers.get_tracee_argument("flags")
+
+    helpers.is_file_write(flags)
+
+    pathname := helpers.get_tracee_argument("pathname")
+
+    pathname == "/etc/ld.so.preload"
+}
+]

--- a/tracee-rules/benchmark/signature/rego/signatures.go
+++ b/tracee-rules/benchmark/signature/rego/signatures.go
@@ -16,6 +16,9 @@ var (
 
 	//go:embed code_injection.rego
 	codeInjectionRego string
+
+	//go:embed aio.rego
+	aioRego string
 )
 
 func NewCodeInjectionSignature() (types.Signature, error) {
@@ -24,4 +27,8 @@ func NewCodeInjectionSignature() (types.Signature, error) {
 
 func NewAntiDebuggingSignature() (types.Signature, error) {
 	return regosig.NewRegoSignature(antiDebuggingPtracemeRego, helpersRego)
+}
+
+func NewAIOSignature() (types.Signature, error) {
+	return regosig.NewRegoSignature(aioRego, helpersRego)
 }

--- a/tracee-rules/benchmark/signature/rego/signatures.go
+++ b/tracee-rules/benchmark/signature/rego/signatures.go
@@ -21,6 +21,8 @@ var (
 	aioRego string
 )
 
+const packageNameRegex string = `package\s.*`
+
 func NewCodeInjectionSignature() (types.Signature, error) {
 	return regosig.NewRegoSignature(codeInjectionRego, helpersRego)
 }

--- a/tracee-rules/go.sum
+++ b/tracee-rules/go.sum
@@ -68,9 +68,6 @@ github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQY
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/aquasecurity/libbpfgo v0.1.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
-github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210608194928-9312e26ed9ac h1:y5FryKCdwS+RJDCXT5eM41kzfdgu40hWzdvuM8CTm2Y=
-github.com/aquasecurity/tracee/tracee-ebpf v0.0.0-20210608194928-9312e26ed9ac/go.mod h1:boZOhSKvYyWMXP6AIw82iU6xWo2d8JIOarZRpa2BuyY=
 github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210714085017-59acd669cdc8 h1:ys03CdRLveOTkLRRFozTYw/6wKZEUMlP8R6kwm3xbGw=
 github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210714085017-59acd669cdc8/go.mod h1:uMfMmEqFz939zU6jV0LCj7YRCkSvnVaUl8gF6C3TOMg=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -606,7 +603,6 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v1.4.6/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
@@ -833,7 +829,6 @@ golang.org/x/sys v0.0.0-20210217105451-b926d437f341/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210228012217-479acdf4ea46/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	_ "embed"
-
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -11,6 +10,7 @@ import (
 	"plugin"
 
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/rego/regosig"
+
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 )
 
@@ -82,12 +82,10 @@ func findRegoSigs(dir string) ([]types.Signature, error) {
 	}
 
 	var res []types.Signature
+	var regoCodes []string
 
 	for _, file := range files {
 		if filepath.Ext(file.Name()) != ".rego" {
-			continue
-		}
-		if file.Name() == "helpers.rego" {
 			continue
 		}
 		regoCode, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
@@ -95,12 +93,12 @@ func findRegoSigs(dir string) ([]types.Signature, error) {
 			log.Printf("error reading file %s/%s: %v", dir, file, err)
 			continue
 		}
-		sig, err := regosig.NewRegoSignature(string(regoCode), regoHelpersCode)
-		if err != nil {
-			log.Printf("error creating rego signature with: %s: %v ", regoCode[0:20], err)
-			continue
-		}
-		res = append(res, sig)
+		regoCodes = append(regoCodes, string(regoCode))
 	}
+	sig, err := regosig.NewRegoSignature(regoCodes...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating rego signature: %s", err)
+	}
+	res = append(res, sig)
 	return res, nil
 }


### PR DESCRIPTION
**Scenario**
This PR includes a new benchmark that tries to demonstrate the scenario of comparing the following:

1. Combining multiple Rego signatures into one policy and one engine (new)
vs
2. One rego policy per rego engine (existing)

**Motivation:**
By combining various Rego signatures into one, we eliminate the need to launch multiple engines per policy. If we're able to apply this approach in practice the numbers show that the results are faster for one engine than launching multiples engines.

**Results:**
```
benchmark                                   iter     time/iter     bytes alloc             allocs
---------                                   ----     ---------     -----------             ------
BenchmarkEngine***/2_separate_rego_sigs-8   1000   16.59 ms/op   10498544 B/op   226044 allocs/op
BenchmarkEngine***/1_combined_rego_sig-8    1000    1.13 ms/op        241 B/op        3 allocs/op
```



**Real World CPU Performance**
Left: AIO (1 combined rego file of TRC-2, TRC-3) 
Right: 2 separate signatures (TRC-2, TRC-3) loaded separately 

<img width="453" alt="image" src="https://user-images.githubusercontent.com/1254783/125710814-110d26ac-5a3f-4799-a693-3cc274f4f743.png">

_In this graph: Less is better_


Signed-off-by: Simar <simar@linux.com>