### PR TITLE
Revert: Disable WASM target

### DIFF
--- a/tracee-rules/benchmark/signature/wasm/signatures.go
+++ b/tracee-rules/benchmark/signature/wasm/signatures.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	"github.com/open-policy-agent/opa/ast"
-	_ "github.com/open-policy-agent/opa/features/wasm"
 	"github.com/open-policy-agent/opa/rego"
 )
 

--- a/tracee-rules/main.go
+++ b/tracee-rules/main.go
@@ -52,7 +52,7 @@ func main() {
 			var target string
 			switch strings.ToLower(c.String("rego-runtime-target")) {
 			case "wasm":
-				target = compile.TargetWasm
+				return errors.New("target unsupported: " + target)
 			case "rego":
 				target = compile.TargetRego
 			default:

--- a/tracee-rules/signatures/rego/regosig/aio_test.go
+++ b/tracee-rules/signatures/rego/regosig/aio_test.go
@@ -71,14 +71,14 @@ func TestAio_OnEvent(t *testing.T) {
 			target:  compile.TargetRego,
 			partial: true,
 		},
-		{
-			target:  compile.TargetWasm,
-			partial: false,
-		},
-		{
-			target:  compile.TargetWasm,
-			partial: true,
-		},
+		//{
+		//	target:  compile.TargetWasm,
+		//	partial: false,
+		//},
+		//{
+		//	target:  compile.TargetWasm,
+		//	partial: true,
+		//},
 	}
 
 	for _, tc := range options {

--- a/tracee-rules/signatures/rego/regosig/traceerego.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego.go
@@ -1,8 +1,6 @@
 package regosig
 
 import (
-	_ "github.com/open-policy-agent/opa/features/wasm"
-
 	"bytes"
 	"context"
 	"encoding/json"

--- a/tracee-rules/signatures/rego/regosig/traceerego_test.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego_test.go
@@ -64,14 +64,14 @@ func TestRegoSignature_OnEvent(t *testing.T) {
 			target:  compile.TargetRego,
 			partial: true,
 		},
-		{
-			target:  compile.TargetWasm,
-			partial: false,
-		},
-		{
-			target:  compile.TargetWasm,
-			partial: true,
-		},
+		//{
+		//	target:  compile.TargetWasm,
+		//	partial: false,
+		//},
+		//{
+		//	target:  compile.TargetWasm,
+		//	partial: true,
+		//},
 	}
 
 	for _, tc := range options {


### PR DESCRIPTION
Fixes the currently broken docker image build:

```
go: downloading github.com/bytecodealliance/wasmtime-go v0.30.0
go: downloading github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
# github.com/bytecodealliance/wasmtime-go
/usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../x86_64-alpine-linux-musl/bin/ld: /go/pkg/mod/github.com/bytecodealliance/wasmtime-go@v0.30.0/build/linux-x86_64/libwasmtime.a(std-008055cc7d873802.std.cf1c8f7e-cgu.0.rcgu.o): in function `std::sys::unix::net::on_resolver_failure':
/rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b//library/std/src/sys/unix/net.rs:450: undefined reference to `__res_init'
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:26: dist/tracee-rules] Error 2
make: *** [Makefile:43: dist/tracee-rules] Error 2
make[1]: Leaving directory '/tracee/tracee-rules'
The command '/bin/sh -c make' returned a non-zero code: 2
make: *** [Makefile:59: docker] Error 2
```


Ref: https://github.com/bytecodealliance/wasmtime/pull/2951
Ref2: https://github.com/bytecodealliance/wasmtime-go/issues/21

Signed-off-by: Simar <simar@linux.com>