### PR TITLE
tracee-ebpf: add stats to external

### DIFF
--- a/tracee-ebpf/external/external.go
+++ b/tracee-ebpf/external/external.go
@@ -30,6 +30,14 @@ type Event struct {
 	Args                []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
 }
 
+type Stats struct {
+	EventCount  int
+	ErrorCount  int
+	LostEvCount int
+	LostWrCount int
+	LostNtCount int
+}
+
 // ToUnstructured returns a JSON compatible map with string, float, int, bool,
 // []interface{}, or map[string]interface{} children.
 //


### PR DESCRIPTION
As a preparation to taking printer out of the tracee package and moving it into main package, we need to export Stats.
Doing this, we will also be able to export Stats to other consumers of tracee-ebpf.

The exported struct will expose statsStore as defined in tracee.go:
```
type statsStore struct {
	eventCounter  counter
	errorCounter  counter
	lostEvCounter counter
	lostWrCounter counter
	lostNtCounter counter
}
```