### PR TITLE
tracee-ebpf: fix network capture with latest libbpf

### DIFF
--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -940,7 +940,9 @@ func (t *Tracee) attachTcProg(ifaceName string, attachPoint bpf.TcAttachPoint, p
 	hook.SetAttachPoint(attachPoint)
 	err = hook.Create()
 	if err != nil {
-		return nil, fmt.Errorf("tc hook create: %v", err)
+		if errno, ok := err.(syscall.Errno); ok && errno != syscall.EEXIST {
+			return nil, fmt.Errorf("tc hook create: %v", err)
+		}
 	}
 	prog, _ := t.bpfModule.GetProgram(progName)
 	if prog == nil {


### PR DESCRIPTION
According to  https://lore.kernel.org/bpf/CAMy7=ZXTiaX9xzNi5aOavwsf+mziJ=w-EcHH2f=cJmCGr3EPQA@mail.gmail.com/T/#u, getting an EEXIST error can happen when a qdisc already exists, and we should explicitly check for it - this PR does exactly that.

Note: We will still get the printed error message from libbpf. To remove it, we will need to figure out how to ignore it from libbpfgo libbpf_print_fn function.

Fix #947 