### PR TITLE
Set TINI_SUBREAPER env variable in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
     org.label-schema.vendor="Aqua Security" \
     org.label-schema.version=$VERSION
 
+ENV TINI_SUBREAPER=true
+
 ENTRYPOINT ["/sbin/tini", "-g", "--", "./entrypoint.sh"]


### PR DESCRIPTION
We use tini as the init process in our main dockerfile,
this causes an issue if we set the pid namespace to the host
because the kernel won't re-parent zombie children to this
proc. As a result, tini fails if it's not pid 1 or if TINI_SUBREAPER
is not set to true.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>