### PR TITLE
tracee/containers: remove generic regex expression

### DIFF
--- a/tracee-ebpf/tracee/containers.go
+++ b/tracee-ebpf/tracee/containers.go
@@ -112,8 +112,6 @@ func (c *Containers) populate() error {
 		r = append(r, ".*docker.*(.{64})/tasks$")
 		// podman:  <cgroupv1mp>/<random>/libpod-<id>.scope/tasks
 		r = append(r, ".*libpod.*(.{64})\\.scope/tasks$")
-		// generic: <cgroupv1mp>/<random>/<id>.scope/tasks
-		r = append(r, ".*(.{64})\\.scope/tasks$")
 
 		err := c.populateProcWalk(c.cgroupv1mp, r)
 		if err != nil {
@@ -126,8 +124,6 @@ func (c *Containers) populate() error {
 		r = append(r, ".*docker.*(.{64})\\.scope/cgroup.procs$")
 		// podman:  <cgroupv2mp>/<random>/libpod-<id>.scope/cgroup.procs
 		r = append(r, ".*libpod.*(.{64})\\.scope/cgroup.procs$")
-		// generic: <cgroupv2mp>/<random>/<id>.scope/cgroup.procs
-		r = append(r, ".*(.{64})\\.scope/cgroup.procs$")
 
 		err := c.populateProcWalk(c.cgroupv2mp, r)
 		if err != nil {


### PR DESCRIPTION
Fixes: #958

The generic expression added as a good faith to the container_id fix
logic cause tracee to have false positives on already running
containers, during startup:

  BTF: bpfenv = false, btfenv = false, vmlinux = true
  BPF: using embedded BPF object
  unpacked CO:RE bpf object file into memory
  TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
  Running container = vice/app.slice/snap.lxd.lxc.4b3296a2-c139-4da5-b782-006c431cca74 pid = 2558259

This patch fixes the issue by removing too generic regex. Detection for
podman and docker continues to work the same.