### PR TITLE
add socket_dup event

### DIFF
--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -120,7 +120,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			s = fmt.Sprintf("{%s}", s)
 			args["local_addr"] = s
 		}
-	case SecuritySocketConnectEventID:
+	case SecuritySocketConnectEventID, SocketDupEventID:
 		if sockAddr, isStrMap := args["remote_addr"].(map[string]string); isStrMap {
 			var s string
 			for key, val := range sockAddr {

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -179,6 +179,7 @@ const (
 	SecurityKernelReadFileEventID
 	SecurityInodeMknodEventID
 	SecurityPostReadFileEventID
+	SocketDupEventID
 	MaxEventID
 )
 
@@ -583,6 +584,7 @@ var EventsIDToEvent = map[int32]EventConfig{
 	SecurityPostReadFileEventID:   {ID: SecurityPostReadFileEventID, ID32Bit: sys32undefined, Name: "security_kernel_post_read_file", Probes: []probe{{event: "security_kernel_post_read_file", attach: kprobe, fn: "trace_security_kernel_post_read_file"}}, Sets: []string{"lsm_hooks"}},
 	SecurityInodeMknodEventID:     {ID: SecurityInodeMknodEventID, ID32Bit: sys32undefined, Name: "security_inode_mknod", Probes: []probe{{event: "security_inode_mknod", attach: kprobe, fn: "trace_security_inode_mknod"}}, Sets: []string{"lsm_hooks"}},
 	InitNamespacesEventID:         {ID: InitNamespacesEventID, ID32Bit: sys32undefined, Name: "init_namespaces", Probes: []probe{}, Sets: []string{}},
+	SocketDupEventID:              {ID: SocketDupEventID, ID32Bit: sys32undefined, Name: "socket_dup", Probes: []probe{}, Sets: []string{}},
 }
 
 // EventsIDToParams is list of the parameters (name and type) used by the events
@@ -958,4 +960,5 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	SecurityPostReadFileEventID:   {{Type: "const char*", Name: "pathname"}, {Type: "long", Name: "size"}, {Type: "int", Name: "type"}},
 	SecurityInodeMknodEventID:     {{Type: "const char*", Name: "file_name"}, {Type: "umode_t", Name: "mode"}, {Type: "dev_t", Name: "dev"}},
 	InitNamespacesEventID:         {{Type: "u32", Name: "cgroup"}, {Type: "u32", Name: "ipc"}, {Type: "u32", Name: "mnt"}, {Type: "u32", Name: "net"}, {Type: "u32", Name: "pid"}, {Type: "u32", Name: "pid_for_children"}, {Type: "u32", Name: "time"}, {Type: "u32", Name: "time_for_children"}, {Type: "u32", Name: "user"}, {Type: "u32", Name: "uts"}},
+	SocketDupEventID:              {{Type: "int", Name: "oldfd"}, {Type: "int", Name: "newfd"}, {Type: "struct sockaddr*", Name: "remote_addr"}},
 }


### PR DESCRIPTION
create a new event to indicate a dup of socket.
in order to do that, we need to know that the file that is being 'dup'ed is of type socket.
we can get the 'struct file' of the duplicated FD, and we have to compare to file_operations of this file to the file_operations of a socket file. this is why i probe into the return of the 'socket' syscall. the return value of this syscall is the FD of the syscall in the current task. then i can go to the file descriptor table of the current task, and get the 'struct file' of this FD that i know to be a socket. i save the socket file_operations in a map, and then i use it in the 'dup*' events.