### PR TITLE
Feature/event origin signature filter

### DIFF
--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -315,6 +315,7 @@ func ToParsedEvent(e tracee.Event) (ParsedEvent, error) {
 	}, nil
 }
 
+// extractEventOriginTag return from which origin the signature expects to receive events from.
 func extractEventOriginTag(signatureMetaData types.SignatureMetadata) string {
 	eventOriginFilter := ALL_EVENT_ORIGINS
 	for _, tag := range signatureMetaData.Tags {
@@ -329,7 +330,7 @@ func extractEventOriginTag(signatureMetaData types.SignatureMetadata) string {
 
 func analyzeEventOrigin(event tracee.Event) string {
 	if event.ContainerID != "" || event.ProcessID != event.HostProcessID {
-		return EVENT_HOST_ORIGIN
+		return EVENT_CONTAINER_ORIGIN
 	} else {
 		return EVENT_HOST_ORIGIN
 	}

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -170,7 +170,7 @@ func (engine *Engine) consumeSources(done <-chan bool) {
 					continue
 				}
 				
-				eventOrigin, _ := analyzeEventOrigin(event)
+				eventOrigin := analyzeEventOrigin(traceeEvt)
 				for _, s := range engine.signaturesIndex[SignaturesFilter{eventSelector: types.SignatureEventSelector{Source: "tracee", Name: traceeEvt.EventName}, origin: eventOrigin}] {
 					engine.dispatchEvent(s, pe)
 				}
@@ -322,7 +322,10 @@ func extractEventOriginTag(signatureMetaData types.SignatureMetadata) string {
 	return eventOriginFilter
 }
 
-func analyzeEventOrigin(event types.Event) (string, error) {
-	// TODO: Implement
-	return "", nil
+func analyzeEventOrigin(event tracee.Event) string {
+	if event.ContainerID != "" || event.ProcessID != event.HostProcessID {
+		return "container"
+	} else {
+		return "host"
+	}
 }

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -179,13 +179,8 @@ func TestConsumeSources(t *testing.T) {
 						{
 							Name:   "test_event",
 							Source: "tracee",
+							Origin: "container",
 						},
-					}, nil
-				},
-				getMetadata: func() (types.SignatureMetadata, error) {
-					return types.SignatureMetadata{
-						Name: "Fake Signature",
-						Tags: []string{"linux", "container"},
 					}, nil
 				},
 			},
@@ -219,13 +214,8 @@ func TestConsumeSources(t *testing.T) {
 						{
 							Name:   "test_event",
 							Source: "tracee",
+							Origin: "host",
 						},
-					}, nil
-				},
-				getMetadata: func() (types.SignatureMetadata, error) {
-					return types.SignatureMetadata{
-						Name: "Fake Signature",
-						Tags: []string{"linux", "host"},
 					}, nil
 				},
 			},
@@ -252,13 +242,8 @@ func TestConsumeSources(t *testing.T) {
 						{
 							Name:   "test_event",
 							Source: "tracee",
+							Origin: "container",
 						},
-					}, nil
-				},
-				getMetadata: func() (types.SignatureMetadata, error) {
-					return types.SignatureMetadata{
-						Name: "Fake Signature",
-						Tags: []string{"linux", "container"},
 					}, nil
 				},
 			},
