### PR TITLE
tracee-ebpf: Adjust MAX_PATH_COMPONENTS limit for kernels >= 5.2

### DIFF
--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -250,7 +250,7 @@ extern bool CONFIG_ARCH_HAS_SYSCALL_WRAPPER __kconfig;
 #define MAX_STR_ARR_ELEM      128
 #define MAX_ARGS_STR_ARR_ELEM 128
 #define MAX_PATH_PREF_SIZE    128
-#define MAX_PATH_COMPONENTS   128
+#define MAX_PATH_COMPONENTS   80
 #define MAX_BIN_CHUNKS        256
 #endif
 #else


### PR DESCRIPTION
Resolves: #815

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>