### PR TITLE
chore: Add Vagrantfile to easily get started with tracee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /dist
 
 coverage.txt
+
+.vagrant/
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,27 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = false
+    vb.memory = "1024"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get install --yes build-essential pkgconf libelf-dev llvm-12 clang-12
+
+    for tool in "clang" "llc" "llvm-strip"
+    do
+      path=$(which $tool-12)
+      sudo ln -s $path ${path%-*}
+    done
+
+    wget --quiet https://golang.org/dl/go1.16.linux-amd64.tar.gz
+    tar -C /usr/local -xzf go1.16.linux-amd64.tar.gz
+    echo 'export PATH=$PATH:/usr/local/go/bin' >> /home/vagrant/.profile
+  SHELL
+end
+


### PR DESCRIPTION
This patch allows using Vagrant with VirtualBox or any
compatible provider to bootstrap tracee project.
It provisions Ubuntu 20.4 LTS with all dependencies to
compile and run tracee.

    git clone https://github.com/aquasecurity/tracee.git
    cd tracee
    $ vagrant up && vagrant ssh
    vagrant@ubuntu-focal:~$ cd /vagrant && make
    vagrant@ubuntu-focal:/vagrant$ sudo ./dist/tracee-ebpf

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>