### PR TITLE
tracee-rules: refactor non used code

### DIFF
--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -93,10 +93,6 @@ func main() {
 				return err
 			}
 
-			if inputs == (engine.EventSources{}) {
-				return err
-			}
-
 			output, err := setupOutput(os.Stdout, c.String("webhook"), c.String("webhook-template"), c.String("webhook-content-type"), c.String("output-template"))
 			if err != nil {
 				return err


### PR DESCRIPTION
This code probably made sense at some point, but it doesn't anymore. The test for an empty event source returns `err`, but all the calls before check `if err != nil { return err}`, so if somehow the code entered inside the if it would `return nil`.  But it doesn't seem like that [inputs](https://github.com/aquasecurity/tracee/blob/main/tracee-rules/main.go#L91-L94) will be empty, it will either have a source or return [error](https://github.com/aquasecurity/tracee/blob/ceece80d347ef5e23777a4f8888cfd3fca9b4447/tracee-rules/input.go#L33)