### PR TITLE
tracee-ebpf: print help for invalid arguments

### DIFF
--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -37,6 +37,13 @@ func main() {
 		Usage:   "Trace OS events and syscalls using eBPF",
 		Version: version,
 		Action: func(c *cli.Context) error {
+
+			// tracee-ebpf does not suport arguments, only flags
+			if c.NArg() > 0 {
+				cli.ShowAppHelp(c)
+				return nil
+			}
+
 			if c.Bool("list") {
 				printList()
 				return nil


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tracee/issues/585