### PR TITLE
Feature/fetch system info

### DIFF
--- a/tracee-ebpf/tracee/system_info.go
+++ b/tracee-ebpf/tracee/system_info.go
@@ -1,0 +1,29 @@
+package tracee
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const INIT_PROC_NS_DIR = "/proc/1/ns"
+
+// FetchSystemInfo Fetch info from the system that might be significant for later use or for signatures.
+func FetchSystemInfo() map[string]interface{} {
+	systemInfo := make(map[string]interface{})
+	systemInfo["initNamespaces"] = fetchInitNamespaces()
+	return systemInfo
+}
+
+func fetchInitNamespaces() map[string]int {
+	initNamespacesMap := make(map[string]int)
+	namespacesLinks, _ := ioutil.ReadDir(INIT_PROC_NS_DIR)
+	for _, namespaceLink := range namespacesLinks {
+		namespaceString, _ := os.Readlink(filepath.Join(INIT_PROC_NS_DIR, namespaceLink.Name()))
+		namespaceNumber, _ := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(namespaceString, ":["), ":]"))
+		initNamespacesMap[namespaceString] = namespaceNumber
+	}
+	return initNamespacesMap
+}

--- a/tracee-ebpf/tracee/system_info.go
+++ b/tracee-ebpf/tracee/system_info.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -39,11 +40,13 @@ func FetchSystemInfo() map[string]interface{} {
 
 func fetchInitNamespaces() map[string]int {
 	initNamespacesMap := make(map[string]int)
+	namespaceValueReg := regexp.MustCompile(":[[[:digit:]]*]")
 	namespacesLinks, _ := ioutil.ReadDir(INIT_PROC_NS_DIR)
 	for _, namespaceLink := range namespacesLinks {
-		namespaceString, _ := os.Readlink(filepath.Join(INIT_PROC_NS_DIR, namespaceLink.Name()))
-		namespaceNumber, _ := strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(namespaceString, ":["), ":]"))
-		initNamespacesMap[namespaceString] = namespaceNumber
+		linkString, _ := os.Readlink(filepath.Join(INIT_PROC_NS_DIR, namespaceLink.Name()))
+		trim := strings.Trim(namespaceValueReg.FindString(linkString), "[]:")
+		namespaceNumber, _ := strconv.Atoi(trim)
+		initNamespacesMap[namespaceLink.Name()] = namespaceNumber
 	}
 	return initNamespacesMap
 }

--- a/tracee-ebpf/tracee/system_info.go
+++ b/tracee-ebpf/tracee/system_info.go
@@ -1,6 +1,8 @@
 package tracee
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -8,7 +10,25 @@ import (
 	"strings"
 )
 
+const SYSTEM_INFO_FILE_NAME = "system_info.json"
+
 const INIT_PROC_NS_DIR = "/proc/1/ns"
