### PR TITLE
tracee-ebpf: fix sched_process_exec argument types

### DIFF
--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -911,7 +911,7 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	SysEnterEventID:               {{Type: "int", Name: "syscall"}},
 	SysExitEventID:                {{Type: "int", Name: "syscall"}},
 	SchedProcessForkEventID:       {{Type: "int", Name: "parent_pid"}, {Type: "int", Name: "parent_ns_pid"}, {Type: "int", Name: "child_pid"}, {Type: "int", Name: "child_ns_pid"}},
-	SchedProcessExecEventID:       {{Type: "const char *", Name: "cmdpath"}, {Type: "const char *", Name: "pathname"}, {Type: "const char *", Name: "argv"}, {Type: "const char *", Name: "env"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "invoked_from_kernel"}},
+	SchedProcessExecEventID:       {{Type: "const char *", Name: "cmdpath"}, {Type: "const char *", Name: "pathname"}, {Type: "const char*const*", Name: "argv"}, {Type: "const char*const*", Name: "env"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "invoked_from_kernel"}},
 	SchedProcessExitEventID:       {},
 	DoExitEventID:                 {},
 	CapCapableEventID:             {{Type: "int", Name: "cap"}, {Type: "int", Name: "syscall"}},


### PR DESCRIPTION
This fix is required for proper json unmarshalling in tracee-rules of the sched_process_exec event