### PR TITLE
tracee-ebpf: make tracee-ebpf static for portability

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -44,8 +44,8 @@ build: $(OUT_BIN)
 go_env := GOOS=linux GOARCH=$(ARCH:x86_64=amd64) CC=$(CMD_CLANG) CGO_CFLAGS="-I $(abspath $(LIBBPF_HEADERS))" CGO_LDFLAGS="$(abspath $(LIBBPF_OBJ))"
 ifndef DOCKER
 $(OUT_BIN): $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(OUT_BPF_CORE) $(filter-out *_test.go,$(GO_SRC)) $(BPF_BUNDLE) | $(OUT_DIR)
-	$(go_env) go build -v -o $(OUT_BIN) \
-	-ldflags "-X main.version=$(VERSION)"
+	$(go_env) go build -tags netgo -v -o $(OUT_BIN) \
+	-ldflags "-w -extldflags \"-static\" -X main.version=$(VERSION)"
 else 
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
 	$(call docker_builder_make,$@ VERSION=$(VERSION))


### PR DESCRIPTION
With CO-RE support, it makes sense that tracee-ebpf binary is also
portable. This way, one may compile tracee-ebpf in one distribution
version and execute in another one, avoiding problems such as:

./dist/tracee-ebpf: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./dist/tracee-ebpf)