### PR TITLE
tracee-rules: Upgrade external package dependency

### DIFF
--- a/tracee-rules/go.mod
+++ b/tracee-rules/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167
+	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210922213431-07969faccea0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/tracee-rules/go.sum
+++ b/tracee-rules/go.sum
@@ -56,6 +56,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167 h1:QpuLpMxwd9fFH8p2aZ4umKqfpI9/6vf37D/fvLUyHMk=
 github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210727091827-bbe411a2a167/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
+github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210922213431-07969faccea0 h1:W2asvJ+Zh4ybmNhjySSgy0O53RDaDH373qCp87jPWbg=
+github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210922213431-07969faccea0/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
This upgrades the tracee-ebpf/external module to
a recent commit which fixes #1009

Signed-off-by: grantseltzer <grantseltzer@gmail.com>