### PR TITLE
Feature/sort events by timestamp

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/flags-output.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-output.go
@@ -20,7 +20,7 @@ Possible options:
 out-file:/path/to/file                             write the output to a specified file. create/trim the file if exists (default: stdout)
 err-file:/path/to/file                             write the errors to a specified file. create/trim the file if exists (default: stderr)
 none                                               ignore stream of events output, usually used with --capture
-option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-hash,parse-arguments}
+option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
   detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
@@ -28,6 +28,7 @@ option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-hash,parse-ar
   relative-time                                    use relative timestamp instead of wall timestamp for events
   exec-hash                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
   parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
+  sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
 Examples:
   --output json                                            | output as json
   --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
@@ -89,6 +90,8 @@ func PrepareOutput(outputSlice []string) (tracee.OutputConfig, printerConfig, er
 				outcfg.ExecHash = true
 			case "parse-arguments":
 				outcfg.ParseArguments = true
+			case "sort-events":
+				outcfg.EventsSorting = true
 			default:
 				return outcfg, printcfg, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}

--- a/cmd/tracee-ebpf/main_test.go
+++ b/cmd/tracee-ebpf/main_test.go
@@ -1275,14 +1275,24 @@ func TestPrepareOutput(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			testName:    "option sort-events",
+			outputSlice: []string{"option:sort-events"},
+			expectedOutput: tracee.OutputConfig{
+				ParseArguments: true,
+				EventsSorting:  true,
+			},
+			expectedError: nil,
+		},
+		{
 			testName:    "all options",
-			outputSlice: []string{"option:stack-addresses", "option:detect-syscall", "option:exec-env", "option:exec-hash"},
+			outputSlice: []string{"option:stack-addresses", "option:detect-syscall", "option:exec-env", "option:exec-hash", "option:sort-events"},
 			expectedOutput: tracee.OutputConfig{
 				StackAddresses: true,
 				DetectSyscall:  true,
 				ExecEnv:        true,
 				ExecHash:       true,
 				ParseArguments: true,
+				EventsSorting:  true,
 			},
 			expectedError: nil,
 		},

--- a/pkg/events/sorting/cpu_queue.go
+++ b/pkg/events/sorting/cpu_queue.go
@@ -1,0 +1,56 @@
+package sorting
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/tracee/pkg/external"
+)
+
+// Events queue with the ability to follow if it was updated since last check and insertion by time specific for CPU
+// queue ordering
+type cpuEventsQueue struct {
+	eventsQueue
+	IsUpdated bool
+}
+
+// InsertByTimestamp insert new event to the queue in the right position according to its timestamp
+func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *external.Event) error {
+	newNode := cq.pool.Alloc(newEvent)
+
+	cq.mutex.Lock()
+	defer cq.mutex.Unlock()
+	if cq.tail != nil &&
+		cq.tail.event.Timestamp > newEvent.Timestamp {
+		// We have a fresh event with a timestamp older than the last event received in this cpu's queue.
+		// This can only happen if this fresh event is a syscall event (for which we take the entry timestamp) which
+		// called some internal kernel functions (that are also traced). Insert the syscall event before these other
+		// events
+		insertLocation := cq.tail
+		for insertLocation.next != nil {
+			if insertLocation.next.event.Timestamp < newEvent.Timestamp {
+				break
+			}
+			if insertLocation.next == insertLocation {
+				return fmt.Errorf("encountered node with self reference at next")
+			}
+			insertLocation = insertLocation.next
+		}
+		cq.insertAfter(newNode, insertLocation)
+	} else {
+		cq.put(newNode)
+	}
+	return nil
+}
+
+// insertAfter insert new event to the queue after another node
+// This is useful if new node place is not at the end of the queue but before it
+func (cq *cpuEventsQueue) insertAfter(newNode *eventNode, baseEvent *eventNode) {
+	if baseEvent.next != nil {
+		baseEvent.next.previous = newNode
+	}
+	newNode.previous = baseEvent
+	newNode.next, baseEvent.next = baseEvent.next, newNode
+	if cq.head == baseEvent {
+		cq.head = newNode
+	}
+}

