### PR TITLE
tracee-ebpf: move printer to main package

### DIFF
--- a/tracee-ebpf/go.mod
+++ b/tracee-ebpf/go.mod
@@ -6,7 +6,7 @@ replace github.com/aquasecurity/tracee/tracee-ebpf/external => ./external/
 
 require (
 	github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7
-	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167
+	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210823140630-61dfcd804bf3
 	github.com/google/gopacket v1.1.19
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635

--- a/tracee-ebpf/go.sum
+++ b/tracee-ebpf/go.sum
@@ -1,8 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7 h1:6bj8UumxqB6xK8wu6Ca3eWBXpbmPbvTPotJ+xM1FN5s=
 github.com/aquasecurity/libbpfgo v0.1.2-0.20210817133513-e8b2d259d9f7/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
-github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167 h1:QpuLpMxwd9fFH8p2aZ4umKqfpI9/6vf37D/fvLUyHMk=
-github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
+github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210823140630-61dfcd804bf3 h1:DqWE8Gw1xw6U5GYZoVlsCFuvBKyPjX97aCFZHUWVlaA=
+github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210823140630-61dfcd804bf3/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/tracee-ebpf/main_test.go
+++ b/tracee-ebpf/main_test.go
@@ -1171,10 +1171,8 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "invalid output option",
 			outputSlice: []string{"foo"},
 			// it's not the preparer job to validate input. in this case foo is considered an implicit output format.
-			expectedOutput: tracee.OutputConfig{
-				Format: "foo",
-			},
-			expectedError: errors.New("unrecognized output format: foo. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info."),
+			expectedOutput: tracee.OutputConfig{},
+			expectedError:  errors.New("unrecognized output format: foo. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info."),
 		},
 		{
 			testName:       "invalid output option",
@@ -1189,61 +1187,16 @@ func TestPrepareOutput(t *testing.T) {
 			expectedError:  errors.New("invalid output option: foo, use '--output help' for more info"),
 		},
 		{
-			testName:    "format explicit",
-			outputSlice: []string{"format:json"},
-			expectedOutput: tracee.OutputConfig{
-				Format: "json",
-			},
-			expectedError: nil,
-		},
-		{
-			testName:    "format implicit",
-			outputSlice: []string{"json"},
-			expectedOutput: tracee.OutputConfig{
-				Format: "json",
-			},
-			expectedError: nil,
-		},
-		{
-			testName:    "format gotemplate",
-			outputSlice: []string{"gotemplate=/path/to/tmpl"},
-			expectedOutput: tracee.OutputConfig{
-				Format: "gotemplate=/path/to/tmpl",
-			},
-			expectedError: nil,
-		},
-		{
-			testName:    "out",
-			outputSlice: []string{"out-file:/path/to/file"},
-			expectedOutput: tracee.OutputConfig{
-				OutPath: "/path/to/file",
-				Format:  "table",
-			},
-			expectedError: nil,
-		},
-		{
-			testName:    "empty val",
-			outputSlice: []string{"out-file"},
-			expectedOutput: tracee.OutputConfig{
-				Format: "out-file",
-			},
-			expectedError: errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info."),
-		},
-		{
-			testName:    "err",
-			outputSlice: []string{"err-file:/path/to/file"},
-			expectedOutput: tracee.OutputConfig{
-				ErrPath: "/path/to/file",
-				Format:  "table",
-			},
-			expectedError: nil,
+			testName:       "empty val",
+			outputSlice:    []string{"out-file"},
+			expectedOutput: tracee.OutputConfig{},
+			expectedError:  errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info."),
 		},
 		{
 			testName:    "option stack-addresses",
 			outputSlice: []string{"option:stack-addresses"},
 			expectedOutput: tracee.OutputConfig{
 				StackAddresses: true,
-				Format:         "table",
 			},
 			expectedError: nil,
 		},
@@ -1252,7 +1205,6 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:detect-syscall"},
 			expectedOutput: tracee.OutputConfig{
 				DetectSyscall: true,
-				Format:        "table",
 			},
 			expectedError: nil,
 		},
