### PR TITLE
Fix tracee-ebpf compilation on RHEL-likes

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -41,10 +41,9 @@ DOCKER_BUILDER_KERN_SRC ?= $(if $(shell readlink -f $(KERN_SRC_PATH)),$(shell re
 DOCKER_BUILDER_KERN_SRC_MNT ?= $(dir $(DOCKER_BUILDER_KERN_SRC))
 LINUX_VERSION_CODE := $(shell uname -r | awk '{split($$0,a,"."); split(a[3], b, "-"); print lshift(a[1], 16) + lshift(a[2],8) + b[1];}')
 
-DIST_ID := $(shell grep -m 1 'ID=' $(OS_RELEASE_FILE) | cut -d '=' -f '2' | sed 's/\"//g')
+DIST_ID_LIKE := $(shell grep -m 1 'ID_LIKE=' $(OS_RELEASE_FILE) | cut -d '=' -f '2' | sed 's/\"//g')
 VERSION_ID := $(shell grep -m 1 'VERSION_ID=' $(OS_RELEASE_FILE) | cut -d '=' -f '2' | sed 's/\"//g')
-CENTOS_MERGED_RHEL := $(shell echo $(DIST_ID) | sed 's/centos/rhel/')
-ifeq ($(CENTOS_MERGED_RHEL), rhel)
+ifneq (,$(findstring rhel,$(DIST_ID_LIKE)))
 	RHEL_MAJOR := $(shell echo $(VERSION_ID) | cut -d '.' -f 1)
 	RHEL_MINOR := $(shell echo $(VERSION_ID) | cut -d '.' -f 2)
 	RHEL_RELEASE_CODE := $(shell echo $$(($(RHEL_MAJOR) << 8 | $(RHEL_MINOR))))


### PR DESCRIPTION
This PR fixes compilation of `tracee-ebpf` on RHEL-likes (AlmaLinux, Rocky Linux, etc.).
The detection is done by checking for the `rhel` substring in the `ID_LIKE` field of the `/etc/os-release` file instead of just using the `ID` field which contains the operating system identifier. This is necessary to avoid having to list all binary compatible RHEL derivatives in the Makefile.

For example in AlmaLinux these fields have the following values:
```
$ grep -m 1 'PRETTY_NAME=' /etc/os-release | cut -d '=' -f '2' | sed 's/\"//g'
AlmaLinux 8.4 (Electric Cheetah)

$ grep -m 1 'ID_LIKE=' /etc/os-release | cut -d '=' -f '2' | sed 's/\"//g'
rhel centos fedora

$ grep -m 1 'ID' /etc/os-release | cut -d '=' -f '2' | sed 's/\"//g'
almalinux
```