### PR TITLE
use tcp_connect kprobe to get tcp handshake packets

### DIFF
--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -178,6 +178,7 @@ const (
 	DebugNetUdpDestroySock
 	DebugNetUdpV6DestroySock
 	DebugNetInetSockSetState
+	DebugNetTcpConnect
 )
 
 // EventsIDToEvent is list of supported events, indexed by their ID

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -198,6 +198,7 @@ extern bool CONFIG_ARCH_HAS_SYSCALL_WRAPPER __kconfig;
 #define DEBUG_NET_UDP_DESTROY_SOCK      4
 #define DEBUG_NET_UDPV6_DESTROY_SOCK    5
 #define DEBUG_NET_INET_SOCK_SET_STATE   6
+#define DEBUG_NET_TCP_CONNECT           7
 
 #define CONFIG_SHOW_SYSCALL         1
 #define CONFIG_EXEC_ENV             2
@@ -3391,19 +3392,7 @@ int tracepoint__inet_sock_set_state(struct bpf_raw_tracepoint_args *ctx)
     }
 
     switch (new_state) {
-    case TCP_SYN_SENT:
-        // When we have an outgoing network connection to a remote server, we get 'TCP_ESTABLISHED' with a context
-        // which is different from the client's context.
-        // We use 'TCP_SYN_SENT' state change, which we observed to always happen in the correct context,
-        // and save the socket in sock_ctx_map so we can avoid performing the should_trace() check
-        // Note that in this state, the port equals to 0, so we don't update the network_map here
-        net_ctx_ext.host_tid = bpf_get_current_pid_tgid();
-        bpf_get_current_comm(&net_ctx_ext.comm, sizeof(net_ctx_ext.comm));
-        net_ctx_ext.local_port = connect_id.port;
-        bpf_map_update_elem(&sock_ctx_map, &sk, &net_ctx_ext, BPF_ANY);
-        break;
     case TCP_LISTEN:
-    case TCP_ESTABLISHED:
         // Ideally, we would update the network map only in 'TCP_ESTABLISHED' state.
         // However, in the case of a local server program and a local client program, which communicate via the 'lo' interface,
         // the change to the 'TCP_ESTABLISHED' state of the server's socket doesn't happen in the (process) context of the server.
@@ -3452,6 +3441,40 @@ int tracepoint__inet_sock_set_state(struct bpf_raw_tracepoint_args *ctx)
 
     return 0;
 }
