### PR TITLE
tracee-ebpf: add SIGTERM support

### DIFF
--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -1080,7 +1080,7 @@ func (t *Tracee) writeProfilerStats(wr io.Writer) error {
 // Run starts the trace. it will run until interrupted
 func (t *Tracee) Run() error {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	done := make(chan struct{})
 	if t.config.ChanEvents == nil {
 		t.printer.Preamble()


### PR DESCRIPTION
Handle SIGTERM  to display the epilogue message, instead of abruptly stop. 

eg:
```
End of events stream
Stats: {eventCounter:7531 errorCounter:0 lostEvCounter:0 lostWrCounter:0 lostNtCounter:0}
```