### PR TITLE
Add etcd to exempted process list

### DIFF
--- a/tracee-rules/signatures/rego/kubernetes_certificate_theft_attempt.rego
+++ b/tracee-rules/signatures/rego/kubernetes_certificate_theft_attempt.rego
@@ -36,6 +36,6 @@ tracee_match {
     pathname = helpers.get_tracee_argument("pathname")
     startswith(pathname, "/etc/kubernetes/pki/")
 
-    process_names_blocklist := {"kube-apiserver", "kubelet", "kube-controller"}
+    process_names_blocklist := {"kube-apiserver", "kubelet", "kube-controller", "etcd"}
     not process_names_blocklist[input.processName]
 }


### PR DESCRIPTION
Adds etcd to the process_names_blocklist , as this is a common system process which will access files in the target directory.