### PR TITLE
Only remove a process from the process tree filter map if it's a tgid

### DIFF
--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2221,11 +2221,7 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
         struct task_struct *group_leader = READ_KERN(task->group_leader);
         struct list_head thread_group_head = READ_KERN(group_leader->thread_group);
         struct list_head *next = READ_KERN(thread_group_head.next);
-        #ifdef CORE
-        if (__builtin_preserve_access_index(&group_leader->thread_group) == next) {
-        #else
-        if (&group_leader->thread_group == next) {
-        #endif
+        if (GET_FIELD_ADDR(group_leader->thread_group) == next) {
             bpf_map_delete_elem(&process_tree_map, &data.context.host_pid);
         }
     }


### PR DESCRIPTION
This should handle #1039 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>