### PR TITLE
update postee manifest with tolerations and  resource limits

### DIFF
--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -33,6 +33,18 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules/
           readOnly: true
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 350m
+            memory: 50Mi
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
       volumes:
       - hostPath:
           path: /tmp/tracee


### PR DESCRIPTION
Adds the resource limits and tolerations in to the Postee based manifest to bring it in line with the falco sidekick manifest. Fixes https://github.com/aquasecurity/tracee/issues/1059