### PR TITLE
tracee-ebpf: add flags support for make test

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -138,7 +138,7 @@ endif
 .PHONY: test 
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
-	$(go_env)	go test -v ./...
+	$(go_env)	go test $(GOTEST_FLAGS) -v ./...
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)

--- a/tracee-rules/Makefile
+++ b/tracee-rules/Makefile
@@ -52,7 +52,7 @@ $(tools): % : check_%
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(tools)
-	go test -v ./...
+	go test $(GOTEST_FLAGS) -v ./...
 	opa test . --verbose --ignore="examples" --ignore="dist" --ignore="benchmark"
 else
 test: $(DOCKER_BUILDER)


### PR DESCRIPTION
Allowing external flags to `go test`. This simplify getting coverage reports or running single tests. Eg:
```
make test GOTEST_FLAGS="-run Test_updateFileSHA"
make test GOTEST_FLAGS="-cover"
...
``` 