### PR TITLE
tracee-ebpf: sys_enter: use temp args_t struct pointer for no args

### DIFF
--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2169,8 +2169,9 @@ if (CONFIG_ARCH_HAS_SYSCALL_WRAPPER) {
     // exit, exit_group and rt_sigreturn syscalls don't return - don't save args for them
     if (id != SYS_EXIT && id != SYS_EXIT_GROUP && id != SYS_RT_SIGRETURN) {
         // save the timestamp at function entry
-        args_tmp.args[6] = bpf_ktime_get_ns();
-        save_args(&args_tmp, id);
+        args_t noargs = {};
+        noargs.args[6] = bpf_ktime_get_ns();
+        save_args(&noargs, id);
     }
 
     // call syscall handler, if exists


### PR DESCRIPTION
Fixes: #851

Somehow eBPF verifier did not like CO-RE object txt using the stack
address pointer from args_tmp as pointer for save_args() inline
function:

    libbpf: prog 'tracepoint__raw_syscalls__sys_enter': failed to
    attach to raw tracepoint 'sys_enter': Invalid argument

This commit creates a temporary args_t structure in the stack just
before calling save_args() and passing the structure pointer as an
argument. That is enough to allow the eBPF program to be loaded.