--- a/pkg/events/sorting/pool.go
+++ b/pkg/events/sorting/pool.go
@@ -1,0 +1,100 @@
+package sorting
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aquasecurity/tracee/pkg/external"
+)
+
+type eventNode struct {
+	event       *external.Event
+	previous    *eventNode
+	next        *eventNode
+	isAllocated bool
+}
+
+const poolFreeingPart = 2
+const minPoolFreeingSize = 200
+
+// eventsPool is a struct used to store empty eventNodes to prevent repeated allocation and freeing from the heap.
+// In details, the struct envelopes the allocation and freeing of the eventNode object, and store freed nodes
+// to to use them again when new allocation is required.
+// Pool is a known mechanism, so you can read more on it online.
+type eventsPool struct {
+	head             *eventNode
+	poolMutex        sync.Mutex
+	allocationsCount int
+	poolSize         int
+}
+
+// Alloc return an eventNode that contains the event given.
+// The function will try to use stored eventNode if there is one available.
+// If there isn't, it will allocate new one.
+func (p *eventsPool) Alloc(event *external.Event) *eventNode {
+	p.poolMutex.Lock()
+	p.allocationsCount += 1
+	defer p.poolMutex.Unlock()
+	node := p.head
+	if node != nil && node.isAllocated == false {
+		p.head = node.previous
+		node.event = event
+		node.isAllocated = true
+		node.previous = nil
+		p.poolSize -= 1
+		return node
+	}
+	return &eventNode{event: event, isAllocated: true}
+}
+
+// Free handle the eventNode after its usage has ended.
+// Free will try to store the node in the pool to be used by a future Alloc call.
+// To prevent the storage of all nodes event when there is no use for them (like after peaks of allocations), whenever
+// the amount of stored nodes pass the amount of nodes in use, a part of the pool will be removed from the pool (and
+// as a result will be garbage collected).
+func (p *eventsPool) Free(node *eventNode) error {
+	p.poolMutex.Lock()
+	defer p.poolMutex.Unlock()
+	// Prevent malicious use of free
+	if p.allocationsCount == 0 {
+		return fmt.Errorf("BUG: free called when no allocated node exist")
+	}
+
+	node.isAllocated = false
+	node.previous = nil
+	node.next = nil
+	p.allocationsCount -= 1
+	// Free memory in case of pooling too many nodes
+	if p.poolSize >= p.allocationsCount &&
+		p.poolSize >= minPoolFreeingSize {
+		freeingAmount := p.poolSize / poolFreeingPart
+		for i := 0; i < freeingAmount; i++ {
+			p.head = p.head.previous
+		}
+		p.poolSize -= freeingAmount
+	} else { // Add unused node to pool
+		if p.head == nil {
+			p.head = node
+		} else {
+			node.previous = p.head
+			p.head.next = node
+			p.head = node
+		}
+		p.poolSize += 1
+	}
+	return nil
+}
+
+func (p *eventsPool) Reset() {
+	p.poolMutex.Lock()
+	defer p.poolMutex.Unlock()
+	node := p.head
+	for node != nil {
+		next := node.previous
+		node.next = nil
+		node.previous = nil
+		node = next
+	}
+	p.allocationsCount = 0
+	p.poolSize = 0
+}

--- a/pkg/events/sorting/pool.go
+++ b/pkg/events/sorting/pool.go
@@ -7,13 +7,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/external"
 )
 
-type eventNode struct {
-	event       *external.Event
-	previous    *eventNode
-	next        *eventNode
-	isAllocated bool
-}
-
 const poolFreeingPart = 2
 const minPoolFreeingSize = 200
 

--- a/pkg/events/sorting/queue.go
+++ b/pkg/events/sorting/queue.go
@@ -1,0 +1,108 @@
+package sorting
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aquasecurity/tracee/pkg/external"
+)
+
+type eventNode struct {
+	event       *external.Event
+	previous    *eventNode
+	next        *eventNode
+	isAllocated bool
+}
+
+// A double linked list used to store events in LIFO order
+type eventsQueue struct {
+	pool  eventsPool
+	tail  *eventNode
+	head  *eventNode
+	mutex sync.Mutex
+}
+
+// Put insert new event to the double linked list
+func (eq *eventsQueue) Put(newEvent *external.Event) {
+	newNode := eq.pool.Alloc(newEvent)
+	eq.mutex.Lock()
+	defer eq.mutex.Unlock()
+	eq.put(newNode)
+}
+
+// Get remove the node at the head of the queue and return it
+// Might return error with a valid event in case of internal pool error, for the user to know that an error occurred
+// but was contained
+func (eq *eventsQueue) Get() (*external.Event, error) {
+	eq.mutex.Lock()
+	defer eq.mutex.Unlock()
+	if eq.head == nil {
+		if eq.tail != nil {
+			return nil, fmt.Errorf("BUG: TAIL without a HEAD")
+		}
+		return nil, nil
+	}
+	headNode := eq.head
+	if headNode == eq.tail {
+		if headNode.next != nil || headNode.previous != nil {
+			return nil, fmt.Errorf("BUG: last existing node still conneced")
+		}
+		eq.tail = nil
+		eq.head = nil
+	} else {
+		if headNode.previous == nil {
+			return nil, fmt.Errorf("BUG: not TAIL lacking previous")
+		}
+		if headNode.next != nil {
+			return nil, fmt.Errorf("BUG: HEAD has next")
+		}
+		headNode.previous.next = nil
+		eq.head = headNode.previous
+	}
+	headNode.previous = nil
+	headNode.next = nil
+	extractedEvent := headNode.event
+	err := eq.pool.Free(headNode)
+	if err != nil {
+		eq.pool.Reset()
+		return extractedEvent, fmt.Errorf("error in queue's node freeing - %v", err)
+	}
+	return extractedEvent, nil
+}
+
+func (eq *eventsQueue) PeekHead() *external.Event {
+	eq.mutex.Lock()
+	defer eq.mutex.Unlock()
+	if eq.head == nil {
+		return nil
+	}
+	return eq.head.event
+}
+
+func (eq *eventsQueue) PeekTail() *external.Event {
+	eq.mutex.Lock()
+	defer eq.mutex.Unlock()
+	if eq.tail == nil {
+		return nil
+	}
+	return eq.tail.event
+}
+
+func (eq *eventsQueue) Empty() {
+	eq.mutex.Lock()
+	defer eq.mutex.Unlock()
+	eq.head = nil
+	eq.tail = nil
+}
+
+// Put insert new event to the double linked list
+func (eq *eventsQueue) put(newNode *eventNode) {
+	if eq.tail != nil {
+		newNode.next = eq.tail
+		eq.tail.previous = newNode
+	}
+	if eq.head == nil {
+		eq.head = newNode
+	}
+	eq.tail = newNode
+}

