### PR TITLE
feat: Add flag for prepared events

### DIFF
--- a/tracee-rules/benchmark/benchmark_test.go
+++ b/tracee-rules/benchmark/benchmark_test.go
@@ -98,12 +98,12 @@ func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 				s, err := bc.sigFunc()
 				require.NoError(b, err, bc.name)
 
-				e, err := engine.NewEngine([]types.Signature{s}, inputs, output, os.Stderr)
+				e, err := engine.NewEngine([]types.Signature{s}, inputs, output, os.Stderr, bc.preparedEvents)
 				require.NoError(b, err, "constructing engine")
 				b.StartTimer()
 
 				// Start rules engine and wait until all events are processed
-				e.Start(bc.preparedEvents, waitForEventsProcessed(inputs.Tracee))
+				e.Start(waitForEventsProcessed(inputs.Tracee))
 			}
 		})
 	}
@@ -153,12 +153,12 @@ func BenchmarkEngineWithMultipleSignatures(b *testing.B) {
 				inputs := ProduceEventsInMemory(inputEventsCount)
 				output := make(chan types.Finding, inputEventsCount*len(sigs))
 
-				e, err := engine.NewEngine(sigs, inputs, output, os.Stderr)
+				e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, bc.preparedEvents)
 				require.NoError(b, err, "constructing engine")
 				b.StartTimer()
 
 				// Start rules engine and wait until all events are processed
-				e.Start(bc.preparedEvents, waitForEventsProcessed(inputs.Tracee))
+				e.Start(waitForEventsProcessed(inputs.Tracee))
 			}
 		})
 	}
@@ -213,12 +213,12 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 					b.StopTimer()
 					inputs := ProduceEventsInMemory(inputEventsCount)
 					output := make(chan types.Finding, inputEventsCount*len(sigs))
-					e, err := engine.NewEngine(sigs, inputs, output, os.Stderr)
+					e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, false)
 					require.NoError(b, err, "constructing engine")
 					b.StartTimer()
 
 					// Start rules engine and wait until all events are processed
-					e.Start(false, waitForEventsProcessed(inputs.Tracee))
+					e.Start(waitForEventsProcessed(inputs.Tracee))
 				}
 			})
 		}

--- a/tracee-rules/benchmark/benchmark_test.go
+++ b/tracee-rules/benchmark/benchmark_test.go
@@ -53,20 +53,36 @@ func BenchmarkOnEventWithCodeInjectionSignature(b *testing.B) {
 
 func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 	benches := []struct {
-		name    string
-		sigFunc func() (types.Signature, error)
+		name           string
+		sigFunc        func() (types.Signature, error)
+		preparedEvents bool
 	}{
 		{
 			name:    "rego",
 			sigFunc: rego.NewCodeInjectionSignature,
 		},
 		{
+			name:           "rego + prepared events",
+			sigFunc:        rego.NewCodeInjectionSignature,
+			preparedEvents: true,
+		},
+		{
 			name:    "golang",
 			sigFunc: golang.NewCodeInjectionSignature,
 		},
 		{
+			name:           "golang + prepared events",
+			sigFunc:        golang.NewCodeInjectionSignature,
+			preparedEvents: true,
+		},
+		{
 			name:    "wasm",
 			sigFunc: wasm.NewCodeInjectionSignature,
+		},
+		{
+			name:           "wasm + prepared events",
+			sigFunc:        wasm.NewCodeInjectionSignature,
+			preparedEvents: true,
 		},
 	}
 
@@ -87,7 +103,7 @@ func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 				b.StartTimer()
 
 				// Start rules engine and wait until all events are processed
-				e.Start(waitForEventsProcessed(inputs.Tracee))
+				e.Start(bc.preparedEvents, waitForEventsProcessed(inputs.Tracee))
 			}
 		})
 	}
