### PR TITLE
init_module capture

### DIFF
--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -90,7 +90,6 @@ const (
 	sendVfsWrite binType = iota + 1
 	sendMprotect
 	sendKernelModule
-	sendBufferModule
 )
 
 // argType is an enum that encodes the argument types that the BPF program may write to the shared buffer

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -79,7 +79,7 @@ const (
 	tailVfsWrite uint32 = iota
 	tailVfsWritev
 	tailSendBin
-	tailSendBinSyscall
+	tailSendBinTP
 )
 
 // binType is an enum that specifies the type of binary data sent in the file perf map

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -79,6 +79,7 @@ const (
 	tailVfsWrite uint32 = iota
 	tailVfsWritev
 	tailSendBin
+	tailSendBinSyscall
 )
 
 // binType is an enum that specifies the type of binary data sent in the file perf map
@@ -89,6 +90,7 @@ const (
 	sendVfsWrite binType = iota + 1
 	sendMprotect
 	sendKernelModule
+	sendBufferModule
 )
 
 // argType is an enum that encodes the argument types that the BPF program may write to the shared buffer

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -108,6 +108,7 @@ Copyright (C) Aqua Security inc.
 #define SEND_VFS_WRITE      1
 #define SEND_MPROTECT       2
 #define SEND_KERNEL_MODULE  3
+#define SEND_BUFFER_MODULE  4
 #define SEND_META_SIZE      24
 
 #define ALERT_MMAP_W_X      1
@@ -115,10 +116,11 @@ Copyright (C) Aqua Security inc.
 #define ALERT_MPROT_W_ADD   3
 #define ALERT_MPROT_W_REM   4
 
-#define TAIL_VFS_WRITE      0
-#define TAIL_VFS_WRITEV     1
-#define TAIL_SEND_BIN       2
-#define MAX_TAIL_CALL       3
+#define TAIL_VFS_WRITE         0
+#define TAIL_VFS_WRITEV        1
+#define TAIL_SEND_BIN          2
+#define TAIL_SEND_BIN_SYSCALL  3
+#define MAX_TAIL_CALL          4
 
 #define NONE_T        0UL
 #define INT_T         1UL
@@ -549,6 +551,7 @@ BPF_ARRAY(string_store, path_filter_t, 1);              // Store strings from us
 BPF_PERCPU_ARRAY(bufs, buf_t, MAX_BUFFERS);             // Percpu global buffer variables
 BPF_PERCPU_ARRAY(bufs_off, u32, MAX_BUFFERS);           // Holds offsets to bufs respectively
 BPF_PROG_ARRAY(prog_array, MAX_TAIL_CALL);              // Used to store programs for tail calls
+BPF_PROG_ARRAY(prog_array_syscall, MAX_TAIL_CALL);      // Used to store programs for tail calls
 BPF_PROG_ARRAY(sys_enter_tails, MAX_EVENT_ID);          // Used to store programs for tail calls
 BPF_PROG_ARRAY(sys_exit_tails, MAX_EVENT_ID);           // Used to store programs for tail calls
 BPF_STACK_TRACE(stack_addresses, MAX_STACK_ADDRESSES);  // Used to store stack traces
@@ -966,6 +969,7 @@ static __always_inline struct sockaddr_un get_unix_sock_addr(struct unix_sock *s
     }
     return sockaddr;
 }
+
 
 /*============================== HELPER FUNCTIONS ==============================*/
 
@@ -3298,8 +3302,7 @@ int BPF_KPROBE(trace_tcp_connect)
     return net_map_update_or_delete_sock(ctx, DEBUG_NET_TCP_CONNECT, sk, data.context.host_tid);
 }
 
-SEC("kprobe/send_bin")
-int BPF_KPROBE(send_bin)
+static __always_inline u32 send_bin_helper(void* ctx, struct bpf_map_def *prog_array, int tail_call)
 {
     // Note: sending the data to the userspace have the following constraints:
     // 1. We need a buffer that we know it's exact size (so we can send chunks of known sizes in BPF)
@@ -3325,7 +3328,7 @@ int BPF_KPROBE(send_bin)
             bpf_probe_read(&io_vec, sizeof(struct iovec), &bin_args->vec[bin_args->iov_idx]);
             bin_args->ptr = io_vec.iov_base;
             bin_args->full_size = io_vec.iov_len;
-            bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
+            bpf_tail_call(ctx, prog_array, tail_call);
         }
         bpf_map_delete_elem(&bin_args_map, &id);
         return 0;
