### PR TITLE
tracee-ebpf: turn MAX_PATH_COMPONENTS down to 48

### DIFF
--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -252,7 +252,7 @@ extern bool CONFIG_ARCH_HAS_SYSCALL_WRAPPER __kconfig;
 #define MAX_STR_ARR_ELEM      128
 #define MAX_ARGS_STR_ARR_ELEM 128
 #define MAX_PATH_PREF_SIZE    128
-#define MAX_PATH_COMPONENTS   80
+#define MAX_PATH_COMPONENTS   48
 #define MAX_BIN_CHUNKS        256
 #endif
 #else


### PR DESCRIPTION
Fixes: #851

For the kprobe security_sb_mount, the save_path_to_str_buf() complexity
is too big with the unroll logic + MAX_PATH_COMPONENTS of 80, even on
higher kernels (like 5.4 in Ubuntu). Reducing to 64 did NOT help.
Reducing to 48 DID help and it worked.

Ubuntu kernel contains c04c0d2b968a ("bpf: increase complexity limit and
maximum program size") commit with no reversions. The commit states
that:

    BPF_COMPLEXITY_LIMIT_INSNS is the kernel internal limit
    and success to load the program no longer depends on program size,
    but on 'smartness' of the verifier only.

which might indicate that the eBPF verifier in older kernels, like 5.4,
is not smart enough to consider an unroll of 80 iterations, in the path
resolution function, a logic less complex than it should.