### PR TITLE
tracee.go: initialize pid_to_cont_id_map during startup

### DIFF
--- a/tracee-ebpf/tracee/containers.go
+++ b/tracee-ebpf/tracee/containers.go
@@ -1,0 +1,180 @@
+package tracee
+
+import (
+	"bufio"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Containers contain information about host running containers in the host.
+type Containers struct {
+	cgroupv1   bool
+	cgroupv1mp string
+	cgroupv2   bool
+	cgroupv2mp string
+	mapContIds map[string][]string
+}
+
+// init will (re)initialize the containers object.
+func (c *Containers) init() {
+
+	c.mapContIds = make(map[string][]string, 0)
+	c.cgroupv1 = false
+	c.cgroupv2 = false
+	c.cgroupv1mp = ""
+	c.cgroupv2mp = ""
+}
+
+// addContainer adds a container given its uuid.
+func (c *Containers) addContainer(contId string) {
+	_, ok := c.mapContIds[contId]
+	if !ok {
+		c.mapContIds[contId] = make([]string, 0)
+	}
+}
+
+// GetContainers provides a list of all added containers by their uuid.
+func (c *Containers) GetContainers() []string {
+	var conts []string
+	for k := range c.mapContIds {
+		conts = append(conts, k)
+	}
+	return conts
+}
+
+// addPid will add a given pid string to an existing container by given uuid.
+// It will also create the container if given container uuid does not exist.
+func (c *Containers) addPid(contId string, pid string) {
+	c.addContainer(contId)
+	c.mapContIds[contId] = append(c.mapContIds[contId], pid)
+}
+
+func (c *Containers) GetPids(contId string) []string {
+	return c.mapContIds[contId]
+}
+
+// Populate will populate all Containers information by reading mounted proc
+// and cgroups filesystems.
+func (c *Containers) Populate() error {
+	// do all the hard work
+
+	c.init()
+
+	err := c.procMountsCgroups()
+	if err != nil {
+		return err
+	}
+
+	return c.populate()
+}
+
+// procMountsCgroups finds cgroups v1 and v2 mountpoints for the procfs walks.
+func (c *Containers) procMountsCgroups() error {
+	// find cgroups v1 and v2 mountpoints for procfs walks
+
+	mountsFile := "/proc/mounts"
+	file, err := os.Open(mountsFile)
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(file)
+	for i := 1; scanner.Scan(); i++ {
+		sline := strings.Split(scanner.Text(), " ")
+		mountpoint := sline[1]
+		fstype := sline[2]
+		if fstype == "cgroup" {
+			if strings.Contains(mountpoint, "cgroup/pids") {
+				c.cgroupv1 = true
+				c.cgroupv1mp = mountpoint
+			}
+		} else if fstype == "cgroup2" {
+			c.cgroupv2 = true
+			c.cgroupv2mp = mountpoint
+		}
+	}
+	_ = file.Close()
+
+	return nil
+}
+
+// populate prepares the regex(es) to be used for the population to be done in
+// proc walk.
+func (c *Containers) populate() error {
+
+	if c.cgroupv1 {
+		var r []string
+		// docker:  <cgroupv1mp>/<random>/docker/<id>/tasks
+		r = append(r, ".*docker.*(.{64})/tasks$")
+		// podman:  <cgroupv1mp>/<random>/libpod-<id>.scope/tasks
+		r = append(r, ".*libpod.*(.{64})\\.scope/tasks$")
+		// generic: <cgroupv1mp>/<random>/<id>.scope/tasks
+		r = append(r, ".*(.{64})\\.scope/tasks$")
+
+		err := c.populateProcWalk(c.cgroupv1mp, r)
+		if err != nil {
+			return err
+		}
+	}
+	if c.cgroupv2 {
+		var r []string
+		// docker:  <cgroupv2mp>/<random>/docker-<id>.scope/cgroup.procs
+		r = append(r, ".*docker.*(.{64})\\.scope/cgroup.procs$")
+		// podman:  <cgroupv2mp>/<random>/libpod-<id>.scope/cgroup.procs
+		r = append(r, ".*libpod.*(.{64})\\.scope/cgroup.procs$")
+		// generic: <cgroupv2mp>/<random>/<id>.scope/cgroup.procs
+		r = append(r, ".*(.{64})\\.scope/cgroup.procs$")
+
+		err := c.populateProcWalk(c.cgroupv2mp, r)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// populateProcWalk walks through procfs for cgroups (v1 & v2) filesystems and
+// find files based on given regex(es). It also extracts containers
+// information from found files and creates containers by their uuid AND adds
+// running pids to those containers.
+func (c *Containers) populateProcWalk(basedir string, allstr []string) error {
+
+	var allres []*regexp.Regexp
+	allres = make([]*regexp.Regexp, len(allstr))
+	for j := 0; j < len(allstr); j++ {
+		allres[j] = regexp.MustCompile(basedir + allstr[j])
+	}
+	err := filepath.WalkDir(basedir,
+		func(fn string, fi fs.DirEntry, err error) error {
+			if err != nil {
+				_, _ = fmt.Fprintln(os.Stderr, err)
+				return nil
+			}
+			for l := 0; l < len(allres); l++ {
+				res := allres[l].FindStringSubmatch(fn)
+				if len(res) == 0 {
+					continue
+				}
+				contId := res[1] // 1st regexp match (Id)
+				c.addContainer(contId)
+				buf, e := ioutil.ReadFile(fn) // res[0] or fn == .tasks or .procs file
+				if e != nil {
+					return e // error if can't read pids file
+				}
+				for _, pid := range strings.Split(string(buf), "\n") {
+					if len(pid) > 0 {
+						c.addPid(contId, pid)
+					}
+				}
+				break // a single match is enough
+			}
+			return nil
+		})
+
+	return err
+}

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -837,21 +837,15 @@ func (t *Tracee) populateBPFMaps() error {
 	}
 
 	// Initialize pid_to_cont_id_map if tracing containers
-	c := Containers{}
-	err = c.Populate()
-	if err != nil {
+	c := InitContainers()
+	if err := c.Populate(); err != nil {
 		return err
 	}
 	bpfPidToContIdMap, _ := t.bpfModule.GetMap("pid_to_cont_id_map")
 	for _, contId := range c.GetContainers() {
-		for _, pidstr := range c.GetPids(contId) {
+		for _, pid := range c.GetPids(contId) {
 			if t.config.Debug {
-				fmt.Println("Running container =", contId, "pid =", pidstr)
-			}
-			var pid uint32
-			_, err = fmt.Sscanf(pidstr, "%d", &pid)
-			if err != nil {
-				return err
+				fmt.Println("Running container =", contId, "pid =", pid)
 			}
 			contIdBytes := []byte(contId)
 			err = bpfPidToContIdMap.Update(unsafe.Pointer(&pid), unsafe.Pointer(&contIdBytes[0]))


### PR DESCRIPTION
Fixes: #862

Initialize pid_to_cont_id_map during tracee startup so that already
running containers can have their container_id resolved when being
traced.

Instead of traversing cgroups filesystem, like tracee eBPF code does, I
have preferred to rely in wrapped 'docker cli' commands to discover
container ids and tasks running in each active container. This made the
code cleaner and easier to be maintained.

Note: There is a small window of opportunity for a container to be
started while this logic is running. I could have made 'Containers'
logic to run in a go coroutine but that would also create another race
window: userland adding a pid to the map that has already been removed
by the - now active - trace event handler.