+
+const INIT_NAMESPACES_KEY = "initNamespaces"
+
+// SaveSystemInfo Writes a map that represent the system info fetched from the machine to output file in json format.
+func SaveSystemInfo(systemInfo map[string]interface{}, outDir string) error {
+	systemInfoFile, err := os.Create(filepath.Join(outDir, SYSTEM_INFO_FILE_NAME))
+	if err != nil {
+		return fmt.Errorf("couldn't create system info dump file: %v", err)
+	}
+	encoder := json.NewEncoder(systemInfoFile)
+	err = encoder.Encode(systemInfo)
+	if err != nil {
+		return fmt.Errorf("couldn't write system info to the output fil: %v", err)
+	}
+	return nil
+}
 
 // FetchSystemInfo Fetch info from the system that might be significant for later use or for signatures.
 func FetchSystemInfo() map[string]interface{} {

--- a/tracee-ebpf/tracee/system_info_test.go
+++ b/tracee-ebpf/tracee/system_info_test.go
@@ -1,0 +1,20 @@
+package tracee
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func getProcNamespaces() []string {
+	return []string{"mnt", "cgroup", "pid", "time", "user", "ipc", "net", "uts"}
+}
+
+func TestFetchSystemInfo(t *testing.T) {
+	systemInfo := FetchSystemInfo()
+	require.Contains(t, systemInfo, INIT_NAMESPACES_KEY)
+	initNamespaces := systemInfo[INIT_NAMESPACES_KEY]
+	for _, namespace := range getProcNamespaces() {
+		assert.Contains(t, initNamespaces, namespace)
+	}
+}

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -393,6 +393,10 @@ func New(cfg Config) (*Tracee, error) {
 	}
 
 	t.systemInfo = FetchSystemInfo()
+	err = SaveSystemInfo(t.systemInfo, t.config.Output.OutPath)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := os.MkdirAll(t.config.Capture.OutputPath, 0755); err != nil {
 		t.Close()

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -237,6 +237,7 @@ type Tracee struct {
 	tcProbe           netProbe
 	pcapWriter        *pcapgo.NgWriter
 	pcapFile          *os.File
+	systemInfo        map[string]interface{}
 }
 
 type counter int32
@@ -390,6 +391,8 @@ func New(cfg Config) (*Tracee, error) {
 			t.pidsInMntns.AddBucketItem(uint32(hostMntns), 1)
 		}
 	}
+
+	t.systemInfo = FetchSystemInfo()
 
 	if err := os.MkdirAll(t.config.Capture.OutputPath, 0755); err != nil {
 		t.Close()

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -393,7 +393,7 @@ func New(cfg Config) (*Tracee, error) {
 	}
 
 	t.systemInfo = FetchSystemInfo()
-	err = SaveSystemInfo(t.systemInfo, t.config.Output.OutPath)
+	err = SaveSystemInfo(t.systemInfo, filepath.Dir(t.config.Output.OutPath))
 	if err != nil {
 		return nil, err
 	}

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/aquasecurity/tracee/tracee-rules/signatures/helpers"
 	"io"
 	"log"
 	"net/http"
@@ -97,6 +98,11 @@ func main() {
 				return err
 			}
 
+			err = helpers.InitSystemInfo(c.String("system-info-file"))
+			if err != nil {
+				fmt.Println("failed to load system info file: ", err)
+			}
+
 			output, err := setupOutput(os.Stdout, c.String("webhook"), c.String("webhook-template"), c.String("webhook-content-type"), c.String("output-template"))
 			if err != nil {
 				return err
@@ -149,6 +155,11 @@ func main() {
 				Name:  "pprof-addr",
 				Usage: "listening address of the pprof endpoints server",
 				Value: ":7777",
+			},
+			&cli.StringFlag{
+				Name:  "system-info-file",
+				Usage: "configure usage of given file as system information of the machine tracee-ebpf have run from",
+				Value: "./system_info.json",
 			},
 		},
 	}

--- a/tracee-rules/signatures/helpers/helpers.go
+++ b/tracee-rules/signatures/helpers/helpers.go
@@ -56,16 +56,19 @@ func GetAddrStructFromArg(addrArg tracee.Argument, connectData *ConnectAddrData)
 	return nil
 }
 
+// GetSystemInfo return the system information fetched from tracee-ebpf for signatures use.
 func GetSystemInfo() map[string]interface{} {
 	return systemInfo
 }
 
+// InitSystemInfo initialize the global, and should only be called from the main tracee-rules package.
 func InitSystemInfo(systemInfoFilePath string) error {
 	var err error
 	systemInfo, err = retrieveSystemInfo(systemInfoFilePath)
 	return err
 }
 
+// retrieveSystemInfo read a file that suppose to contain the system information in json format.
 func retrieveSystemInfo(systemInfoFilePath string) (map[string]interface{}, error) {
 	systemInfo := make(map[string]interface{})
 	systemInfoFile, err := os.Open(systemInfoFilePath)


### PR DESCRIPTION
Fetching system information at the start of tracee-ebpf run, and save it to file.
Added support in tracee-rules for the file.
The purpose is to give more sophisticated signatures access to interesting information from the machine tracee-ebpf runs on at the start of its runtime.