### PR TITLE
feat: Update tracee-rules base image to golang:1.17-buster

### DIFF
--- a/tracee-rules/Dockerfile.builder
+++ b/tracee-rules/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster as builder
+FROM golang:1.17-buster as builder
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y && apt-get install -y --no-install-recommends curl && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.26.0/opa_linux_amd64 && chmod 755 /usr/bin/opa
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64 && chmod 755 /usr/bin/opa
 WORKDIR /tracee


### PR DESCRIPTION
Signed-off-by: Simar <simar@linux.com>