### PR TITLE
update docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,20 +22,23 @@ The full documentation of Tracee is available at [https://aquasecurity.github.io
 
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](https://aquasecurity.github.io/tracee/dev/install/prerequisites/).
 
-If running on BTF enabled kernel:
+If running on __BTF enabled kernel__:
 
 ```bash
-docker run --name tracee --rm --privileged -it aquasec/tracee:latest
+docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
 ```
 
-Note: __Running bpf requires access to the kernel configuration file. Depending on the linux distribution this can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly)._
+> Note: Running on BTF enabled kernel requires access to the kernel configuration file. Depending on the linux distribution this can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
 
-If running on BTF disabled kernel see [here](https://aquasecurity.github.io/tracee/dev/install/prerequisites/):
+If running on __BTF disabled kernel__:
+```bash
+docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
+```
+
+> Note: You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](https://aquasecurity.github.io/tracee/install/headers.md) section for more info.
 
 This will run Tracee with default settings and start reporting detections to standard output.  
 In order to simulate a suspicious behavior, you can run `strace ls` in another terminal, which will trigger the "Anti-Debugging" signature, which is loaded by default.
-
-> Note: You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](https://aquasecurity.github.io/tracee/install/headers.md) section for more info.
 
 ## Trace
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,16 +18,23 @@ Check out the [Tracee video hub](https://info.aquasec.com/ebpf-runtime-security)
 
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](install/prerequisites.md).
 
+If running on __BTF enabled kernel__:
+
 ```bash
-docker run --name tracee --rm --privileged -it aquasec/tracee:latest
+docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
 ```
 
-Note: __Running bpf requires access to the kernel configuration file. Depending on the linux distribution this can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly)._
+> Note: Running on BTF enabled kernel requires access to the kernel configuration file. Depending on the linux distribution this can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
 
-This will run Tracee with the portable CO:RE bpf object and default settings. It will start reporting detections to standard output.  
+If running on __BTF disabled kernel__:
+```bash
+docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
+```
+
+> Note: You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](install/headers.md) section for more info.
+
+This will run Tracee with default settings and start reporting detections to standard output.
 In order to simulate a suspicious behavior, you can run `strace ls` in another terminal, which will trigger the "Anti-Debugging" signature, which is loaded by default.
-
-> Note: You may need to change the volume mounts for the kernel headers based on your setup if the kernel doesn't have BTF enabled. See [Linux Headers](install/headers.md) section for more info.
 
 ## Trace
 

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -1,24 +1,27 @@
 # Prerequisites
 
-Portable (CO:RE) option:
-- Linux kernel version >= 4.18
-- BTF enabled (_You can manually detect if your environments supports it by checking if the following file exists on your machine: /sys/kernel/btf/vmlinux or consult the following documentation: https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere_)
+__Portable (CO:RE) option:__
+* Linux kernel version >= 4.18
+* BTF enabled (_You can manually detect if your environments supports it by checking if the following file exists on your machine: /sys/kernel/btf/vmlinux or consult the following documentation: https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere)_
 
-Kernel version specific option:
-- Linux kernel version >= 4.18
-- Linux kernel headers available under conventional location (see [Linux Headers](../headers) section for more info)
-- libc, and the libraries: libelf, zlib
-- GNU Make >= 4.3
-- clang >= 11
-Exceptions:
+> Note: When using Tracee's Docker image, an extra mount might be required to access the kernel configuration file. Depending on the linux distribution this can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
 
-- Tracee supports loading a pre-compiled eBPF file, in which case the kernel headers are not required at runtime, but only for the one-time compilation of the eBPF program. See [Setup Options](../ebpf-compilation) for more info.
-- When using Tracee's Docker image, all of the tooling is built into the image. The only requirement left is the kernel headers or the pre-built eBPF artifact. See [Setup Options](../ebpf-compilation) for more info.
+__Kernel version specific option:__
+* Linux kernel version >= 4.18
+* Linux kernel headers available under conventional location (see [Linux Headers](../headers) section for more info)
+* libc, and the libraries: libelf, zlib
+* GNU Make >= 4.3
+* clang >= 11
+
+_Exceptions:_
+* Tracee supports loading a pre-compiled eBPF file, in which case the kernel headers are not required at runtime, but only for the one-time compilation of the eBPF program. See [Setup Options](../ebpf-compilation) for more info.
+* When using Tracee's Docker image, all of the tooling is built into the image. The only requirement left is the kernel headers or the pre-built eBPF artifact. See [Setup Options](../ebpf-compilation) for more info.
 
 # Permissions
 
 For using the eBPF Linux subsystem, Tracee needs to run with sufficient capabilities: 
-- `CAP_SYS_RESOURCE` (to manage eBPF maps limits)
-- `CAP_BPF`+`CAP_TRACING` which are available on recent kernels (>=5.8), or `SYS_ADMIN` on older kernels (to load and attach the eBPF programs).
+* `CAP_SYS_RESOURCE` (to manage eBPF maps limits)
+* `CAP_BPF`+`CAP_PERFMON` which are available on recent kernels (>=5.8), or `CAP_SYS_ADMIN` on older kernels (to load and attach the eBPF programs).
+* On some environments (e.g. Ubuntu) `CAP_IPC_LOCK` might be required as well
 
 Alternatively, run as `root` or with the `--privileged` flag of Docker.

--- a/tracee-ebpf/Readme.md
+++ b/tracee-ebpf/Readme.md
@@ -13,7 +13,7 @@ The full documentation of Tracee's eBPF tracing is available at [https://aquasec
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](https://aquasecurity.github.io/tracee/dev/install/prerequisites/).
 
 ```bash
-docker run --name tracee --rm --privileged -it aquasec/tracee:latest trace
+docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest trace
 ```
 
 Here we are running the same `aquasec/tracee` container, but with the `trace` sub-command, which will start just a raw trace (Tracee-eBPF), without the detection engine (Tracee-Rules). Here's a sample output of running with no additional arguments:


### PR DESCRIPTION
This PR fixes the following in the documentation:
1. Added `pid=host` to the docker command. This is required by some of the features used by tracee (tree-filter and capture exec)
2. Added `/tmp` mount to the docker command. This is required for saving captured artifacts and to speed-up init time when running on a non-BTF enabled kernel (to save the compiled bpf file)
3. Explicitly write the docker command used to run Tracee on a non-BTF enabled kernels
4. Update the required capabilities with the correct values
5. Some other small fixes