### PR TITLE
separate pcaps by process context

### DIFF
--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -345,7 +345,7 @@ err-file:/path/to/file                             write the errors to a specifi
 
 none                                               ignore stream of events output, usually used with --capture
 
-option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,per-process-pcaps}
+option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,per-process-pcaps,per-container-pcaps}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
   detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
@@ -353,6 +353,7 @@ option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,per-proc
   relative-time                                    use relative timestamp instead of wall timestamp for events
   exec-info                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
   per-process-pcaps								   when capturing network packets, save pcap per process
+  per-container-pcaps							   when capturing network packets, save pcap per container
 
 Examples:
   --output json                                            | output as json
@@ -408,13 +409,19 @@ func prepareOutput(outputSlice []string, containerMode bool) (tracee.OutputConfi
 			case "exec-info":
 				res.ExecInfo = true
 			case "per-process-pcaps":
-				res.SeparatePcap = true
+				res.PcapPerProcess = true
+			case "per-container-pcaps":
+				res.PcapPerContainer = true
 			default:
 				return res, nil, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}
 		default:
 			return res, nil, fmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
 		}
+	}
+
+	if res.PcapPerContainer && res.PcapPerProcess {
+		return res, nil, fmt.Errorf("invalid output flags: can't use both per-process-pcaps and per-container-pcaps output options")
 	}
 
 	outf := os.Stdout

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -345,13 +345,14 @@ err-file:/path/to/file                             write the errors to a specifi
 
 none                                               ignore stream of events output, usually used with --capture
 
-option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info}
+option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,per-process-pcaps}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
   detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
   relative-time                                    use relative timestamp instead of wall timestamp for events
   exec-info                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
+  per-process-pcaps								   when capturing network packets, save pcap per process
 
 Examples:
   --output json                                            | output as json