--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -1,0 +1,256 @@
+// Package sorting is responsible for sorting incoming events from the BPF programs chronologically.
+//
+// There are 3 known sources to events sorting issues:
+//   1. In perf buffer, events are read in round robing order from CPUs buffers (and not according to invocation time).
+//   2. Syscall events are invoked after internal events of the syscall (though the syscall happened before the
+//      internal events).
+//   3. Virtual CPUs might enter sleep mode by host machine scheduler and send events after some delay.
+//
+// To address the events perf buffers issue, the events are divided to queues according to the source CPU. This way
+// the events are almost ordered (except for syscalls). The syscall events are inserted to their right chronological
+// place manually.
+// This way, all events which occurred before the last event of the most delaying CPU could be sent forward with
+// guaranteed order.
+// To make sure syscall events are not missed when sending, a small delay is needed.
+// Lastly, to address the vCPU sleep issue (which might cause up to 2 events received in a delay), the events need to be
+// sent after a delay which is bigger than max possible vCPU sleep time (which is just an increase of the syscall events
+// delay sending).
+//
+// To summarize the algorithm main logic, here is textual simulation of the operation (assume that 2 scheduler ticks
+// are larger than max possible vCPU sleep time):
+//   -------------------------------------------------------------------
+// Tn = Timestamp (n == TOD)
+// #m = Event's Source CPU
+//
+// ### Initial State
+//
+//        [ CPU 0 ]    [ CPU 1 ]    [ CPU 2 ]
+//   HEAD    T1           T2           T4
+//           T3           T5
+//           T6
+//   TAIL    T8
+//
+// ### Scheduler Tick #1
+//
+// Incoming events: T9#1, T11#2, T13#1, T10#2, T12#2
+//
+// Queues state after insert:
+//        [ CPU 0 ]    [ CPU 1 ]    [ CPU 2 ]
+//   HEAD    T1           T2           T4
+//           T3           T5           T10 +
+//           T6           T9  +        T11 +
+//   TAIL    T8           T13 +        T12 +
+//
+//   - No event sent.
+//   - Oldest timestamp = T1.
+//   - T8 is oldest timestamp in most recent timestamps.
+//   - In 2 ticks from now: send all events up to T8.
+//   - Bigger timestamps than T8 (+) will be sent in future scheduling.
+//
+// ### Scheduler Tick #2
+//
+// Incoming events: T7#0, T22#1, T23#2, T20#0, T25#1, T24#2, T21#0
+//
+// Queues state after insert:
+//        [ CPU 0 ]    [ CPU 1 ]    [ CPU 2 ]
+//   HEAD    T1  ^        T2  ^        T4  ^
+//           T3  ^        T5  ^        T10
+//           T6  ^        T9           T11
+//           T7  +^       T13          T12
+//           T8  ^        T22 +        T23 +
+//           T20 +        T25 +        T24 +
+//   TAIL    T21 +
+//
+//   - No event sent.
+//   - Oldest timestamp = T1.
+//   - T21 is oldest timestamp in most recent timestamps.
+//   - In 2 ticks from now: send all events up to T21.
+//   - T8 is previous oldest timestamp in most recent timestamps.
+//   - Next tick: send all events up to T8.
+//   - Bigger timestamps than T21 (+) will be sent in future scheduling.
+//
+// ### Scheduler Tick #3
+//
+// Incoming events: T30#0, T34#1, T35#2, T31#0, T36#2, T32#0, T37#2, T33#0, T38#2, T50#1, T51#1
+//
+// Queues state after insert:
+//        [ CPU 0 ]    [ CPU 1 ]    [ CPU 2 ]
+//   HEAD    T20 ^        T9  ^        T10 ^
+//           T21 ^        T13 ^        T11 ^
+//           T30 +        T22          T12 ^
+//           T31 +        T23          T24
+//           T32 +        T25          T35 +
+//           T33 +        T34 +        T36 +
+//                        T50 +        T37 +
+//    TAIL                T51 +        T38 +
+//
+//   - Max sent timestamp = T8.
+//   - Oldest timestamp = T9.
+//   - T33 is oldest timestamp in most recent timestamps.
+//   - In 2 ticks from now: send all events up to T33.
+//   - T21 is previous oldest timestamp in most recent timestamps.
+//   - Next tick: send all events up to T21.
+//   - Bigger timestamps than T33 (+) will be sent in future scheduling.
+//   -------------------------------------------------------------------
+package sorting
+
+import (
+	gocontext "context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/aquasecurity/tracee/pkg/external"
+	"github.com/aquasecurity/tracee/pkg/utils/environment"
+)
+
+// The minimum time of delay before sending events forward.
+// It should resolve disorders originated from the way syscalls timestamps are taken (about 1ms disorder) and potential
+// vCPU sleep (up to 98ms) [source - https://kinvolk.io/blog/2018/02/timing-issues-when-using-bpf-with-virtual-cpus/]
+const minDelay = 100 * time.Millisecond
+const eventsPassingInterval = 50 * time.Millisecond
+const intervalsAmountThresholdForDelay = int(minDelay / eventsPassingInterval)
+
+// EventsChronologicalSorter is an object responsible for sorting arriving events from perf buffer according to their
+// chronological order - the time they were invoked in the kernel.
+type EventsChronologicalSorter struct {
+	cpuEventsQueues           []cpuEventsQueue // Each CPU has its own events queue because events per CPU arrive in almost chronological order
+	outputChanMutex           sync.Mutex
+	extractionSavedTimestamps []int // Buffer to store timestamps of events for delayed extraction
+	errorChan                 chan<- error
+}
+
+func InitEventSorter() (*EventsChronologicalSorter, error) {
+	cpusAmount, err := environment.GetCPUAmount()
+	if err != nil {
+		return nil, err
+	}
+	newSorter := EventsChronologicalSorter{}
+	newSorter.cpuEventsQueues = make([]cpuEventsQueue, cpusAmount)
+	return &newSorter, nil
+}
+
+func (sorter *EventsChronologicalSorter) StartPipeline(ctx gocontext.Context, in <-chan *external.Event) (
+	chan *external.Event, chan error) {
+	out := make(chan *external.Event, 1000)
+	errc := make(chan error, 1)
+	go sorter.Start(in, out, ctx, errc)
+	return out, errc
+}
+
+// Start is the main function of the EventsChronologicalSorter class, which orders input events from events channels
+// and pass forward all ordered events to the output channel after each interval.
+// When exits, the sorter will send forward all buffered events in ordered matter.
+func (sorter *EventsChronologicalSorter) Start(in <-chan *external.Event, out chan<- *external.Event,
+	ctx gocontext.Context, errc chan error) {
+	sorter.errorChan = errc
+	defer close(out)
+	defer close(errc)
+	ticker := time.NewTicker(eventsPassingInterval)
+	for {
+		select {
+		case newEvent := <-in:
+			if newEvent == nil {
+				sorter.sendEvents(out, math.MaxInt64)
+				return
+			}
+			sorter.addEvent(newEvent)
+		case <-ticker.C:
+			sorter.updateSavedTimestamps()
+			if len(sorter.extractionSavedTimestamps) > intervalsAmountThresholdForDelay {
+				extractionTimestamp := sorter.extractionSavedTimestamps[0]
+				sorter.extractionSavedTimestamps = sorter.extractionSavedTimestamps[1:]
+				go sorter.sendEvents(out, extractionTimestamp)
+			}
+
+		case <-ctx.Done():
+			sorter.sendEvents(out, math.MaxInt64)
+			return
+		}
+	}
+}
+
+// addEvent add a new event to the appropriate place in queue according to its timestamp
+func (sorter *EventsChronologicalSorter) addEvent(newEvent *external.Event) {
+	cq := &sorter.cpuEventsQueues[newEvent.ProcessorID]
+	err := cq.InsertByTimestamp(newEvent)
+	if err != nil {
+		sorter.errorChan <- err
+	}
+	cq.IsUpdated = true
+}
+
+// sendEvents send to output channel all events up to given timestamp
+func (sorter *EventsChronologicalSorter) sendEvents(outputChan chan<- *external.Event, extractionMaxTimestamp int) {
+	sorter.outputChanMutex.Lock()
+	defer sorter.outputChanMutex.Unlock()
+	for {
+		mostDelayingQueue, err := sorter.getMostDelayingEventCPUQueue()
+		if err != nil || mostDelayingQueue.PeekHead().Timestamp > extractionMaxTimestamp {
+			break
+		}
+		extractionEvent, err := mostDelayingQueue.Get()
+		if err != nil {
+			sorter.errorChan <- err
+			if extractionEvent == nil {
+				mostDelayingQueue.Empty()
+				continue
+			}
+		}
+		outputChan <- extractionEvent
+	}
+}
+
+// updateSavedTimestamps add current most delaying timestamp to saved list
+func (sorter *EventsChronologicalSorter) updateSavedTimestamps() {
+	mostDelayingLastEventTimestamp, err := sorter.getMostDelayedLastCPUEventTimestamp()
+	if err != nil { // An error means no new event was received since last update
+		if len(sorter.extractionSavedTimestamps) > 0 {
+			mostDelayingLastEventTimestamp = sorter.extractionSavedTimestamps[len(sorter.extractionSavedTimestamps)-1]
+		} else {
+			mostDelayingLastEventTimestamp = 0
+		}
+	}
+	sorter.extractionSavedTimestamps = append(sorter.extractionSavedTimestamps, mostDelayingLastEventTimestamp)
+}
+
+// getMostDelayingEventCPUQueue search for the CPU queue which contains the oldest event
+// Return nil if no valid queue found
+func (sorter *EventsChronologicalSorter) getMostDelayingEventCPUQueue() (*cpuEventsQueue, error) {
+	var mostDelayingEventQueue *cpuEventsQueue = nil
+	for i := 0; i < len(sorter.cpuEventsQueues); i++ {
+		cq := &sorter.cpuEventsQueues[i]
+		if cq.PeekHead() != nil &&
+			(mostDelayingEventQueue == nil ||
+				cq.PeekHead().Timestamp < mostDelayingEventQueue.PeekHead().Timestamp) {
+			mostDelayingEventQueue = cq
+		}
+	}
+	if mostDelayingEventQueue == nil {
+		return nil, fmt.Errorf("no queue with events found")
+	}
+	return mostDelayingEventQueue, nil
+}
+
+// getMostDelayedLastCPUEventTimestamp search for the CPU queue with the oldest last inserted event which was updated since
+// last check
+// Queues which were not updated since last check are ignored to prevent events starvation if a CPU is not active
+func (sorter *EventsChronologicalSorter) getMostDelayedLastCPUEventTimestamp() (int, error) {
+	var mostDelayingEventQueue *cpuEventsQueue = nil
+	for i := 0; i < len(sorter.cpuEventsQueues); i++ {
+		cq := &sorter.cpuEventsQueues[i]
+		queueTail := cq.PeekTail()
+		if queueTail != nil &&
+			cq.IsUpdated == true &&
+			(mostDelayingEventQueue == nil ||
+				queueTail.Timestamp < mostDelayingEventQueue.PeekTail().Timestamp) {
+			mostDelayingEventQueue = &sorter.cpuEventsQueues[i]
+		}
+		cq.IsUpdated = false // Mark that the values of the queue were checked from previous time
+	}
+	if mostDelayingEventQueue == nil {
+		return 0, fmt.Errorf("no valid CPU events queue was updated since last interval")
+	}
+	return mostDelayingEventQueue.PeekTail().Timestamp, nil
+}

