### PR TITLE
Parse the version from module tags

### DIFF
--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -13,7 +13,8 @@ ARCH ?= $(ARCH_UNAME:aarch64=arm64)
 KERN_RELEASE ?= $(shell uname -r)
 KERN_BLD_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),/lib/modules/$(KERN_RELEASE)/build)
 KERN_SRC_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),$(if $(wildcard /lib/modules/$(KERN_RELEASE)/source),/lib/modules/$(KERN_RELEASE)/source,$(KERN_BLD_PATH)))
-VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(shell $(CMD_GIT) describe --tags 2>/dev/null || echo '0'))
+LAST_GIT_TAG ?= $(shell $(CMD_GIT) describe --tags 2>/dev/null)
+VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(notdir $(LAST_GIT_TAG)))
 # inputs and outputs:
 OUT_DIR ?= dist
 GO_SRC := $(shell find . -type f -name '*.go')


### PR DESCRIPTION
As described in #1061, our new module git tag versioning scheme breaks the build. This is because the tags have a `/` in them, meaning when clang tries to output to a file, it can't find the directories in this 'path'.

This uses `notdir` to extract the version at the end of the git tags.

i.e. tracee-ebpf/external/v0.6.2 -> v0.6.2

Signed-off-by: grantseltzer <grantseltzer@gmail.com>