### PR TITLE
tracee: support external BTF files

### DIFF
--- a/tracee-ebpf/go.mod
+++ b/tracee-ebpf/go.mod
@@ -3,7 +3,7 @@ module github.com/aquasecurity/tracee/tracee-ebpf
 go 1.16
 
 require (
-	github.com/aquasecurity/libbpfgo v0.1.2-0.20210803032413-c500b6207bf6
+	github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7
 	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167
 	github.com/google/gopacket v1.1.19
 	github.com/stretchr/testify v1.7.0

--- a/tracee-ebpf/go.sum
+++ b/tracee-ebpf/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/aquasecurity/libbpfgo v0.1.2-0.20210803032413-c500b6207bf6 h1:5DmiBAntdMSoMC4Be4D8h4cswNnkpkDREiWeluK0BC0=
-github.com/aquasecurity/libbpfgo v0.1.2-0.20210803032413-c500b6207bf6/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7 h1:6bj8UumxqB6xK8wu6Ca3eWBXpbmPbvTPotJ+xM1FN5s=
+github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167 h1:QpuLpMxwd9fFH8p2aZ4umKqfpI9/6vf37D/fvLUyHMk=
 github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -42,6 +42,7 @@ type Config struct {
 	SecurityAlerts     bool
 	Debug              bool
 	maxPidsCache       int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
+	BTFObjPath         string
 	BPFObjPath         string
 	BPFObjBytes        []byte
 	ChanEvents         chan external.Event
@@ -1027,7 +1028,7 @@ func (t *Tracee) attachNetProbes() error {
 func (t *Tracee) initBPF() error {
 	var err error
 
-	t.bpfModule, err = bpf.NewModuleFromBuffer(t.config.BPFObjBytes, t.config.BPFObjPath)
+	t.bpfModule, err = bpf.NewModuleFromBufferBtf(t.config.BTFObjPath, t.config.BPFObjBytes, t.config.BPFObjPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. start using libbpfgo initial btfinfo helper
2. allow external BTF files through TRACEE_BTF_FILE env variable
3. execution decisions based on available environment
4. update to libbpfgo with initial btfinfo