@@ -95,12 +111,18 @@ func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 
 func BenchmarkEngineWithMultipleSignatures(b *testing.B) {
 	benches := []struct {
-		name     string
-		sigFuncs []func() (types.Signature, error)
+		name           string
+		sigFuncs       []func() (types.Signature, error)
+		preparedEvents bool
 	}{
 		{
 			name:     "rego and golang",
 			sigFuncs: []func() (types.Signature, error){rego.NewCodeInjectionSignature, golang.NewCodeInjectionSignature},
+		},
+		{
+			name:           "rego and golang, with prepared events",
+			sigFuncs:       []func() (types.Signature, error){rego.NewCodeInjectionSignature, golang.NewCodeInjectionSignature},
+			preparedEvents: true,
 		},
 		{
 			name:     "wasm and golang",
@@ -136,7 +158,7 @@ func BenchmarkEngineWithMultipleSignatures(b *testing.B) {
 				b.StartTimer()
 
 				// Start rules engine and wait until all events are processed
-				e.Start(waitForEventsProcessed(inputs.Tracee))
+				e.Start(bc.preparedEvents, waitForEventsProcessed(inputs.Tracee))
 			}
 		})
 	}
@@ -196,7 +218,7 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 					b.StartTimer()
 
 					// Start rules engine and wait until all events are processed
-					e.Start(waitForEventsProcessed(inputs.Tracee))
+					e.Start(false, waitForEventsProcessed(inputs.Tracee))
 				}
 			})
 		}

--- a/tracee-rules/benchmark/signature/wasm/signatures.go
+++ b/tracee-rules/benchmark/signature/wasm/signatures.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	"github.com/open-policy-agent/opa/ast"
+	_ "github.com/open-policy-agent/opa/features/wasm"
 	"github.com/open-policy-agent/opa/rego"
 )
 

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -186,16 +186,16 @@ func (engine *Engine) consumeSources(done <-chan bool) {
 
 				eventOrigin := analyzeEventOrigin(traceeEvt)
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: traceeEvt.EventName, Origin: eventOrigin}] {
-					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt)
 				}
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: traceeEvt.EventName, Origin: ALL_EVENT_ORIGINS}] {
-					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt)
 				}
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: ALL_EVENT_TYPES, Origin: eventOrigin}] {
-					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt)
 				}
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: ALL_EVENT_TYPES, Origin: ALL_EVENT_ORIGINS}] {
-					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt)
 				}
 				engine.signaturesMutex.RUnlock()
 			}
@@ -205,10 +205,10 @@ func (engine *Engine) consumeSources(done <-chan bool) {
 	}
 }
 
