### PR TITLE
fix type of security_kernel_read_file event

### DIFF
--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -177,8 +177,8 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args["cmd"] = helpers.ParseBPFCmd(cmd)
 		}
 	case SecurityKernelReadFileEventID:
-		if readFileId, isUint32 := args["type"].(uint32); isUint32 {
-			typeIdStr, err := ParseKernelReadFileId(int32(readFileId))
+		if readFileId, isInt32 := args["type"].(int32); isInt32 {
+			typeIdStr, err := ParseKernelReadFileId(readFileId)
 			if err == nil {
 				args["type"] = typeIdStr
 			}

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -949,7 +949,7 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	SecuritySbMountEventID:        {{Type: "const char*", Name: "dev_name"}, {Type: "const char*", Name: "path"}, {Type: "const char*", Name: "type"}, {Type: "unsigned long", Name: "flags"}},
 	SecurityBPFEventID:            {{Type: "int", Name: "cmd"}},
 	SecurityBPFMapEventID:         {{Type: "unsigned int", Name: "map_id"}, {Type: "const char*", Name: "map_name"}},
-	SecurityKernelReadFileEventID: {{Type: "const char*", Name: "pathname"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "const char*", Name: "type"}},
+	SecurityKernelReadFileEventID: {{Type: "const char*", Name: "pathname"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "type"}},
 	SecurityInodeMknodEventID:     {{Type: "const char*", Name: "file_name"}, {Type: "umode_t", Name: "mode"}, {Type: "dev_t", Name: "dev"}},
 	InitNamespacesEventID:         {{Type: "u32", Name: "cgroup"}, {Type: "u32", Name: "ipc"}, {Type: "u32", Name: "mnt"}, {Type: "u32", Name: "net"}, {Type: "u32", Name: "pid"}, {Type: "u32", Name: "pid_for_children"}, {Type: "u32", Name: "time"}, {Type: "u32", Name: "time_for_children"}, {Type: "u32", Name: "user"}, {Type: "u32", Name: "uts"}},
 }


### PR DESCRIPTION
this was broken on a recent change, because the Type of the 'type' argument was char*, but it is received as an int (and then changed to string in the argprinter).