### PR TITLE
tracee-rules: enable pprof endpoints

### DIFF
--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,6 +37,26 @@ func main() {
 			if c.NumFlags() == 0 {
 				cli.ShowAppHelp(c)
 				return errors.New("no flags specified")
+			}
+
+			if c.Bool("pprof") {
+				mux := http.NewServeMux()
+				mux.HandleFunc("/debug/pprof/", pprof.Index)
+				mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+				mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+				mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+				mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+				mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+				mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+				mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+				mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+				go func() {
+					addr := c.String("pprof-addr")
+					fmt.Fprintf(os.Stdout, "Serving pprof endpoints at %s\n", addr)
+					if err := http.ListenAndServe(addr, mux); err != http.ErrServerClosed {
+						fmt.Fprintf(os.Stderr, "Error serving pprof endpoints: %v\n", err)
+					}
+				}()
 			}
 
 			sigs, err := getSignatures(c.String("rules-dir"), c.StringSlice("rules"))
@@ -118,6 +140,15 @@ func main() {
 			&cli.StringFlag{
 				Name:  "output-template",
 				Usage: "configure output format via templates. Usage: --output-template=path/to/my.tmpl",
+			},
+			&cli.BoolFlag{
+				Name:  "pprof",
+				Usage: "enables pprof endpoints",
+			},
+			&cli.StringFlag{
+				Name:  "pprof-addr",
+				Usage: "listening address of the pprof endpoints server",
+				Value: ":7777",
 			},
 		},
 	}


### PR DESCRIPTION
1. You can run Tracee-rules with `--pprof` and `--pprof-addr :7777` flags to enable (remote) profiling:
   ```
   sudo ./tracee-ebpf --output=format:gob --security-alerts | ./tracee-rules \
     --pprof --pprof-addr:7777 \
     --input-tracee=file:stdin --input-tracee=format:gob
   ```
2. Profile **cpu** for **60 seconds** and access Graph or Flame Graph visualisation in your web browser:
   ```
   go tool pprof -http=0.0.0.0:6060 http://localhost:7777/debug/pprof/profile?seconds=60
   ```
   ![tracee_pprof_profile](https://user-images.githubusercontent.com/1322923/127646908-9f0262f5-bcab-4397-9fb4-ce994ec3d0c5.png)
3. Profile **goroutine** stack traces of all current goroutines:
   ```
   go tool pprof -http=0.0.0.0:6060 http://localhost:7777/debug/pprof/goroutine
   ```
   ![tracee_pprof_goroutine](https://user-images.githubusercontent.com/1322923/127646963-d1c3d559-6679-4c2a-878a-37b78ed8cba7.png)

Check all available profiles on https://golang.org/doc/diagnostics#profiling.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>