### PR TITLE
fix rego ext check

### DIFF
--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -87,6 +87,10 @@ func findRegoSigs(dir string) ([]types.Signature, error) {
 
 	regoHelpers := []string{regoHelpersCode}
 	for _, file := range files {
+		if filepath.Ext(file.Name()) != ".rego" {
+			continue
+		}
+
 		if file.Name() == "helpers.rego" {
 			continue
 		}


### PR DESCRIPTION
fixes the error getting when tracee-rules tries to load builtin.so as a rego signature.
the check was removed on this commit:
https://github.com/aquasecurity/tracee/commit/82a1289c12da2255682743f6d762bf6adde69a9b#diff-c56a5239a886de2c9586c32e19abf0abcc3ae40b97437bc5fd3a9a78538281b5L87