### PR TITLE
tracee-ebpf: read exec arguments without a loop

### DIFF
--- a/tracee-ebpf/external/external.go
+++ b/tracee-ebpf/external/external.go
@@ -174,7 +174,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 			return fmt.Errorf("unrecognized argument type")
 		}
 	}
-	if arg.Type == "const char*const*" {
+	if arg.Type == "const char*const*" || arg.Type == "const char**" {
 		argValue := arg.Value.([]interface{})
 		tmp := make([]string, len(argValue))
 		for i, v := range argValue {

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -112,6 +112,7 @@ const (
 	u16T
 	credT
 	intArr2T
+	argsArrT
 )
 
 // ProbeType is an enum that describes the mechanism used to attach the event
@@ -926,7 +927,7 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	SysEnterEventID:               {{Type: "int", Name: "syscall"}},
 	SysExitEventID:                {{Type: "int", Name: "syscall"}},
 	SchedProcessForkEventID:       {{Type: "int", Name: "parent_tid"}, {Type: "int", Name: "parent_ns_tid"}, {Type: "int", Name: "child_tid"}, {Type: "int", Name: "child_ns_tid"}},
-	SchedProcessExecEventID:       {{Type: "const char*", Name: "cmdpath"}, {Type: "const char*", Name: "pathname"}, {Type: "const char*const*", Name: "argv"}, {Type: "const char*const*", Name: "env"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "invoked_from_kernel"}},
+	SchedProcessExecEventID:       {{Type: "const char*", Name: "cmdpath"}, {Type: "const char*", Name: "pathname"}, {Type: "const char**", Name: "argv"}, {Type: "const char**", Name: "env"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "invoked_from_kernel"}},
 	SchedProcessExitEventID:       {{Type: "long", Name: "exit_code"}},
 	SchedSwitchEventID:            {{Type: "int", Name: "cpu"}, {Type: "int", Name: "prev_tid"}, {Type: "const char*", Name: "prev_comm"}, {Type: "int", Name: "next_tid"}, {Type: "const char*", Name: "next_comm"}},
 	DoExitEventID:                 {},

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -404,8 +404,10 @@ func getParamType(paramType string) argType {
 		return pointerT
 	case "char*", "const char*":
 		return strT
-	case "const char*const*", "const char**", "char**":
+	case "const char*const*": // used by execve(at) argv and env
 		return strArrT
+	case "const char**": // used by sched_process_exec argv and envp
+		return argsArrT
 	case "const struct sockaddr*", "struct sockaddr*":
 		return sockAddrT
 	case "bytes":

--- a/tracee-ebpf/tracee/tracee_test.go
+++ b/tracee-ebpf/tracee/tracee_test.go
@@ -113,7 +113,18 @@ func TestReadArgFromBuff(t *testing.T) {
 				7, 0, 0, 0, //len=7
 				100, 111, 99, 107, 101, 114, 0, //docker
 			},
-			params:      []external.ArgMeta{{Type: "const char**", Name: "strArr0"}},
+			params:      []external.ArgMeta{{Type: "const char*const*", Name: "strArr0"}},
+			expectedArg: []string{"/usr/bin", "docker"},
+		},
+		{
+			name: "argsArrT",
+			input: []byte{0,
+				16, 0, 0, 0, //array len
+				2, 0, 0, 0, //number of arguments
+				47, 117, 115, 114, 47, 98, 105, 110, 0, // /usr/bin
+				100, 111, 99, 107, 101, 114, 0, //docker
+			},
+			params:      []external.ArgMeta{{Type: "const char**", Name: "argsArr0"}},
 			expectedArg: []string{"/usr/bin", "docker"},
 		},
 		{


### PR DESCRIPTION
This PR changes the way we send sched_process_exec arguments.
Instead of looping the null-delimited array, which is expensive both in time and number of instructions, we just read the memory area containing the arguments once.
By doing this change, we can now also support sending the environment variables in sched_process_exec events, which we avoided doing until now because it exceeded the instructions limit in old kernels.