### PR TITLE
tracee-rules: fix minimum requirements link

### DIFF
--- a/tracee-rules/Readme.md
+++ b/tracee-rules/Readme.md
@@ -10,7 +10,7 @@ There are 3 basic concepts for Tracee-Rules:
 
 ## Getting started
 
-Tracee-Rules doesn't have any requirement, but in order to run with Tracee-eBPF, make sure you follow the [minimum requirements for running Tracee](TODO).
+Tracee-Rules doesn't have any requirement, but in order to run with Tracee-eBPF, make sure you follow the [minimum requirements for running Tracee](https://aquasecurity.github.io/tracee/dev/install/prerequisites/).
 
 Getting Tracee-Rules:
 Currently you need to build from source. `cd tracee-rules && make` will build the executable as well as all built-in signatures into the local `dist` directory.  


### PR DESCRIPTION
Fix minimum requeriments links, it uses the link from the [tracee-ebpf/Readme.md](https://github.com/aquasecurity/tracee/blob/main/tracee-ebpf/Readme.md#quickstart) 