+
+SEC("kprobe/tcp_connect")
+int BPF_KPROBE(trace_tcp_connect)
+{
+    if (!should_trace())
+        return 0;
+
+    local_net_id_t connect_id = {0};
+    net_ctx_ext_t net_ctx_ext = {0};
+
+    struct sock *sk = (struct sock *)PT_REGS_PARM1(ctx);
+
+    u16 family = get_sock_family(sk);
+    if (family == AF_INET) {
+        net_conn_v4_t net_details = {};
+        get_network_details_from_sock_v4(sk, &net_details, 0);
+        get_local_net_id_from_network_details_v4(sk, &connect_id, &net_details, family);
+    } else if (family == AF_INET6) {
+        net_conn_v6_t net_details = {};
+        get_network_details_from_sock_v6(sk, &net_details, 0);
+        get_local_net_id_from_network_details_v6(sk, &connect_id, &net_details, family);
+    } else {
+        return 0;
+    }
+
+    u32 tid = bpf_get_current_pid_tgid();
+
+    net_ctx_ext.host_tid = tid;
+    bpf_get_current_comm(&net_ctx_ext.comm, sizeof(net_ctx_ext.comm));
+    net_ctx_ext.local_port = connect_id.port;
+    bpf_map_update_elem(&sock_ctx_map, &sk, &net_ctx_ext, BPF_ANY);
+
+    return net_map_update_or_delete_sock(ctx, DEBUG_NET_TCP_CONNECT, sk, tid);
+};
 
 SEC("kprobe/send_bin")
 int BPF_KPROBE(send_bin)

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -3393,10 +3393,6 @@ int tracepoint__inet_sock_set_state(struct bpf_raw_tracepoint_args *ctx)
 
     switch (new_state) {
     case TCP_LISTEN:
-        // Ideally, we would update the network map only in 'TCP_ESTABLISHED' state.
-        // However, in the case of a local server program and a local client program, which communicate via the 'lo' interface,
-        // the change to the 'TCP_ESTABLISHED' state of the server's socket doesn't happen in the (process) context of the server.
-        // To update the network_map correctly in that case, we use the 'TCP_LISTEN' state.
         if (connect_id.port) {
             if (!sock_ctx_p) {
                 net_ctx_ext.host_tid = bpf_get_current_pid_tgid();

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -930,6 +930,15 @@ func (t *Tracee) attachNetProbes() error {
 		return fmt.Errorf("error attaching event sock:inet_sock_set_state: %v", err)
 	}
 
+	prog, _ = t.bpfModule.GetProgram("trace_tcp_connect")
+	if prog == nil {
+		return fmt.Errorf("couldn't find trace_tcp_connect program")
+	}
+	_, err = prog.AttachKprobe("tcp_connect")
+	if err != nil {
+		return fmt.Errorf("error attaching event tcp_connect: %v", err)
+	}
+
 	return nil
 }
 
@@ -1810,6 +1819,19 @@ func (t *Tracee) processNetEvents() {
 						timeStampObj, comm, hostTid, netaddr.IPFrom16(pkt.LocalIP), pkt.LocalPort, pkt.Protocol)
 				case DebugNetInetSockSetState:
 					fmt.Printf("%v  %-16s  %-7d  debug_net/inet_sock_set_state  LocalIP: %v, LocalPort: %d, RemoteIP: %v, RemotePort: %d, Protocol: %d, OldState: %d, NewState: %d, SockPtr: 0x%x\n",
+						timeStampObj,
+						comm,
+						hostTid,
+						netaddr.IPFrom16(pkt.LocalIP),
+						pkt.LocalPort,
+						netaddr.IPFrom16(pkt.RemoteIP),
+						pkt.RemotePort,
+						pkt.Protocol,
+						pkt.TcpOldState,
+						pkt.TcpNewState,
+						pkt.SockPtr)
+				case DebugNetTcpConnect:
+					fmt.Printf("%v  %-16s  %-7d  debug_net/tcp_connect  LocalIP: %v, LocalPort: %d, RemoteIP: %v, RemotePort: %d, Protocol: %d, OldState: %d, NewState: %d, SockPtr: 0x%x\n",
 						timeStampObj,
 						comm,
 						hostTid,

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -1710,7 +1710,6 @@ func (t *Tracee) processFileWrites() {
 func (t *Tracee) processNetEvents() {
 	// Todo: split pcap files by context (tid + comm)
 	// Todo: add stats for network packets (in epilog)
-	// Todo: support syn+syn-ack packets
 	for {
 		select {
 		case in := <-t.netChannel:
@@ -1831,18 +1830,8 @@ func (t *Tracee) processNetEvents() {
 						pkt.TcpNewState,
 						pkt.SockPtr)
 				case DebugNetTcpConnect:
-					fmt.Printf("%v  %-16s  %-7d  debug_net/tcp_connect  LocalIP: %v, LocalPort: %d, RemoteIP: %v, RemotePort: %d, Protocol: %d, OldState: %d, NewState: %d, SockPtr: 0x%x\n",
-						timeStampObj,
-						comm,
-						hostTid,
-						netaddr.IPFrom16(pkt.LocalIP),
-						pkt.LocalPort,
-						netaddr.IPFrom16(pkt.RemoteIP),
-						pkt.RemotePort,
-						pkt.Protocol,
-						pkt.TcpOldState,
-						pkt.TcpNewState,
-						pkt.SockPtr)
+					fmt.Printf("%v  %-16s  %-7d  debug_net/tcp_connect     LocalIP: %v, LocalPort: %d, Protocol: %d\n",
+						timeStampObj, comm, hostTid, netaddr.IPFrom16(pkt.LocalIP), pkt.LocalPort, pkt.Protocol)
 				}
 			}
 		case lost := <-t.lostNetChannel:


### PR DESCRIPTION
using kprobe tcp_connect, in order to capture tcp SYN and SYN-ACK packets. 

this internal kernel function is a good place to identify outgoing tcp connections:
- this function is called both for ipv4 and ipv6. 
- this function is called after the kernel assigns a local port to the socket.
- this function is called before the first SYN packet is sent.

we no longer have use of the tcp states TCP_SYN_SENT and TCP_ESTABLISHED in the inet_sock_set_state tracepoint - this is because these states were only used to capture outgoing tcp connections.
TCP_LISTEN is still needed because it is used to capture incoming tcp connections.

TCP_CLOSE is now used for both outgoing and incoming tcp connections, but we have to update sock_ctx_map in tcp_connect, so we can remove this network flow from network_map on TCP_CLOSE state.