--- a/pkg/events/sorting/sorting_test.go
+++ b/pkg/events/sorting/sorting_test.go
@@ -1,0 +1,308 @@
+package sorting
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aquasecurity/tracee/pkg/external"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sortableEventsList struct {
+	eventsList []external.Event
+}
+
+func (e sortableEventsList) Len() int {
+	return len(e.eventsList)
+}
+
+func (e sortableEventsList) Less(i, j int) bool {
+	return e.eventsList[i].Timestamp < e.eventsList[j].Timestamp
+}
+
+func (e sortableEventsList) Swap(i, j int) {
+	return
+}
+
+func TestEventsChronologicalSorter_addEvent(t *testing.T) {
+	testCases := []struct {
+		events                []external.Event
+		expectedCpuQueuesLens map[int]int
+		name                  string
+	}{{
+		events: []external.Event{
+			{ProcessorID: 0, Timestamp: 1},
+			{ProcessorID: 0, Timestamp: 2},
+			{ProcessorID: 0, Timestamp: 3},
+		},
+		expectedCpuQueuesLens: map[int]int{
+			0: 3,
+			1: 0,
+		},
+		name: "Sorting chronological order events from 1 CPU",
+	},
+		{
+			events: []external.Event{
+				{ProcessorID: 0, Timestamp: 1},
+				{ProcessorID: 1, Timestamp: 2},
+				{ProcessorID: 0, Timestamp: 3},
+			},
+			expectedCpuQueuesLens: map[int]int{
+				0: 2,
+				1: 1,
+			},
+			name: "Sorting chronological order events from multiple CPUs",
+		},
+		{
+			events: []external.Event{
+				{ProcessorID: 0, Timestamp: 2},
+				{ProcessorID: 0, Timestamp: 3},
+				{ProcessorID: 0, Timestamp: 4},
+				{ProcessorID: 0, Timestamp: 5},
+				{ProcessorID: 0, Timestamp: 1},
+			},
+			expectedCpuQueuesLens: map[int]int{
+				0: 5,
+				1: 0,
+			},
+			name: "Sorting not chronological order events from 1 CPU",
+		},
+		{
+			events: []external.Event{
+				{ProcessorID: 0, Timestamp: 2},
+				{ProcessorID: 0, Timestamp: 3},
+				{ProcessorID: 1, Timestamp: 4},
+				{ProcessorID: 1, Timestamp: 5},
+				{ProcessorID: 1, Timestamp: 1},
+			},
+			expectedCpuQueuesLens: map[int]int{
+				0: 2,
+				1: 3,
+			},
+			name: "Sorting not chronological order events",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			errChan := make(chan error)
+			newSorter, err := InitEventSorter()
+			require.NoError(t, err)
+			newSorter.cpuEventsQueues = make([]cpuEventsQueue, len(testCase.expectedCpuQueuesLens))
+			require.NoError(t, err, testCase.name)
+			for i := 0; i < len(testCase.events); i++ {
+				newSorter.addEvent(&testCase.events[i])
+			}
+			assert.Empty(t, errChan)
+			for cpuid, cpuEventsQueue := range newSorter.cpuEventsQueues {
+				require.Contains(t, testCase.expectedCpuQueuesLens, cpuid)
+				eventsCounter := 0
+				if cpuEventsQueue.head != nil {
+					eventsCounter += 1
+					for testEvent := cpuEventsQueue.head; testEvent.previous != nil; testEvent = testEvent.previous {
+						require.NotEqual(t, testEvent, testEvent.previous) // Prevent infinite loops
+						assert.True(t, testEvent.event.Timestamp < testEvent.previous.event.Timestamp)
+						eventsCounter += 1
+					}
+				}
+				assert.Equal(t, testCase.expectedCpuQueuesLens[cpuid], eventsCounter)
+			}
+		})
+
+	}
+}
+
+type eventsIteration struct {
+	events []external.Event
+	delay  time.Duration // Delay from last iteration
+}
+
+type sorterTestCase struct {
+	eventsPools  []eventsIteration
+	name         string
+	eventsAmount int
+	cpuAmount    int
+}
+
+func TestEventsChronologicalSorter_Start(t *testing.T) {
+	testCases := []sorterTestCase{
+		{
+			eventsPools: []eventsIteration{
+				{
+					delay: 0,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 1},
+						{ProcessorID: 0, Timestamp: 2},
+						{ProcessorID: 0, Timestamp: 3},
+					},
+				},
+			},
+			name:         "Sorting chronological order events from 1 CPU",
+			eventsAmount: 3,
+			cpuAmount:    1,
+		},
+		{
+			eventsPools: []eventsIteration{
+				{
+					delay: 0,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 1},
+						{ProcessorID: 1, Timestamp: 2},
+						{ProcessorID: 0, Timestamp: 3},
+					},
+				},
+			},
+			name:         "Sorting chronological order events from multiple CPUs",
+			eventsAmount: 3,
+			cpuAmount:    2,
+		},
+		{
+			eventsPools: []eventsIteration{
+				{
+					delay: 0,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 2},
+						{ProcessorID: 0, Timestamp: 3},
+						{ProcessorID: 0, Timestamp: 4},
+						{ProcessorID: 0, Timestamp: 5},
+						{ProcessorID: 0, Timestamp: 1},
+					},
+				},
+			},
+			name:         "Sorting not chronological order events from 1 CPU",
+			eventsAmount: 5,
+			cpuAmount:    1,
+		},
+		{
+			eventsPools: []eventsIteration{
+				{
+					delay: 0,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 2},
+						{ProcessorID: 0, Timestamp: 3},
+						{ProcessorID: 1, Timestamp: 4},
+						{ProcessorID: 1, Timestamp: 5},
+						{ProcessorID: 1, Timestamp: 1},
+					},
+				},
+			},
+			name:         "Sorting not chronological order events from multiple CPUs",
+			eventsAmount: 5,
+			cpuAmount:    2,
+		},
+		{
+			eventsPools: []eventsIteration{
+				{
+					delay: 0,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 2},
+						{ProcessorID: 0, Timestamp: 3},
+						{ProcessorID: 1, Timestamp: 4},
+						{ProcessorID: 1, Timestamp: 5},
+						{ProcessorID: 0, Timestamp: 7},
+					},
+				},
+				{
+					delay: minDelay - time.Millisecond,
+					events: []external.Event{
+						{ProcessorID: 1, Timestamp: 10},
+						{ProcessorID: 1, Timestamp: 11},
+						{ProcessorID: 1, Timestamp: 6},
+					},
+				},
+			},
+			name:         "Sorting unsorted events after vCPU sleep",
+			eventsAmount: 8,
+			cpuAmount:    2,
+		},
+		{
+			eventsPools:  []eventsIteration{},
+			name:         "Sorting with no events",
+			eventsAmount: 0,
+			cpuAmount:    1,
+		},
+		{
+			eventsPools: []eventsIteration{
+				{
+					delay: 100 * time.Millisecond,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 1},
+					},
+				},
+				{
+					delay: 300 * time.Millisecond,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 2},
+					},
+				},
+				{
+					delay: 300 * time.Millisecond,
+					events: []external.Event{
+						{ProcessorID: 0, Timestamp: 3},
+					},
+				},
+			},
+			name:         "Sorting chronological order events from 1 CPU low pace",
+			eventsAmount: 3,
+			cpuAmount:    1,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			inputChan := make(chan *external.Event, 100)
+			outputChan := make(chan *external.Event, 100)
+			fatalErrorsChan := make(chan error)
+			errChan := make(chan error)
+			newSorter, err := InitEventSorter()
+			require.NoError(t, err)
+			newSorter.cpuEventsQueues = make([]cpuEventsQueue, testCase.cpuAmount)
+			ctx := context.Background()
+			ctx, cancel := context.WithCancel(ctx)
+			go newSorter.Start(inputChan, outputChan, ctx, fatalErrorsChan)
+			go sendTestEvents(inputChan, testCase.eventsPools)
+			outputList, sorterErr := retrieveEventsFromSorter(testCase.eventsAmount, outputChan, fatalErrorsChan)
+			cancel()
+			require.NoError(t, sorterErr)
+			assert.Empty(t, errChan)
+			assert.True(t, sort.IsSorted(sortableEventsList{outputList}))
+		})
+	}
+}
+
+func retrieveEventsFromSorter(expectedEventsAmount int, sorterOutputChan chan *external.Event, fatalErrorsChan chan error) ([]external.Event, error) {
+	ticker := time.NewTicker(time.Second)
+	outputList := make([]external.Event, 0)
+	eventsReceived := 0
+	for {
+		select {
+		case event := <-sorterOutputChan:
+			outputList = append(outputList, *event)
+			eventsReceived += 1
+			if eventsReceived > expectedEventsAmount {
+				return outputList, fmt.Errorf("more events returned from sorter than expected")
+			}
+		case err := <-fatalErrorsChan:
+			return nil, err
+		case <-ticker.C:
+			if eventsReceived != expectedEventsAmount {
+				return nil, fmt.Errorf("not all events received until timeout")
+			} else {
+				return outputList, nil
+			}
+		}
+	}
+}
+
+func sendTestEvents(sorterInputChannel chan *external.Event, eventPool []eventsIteration) {
+	startTime := int(time.Now().UnixNano())
+	for _, eventsIteration := range eventPool {
+		time.Sleep(eventsIteration.delay)
+		for _, event := range eventsIteration.events {
+			event.Timestamp = startTime + (event.Timestamp * int(time.Millisecond.Nanoseconds()))
+			sorterInputChannel <- &event
+		}
+	}
+}

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -10,6 +10,7 @@ import (
 // Event is a user facing data structure representing a single event
 type Event struct {
 	Timestamp           int        `json:"timestamp"`
+	ProcessorID         int        `json:"processorId"`
 	ProcessID           int        `json:"processId"`
 	ThreadID            int        `json:"threadId"`
 	ParentProcessID     int        `json:"parentProcessId"`
@@ -71,6 +72,7 @@ func (e Event) ToUnstructured() (map[string]interface{}, error) {
 
 	return map[string]interface{}{
 		"timestamp":           json.Number(strconv.Itoa(e.Timestamp)),
+		"processorId":         json.Number(strconv.Itoa(e.ProcessorID)),
 		"processId":           json.Number(strconv.Itoa(e.ProcessID)),
 		"threadId":            json.Number(strconv.Itoa(e.ThreadID)),
 		"parentProcessId":     json.Number(strconv.Itoa(e.ParentProcessID)),

--- a/pkg/external/external_test.go
+++ b/pkg/external/external_test.go
@@ -171,6 +171,7 @@ func TestEvent_ToUnstructured(t *testing.T) {
 			name: "Should unstructure Event",
 			event: Event{
 				Timestamp:           7126141189,
+				ProcessorID:         0,
 				ProcessID:           1,
 				ThreadID:            1,
 				ParentProcessID:     4798,

--- a/pkg/utils/environment/cpu_analyzing.go
+++ b/pkg/utils/environment/cpu_analyzing.go
@@ -1,0 +1,59 @@
+package environment
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const possibleCPUsFilePath = "/sys/devices/system/cpu/possible"
+
+func GetCPUAmount() (int, error) {
+	possibleCPUsFileContent, err := os.ReadFile(possibleCPUsFilePath)
+	if err == nil {
+		cpusAmount, err := parsePossibleCPUAmountFromCPUFileFormat(string(possibleCPUsFileContent))
+		if err == nil {
+			return cpusAmount, nil
+		}
+	}
+	return 0, err
+}
+
+const singleValue = 1
+const rangeValues = 2
+const rangeValuesWithGroups = 4
+
+// parsePossibleCPUAmountFromCPUFileFormat parse the format of /sys/devices/system/cpu files and return the amount of CPUs
+// specified. The format expected is according to the bitmap_parselist function in the linux kernel.
+// Notice that possible CPUs should be sequential values starting with 0, because the OS gives indexes from 0 onward to
+// all possible CPUs.
+//
+// Note: 'sysconf(_SC_NPROCESSORS_CONF)' is not used because it is found to be broken.
+// For more info see thread from libbpf - https://lore.kernel.org/bpf/ef0f23d0-456a-70b0-1ef9-2615a5528278@iogearbox.net/
+func parsePossibleCPUAmountFromCPUFileFormat(cpuFileContent string) (int, error) {
+	var rangeStart, rangeEnd int
+	var usedSize, groupSize int
+	bitmapsRegions := strings.Split(cpuFileContent, ",")
+	if len(bitmapsRegions) > 1 {
+		return 0, fmt.Errorf("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
+	}
+	cpusAmount := 0
+	n, _ := fmt.Sscanf(bitmapsRegions[0], "%d-%d:%d/%d", &rangeStart, &rangeEnd, &usedSize, &groupSize)
+	switch n {
+	case singleValue:
+		if rangeStart != 0 {
+			return 0, fmt.Errorf("possible cpus must start from the index 0, so single CPU index value must be 0")
+		}
+		cpusAmount = 1
+	case rangeValues:
+		if rangeStart != 0 {
+			return 0, fmt.Errorf("possible cpus should be following indexes range starting with 0")
+		}
+		cpusAmount = rangeEnd - rangeStart + 1
+	case rangeValuesWithGroups:
+		return 0, fmt.Errorf("possible cpus should be following indexes, but received groups format")
+	default:
+		return 0, fmt.Errorf("unkown possible cpu file format")
+	}
+	return cpusAmount, nil
+}

--- a/tracee-ebpf/tracee/events_pipeline.go
+++ b/tracee-ebpf/tracee/events_pipeline.go
@@ -50,6 +50,9 @@ func (t *Tracee) handleEvents(ctx gocontext.Context) {
 	eventsChan, errc := t.decodeEvents(ctx)
 	errcList = append(errcList, errc)
 
+	eventsChan, errc = t.eventsSorter.StartPipeline(ctx, eventsChan)
+	errcList = append(errcList, errc)
+
 	// Sink pipeline stage.
 	errc = t.processEvents(ctx, eventsChan)
 	errcList = append(errcList, errc)

--- a/tracee-ebpf/tracee/events_pipeline.go
+++ b/tracee-ebpf/tracee/events_pipeline.go
@@ -50,8 +50,10 @@ func (t *Tracee) handleEvents(ctx gocontext.Context) {
 	eventsChan, errc := t.decodeEvents(ctx)
 	errcList = append(errcList, errc)
 
-	eventsChan, errc = t.eventsSorter.StartPipeline(ctx, eventsChan)
-	errcList = append(errcList, errc)
+	if t.config.Output.EventsSorting {
+		eventsChan, errc = t.eventsSorter.StartPipeline(ctx, eventsChan)
+		errcList = append(errcList, errc)
+	}
 
 	// Sink pipeline stage.
 	errc = t.processEvents(ctx, eventsChan)

--- a/tracee-ebpf/tracee/events_pipeline.go
+++ b/tracee-ebpf/tracee/events_pipeline.go
@@ -21,24 +21,25 @@ const maxStackDepth int = 20
 // NOTE: Integers want to be aligned in memory, so if changing the format of this struct
 // keep the 1-byte 'Argnum' as the final parameter before the padding (if padding is needed).
 type context struct {
-	Ts       uint64
-	CgroupID uint64
-	Pid      uint32
-	Tid      uint32
-	Ppid     uint32
-	HostPid  uint32
-	HostTid  uint32
-	HostPpid uint32
-	Uid      uint32
-	MntID    uint32
-	PidID    uint32
-	Comm     [16]byte
-	UtsName  [16]byte
-	EventID  int32
-	Retval   int64
-	StackID  uint32
-	Argnum   uint8
-	_        [3]byte //padding
+	Ts          uint64
+	CgroupID    uint64
+	ProcessorId uint64
+	Pid         uint32
+	Tid         uint32
+	Ppid        uint32
+	HostPid     uint32
+	HostTid     uint32
+	HostPpid    uint32
+	Uid         uint32
+	MntID       uint32
+	PidID       uint32
+	Comm        [16]byte
+	UtsName     [16]byte
+	EventID     int32
+	Retval      int64
+	StackID     uint32
+	Argnum      uint8
+	_           [3]byte //padding
 }
 
 // handleEvents is a high-level function that starts all operations related to events processing
@@ -114,6 +115,7 @@ func (t *Tracee) decodeEvents(outerCtx gocontext.Context) (<-chan *external.Even
 
 			evt := external.Event{
 				Timestamp:           int(ctx.Ts),
+				ProcessorID:         int(ctx.ProcessorId),
 				ProcessID:           int(ctx.Pid),
 				ThreadID:            int(ctx.Tid),
 				ParentProcessID:     int(ctx.Ppid),

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -372,6 +372,7 @@ Copyright (C) Aqua Security inc.
 typedef struct event_context {
     u64 ts;                        // Timestamp
     u64 cgroup_id;
+    u64 processor_id;              // The ID of the processor which processed the event
     u32 pid;                       // PID as in the userspace term
     u32 tid;                       // TID as in the userspace term
     u32 ppid;                      // Parent PID as in the userspace term
@@ -1162,6 +1163,8 @@ static __always_inline int init_context(context_t *context, struct task_struct *
 
     // Clean Stack Trace ID
     context->stack_id = 0;
+
+    context->processor_id = bpf_get_smp_processor_id();
 
     return 0;
 }

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -67,6 +67,7 @@ type OutputConfig struct {
 	RelativeTime   bool
 	ExecHash       bool
 	ParseArguments bool
+	EventsSorting  bool
 }
 
 type netProbe struct {
@@ -388,9 +389,11 @@ func New(cfg Config) (*Tracee, error) {
 		return nil, fmt.Errorf("error creating process tree: %v", err)
 	}
 
-	t.eventsSorter, err = sorting.InitEventSorter()
-	if err != nil {
-		return nil, err
+	if t.config.Output.EventsSorting {
+		t.eventsSorter, err = sorting.InitEventSorter()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return t, nil

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/bucketscache"
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/events/sorting"
 	"github.com/aquasecurity/tracee/pkg/external"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
@@ -175,6 +176,7 @@ type Tracee struct {
 	ngIfacesIndex     map[int]int
 	containers        *containers.Containers
 	processTree       *ProcessTree
+	eventsSorter      *sorting.EventsChronologicalSorter
 }
 
 type counter int32
@@ -385,6 +387,12 @@ func New(cfg Config) (*Tracee, error) {
 		t.Close()
 		return nil, fmt.Errorf("error creating process tree: %v", err)
 	}
+
+	t.eventsSorter, err = sorting.InitEventSorter()
+	if err != nil {
+		return nil, err
+	}
+
 	return t, nil
 }
 


### PR DESCRIPTION
Created a method to reorder events and passing them forward sorted by chronological order.
For more information about the issue, see #1113 .

## Algorithm
Events from the kernel are received one-by-one from the data channel.
We can rely on the fact that for each CPU, all the events received from it should be ordered by timestamps (except for syscalls which are not ordered because of the way we create the event in 2 steps).
So by adding to each event the source CPU, we can put it in its own CPU queue of events and get all the events to be almost ordered.

To avoid syscalls sorting problem, we can find the appropriate place to put the event in the queue from the end of it, and with maximum of 3 iterations we should find the matching place chronologically.

After we put all the events in queues according to the source CPU, we can extract each time the oldest first-in-queue event from all CPUs and send it forward.

To be able to promise that all events prior to oldest first-in-queue event arrived to other CPU's queues, we can use the fact that the CPUs' queues are ordered and be sure that if all queues sent events after given timestamp, all events prior to that timestamp have arrived. So, we can check for each CPU what is the most recent event it sent (for CPUs that sent new events). From those, we can check which one has the most ancient timestamp. Then, we can be sure that all events with older timestamps than that timestamp were received - and send them.

However, because of the other sorting problem cases (syscalls case and the vCPU case) we cannot send them right away, we need a time buffer. **This part is a bit complicated** - the vCPU case makes us wait at least 100ms to be sure that a vCPU didn't send a new event right after the previous (the other case is that it has no events to send). The syscalls case makes us wait about 3ms to be sure that there are no new events older than last event received in the CPU. Because the vCPU delayed event can be a syscall event (with older timestamp than the newest event in the CPU's queue), this make things event more complicated.
The solution to the 2 sorting problem cases is to wait at least 100ms until we send the events up to the decided timestamp. This way we can be sure that there won't be any new events received with older timestamp than the chosen one.

To summarize the algorithm - we have a CPU queue for each CPU. We insert new events to the matching CPU's queue, and follow which CPU was updated with new event. Each interval, we check from the most recent events from each CPU which has the oldest timestamp. After a delay of at least 100ms, we send all events from queues up to that timestamp in an ordered way. This way, we can be sure that all sent events are sorted.

## Concepts Used
### Queues
I implemented a queue structure myself for this PR, because I need an access to the internal queue to be able to insert new events not at the tail of the queue (in the case of syscalls events that are received in unsorted way).
### Pools
To reduce allocations and freeing amount, I introduced a Pool struct in this PR. The struct is used to make through it `alloc` and `free` of new event nodes which are used in the CPU queues. The pool save the freed nodes, and when `alloc` is required it return a saved free node if there is one saved, or alloc new one.
To avoid pooling large amount of nodes, the max pooled amount is the number of allocated nodes. If the number exceeds it, the Pool will free half of the amount pooled in it.