### PR TITLE
tracee: add tini tracee docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make
 
 # base image for tracee which includes all tools to build the bpf object at runtime
 FROM alpine as fat
-RUN apk --no-cache update && apk --no-cache add clang llvm make gcc libc6-compat coreutils linux-headers musl-dev elfutils-dev libelf-static zlib-static
+RUN apk --no-cache update && apk --no-cache add clang llvm make gcc libc6-compat coreutils linux-headers musl-dev elfutils-dev libelf-static zlib-static tini
 
 # base image for tracee which includes minimal dependencies and expects the bpf object to be provided at runtime
 FROM alpine as slim
@@ -39,4 +39,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vendor="Aqua Security" \
     org.label-schema.version=$VERSION
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/sbin/tini", "-g", "--", "./entrypoint.sh"]


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tracee/issues/736. If adding a dependency is not a problem, [tini](https://github.com/krallin/tini) is a very common solution to handle signals properly on containers.

The image size doesn't  change:
```
tracee:with_tini         446MB
tracee:without_tini      446MB
```

Testing:
```
# first shell
# build trace image
docker build  -t tracee:with_tini .
# run tracee
docker run -v /boot/config-$(uname -r):/boot/config-$(uname -r) --name tracee --rm --privileged -it tracee:with_ini

# second shell
docker kill --signal=SIGINT tracee
# or
docker kill --signal=SIGTERM tracee
```