### PR TITLE
fix: Ignore order of elements in engine_test.go

### DIFF
--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -467,6 +467,5 @@ func TestGetSelectedEvents(t *testing.T) {
 			Origin: "host",
 		},
 	}
-	require.Equal(t, se, expected)
-
+	assert.ElementsMatch(t, expected, se)
 }


### PR DESCRIPTION
This test will currently fail intermittently as seen here:
<img width="920" alt="image" src="https://user-images.githubusercontent.com/1254783/135936288-9204e050-c367-4302-b51b-c12d3d452d9a.png">

We need to ignore the order of elements received as its not important to assert. 

Signed-off-by: Simar <simar@linux.com>