@@ -406,6 +407,8 @@ func prepareOutput(outputSlice []string, containerMode bool) (tracee.OutputConfi
 				res.RelativeTime = true
 			case "exec-info":
 				res.ExecInfo = true
+			case "per-process-pcaps":
+				res.SeparatePcap = true
 			default:
 				return res, nil, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -40,6 +40,7 @@ const (
 	configNewContFilter
 	configDebugNet
 	configProcTreeFilter
+	configCaptureNet
 )
 
 const (
@@ -193,6 +194,7 @@ const (
 	DebugNetUdpV6DestroySock
 	DebugNetInetSockSetState
 	DebugNetTcpConnect
+	NetProcessExec
 )
 
 // EventsIDToEvent is list of supported events, indexed by their ID

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -194,7 +194,7 @@ const (
 	DebugNetUdpV6DestroySock
 	DebugNetInetSockSetState
 	DebugNetTcpConnect
-	NetProcessExit
+	NetConnectionExit
 	NetContainerExit
 )
 

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -195,6 +195,7 @@ const (
 	DebugNetInetSockSetState
 	DebugNetTcpConnect
 	NetProcessExit
+	NetContainerExit
 )
 
 // EventsIDToEvent is list of supported events, indexed by their ID

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -194,7 +194,7 @@ const (
 	DebugNetUdpV6DestroySock
 	DebugNetInetSockSetState
 	DebugNetTcpConnect
-	NetProcessExec
+	NetProcessExit
 )
 
 // EventsIDToEvent is list of supported events, indexed by their ID

--- a/tracee-ebpf/tracee/events_processor.go
+++ b/tracee-ebpf/tracee/events_processor.go
@@ -1,6 +1,7 @@
 package tracee
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -147,7 +148,11 @@ func (t *Tracee) processEvent(ctx *context, args map[string]interface{}, argMeta
 				sourceFileCtime := sourceFileStat.Sys().(*syscall.Stat_t).Ctim.Nano()
 				capturedFileID := fmt.Sprintf("%d:%s", ctx.MntID, sourceFilePath)
 				if t.config.Capture.Exec {
-					destinationDirPath := filepath.Join(t.config.Capture.OutputPath, strconv.Itoa(int(ctx.MntID)))
+					contId := string(bytes.TrimRight(ctx.ContID[:], "\x00"))
+					if contId == "" {
+						contId = "host"
+					}
+					destinationDirPath := filepath.Join(t.config.Capture.OutputPath, contId)
 					if err := os.MkdirAll(destinationDirPath, 0755); err != nil {
 						return err
 					}

--- a/tracee-ebpf/tracee/net_events.go
+++ b/tracee-ebpf/tracee/net_events.go
@@ -43,7 +43,11 @@ func (t *Tracee) getPcapFilePath(pcapContext processPcapId) string {
 	if t.config.Output.PcapPerProcess {
 		pcapFileName = fmt.Sprintf("%s_%d_%d.pcap", pcapContext.comm, pcapContext.hostPid, pcapContext.procStartTime)
 	} else if t.config.Output.PcapPerContainer {
-		pcapFileName = fmt.Sprintf("%s.pcap", pcapContext.contID)
+		if pcapContext.contID == "" {
+			pcapFileName = "host.pcap"
+		} else {
+			pcapFileName = fmt.Sprintf("%s.pcap", pcapContext.contID)
+		}
 	} else {
 		pcapFileName = "dump.pcap"
 	}

--- a/tracee-ebpf/tracee/net_events.go
+++ b/tracee-ebpf/tracee/net_events.go
@@ -120,6 +120,19 @@ func (t *Tracee) netExit(pcapContext processPcapId, timeStamp time.Time) {
 	}
 }
 
+func (t *Tracee) getPacketContext(hostTid uint32, comm string, containerId string) processPcapId {
+	var packetContext processPcapId
+	if t.config.Output.PcapPerProcess {
+		packetContext = processPcapId{hostTid: hostTid, comm: comm}
+	} else if t.config.Output.PcapPerContainer {
+		packetContext = processPcapId{contID: containerId}
+	} else {
+		packetContext = processPcapId{comm: "dump.pcap"}
+	}
+
+	return packetContext
+}
+
 func (t *Tracee) processNetEvents() {
 	// Todo: add stats for network packets (in epilog)
 	for {
@@ -140,7 +153,7 @@ func (t *Tracee) processNetEvents() {
 			// timeStamp is nanoseconds since system boot time
 			timeStampObj := time.Unix(0, int64(timeStamp+t.bootTime))
 
-			packetContext := processPcapId{hostTid: hostTid, comm: comm, contID: containerId}
+			packetContext := t.getPacketContext(hostTid, comm, containerId)
 
 			if netEventId == NetPacket {
 				var pktLen uint32

--- a/tracee-ebpf/tracee/net_events.go
+++ b/tracee-ebpf/tracee/net_events.go
@@ -31,7 +31,7 @@ func (t *Tracee) getPcapFilePathWithTime(pcapContext processPcapId, timeStampObj
 	if t.config.Output.PcapPerProcess {
 		pcapFileName = fmt.Sprintf("%s_%d_%d.pcap", pcapContext.comm, pcapContext.hostPid, pcapContext.procStartTime)
 	} else if t.config.Output.PcapPerContainer {
-		pcapFileName = fmt.Sprintf("%s_%d.pcap", pcapContext.contID, timeStampObj.Unix())
+		pcapFileName = fmt.Sprintf("%s.pcap", pcapContext.contID)
 	} else {
 		pcapFileName = "dump.pcap"
 	}

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -346,13 +346,18 @@ struct bpf_map_def SEC("maps") _name = { \
 /*=============================== INTERNAL STRUCTS ===========================*/
 
 typedef struct process_context {
-    u32 tid;                    // TID as in the userspace term
-    u32 host_tid;               // TID in host pid namespace
+    u32 pid;
+    u32 tid;
+    u32 ppid;
+    u32 host_pid;
+    u32 host_tid;
+    u32 host_ppid;
     u32 uid;
     u32 mnt_id;
     u32 pid_id;
     char comm[TASK_COMM_LEN];
-    char cont_id[CONT_ID_PADDED];           // Container ID, padding to 16 to keep the context struct aligned
+    char uts_name[TASK_COMM_LEN];
+    char cont_id[CONT_ID_PADDED];
 } process_context_t;
 
 typedef struct event_context {
@@ -1031,12 +1036,17 @@ static __always_inline int init_event_data(event_data_t *data, void *ctx)
 static __always_inline int proc_ctx_from_context_t(process_context_t *proc_ctx, context_t *context)
 {
     proc_ctx->host_tid = context->host_tid;
-//    proc_ctx->tid = context->tid;
+    proc_ctx->tid = context->tid;
+    proc_ctx->pid = context->pid;
+    proc_ctx->ppid = context->ppid;
+    proc_ctx->host_pid = context->host_pid;
+    proc_ctx->host_ppid = context->host_ppid;
     proc_ctx->mnt_id = context->mnt_id;
     proc_ctx->pid_id = context->pid_id;
     proc_ctx->uid = context->uid;
     __builtin_memcpy(proc_ctx->comm, context->comm, TASK_COMM_LEN);
     __builtin_memcpy(proc_ctx->cont_id, context->cont_id, CONT_ID_PADDED);
+    __builtin_memcpy(proc_ctx->uts_name, context->uts_name, TASK_COMM_LEN);
 
     return 0;
 }

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -58,12 +58,13 @@ type CaptureConfig struct {
 }
 
 type OutputConfig struct {
-	StackAddresses bool
-	DetectSyscall  bool
-	ExecEnv        bool
-	RelativeTime   bool
-	ExecInfo       bool
-	SeparatePcap   bool
+	StackAddresses   bool
+	DetectSyscall    bool
+	ExecEnv          bool
+	RelativeTime     bool
+	ExecInfo         bool
+	PcapPerProcess   bool
+	PcapPerContainer bool
 }
 
 type netProbe struct {

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -63,6 +63,7 @@ type OutputConfig struct {
 	ExecEnv        bool
 	RelativeTime   bool
 	ExecInfo       bool
+	SeparatePcap   bool
 }
 
 type netProbe struct {

--- a/tracee-ebpf/tracee/write_capture.go
+++ b/tracee-ebpf/tracee/write_capture.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"os"
 	"path"
-	"strconv"
 )
 
 func (t *Tracee) processFileWrites() {
 	type chunkMeta struct {
 		BinType  binType
 		MntID    uint32
+		ContID   [16]byte
 		Metadata [20]byte
 		Size     int32
 		Off      uint64
@@ -66,7 +66,12 @@ func (t *Tracee) processFileWrites() {
 				continue
 			}
 
-			pathname := path.Join(t.config.Capture.OutputPath, strconv.Itoa(int(meta.MntID)))
+			containerIdDir := "host"
+			s := string(bytes.TrimRight(meta.ContID[:], "\x00"))
+			if s != "" {
+				containerIdDir = s
+			}
+			pathname := path.Join(t.config.Capture.OutputPath, containerIdDir)
 			if err := os.MkdirAll(pathname, 0755); err != nil {
 				t.handleError(err)
 				continue


### PR DESCRIPTION
the purpose of this PR is to save a separate pcap for each process on the host.

we distinguish processes by their PID.
but as we all know - PIDs can be reassigned to new processes. this behavior would cause us to save different processes packets in the same pcap file. to overcome this problem, ideally, we would use the SCHED_PROCESS_EXIT event to close the pcap file and rename it with unique info (such as the timestamp of the SCHED_PROCESS_EXIT event) - so no more packets will be written to this pcap file.
after trying this method on my machine, i have noticed that in some cases we get the SCHED_PROCESS_EXIT event, and then we get some more packets from this process.
therefore I've decided to use the SCHED_PROCESS_EXEC event - when we receive this event for a PID we already have pcap for, we can rename the old pcap and avoid the problem described above.
this is not ideal as the pcapWriters are stored in memory and are never deleted (only deleted when SCHED_PROCESS_EXEC event for PID we already have pcap for, but then we create a new pcapWriter)

a better approach might be to tap into another tracepoint, one that is ensured that no packets will be sent/reveived after it.
i tried tracepoint:sched_process_free and kprobe:do_task_dead - both are not ensuring no packets will be sent/reveived after them.

meanwhile, i'm creating this PR as draft. 
if anyone has any insight about this i would love to hear.

also - 
do you think we should save separate pcaps only on user request (via a flag)?
or maybe we should keep a copy of the entire pcap of the host on top of the separated pcaps?


thanks,
Roi.

