### PR TITLE
change invoked_from_kernel detection method

### DIFF
--- a/tracee-ebpf/tracee/co_re_missing_definitions.h
+++ b/tracee-ebpf/tracee/co_re_missing_definitions.h
@@ -53,6 +53,8 @@
 
 #define TS_COMPAT 0x0002    /* 32bit syscall active (64BIT)*/
 
+#define PF_KTHREAD  0x00200000	/* I am a kernel thread */
+
 #define TASK_COMM_LEN 16
 
 #define THREAD_SIZE_ORDER 1

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2416,8 +2416,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     }
 
     int invoked_from_kernel = 0;
-    int parent_flags = get_task_parent_flags(task);
-    if (parent_flags & PF_KTHREAD) {
+    if (get_task_parent_flags(task) & PF_KTHREAD) {
         invoked_from_kernel = 1;
     }
 


### PR DESCRIPTION
Changed the way tracee-ebpf detects invocation of a user mode process from the kernel.
Now uses the `PF_KTHREAD` flag in the parent task struct flags.

Will detect userland process creation from kworker or kthread.