### PR TITLE
Fix CO:RE support for RHEL 8 and derivatives

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -35,6 +35,14 @@ DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink $(KERN_SRC_PATH)),$(shell readl
 DOCKER_BUILDER_KERN_SRC_MNT ?= $(dir $(DOCKER_BUILDER_KERN_SRC))
 LINUX_VERSION_CODE := $(shell uname -r | awk '{split($$0,a,"."); split(a[3], b, "-"); print lshift(a[1], 16) + lshift(a[2],8) + b[1];}')
 
+ifneq (,$(wildcard /etc/redhat-release))
+	RHEL_MAJOR := $(shell grep -Eoh -m 1 '[0-9]+\.[0-9]+' /etc/redhat-release | cut -d '.' -f 1)
+	RHEL_MINOR := $(shell grep -Eoh -m 1 '[0-9]+\.[0-9]+' /etc/redhat-release | cut -d '.' -f 2)
+	RHEL_RELEASE_CODE := $(shell echo $$(($(RHEL_MAJOR) << 8 | $(RHEL_MINOR))))
+else
+	RHEL_RELEASE_CODE := 0
+endif
+
 $(OUT_DIR):
 	mkdir -p $@
 
@@ -124,6 +132,7 @@ $(OUT_BPF_CORE): $(BPF_SRC) $(LIBBPF_HEADERS) $(CMD_CLANG)
 		-D__VM_LINUX_H__ \
 		-D__KERNEL__ \
 		-DLINUX_VERSION_CODE=$(LINUX_VERSION_CODE) \
+		-DRHEL_RELEASE_CODE=$(RHEL_RELEASE_CODE) \
 		-target bpf \
 		-O2 -c -g -o $@ $<
 else

--- a/tracee-ebpf/tracee/co_re_missing_definitions.h
+++ b/tracee-ebpf/tracee/co_re_missing_definitions.h
@@ -11,6 +11,8 @@
 #ifndef __TRACEE_MISSING_MACROS_H__
 #define __TRACEE_MISSING_MACROS_H__
 
+#define RHEL_RELEASE_VERSION(a,b) (((a) << 8) + (b))
+
 #define ULLONG_MAX (~0ULL)
 
 #define inet_daddr     sk.__sk_common.skc_daddr


### PR DESCRIPTION
This PR fixes CO:RE support in `tracee-ebpf` on RHEL 8 and its derivatives.
RedHat kernel support was added some time ago by #351 but additional changes are now needed to make that fix work for CO:RE since this mode doesn't use actual RedHat Linux kernel header files and some definitions are missing.
