### PR TITLE
fix rule name partially cropped in error message

### DIFF
--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	_ "embed"
 
 	"fmt"
@@ -97,7 +98,11 @@ func findRegoSigs(dir string) ([]types.Signature, error) {
 		}
 		sig, err := regosig.NewRegoSignature(string(regoCode), regoHelpersCode)
 		if err != nil {
-			log.Printf("error creating rego signature with: %s: %v ", regoCode[0:20], err)
+			newlineOffset := bytes.Index(regoCode, []byte("\n"))
+			if newlineOffset == -1 {
+				newlineOffset = len(regoCode)
+			}
+			log.Printf("error creating rego signature with: %s: %v ", regoCode[0:newlineOffset], err)
 			continue
 		}
 		res = append(res, sig)

--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -100,7 +100,12 @@ func findRegoSigs(dir string) ([]types.Signature, error) {
 		if err != nil {
 			newlineOffset := bytes.Index(regoCode, []byte("\n"))
 			if newlineOffset == -1 {
-				newlineOffset = len(regoCode)
+				codeLength := len(regoCode)
+				if codeLength < 22 {
+					newlineOffset = codeLength
+				} else {
+					newlineOffset = 22
+				}
 			}
 			log.Printf("error creating rego signature with: %s: %v ", regoCode[0:newlineOffset], err)
 			continue


### PR DESCRIPTION
When an error occurs in rego rule - the error message used to print the first 20 bytes - effectively cropping the full name of the rules for rule names longer than 20 bytes.
This PR should fix it.