-func (engine *Engine) dispatchEvent(s types.Signature, event tracee.Event, parsedEvent bool) {
+func (engine *Engine) dispatchEvent(s types.Signature, event tracee.Event) {
 	switch {
 	case strings.Contains(reflect.TypeOf(s).String(), "rego"):
-		if parsedEvent {
+		if engine.parsedEvents {
 			pe, err := ToParsedEvent(event)
 			if err != nil {
 				engine.logger.Printf("error converting tracee event to OPA ast.Value: %v", err)

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -186,16 +186,16 @@ func (engine *Engine) consumeSources(done <-chan bool) {
 
 				eventOrigin := analyzeEventOrigin(traceeEvt)
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: traceeEvt.EventName, Origin: eventOrigin}] {
-					engine.dispatchEvent(s, event.(tracee.Event), engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
 				}
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: traceeEvt.EventName, Origin: ALL_EVENT_ORIGINS}] {
-					engine.dispatchEvent(s, event.(tracee.Event), engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
 				}
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: ALL_EVENT_TYPES, Origin: eventOrigin}] {
-					engine.dispatchEvent(s, event.(tracee.Event), engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
 				}
 				for _, s := range engine.signaturesIndex[types.SignatureEventSelector{Source: "tracee", Name: ALL_EVENT_TYPES, Origin: ALL_EVENT_ORIGINS}] {
-					engine.dispatchEvent(s, event.(tracee.Event), engine.parsedEvents)
+					engine.dispatchEvent(s, traceeEvt, engine.parsedEvents)
 				}
 				engine.signaturesMutex.RUnlock()
 			}

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -447,7 +447,7 @@ func TestGetSelectedEvents(t *testing.T) {
 			},
 		},
 	}
-	e, err := NewEngine(sigs, EventSources{Tracee: make(chan types.Event)}, make(chan types.Finding), &bytes.Buffer{})
+	e, err := NewEngine(sigs, EventSources{Tracee: make(chan types.Event)}, make(chan types.Finding), &bytes.Buffer{}, false)
 	require.NoError(t, err, "constructing engine")
 	se := e.GetSelectedEvents()
 	expected := []types.SignatureEventSelector{

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -388,10 +388,10 @@ func TestConsumeSources(t *testing.T) {
 				return nil
 			}
 
-			e, err := NewEngine(sigs, inputs, outputChan, logger)
+			e, err := NewEngine(sigs, inputs, outputChan, logger, tc.enableParsedEvent)
 			require.NoError(t, err, "constructing engine")
 			go func() {
-				e.Start(tc.enableParsedEvent, done)
+				e.Start(done)
 			}()
 
 			// send a test event

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -97,11 +97,11 @@ func main() {
 			if err != nil {
 				return err
 			}
-			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr)
+			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, c.Bool("enable-parsed-events"))
 			if err != nil {
 				return fmt.Errorf("constructing engine: %w", err)
 			}
-			e.Start(c.Bool("enable-parsed-events"), sigHandler())
+			e.Start(sigHandler())
 			return nil
 		},
 		Flags: []cli.Flag{

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -97,7 +97,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, c.Bool("enable-parsed-events"))
+			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, c.Bool("rego-enable-parsed-events"))
 			if err != nil {
 				return fmt.Errorf("constructing engine: %w", err)
 			}
@@ -147,7 +147,7 @@ func main() {
 				Value: ":7777",
 			},
 			&cli.BoolFlag{
-				Name:  "enable-parsed-events",
+				Name:  "rego-enable-parsed-events",
 				Usage: "enables pre parsing of input events to rego prior to evaluation",
 			},
 		},

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -101,7 +101,7 @@ func main() {
 			if err != nil {
 				return fmt.Errorf("constructing engine: %w", err)
 			}
-			e.Start(sigHandler())
+			e.Start(c.Bool("enable-parsed-events"), sigHandler())
 			return nil
 		},
 		Flags: []cli.Flag{
@@ -145,6 +145,10 @@ func main() {
 				Name:  "pprof-addr",
 				Usage: "listening address of the pprof endpoints server",
 				Value: ":7777",
+			},
+			&cli.BoolFlag{
+				Name:  "enable-parsed-events",
+				Usage: "enables pre parsing of input events to rego prior to evaluation",
 			},
 		},
 	}


### PR DESCRIPTION
Adds a new flag `--rego-enable-parsed-events` which enables parsed events.

```
benchmark                                                              iter         time/iter    bytes alloc             allocs
---------                                                              ----         ---------    -----------             ------
BenchmarkEngineWithCodeInjectionSignature/rego-8                        100    12760.62 μs/op   5807573 B/op   123602 allocs/op
BenchmarkEngineWithCodeInjectionSignature/rego_+_prepared_events-8      100     8942.85 μs/op   6026101 B/op   112120 allocs/op
BenchmarkEngineWithCodeInjectionSignature/golang-8                      100      991.93 μs/op    441537 B/op     3004 allocs/op
BenchmarkEngineWithCodeInjectionSignature/golang_+_prepared_events-8    100      986.84 μs/op    445371 B/op     3011 allocs/op
BenchmarkEngineWithCodeInjectionSignature/wasm-8                        100    34173.33 μs/op   6380418 B/op   116519 allocs/op
BenchmarkEngineWithCodeInjectionSignature/wasm_+_prepared_events-8      100    32303.88 μs/op   6374508 B/op   116451 allocs/op
```

Signed-off-by: Simar <simar@linux.com>