### PR TITLE
tracee-ebpf: don't filter security_file_open for open/openat

### DIFF
--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2560,11 +2560,6 @@ int BPF_KPROBE(trace_security_file_open)
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
 
-    // only monitor open and openat syscalls
-    int syscall_nr = get_syscall_ev_id_from_regs();
-    if (syscall_nr != SYS_OPEN && syscall_nr != SYS_OPENAT)
-        return 0;
-
     // Get per-cpu string buffer
     buf_t *string_p = get_buf(STRING_BUF_IDX);
     if (string_p == NULL)


### PR DESCRIPTION
We originally created this filter (only tracing security_file_open that was originated from open/openat syscalls) as we've noticed there were times it was called not from open/openat context (e.g. during execve), and we wanted to reduce the amount of events triggered by it. As such events frequency is low (which are not originating from open/openat), and as users might expect to get an event for every time that security_file_open is triggered, we can remove this filter.