### PR TITLE
feat: Add flag for Runtime Target

### DIFF
--- a/tracee-rules/benchmark/signature/rego/signatures.go
+++ b/tracee-rules/benchmark/signature/rego/signatures.go
@@ -3,6 +3,8 @@ package rego
 import (
 	_ "embed"
 
+	"github.com/open-policy-agent/opa/compile"
+
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/rego/regosig"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 )
@@ -19,9 +21,9 @@ var (
 )
 
 func NewCodeInjectionSignature() (types.Signature, error) {
-	return regosig.NewRegoSignature(false, codeInjectionRego, helpersRego)
+	return regosig.NewRegoSignature(compile.TargetRego, false, codeInjectionRego, helpersRego)
 }
 
 func NewAntiDebuggingSignature() (types.Signature, error) {
-	return regosig.NewRegoSignature(false, antiDebuggingPtracemeRego, helpersRego)
+	return regosig.NewRegoSignature(compile.TargetRego, false, antiDebuggingPtracemeRego, helpersRego)
 }

--- a/tracee-rules/signature.go
+++ b/tracee-rules/signature.go
@@ -19,7 +19,7 @@ import (
 //go:embed signatures/rego/helpers.rego
 var regoHelpersCode string
 
-func getSignatures(partialEval bool, rulesDir string, rules []string) ([]types.Signature, error) {
+func getSignatures(target string, partialEval bool, rulesDir string, rules []string) ([]types.Signature, error) {
 	if rulesDir == "" {
 		exePath, err := os.Executable()
 		if err != nil {
@@ -31,7 +31,7 @@ func getSignatures(partialEval bool, rulesDir string, rules []string) ([]types.S
 	if err != nil {
 		return nil, err
 	}
-	opasigs, err := findRegoSigs(partialEval, rulesDir)
+	opasigs, err := findRegoSigs(target, partialEval, rulesDir)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func findGoSigs(dir string) ([]types.Signature, error) {
 	return res, nil
 }
 
-func findRegoSigs(partialEval bool, dir string) ([]types.Signature, error) {
+func findRegoSigs(target string, partialEval bool, dir string) ([]types.Signature, error) {
 	regoHelpers := []string{regoHelpersCode}
 	filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -119,7 +119,7 @@ func findRegoSigs(partialEval bool, dir string) ([]types.Signature, error) {
 			log.Printf("error reading file %s: %v", path, err)
 			return nil
 		}
-		sig, err := regosig.NewRegoSignature(partialEval, append(regoHelpers, string(regoCode))...)
+		sig, err := regosig.NewRegoSignature(target, partialEval, append(regoHelpers, string(regoCode))...)
 		if err != nil {
 			newlineOffset := bytes.Index(regoCode, []byte("\n"))
 			if newlineOffset == -1 {

--- a/tracee-rules/signature_test.go
+++ b/tracee-rules/signature_test.go
@@ -9,13 +9,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/open-policy-agent/opa/compile"
+
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_getSignatures(t *testing.T) {
-	sigs, err := getSignatures(false, "signatures/rego", []string{"TRC-2"})
+	sigs, err := getSignatures(compile.TargetRego, false, "signatures/rego", []string{"TRC-2"})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sigs))
 
@@ -77,7 +79,7 @@ func Test_findRegoSigs(t *testing.T) {
 	require.NoError(t, err)
 
 	// find rego signatures
-	sigs, err := findRegoSigs(false, testRoot)
+	sigs, err := findRegoSigs(compile.TargetRego, false, testRoot)
 	require.NoError(t, err)
 
 	assert.Equal(t, len(sigs), 2)

--- a/tracee-rules/signatures/rego/regosig/traceerego.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego.go
@@ -35,7 +35,7 @@ const queryMetadata string = "data.%s.__rego_metadoc__"
 const packageNameRegex string = `package\s.*`
 
 // NewRegoSignature creates a new RegoSignature with the provided rego code string
-func NewRegoSignature(partialEval bool, regoCodes ...string) (types.Signature, error) {
+func NewRegoSignature(target string, partialEval bool, regoCodes ...string) (types.Signature, error) {
 	var err error
 	res := RegoSignature{}
 	regoMap := make(map[string]string)
@@ -65,6 +65,7 @@ func NewRegoSignature(partialEval bool, regoCodes ...string) (types.Signature, e
 	ctx := context.Background()
 	if partialEval {
 		pr, err := rego.New(
+
 			rego.Compiler(res.compiledRego),
 			rego.Query(fmt.Sprintf(queryMatch, pkgName)),
 		).PartialResult(ctx)
@@ -72,12 +73,13 @@ func NewRegoSignature(partialEval bool, regoCodes ...string) (types.Signature, e
 			return nil, err
 		}
 
-		res.matchPQ, err = pr.Rego().PrepareForEval(ctx)
+		res.matchPQ, err = pr.Rego(rego.Target(target)).PrepareForEval(ctx)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		res.matchPQ, err = rego.New(
+			rego.Target(target),
 			rego.Compiler(res.compiledRego),
 			rego.Query(fmt.Sprintf(queryMatch, pkgName)),
 		).PrepareForEval(ctx)

--- a/tracee-rules/signatures/rego/regosig/traceerego_test.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/compile"
+
 	tracee "github.com/aquasecurity/tracee/tracee-ebpf/external"
 	"github.com/aquasecurity/tracee/tracee-rules/engine"
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
@@ -35,7 +37,7 @@ __rego_metadoc__ := {
 }
 `
 
-	sig, err := NewRegoSignature(false, testRegoMeta)
+	sig, err := NewRegoSignature(compile.TargetRego, false, testRegoMeta)
 	if err != nil {
 		t.Error(err)
 	}
@@ -66,7 +68,7 @@ tracee_selected_events[eventSelector] {
 	}
 }
 `
-	sig, err := NewRegoSignature(false, testRegoSelectedEvents)
+	sig, err := NewRegoSignature(compile.TargetRego, false, testRegoSelectedEvents)
 	if err != nil {
 		t.Error(err)
 	}
@@ -119,7 +121,7 @@ tracee_match {
 		},
 	}
 	for _, st := range sts {
-		sig, err := NewRegoSignature(false, testRegoBool)
+		sig, err := NewRegoSignature(compile.TargetRego, false, testRegoBool)
 		if err != nil {
 			t.Error(err)
 		}
@@ -229,7 +231,7 @@ tracee_match = res {
 		},
 	}
 	for _, st := range sts {
-		sig, err := NewRegoSignature(false, testRegoObj)
+		sig, err := NewRegoSignature(compile.TargetRego, false, testRegoObj)
 		if err != nil {
 			t.Error(err)
 		}
@@ -268,7 +270,7 @@ func TestNewRegoSignature(t *testing.T) {
 
 	// assert basic attributes
 	for i, rc := range testRegoCodes {
-		gotSig, err := NewRegoSignature(false, rc)
+		gotSig, err := NewRegoSignature(compile.TargetRego, false, rc)
 		require.NoError(t, err)
 
 		gotMetadata, err := gotSig.GetMetadata()


### PR DESCRIPTION
Adds a new flag `--rego-runtime-target` that can be specified with potential runtime targets for rego rules: `rego` or `wasm`.

Requires: https://github.com/aquasecurity/tracee/pull/979

Signed-off-by: Simar simar@linux.com