### PR TITLE
tracee-ebpf: fix capabilities documentation

### DIFF
--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -19,6 +19,6 @@ Exceptions:
 
 For using the eBPF Linux subsystem, Tracee needs to run with sufficient capabilities: 
 - `CAP_SYS_RESOURCE` (to manage eBPF maps limits)
-- `CAP_BPF`+`CAP_TRACING` which are available on recent kernels (>=5.8), or `SYS_ADMIN` on older kernels (to load and attach the eBPF programs).
+- `CAP_SYS_ADMIN` and `CAP_IPC_LOCK` (to load and attach the eBPF programs).
 
 Alternatively, run as `root` or with the `--privileged` flag of Docker.


### PR DESCRIPTION
Fixes capabilities documentation to `tracee-ebpf` current state. I know we have https://github.com/aquasecurity/tracee/issues/747 to add support for the newer capabilities, but while it is not done let's have the documentation represent the current requirements. 

Also, although implementing https://github.com/aquasecurity/tracee/issues/747 is an easy change, currently, it doesn't make much sense considering the latest versions of `docker` and `podman` still doesn't support it, for `docker` it was recently re-added (it was disabled after it was first added) but it didn't make its way to a release yet. https://github.com/moby/moby/pull/42011