### PR TITLE
tracee-ebpf: use wall and relative timestamps

### DIFF
--- a/tracee-ebpf/external/external.go
+++ b/tracee-ebpf/external/external.go
@@ -9,7 +9,7 @@ import (
 
 // Event is a user facing data structure representing a single event
 type Event struct {
-	Timestamp           float64    `json:"timestamp"`
+	Timestamp           int        `json:"timestamp"`
 	ProcessID           int        `json:"processId"`
 	ThreadID            int        `json:"threadId"`
 	ParentProcessID     int        `json:"parentProcessId"`

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -208,6 +208,7 @@ option:{stack-addresses,detect-syscall,exec-env}   augment output according to g
   stack-addresses                                  include stack memory addresses for each event
   detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
+  relative-time                                    use relative timestamp instead of wall timestamp for events
 
 Examples:
   --output json                                            | output as json
@@ -254,6 +255,8 @@ Use this flag multiple times to choose multiple output options
 				res.DetectSyscall = true
 			case "exec-env":
 				res.ExecEnv = true
+			case "relative-time":
+				res.RelativeTime = true
 			default:
 				return res, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -968,8 +968,7 @@ static __always_inline int init_context(context_t *context)
     if (container_id != NULL) {
         __builtin_memcpy(context->cont_id, container_id->id, CONT_ID_LEN);
     }
-    // Save timestamp in microsecond resolution
-    context->ts = bpf_ktime_get_ns()/1000;
+    context->ts = bpf_ktime_get_ns();
 
     // Clean Stack Trace ID
     context->stack_id = 0;
@@ -2162,7 +2161,7 @@ if (CONFIG_ARCH_HAS_SYSCALL_WRAPPER) {
     // exit, exit_group and rt_sigreturn syscalls don't return - don't save args for them
     if (id != SYS_EXIT && id != SYS_EXIT_GROUP && id != SYS_RT_SIGRETURN) {
         // save the timestamp at function entry
-        args_tmp.args[6] = bpf_ktime_get_ns()/1000;
+        args_tmp.args[6] = bpf_ktime_get_ns();
         save_args(&args_tmp, id);
     }
 


### PR DESCRIPTION
This PR sets the default timestamp to be the realtime (wall) timestamp.
In addition, it is possible to use a monotonic timestamp relative to tracee start time using a new output option.
The format of the timestamp is changed to accommodate these changes.


![Screenshot_2021-07-25_17-26-07](https://user-images.githubusercontent.com/10260518/126902666-635ecc52-1518-4e5e-8947-83364d1580c5.png)
