### PR TITLE
feat: Add ToUnstructured method to Event

### DIFF
--- a/tracee-ebpf/external/external_test.go
+++ b/tracee-ebpf/external/external_test.go
@@ -1,11 +1,15 @@
 package external
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEventUnmarshalJSON(t *testing.T) {
@@ -102,4 +106,110 @@ func TestArgumentUnmarshalJSON(t *testing.T) {
 			t.Errorf("want %v (Value type %T), have %v (Value type %T)", tc.expect, tc.expect.Value, res, res.Value)
 		}
 	}
+}
+
+func TestEvent_ToUnstructured(t *testing.T) {
+	testCases := []struct {
+		name  string
+		event Event
+	}{
+		{
+			name:  "Should unstructure zero Event",
+			event: Event{},
+		},
+		{
+			name: "Should unstructure Event with empty slices",
+			event: Event{
+				Args:           []Argument{},
+				StackAddresses: []uint64{},
+			},
+		},
+		{
+			name: "should unstructure args",
+			event: Event{
+				Args: []Argument{
+					{
+						ArgMeta: ArgMeta{
+							Name: "dirfd",
+							Type: "int",
+						},
+						Value: -100,
+					},
+					{
+						ArgMeta: ArgMeta{
+							Name: "pathname",
+							Type: "const char",
+						},
+						Value: "/sys/fs/cgroup/cpu,cpuacct/cpuacct.stat",
+					},
+					{
+						ArgMeta: ArgMeta{
+							Name: "flags",
+							Type: "int",
+						},
+						Value: "O_RDONLY|O_CLOEXEC",
+					},
+					{
+						ArgMeta: ArgMeta{
+							Name: "mode",
+							Type: "mode_t",
+						},
+						Value: 5038682,
+					},
+				},
+			},
+		},
+		{
+			name: "Should unstructure Event",
+			event: Event{
+				Timestamp:           7126.141189,
+				ProcessID:           1,
+				ThreadID:            1,
+				ParentProcessID:     4798,
+				HostProcessID:       4819,
+				HostThreadID:        4819,
+				HostParentProcessID: 4798,
+				UserID:              0,
+				MountNS:             4026532256,
+				PIDNS:               4026532259,
+				ProcessName:         "cadvisor",
+				HostName:            "4213291591ab",
+				EventID:             257,
+				EventName:           "openat",
+				ArgsNum:             4,
+				ReturnValue:         14,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.event.ToUnstructured()
+			require.NoError(t, err)
+			expected, err := jsonRoundTrip(tc.event)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected, actual)
+		})
+	}
+
+}
+
+// jsonRoundTrip is a helper to assert that a static serialization to JSON
+// compatible object is equivalent to the built-in JSON marshaller.
+func jsonRoundTrip(v interface{}) (map[string]interface{}, error) {
+	m, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(m)
+
+	var u interface{}
+	d := json.NewDecoder(buf)
+	d.UseNumber()
+	err = d.Decode(&u)
+	if err != nil {
+		return nil, err
+	}
+	return u.(map[string]interface{}), nil
 }

--- a/tracee-ebpf/external/go.mod
+++ b/tracee-ebpf/external/go.mod
@@ -1,3 +1,5 @@
 module github.com/aquasecurity/tracee/tracee-ebpf/external
 
 go 1.16
+
+require github.com/stretchr/testify v1.7.0

--- a/tracee-ebpf/external/go.sum
+++ b/tracee-ebpf/external/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
ToUnstructured returns a JSON compatible map which can
be used as a parsed input with OPA Go SDK to avoid
relatively expensive JSON encoding round trip.

Looking at benchmarks it's not a game changer, but we can observer a slight improvement:

```
➜  benchmark git:(main) go test -bench=EngineWithNSignatures/rego -benchtime=100x -benchmem
goos: darwin
goarch: amd64
pkg: github.com/aquasecurity/tracee/tracee-rules/benchmark
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
BenchmarkEngineWithNSignatures/rego/2Signatures-16         	     100	  14135044 ns/op	11575729 B/op	  245983 allocs/op
BenchmarkEngineWithNSignatures/rego/4Signatures-16         	     100	  22670464 ns/op	23365947 B/op	  494621 allocs/op
BenchmarkEngineWithNSignatures/rego/8Signatures-16         	     100	  44750550 ns/op	46439232 B/op	  983656 allocs/op
BenchmarkEngineWithNSignatures/rego/16Signatures-16        	     100	  59082641 ns/op	92543772 B/op	 1971349 allocs/op
BenchmarkEngineWithNSignatures/rego/32Signatures-16        	     100	  87702240 ns/op	185807271 B/op	 3960792 allocs/op
BenchmarkEngineWithNSignatures/rego/64Signatures-16        	     100	 147384928 ns/op	365204354 B/op	 7788096 allocs/op
BenchmarkEngineWithNSignatures/rego/128Signatures-16       	     100	 280088130 ns/op	737913634 B/op	15737458 allocs/op
PASS
ok  	github.com/aquasecurity/tracee/tracee-rules/benchmark	68.119s
```

```
➜  benchmark git:(event_to_unstructured) ✗ go test -bench=EngineWithNSignatures/rego -benchtime=100x -benchmem
goos: darwin
goarch: amd64
pkg: github.com/aquasecurity/tracee/tracee-rules/benchmark
cpu: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
BenchmarkEngineWithNSignatures/rego/2Signatures-16         	     100	  12211402 ns/op	11796871 B/op	  222644 allocs/op
BenchmarkEngineWithNSignatures/rego/4Signatures-16         	     100	  20457959 ns/op	23717600 B/op	  447456 allocs/op
BenchmarkEngineWithNSignatures/rego/8Signatures-16         	     100	  35967881 ns/op	47136604 B/op	  889711 allocs/op
BenchmarkEngineWithNSignatures/rego/16Signatures-16        	     100	  53071508 ns/op	94459594 B/op	 1784532 allocs/op
BenchmarkEngineWithNSignatures/rego/32Signatures-16        	     100	  76496260 ns/op	189707373 B/op	 3585234 allocs/op
BenchmarkEngineWithNSignatures/rego/64Signatures-16        	     100	 131655093 ns/op	372987305 B/op	 7050512 allocs/op
BenchmarkEngineWithNSignatures/rego/128Signatures-16       	     100	 246052599 ns/op	753751712 B/op	14247815 allocs/op
PASS
```

NB To benchmark I had to modify Rego signature implementation, which is not part of this PR:

```
diff --git a/tracee-rules/signatures/rego/regosig/traceerego.go b/tracee-rules/signatures/rego/regosig/traceerego.go
index 9793a9d..ab979cf 100644
--- a/tracee-rules/signatures/rego/regosig/traceerego.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego.go
@@ -144,7 +144,16 @@ func (sig *RegoSignature) OnEvent(e types.Event) error {
                return fmt.Errorf("invalid event")
        }

-       results, err := sig.matchPQ.Eval(context.TODO(), rego.EvalInput(ee))
+       u ,err := ee.ToUnstructured()
+       if err != nil {
+               return err
+       }
+       value ,err:= ast.InterfaceToValue(u)
+       if err != nil {
+               return err
+       }
+
+       results, err := sig.matchPQ.Eval(context.TODO(), rego.EvalParsedInput(value))
        if err != nil {
                return err
        }
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>