@@ -1261,17 +1213,13 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:exec-env"},
 			expectedOutput: tracee.OutputConfig{
 				ExecEnv: true,
-				Format:  "table",
 			},
 			expectedError: nil,
 		},
 		{
-			testName:    "all",
-			outputSlice: []string{"gotemplate=/path/to/tmpl", "option:stack-addresses", "option:detect-syscall", "option:exec-env", "out-file:/path/to/file", "err-file:/path/to/file"},
+			testName:    "all options",
+			outputSlice: []string{"option:stack-addresses", "option:detect-syscall", "option:exec-env"},
 			expectedOutput: tracee.OutputConfig{
-				Format:         "gotemplate=/path/to/tmpl",
-				OutPath:        "/path/to/file",
-				ErrPath:        "/path/to/file",
 				StackAddresses: true,
 				DetectSyscall:  true,
 				ExecEnv:        true,
@@ -1281,7 +1229,7 @@ func TestPrepareOutput(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			output, err := prepareOutput(testcase.outputSlice)
+			output, _, err := prepareOutput(testcase.outputSlice, false)
 			if err != nil {
 				assert.Equal(t, testcase.expectedError, err)
 			} else {

--- a/tracee-ebpf/printer.go
+++ b/tracee-ebpf/printer.go
@@ -1,7 +1,6 @@
-package tracee
+package main
 
 import (
-	"bytes"
 	"encoding/gob"
 	"encoding/json"
 	"errors"
@@ -20,7 +19,7 @@ type eventPrinter interface {
 	// Preamble prints something before event printing begins (one time)
 	Preamble()
 	// Epilogue prints something after event printing ends (one time)
-	Epilogue(stats statsStore)
+	Epilogue(stats external.Stats)
 	// Print prints a single event
 	Print(event external.Event)
 	// Error prints a single error
@@ -78,39 +77,7 @@ func newEventPrinter(kind string, containerMode bool, relativeTS bool, out io.Wr
 	return res, nil
 }
 
-func newEvent(ctx context, argMetas []external.ArgMeta, args []interface{}, StackAddresses []uint64) (external.Event, error) {
-	e := external.Event{
-		Timestamp:           int(ctx.Ts),
-		ProcessID:           int(ctx.Pid),
-		ThreadID:            int(ctx.Tid),
-		ParentProcessID:     int(ctx.Ppid),
-		HostProcessID:       int(ctx.HostPid),
-		HostThreadID:        int(ctx.HostTid),
-		HostParentProcessID: int(ctx.HostPpid),
-		UserID:              int(ctx.Uid),
-		MountNS:             int(ctx.MntID),
-		PIDNS:               int(ctx.PidID),
-		ProcessName:         string(bytes.TrimRight(ctx.Comm[:], "\x00")),
-		HostName:            string(bytes.TrimRight(ctx.UtsName[:], "\x00")),
-		ContainerID:         string(bytes.TrimRight(ctx.ContID[:], "\x00")),
-		EventID:             int(ctx.EventID),
-		EventName:           EventsIDToEvent[int32(ctx.EventID)].Name,
-		ArgsNum:             int(ctx.Argnum),
-		ReturnValue:         int(ctx.Retval),
-		Args:                make([]external.Argument, 0, len(args)),
-		StackAddresses:      StackAddresses,
-	}
-	for i, arg := range args {
-		e.Args = append(e.Args, external.Argument{
-			ArgMeta: argMetas[i],
-			Value:   arg,
-		})
-	}
-	return e, nil
-}
-
 type tableEventPrinter struct {
-	tracee        *Tracee
 	out           io.WriteCloser
 	err           io.WriteCloser
 	verbose       bool
@@ -170,7 +137,7 @@ func (p tableEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p tableEventPrinter) Epilogue(stats statsStore) {
+func (p tableEventPrinter) Epilogue(stats external.Stats) {
 	fmt.Println()
 	fmt.Fprintf(p.out, "End of events stream\n")
 	fmt.Fprintf(p.out, "Stats: %+v\n", stats)
@@ -180,7 +147,6 @@ func (p tableEventPrinter) Close() {
 }
 
 type templateEventPrinter struct {
-	tracee        *Tracee
 	out           io.WriteCloser
 	err           io.WriteCloser
 	containerMode bool
@@ -219,7 +185,7 @@ func (p templateEventPrinter) Print(event external.Event) {
 	}
 }
 
-func (p templateEventPrinter) Epilogue(stats statsStore) {}
+func (p templateEventPrinter) Epilogue(stats external.Stats) {}
 
 func (p templateEventPrinter) Close() {
 }
@@ -245,7 +211,7 @@ func (p jsonEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p jsonEventPrinter) Epilogue(stats statsStore) {}
+func (p jsonEventPrinter) Epilogue(stats external.Stats) {}
 
 func (p jsonEventPrinter) Close() {
 }
@@ -277,7 +243,7 @@ func (p *gobEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p *gobEventPrinter) Epilogue(stats statsStore) {}
+func (p *gobEventPrinter) Epilogue(stats external.Stats) {}
 
 func (p gobEventPrinter) Close() {
 }
@@ -299,6 +265,6 @@ func (p *ignoreEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p *ignoreEventPrinter) Epilogue(stats statsStore) {}
+func (p *ignoreEventPrinter) Epilogue(stats external.Stats) {}
 
 func (p ignoreEventPrinter) Close() {}

--- a/tracee-ebpf/tracee/tracee_test.go
+++ b/tracee-ebpf/tracee/tracee_test.go
@@ -268,27 +268,3 @@ func Test_updateFileSHA(t *testing.T) {
 		},
 	}, trc.profiledFiles)
 }
-
-func TestOutputConfigValidate(t *testing.T) {
-
-	testCases := []struct {
-		name          string
-		format        string
-		expectedError error
-	}{
-		{"format:table", "table", nil},
-		{"format:table-verbose", "table-verbose", nil},
-		{"format:json", "json", nil},
-		{"format:gob", "gob", nil},
-		{"format:gotemplate=tmpl", "gotemplate=tmpl", nil},
-		{"invalid format", "invalid", errors.New("unrecognized output format: invalid. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info.")},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := OutputConfig{Format: tc.format}
-			err := cfg.Validate()
-			assert.Equal(t, tc.expectedError, err)
-		})
-	}
-}


### PR DESCRIPTION
This PR moves the printer logic out of the tracee package into the main package, and decouples events generation from printing.
This will also allow a consumer of tracee-ebpf as a library to use channels to get stdout,stderr and tracee stats on close.