### PR TITLE
tracee-ebpf: add output validate test

### DIFF
--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -134,9 +134,14 @@ type netProbe struct {
 
 // Validate does static validation of the configuration
 func (cfg OutputConfig) Validate() error {
-	if cfg.Format != "table" && cfg.Format != "table-verbose" && cfg.Format != "json" && cfg.Format != "gob" && !strings.HasPrefix(cfg.Format, "gotemplate=") {
+	if cfg.Format != "table" &&
+		cfg.Format != "table-verbose" &&
+		cfg.Format != "json" &&
+		cfg.Format != "gob" &&
+		!strings.HasPrefix(cfg.Format, "gotemplate=") {
 		return fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.", cfg.Format)
 	}
+
 	return nil
 }
 

--- a/tracee-ebpf/tracee/tracee_test.go
+++ b/tracee-ebpf/tracee/tracee_test.go
@@ -268,3 +268,27 @@ func Test_updateFileSHA(t *testing.T) {
 		},
 	}, trc.profiledFiles)
 }
+
+func TestOutputConfigValidate(t *testing.T) {
+
+	testCases := []struct {
+		name          string
+		format        string
+		expectedError error
+	}{
+		{"format:table", "table", nil},
+		{"format:table-verbose", "table-verbose", nil},
+		{"format:json", "json", nil},
+		{"format:gob", "gob", nil},
+		{"format:gotemplate=tmpl", "gotemplate=tmpl", nil},
+		{"invalid format", "invalid", errors.New("unrecognized output format: invalid. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := OutputConfig{Format: tc.format}
+			err := cfg.Validate()
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}


### PR DESCRIPTION
Add tests for `OutputConfig.Validate()`:

```
=== RUN   TestOutputConfigValidate
=== RUN   TestOutputConfigValidate/format:table
=== RUN   TestOutputConfigValidate/format:table-verbose
=== RUN   TestOutputConfigValidate/format:json
=== RUN   TestOutputConfigValidate/format:gob
=== RUN   TestOutputConfigValidate/format:gotemplate=tmpl
=== RUN   TestOutputConfigValidate/invalid_format
```

I also refactored the code in a way I consider more readable than the huge `if`, but I can revert it if you prefer the previous version.