### PR TITLE
tracee-ebpf: use replace for the external package

### DIFF
--- a/tracee-ebpf/go.mod
+++ b/tracee-ebpf/go.mod
@@ -2,6 +2,8 @@ module github.com/aquasecurity/tracee/tracee-ebpf
 
 go 1.16
 
+replace github.com/aquasecurity/tracee/tracee-ebpf/external => ./external/
+
 require (
 	github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7
 	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167


### PR DESCRIPTION
Currently, when we make changes that also require changing the external package, we first have to commit the changes in external, wait for it to be merged, fetch the new package and update go.mod, and only then submit the other changes. 
This is annoying, and can be avoided by replacing external in go.mod with a relative path