@@ -3383,7 +3386,7 @@ int BPF_KPROBE(send_bin)
     if (chunk_size > F_CHUNK_SIZE) {
         // Handle the rest of write recursively
         bin_args->full_size = chunk_size;
-        bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
+        bpf_tail_call(ctx, prog_array, tail_call);
         bpf_map_delete_elem(&bin_args_map, &id);
         return 0;
     }
@@ -3408,12 +3411,25 @@ int BPF_KPROBE(send_bin)
         bpf_probe_read(&io_vec, sizeof(struct iovec), &bin_args->vec[bin_args->iov_idx]);
         bin_args->ptr = io_vec.iov_base;
         bin_args->full_size = io_vec.iov_len;
-        bpf_tail_call(ctx, &prog_array, TAIL_SEND_BIN);
+        bpf_tail_call(ctx, prog_array, tail_call);
     }
 
     bpf_map_delete_elem(&bin_args_map, &id);
     return 0;
 }
+
+SEC("kprobe/send_bin")
+int BPF_KPROBE(send_bin)
+{
+    return send_bin_helper(ctx, &prog_array, TAIL_SEND_BIN);
+}
+
+SEC("raw_tracepoint/send_bin_syscall")
+int send_bin_syscall(void* ctx)
+{
+    return send_bin_helper(ctx, &prog_array_syscall, TAIL_SEND_BIN_SYSCALL);
+}
+
 
 static __always_inline int do_vfs_write_writev(struct pt_regs *ctx, u32 event_id, u32 tail_call_id)
 {
@@ -3754,6 +3770,38 @@ int BPF_KPROBE(trace_mprotect_alert)
         }
     }
 
+    return 0;
+}
+
+SEC("raw_tracepoint/sys_init_module")
+int syscall__init_module(void *ctx)
+{
+    event_data_t data = {};
+    if (!init_event_data(&data, ctx))
+        return 0;
+
+    syscall_data_t *sys = bpf_map_lookup_elem(&syscall_data_map, &data.context.host_tid);
+    if (!sys)
+        return -1;
+
+    bin_args_t bin_args = {};
+
+    u32 pid = data.context.host_pid;
+    void *addr = (void*)sys->args.args[0];
+    unsigned long len = (unsigned int)sys->args.args[1];
+
+    if (get_config(CONFIG_CAPTURE_MODULES)) {
+        bin_args.type = SEND_BUFFER_MODULE;
+        bpf_probe_read(bin_args.metadata, 4, &pid);
+        bpf_probe_read(&bin_args.metadata[4], sizeof(unsigned long), &len);
+        bin_args.ptr = (char *)addr;
+        bin_args.start_off = 0;
+        bin_args.full_size = (unsigned long)len;
+
+        u64 id = bpf_get_current_pid_tgid();
+        bpf_map_update_elem(&bin_args_map, &id, &bin_args, BPF_ANY);
+        bpf_tail_call(ctx, &prog_array_syscall, TAIL_SEND_BIN_SYSCALL);
+    }
     return 0;
 }
 

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -3785,15 +3785,14 @@ int syscall__init_module(void *ctx)
     bin_args_t bin_args = {};
 
     u32 pid = data.context.host_pid;
