### PR TITLE
change version format from string to int

### DIFF
--- a/tracee-rules/signatures/golang/examples/example.go
+++ b/tracee-rules/signatures/golang/examples/example.go
@@ -26,7 +26,7 @@ func (sig *counter) Init(cb types.SignatureHandler) error {
 // GetMetadata implements the Signature interface by declaring information about the signature
 func (sig *counter) GetMetadata() (types.SignatureMetadata, error) {
 	return types.SignatureMetadata{
-		Version: "0.1.0",
+		Version: 1,
 		Name:    "count to " + strconv.Itoa(sig.target),
 	}, nil
 }

--- a/tracee-rules/signatures/golang/stdio_over_socket.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket.go
@@ -28,7 +28,7 @@ func (sig *stdioOverSocket) Init(cb types.SignatureHandler) error {
 func (sig *stdioOverSocket) GetMetadata() (types.SignatureMetadata, error) {
 	return types.SignatureMetadata{
 		ID:          "TRC-1",
-		Version:     "0.1.0",
+		Version:     1,
 		Name:        "Standard Input/Output Over Socket",
 		Description: "Redirection of process's standard input/output to socket",
 		Tags:        []string{"linux", "container"},

--- a/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
+++ b/tracee-rules/signatures/rego/anti_debugging_ptraceme.rego
@@ -2,7 +2,7 @@ package tracee.TRC_2
 
 __rego_metadoc__ := {
     "id": "TRC-2",
-    "version": "0.1.0",
+    "version": 1,
     "name": "Anti-Debugging",
     "description": "Process uses anti-debugging technique to block debugger",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/code_injection.rego
+++ b/tracee-rules/signatures/rego/code_injection.rego
@@ -4,7 +4,7 @@ import data.tracee.helpers
 
 __rego_metadoc__ := {
     "id": "TRC-3",
-    "version": "0.1.0",
+    "version": 1,
     "name": "Code injection",
     "description": "Possible code injection into another process",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/dynamic_code_loading.rego
+++ b/tracee-rules/signatures/rego/dynamic_code_loading.rego
@@ -4,7 +4,7 @@ import data.tracee.helpers
 
 __rego_metadoc__ := {
     "id": "TRC-4",
-    "version": "0.1.0",
+    "version": 1,
     "name": "Dynamic Code Loading",
     "description": "Writing to executable allocated memory region",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/fileless_execution.rego
+++ b/tracee-rules/signatures/rego/fileless_execution.rego
@@ -4,7 +4,7 @@ import data.tracee.helpers
 
 __rego_metadoc__ := {
     "id": "TRC-5",
-    "version": "0.1.0",
+    "version": 1,
     "name": "Fileless Execution",
     "description": "Executing a process from memory, without a file in the disk",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/kernel_module_loading.rego
+++ b/tracee-rules/signatures/rego/kernel_module_loading.rego
@@ -2,7 +2,7 @@ package tracee.TRC_6
 
 __rego_metadoc__ := {
     "id": "TRC-6",
-    "version": "0.1.0",
+    "version": 1,
     "name": "kernel module loading",
     "description": "Attempt to load a kernel module detection",
     "tags": ["linux", "container"],

--- a/tracee-rules/signatures/rego/ld_preload.rego
+++ b/tracee-rules/signatures/rego/ld_preload.rego
@@ -4,7 +4,7 @@ import data.tracee.helpers
 
 __rego_metadoc__ := {
     "id": "TRC-7",
-    "version": "0.1.0",
+    "version": 1,
     "name": "LD_PRELOAD",
     "description": "Usage of LD_PRELOAD to allow hooks on process",
     "tags": ["linux", "container"],

--- a/tracee-rules/types/types.go
+++ b/tracee-rules/types/types.go
@@ -20,7 +20,7 @@ type Signature interface {
 //SignatureMetadata represents information about the signature
 type SignatureMetadata struct {
 	ID          string
-	Version     string
+	Version     int
 	Name        string
 	Description string
 	Tags        []string


### PR DESCRIPTION
Changing the version type from string to int and modifying the default rules.