@@ -332,13 +317,8 @@ func TestConsumeSources(t *testing.T) {
 						{
 							Name:   "test_event",
 							Source: "tracee",
+							Origin: "container",
 						},
-					}, nil
-				},
-				getMetadata: func() (types.SignatureMetadata, error) {
-					return types.SignatureMetadata{
-						Name: "Fake Signature",
-						Tags: []string{"linux", "container"},
 					}, nil
 				},
 			},

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -158,6 +158,107 @@ func TestConsumeSources(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path - with one matching selector including event origin from container",
+			inputEvent: tracee.Event{
+				EventName:       "test_event",
+				ProcessID:       2,
+				ParentProcessID: 1,
+				ContainerID:     "container ID",
+				Args: []tracee.Argument{
+					{
+						ArgMeta: tracee.ArgMeta{
+							Name: "pathname",
+						},
+						Value: "/proc/self/mem",
+					},
+				},
+			},
+			inputSignature: fakeSignature{
+				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
+					return []types.SignatureEventSelector{
+						{
+							Name:   "test_event",
+							Source: "tracee",
+						},
+					}, nil
+				},
+				getMetadata: func() (types.SignatureMetadata, error) {
+					return types.SignatureMetadata{
+						Name: "Fake Signature",
+						Tags: []string{"linux", "container"},
+					}, nil
+				},
+			},
+			expectedNumEvents: 1,
+		},
+		{
+			name: "happy path - with one matching selector with mismatching event origin from container",
+			inputEvent: tracee.Event{
+				EventName:       "test_event",
+				ProcessID:       2,
+				ParentProcessID: 1,
+				ContainerID:     "container ID",
+				Args: []tracee.Argument{
+					{
+						ArgMeta: tracee.ArgMeta{
+							Name: "pathname",
+						},
+						Value: "/proc/self/mem",
+					},
+				},
+			},
+			inputSignature: fakeSignature{
+				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
+					return []types.SignatureEventSelector{
+						{
+							Name:   "test_event",
+							Source: "tracee",
+						},
+					}, nil
+				},
+				getMetadata: func() (types.SignatureMetadata, error) {
+					return types.SignatureMetadata{
+						Name: "Fake Signature",
+						Tags: []string{"linux", "host"},
+					}, nil
+				},
+			},
+			expectedNumEvents: 0,
+		},
+		{
+			name: "happy path - with one matching selector including event origin from host",
+			inputEvent: tracee.Event{
+				EventName:       "test_event",
+				ProcessID:       2,
+				ParentProcessID: 2,
+				Args: []tracee.Argument{
+					{
+						ArgMeta: tracee.ArgMeta{
+							Name: "pathname",
+						},
+						Value: "/proc/self/mem",
+					},
+				},
+			},
+			inputSignature: fakeSignature{
+				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
+					return []types.SignatureEventSelector{
+						{
+							Name:   "test_event",
+							Source: "tracee",
+						},
+					}, nil
+				},
+				getMetadata: func() (types.SignatureMetadata, error) {
+					return types.SignatureMetadata{
+						Name: "Fake Signature",
+						Tags: []string{"linux", "container"},
+					}, nil
+				},
+			},
+			expectedNumEvents: 1,
+		},
+		{
 			name: "sad path - with all events selector, no source",
 			inputSignature: regoFakeSignature{
 				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
@@ -197,6 +298,39 @@ func TestConsumeSources(t *testing.T) {
 				},
 			},
 			expectedError: "error getting metadata: getMetadata error\n",
+		},
+		{
+			name: "sad path - event ContainerID was not parsed but event is from container",
+			inputEvent: tracee.Event{
+				EventName:       "test_event",
+				ProcessID:       2,
+				ParentProcessID: 1,
+				Args: []tracee.Argument{
+					{
+						ArgMeta: tracee.ArgMeta{
+							Name: "pathname",
+						},
+						Value: "/proc/self/mem",
+					},
+				},
+			},
+			inputSignature: fakeSignature{
+				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
+					return []types.SignatureEventSelector{
+						{
+							Name:   "test_event",
+							Source: "tracee",
+						},
+					}, nil
+				},
+				getMetadata: func() (types.SignatureMetadata, error) {
+					return types.SignatureMetadata{
+						Name: "Fake Signature",
+						Tags: []string{"linux", "container"},
+					}, nil
+				},
+			},
+			expectedNumEvents: 1,
 		},
 	}
 

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -173,7 +173,7 @@ func TestConsumeSources(t *testing.T) {
 					},
 				},
 			},
-			inputSignature: fakeSignature{
+			inputSignature: regoFakeSignature{
 				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
 					return []types.SignatureEventSelector{
 						{
@@ -190,6 +190,12 @@ func TestConsumeSources(t *testing.T) {
 				},
 			},
 			expectedNumEvents: 1,
+			expectedEvent: ParsedEvent{
+				Event: tracee.Event{
+					ProcessID: 2, ParentProcessID: 1, ContainerID: "container ID", Args: []external.Argument{{ArgMeta: external.ArgMeta{Name: "pathname", Type: ""}, Value: "/proc/self/mem"}},
+					EventName: "test_event",
+				},
+			},
 		},
 		{
 			name: "happy path - with one matching selector with mismatching event origin from container",
@@ -207,7 +213,7 @@ func TestConsumeSources(t *testing.T) {
 					},
 				},
 			},
-			inputSignature: fakeSignature{
+			inputSignature: regoFakeSignature{
 				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
 					return []types.SignatureEventSelector{
 						{
@@ -240,7 +246,7 @@ func TestConsumeSources(t *testing.T) {
 					},
 				},
 			},
-			inputSignature: fakeSignature{
+			inputSignature: regoFakeSignature{
 				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
 					return []types.SignatureEventSelector{
 						{
@@ -257,6 +263,12 @@ func TestConsumeSources(t *testing.T) {
 				},
 			},
 			expectedNumEvents: 1,
+			expectedEvent: ParsedEvent{
+				Event: tracee.Event{
+					ProcessID: 2, ParentProcessID: 2, Args: []external.Argument{{ArgMeta: external.ArgMeta{Name: "pathname", Type: ""}, Value: "/proc/self/mem"}},
+					EventName: "test_event",
+				},
+			},
 		},
 		{
 			name: "sad path - with all events selector, no source",
@@ -314,7 +326,7 @@ func TestConsumeSources(t *testing.T) {
 					},
 				},
 			},
-			inputSignature: fakeSignature{
+			inputSignature: regoFakeSignature{
 				getSelectedEvents: func() ([]types.SignatureEventSelector, error) {
 					return []types.SignatureEventSelector{
 						{
@@ -331,6 +343,12 @@ func TestConsumeSources(t *testing.T) {
 				},
 			},
 			expectedNumEvents: 1,
+			expectedEvent: ParsedEvent{
+				Event: tracee.Event{
+					ProcessID: 2, ParentProcessID: 1, Args: []external.Argument{{ArgMeta: external.ArgMeta{Name: "pathname", Type: ""}, Value: "/proc/self/mem"}},
+					EventName: "test_event",
+				},
+			},
 		},
 	}
 

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -31,6 +31,7 @@ type SignatureMetadata struct {
 type SignatureEventSelector struct {
 	Source string
 	Name   string
+	Origin string
 }
 
 //SignatureHandler is a callback function that reports a finding


### PR DESCRIPTION
Added filter upon request of the signatures called according to the signature origin - from the container or the hos (with backward compatibility).
The filtering use the `SignatureMetaData.Tag` member to determine which event origin the signature expect to receive.