-    u32 dev = 0;
-    u64 inode = 0;
+    u64 dummy = 0;
     void *addr = (void*)sys->args.args[0];
     unsigned long len = (unsigned long)sys->args.args[1];
 
     if (get_config(CONFIG_CAPTURE_MODULES)) {
         bin_args.type = SEND_KERNEL_MODULE;
-        bpf_probe_read(bin_args.metadata, 4, &dev);
-        bpf_probe_read(&bin_args.metadata[4], 8, &inode);
+        bpf_probe_read(bin_args.metadata, 4, &dummy);
+        bpf_probe_read(&bin_args.metadata[4], 8, &dummy);
         bpf_probe_read(&bin_args.metadata[12], 4, &pid);
         bpf_probe_read(&bin_args.metadata[16], 8, &len);
         bin_args.ptr = (char *)addr;

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -588,7 +588,7 @@ func (t *Tracee) populateBPFMaps() error {
 	errs = append(errs, t.initTailCall(tailVfsWrite, "prog_array", "trace_ret_vfs_write_tail"))
 	errs = append(errs, t.initTailCall(tailVfsWritev, "prog_array", "trace_ret_vfs_writev_tail"))
 	errs = append(errs, t.initTailCall(tailSendBin, "prog_array", "send_bin"))
-	errs = append(errs, t.initTailCall(tailSendBinSyscall, "prog_array_syscall", "send_bin_syscall"))
+	errs = append(errs, t.initTailCall(tailSendBinTP, "prog_array_tp", "send_bin_tp"))
 	for _, e := range errs {
 		if e != nil {
 			return e

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -233,6 +233,7 @@ func New(cfg Config) (*Tracee, error) {
 	}
 	if cfg.Capture.Module {
 		setEssential(SecurityPostReadFileEventID)
+		setEssential(InitModuleEventID)
 	}
 	if cfg.Capture.Mem {
 		setEssential(MmapEventID)
@@ -587,6 +588,7 @@ func (t *Tracee) populateBPFMaps() error {
 	errs = append(errs, t.initTailCall(tailVfsWrite, "prog_array", "trace_ret_vfs_write_tail"))
 	errs = append(errs, t.initTailCall(tailVfsWritev, "prog_array", "trace_ret_vfs_writev_tail"))
 	errs = append(errs, t.initTailCall(tailSendBin, "prog_array", "send_bin"))
+	errs = append(errs, t.initTailCall(tailSendBinSyscall, "prog_array_syscall", "send_bin_syscall"))
 	for _, e := range errs {
 		if e != nil {
 			return e
@@ -656,7 +658,7 @@ func (t *Tracee) populateBPFMaps() error {
 		}
 
 		// some functions require tail call on syscall enter/exit as they perform extra work
-		if e == ExecveEventID || e == ExecveatEventID {
+		if e == ExecveEventID || e == ExecveatEventID || e == InitModuleEventID {
 			event, ok := EventsIDToEvent[e]
 			if !ok {
 				continue

--- a/tracee-ebpf/tracee/write_capture.go
+++ b/tracee-ebpf/tracee/write_capture.go
@@ -33,6 +33,11 @@ func (t *Tracee) processFileWrites() {
 		Size  uint64
 	}
 
+	type bufferModuleMeta struct {
+		Pid  uint32
+		Size uint64
+	}
+
 	type mprotectWriteMeta struct {
 		Ts uint64
 	}
@@ -81,6 +86,7 @@ func (t *Tracee) processFileWrites() {
 			filename := ""
 			metaBuff := bytes.NewBuffer(meta.Metadata[:])
 			var kernelModuleMeta kernelModuleMeta
+			var bufferModuleMeta bufferModuleMeta
 			if meta.BinType == sendVfsWrite {
 				var vfsMeta vfsWriteMeta
 				err = binary.Read(metaBuff, binary.LittleEndian, &vfsMeta)
@@ -115,6 +121,17 @@ func (t *Tracee) processFileWrites() {
 					filename = fmt.Sprintf("module.dev-%d.inode-%d", kernelModuleMeta.DevID, kernelModuleMeta.Inode)
 				} else {
 					filename = fmt.Sprintf("module.dev-%d.inode-%d.pid-%d", kernelModuleMeta.DevID, kernelModuleMeta.Inode, kernelModuleMeta.Pid)
+				}
+			} else if meta.BinType == sendBufferModule {
+				err = binary.Read(metaBuff, binary.LittleEndian, &bufferModuleMeta)
+				if err != nil {
+					t.handleError(err)
+					continue
+				}
+				if bufferModuleMeta.Pid == 0 {
+					filename = "module"
+				} else {
+					filename = fmt.Sprintf("module.pid-%d", bufferModuleMeta.Pid)
 				}
 			} else {
 				t.handleError(fmt.Errorf("error in file writer: unknown binary type: %d", meta.BinType))
@@ -158,8 +175,14 @@ func (t *Tracee) processFileWrites() {
 				continue
 			}
 			// Rename the file to add hash when last chunk was received
-			if meta.BinType == sendKernelModule {
-				if uint64(meta.Size)+meta.Off == kernelModuleMeta.Size {
+			if meta.BinType == sendKernelModule || meta.BinType == sendBufferModule {
+				var moduleSize uint64
+				if meta.BinType == sendKernelModule {
+					moduleSize = kernelModuleMeta.Size
+				} else {
+					moduleSize = bufferModuleMeta.Size
+				}
+				if uint64(meta.Size)+meta.Off == moduleSize {
 					fileHash := getFileHash(fullname)
 					os.Rename(fullname, fullname+"."+fileHash)
 				}


### PR DESCRIPTION
Add init_module capture.
Split `send_bin` to helper and calling tail bpf programs for `raw_tracepoint` and `kprobe`.

The split was needed because a tail call cannot be called to a different type bpf program.