### PR TITLE
Add option for raw arguments from various event flags

### DIFF
--- a/docs/tracee-ebpf/output.md
+++ b/docs/tracee-ebpf/output.md
@@ -10,13 +10,13 @@ CLI Option | Description
 `none` | ignore stream of events output, usually used with `--capture`
 `out-file:/path/to/file` | write the output to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (default: stdout)
 `err-file:/path/to/file` | write the errors to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (default: stderr)
-`option:{stack-addresses,detect-syscall,exec-env,exec-info,relative-time,raw-arguments}` | augment output according to given options (default: none)
+`option:{stack-addresses,detect-syscall,exec-env,exec-info,relative-time,parse-arguments}` | augment output according to given options (default: none)
   stack-addresses | include stack memory addresses for each event
   detect-syscall | when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env | when tracing execve/execveat, show the environment variables that were used for execution
 exec-info | when tracing sched_process_exec, show the file hash(sha256) and ctime
 relative-time | use relative timestamp instead of wall timestamp for events
-raw-arguments | do not show raw machine-readable values for event arguments, instead parse into human readable strings
+parse-arguments | do not show raw machine-readable values for event arguments, instead parse into human readable strings
 
 
 

--- a/docs/tracee-ebpf/output.md
+++ b/docs/tracee-ebpf/output.md
@@ -10,12 +10,14 @@ CLI Option | Description
 `none` | ignore stream of events output, usually used with `--capture`
 `out-file:/path/to/file` | write the output to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (default: stdout)
 `err-file:/path/to/file` | write the errors to a specified file. the path to the file will be created if not existing and the file will be deleted if existing (default: stderr)
-`option:{stack-addresses,detect-syscall,exec-env,exec-info,relative-time}` | augment output according to given options (default: none)
+`option:{stack-addresses,detect-syscall,exec-env,exec-info,relative-time,raw-arguments}` | augment output according to given options (default: none)
   stack-addresses | include stack memory addresses for each event
   detect-syscall | when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env | when tracing execve/execveat, show the environment variables that were used for execution
 exec-info | when tracing sched_process_exec, show the file hash(sha256) and ctime
 relative-time | use relative timestamp instead of wall timestamp for events
+raw-arguments | show raw values for event arguments that are otherwise parsed into strings, such as clone(2) flags
+
 
 
 (Use this flag multiple times to choose multiple capture options)

--- a/docs/tracee-ebpf/output.md
+++ b/docs/tracee-ebpf/output.md
@@ -16,7 +16,7 @@ CLI Option | Description
   exec-env | when tracing execve/execveat, show the environment variables that were used for execution
 exec-info | when tracing sched_process_exec, show the file hash(sha256) and ctime
 relative-time | use relative timestamp instead of wall timestamp for events
-raw-arguments | show raw values for event arguments that are otherwise parsed into strings, such as clone(2) flags
+raw-arguments | do not show raw machine-readable values for event arguments, instead parse into human readable strings
 
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,4 +27,4 @@ done
 
 # start, and pass all remaining flags to tracee-rules
 EVENTS=$($TRACEE_RULES_EXE --list-events)
-$TRACEE_EBPF_EXE --output=format:gob --trace event=$EVENTS,mem_prot_alert | $TRACEE_RULES_EXE --input-tracee=file:stdin --input-tracee=format:gob $@
+$TRACEE_EBPF_EXE --output=format:gob --output=option:parse-arguments --trace event=$EVENTS,mem_prot_alert | $TRACEE_RULES_EXE --input-tracee=file:stdin --input-tracee=format:gob $@

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -335,13 +335,14 @@ err-file:/path/to/file                             write the errors to a specifi
 
 none                                               ignore stream of events output, usually used with --capture
 
-option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info}
+option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,raw-arguments}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
   detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
   relative-time                                    use relative timestamp instead of wall timestamp for events
   exec-info                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
+  raw-arguments                                    show raw values for event arguments that are otherwise parsed into strings, such as clone(2) flags
 
 Examples:
   --output json                                            | output as json
@@ -396,6 +397,8 @@ func prepareOutput(outputSlice []string, containerMode bool) (tracee.OutputConfi
 				res.RelativeTime = true
 			case "exec-info":
 				res.ExecInfo = true
+			case "raw-arguments":
+				res.RawArguments = true
 			default:
 				return res, nil, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -335,14 +335,14 @@ err-file:/path/to/file                             write the errors to a specifi
 
 none                                               ignore stream of events output, usually used with --capture
 
-option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,raw-arguments}
+option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-info,parse-arguments}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
   detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
   relative-time                                    use relative timestamp instead of wall timestamp for events
   exec-info                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
-  raw-arguments                                    show raw values for event arguments that are otherwise parsed into strings, such as clone(2) flags
+  parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
 
 Examples:
   --output json                                            | output as json
@@ -397,14 +397,19 @@ func prepareOutput(outputSlice []string, containerMode bool) (tracee.OutputConfi
 				res.RelativeTime = true
 			case "exec-info":
 				res.ExecInfo = true
-			case "raw-arguments":
-				res.RawArguments = true
+			case "parse-arguments":
+				res.ParseArguments = true
 			default:
 				return res, nil, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}
 		default:
 			return res, nil, fmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
 		}
+	}
+
+	if printerKind == "table" ||
+		true { // XXX: Remove this line once tracee-rules signatures have been updated to take raw args by default into account (see #1123, libbpfgo#88)
+		res.ParseArguments = true
 	}
 
 	outf := os.Stdout

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -361,6 +361,7 @@ func prepareOutput(outputSlice []string, containerMode bool) (tracee.OutputConfi
 	outPath := ""
 	errPath := ""
 	var err error
+
 	for _, o := range outputSlice {
 		outputParts := strings.SplitN(o, ":", 2)
 		numParts := len(outputParts)
@@ -407,8 +408,7 @@ func prepareOutput(outputSlice []string, containerMode bool) (tracee.OutputConfi
 		}
 	}
 
-	if printerKind == "table" ||
-		true { // XXX: Remove this line once tracee-rules signatures have been updated to take raw args by default into account (see #1123, libbpfgo#88)
+	if printerKind == "table" {
 		res.ParseArguments = true
 	}
 

--- a/tracee-ebpf/main_test.go
+++ b/tracee-ebpf/main_test.go
@@ -1258,6 +1258,7 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:stack-addresses"},
 			expectedOutput: tracee.OutputConfig{
 				StackAddresses: true,
+				ParseArguments: true,
 			},
 			expectedError: nil,
 		},
@@ -1265,7 +1266,8 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "option detect-syscall",
 			outputSlice: []string{"option:detect-syscall"},
 			expectedOutput: tracee.OutputConfig{
-				DetectSyscall: true,
+				DetectSyscall:  true,
+				ParseArguments: true,
 			},
 			expectedError: nil,
 		},
@@ -1273,7 +1275,8 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "option exec-env",
 			outputSlice: []string{"option:exec-env"},
 			expectedOutput: tracee.OutputConfig{
-				ExecEnv: true,
+				ExecEnv:        true,
+				ParseArguments: true,
 			},
 			expectedError: nil,
 		},
@@ -1281,7 +1284,8 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "option exec-info",
 			outputSlice: []string{"option:exec-info"},
 			expectedOutput: tracee.OutputConfig{
-				ExecInfo: true,
+				ExecInfo:       true,
+				ParseArguments: true,
 			},
 			expectedError: nil,
 		},
@@ -1293,6 +1297,7 @@ func TestPrepareOutput(t *testing.T) {
 				DetectSyscall:  true,
 				ExecEnv:        true,
 				ExecInfo:       true,
+				ParseArguments: true,
 			},
 			expectedError: nil,
 		},

--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -57,7 +57,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 	switch ctx.EventID {
 	case SysEnterEventID, SysExitEventID, CapCapableEventID, CommitCredsEventID, SecurityFileOpenEventID:
 		//show syscall name instead of id
-		if id, isInt32 := args["syscall"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if id, isInt32 := args["syscall"].(int32); isInt32 && t.config.Output.ParseArguments {
 			if event, isKnown := EventsIDToEvent[id]; isKnown {
 				if event.Probes[0].attach == sysCall {
 					args["syscall"] = event.Probes[0].event
@@ -65,39 +65,39 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			}
 		}
 		if ctx.EventID == CapCapableEventID {
-			if capability, isInt32 := args["cap"].(int32); isInt32 && !t.config.Output.RawArguments {
+			if capability, isInt32 := args["cap"].(int32); isInt32 && t.config.Output.ParseArguments {
 				args["cap"] = helpers.ParseCapability(capability)
 			}
 		}
 		if ctx.EventID == SecurityFileOpenEventID {
-			if flags, isInt32 := args["flags"].(int32); isInt32 && !t.config.Output.RawArguments {
+			if flags, isInt32 := args["flags"].(int32); isInt32 && t.config.Output.ParseArguments {
 				args["flags"] = helpers.ParseOpenFlags(uint32(flags))
 			}
 		}
 	case MmapEventID, MprotectEventID, PkeyMprotectEventID:
-		if prot, isInt32 := args["prot"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if prot, isInt32 := args["prot"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["prot"] = helpers.ParseMemProt(uint32(prot))
 		}
 	case PtraceEventID:
-		if req, isInt64 := args["request"].(int64); isInt64 && !t.config.Output.RawArguments {
+		if req, isInt64 := args["request"].(int64); isInt64 && t.config.Output.ParseArguments {
 			args["request"] = helpers.ParsePtraceRequest(req)
 		}
 	case PrctlEventID:
-		if opt, isInt32 := args["option"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if opt, isInt32 := args["option"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["option"] = helpers.ParsePrctlOption(opt)
 		}
 	case SocketEventID:
-		if dom, isInt32 := args["domain"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if dom, isInt32 := args["domain"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["domain"] = helpers.ParseSocketDomain(uint32(dom))
 		}
-		if typ, isInt32 := args["type"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if typ, isInt32 := args["type"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["type"] = helpers.ParseSocketType(uint32(typ))
 		}
 	case SecuritySocketCreateEventID:
-		if dom, isInt32 := args["family"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if dom, isInt32 := args["family"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["family"] = helpers.ParseSocketDomain(uint32(dom))
 		}
-		if typ, isInt32 := args["type"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if typ, isInt32 := args["type"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["type"] = helpers.ParseSocketType(uint32(typ))
 		}
 	case ConnectEventID, AcceptEventID, Accept4EventID, BindEventID, GetsocknameEventID:
@@ -131,23 +131,23 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args["remote_addr"] = s
 		}
 	case AccessEventID, FaccessatEventID:
-		if mode, isInt32 := args["mode"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if mode, isInt32 := args["mode"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["mode"] = helpers.ParseAccessMode(uint32(mode))
 		}
 	case ExecveatEventID:
-		if flags, isInt32 := args["flags"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if flags, isInt32 := args["flags"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["flags"] = helpers.ParseExecFlags(uint32(flags))
 		}
 	case OpenEventID, OpenatEventID:
-		if flags, isInt32 := args["flags"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if flags, isInt32 := args["flags"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["flags"] = helpers.ParseOpenFlags(uint32(flags))
 		}
 	case MknodEventID, MknodatEventID, ChmodEventID, FchmodEventID, FchmodatEventID:
-		if mode, isUint32 := args["mode"].(uint32); isUint32 && !t.config.Output.RawArguments {
+		if mode, isUint32 := args["mode"].(uint32); isUint32 && t.config.Output.ParseArguments {
 			args["mode"] = helpers.ParseInodeMode(mode)
 		}
 	case SecurityInodeMknodEventID:
-		if mode, isUint16 := args["mode"].(uint16); isUint16 && !t.config.Output.RawArguments {
+		if mode, isUint16 := args["mode"].(uint16); isUint16 && t.config.Output.ParseArguments {
 			args["mode"] = helpers.ParseInodeMode(uint32(mode))
 		}
 	case MemProtAlertEventID:
@@ -155,7 +155,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args["alert"] = PrintAlert(alert)
 		}
 	case CloneEventID:
-		if flags, isUint64 := args["flags"].(uint64); isUint64 && !t.config.Output.RawArguments {
+		if flags, isUint64 := args["flags"].(uint64); isUint64 && t.config.Output.ParseArguments {
 			args["flags"] = helpers.ParseCloneFlags(flags)
 		}
 	case SendtoEventID, RecvfromEventID:
@@ -163,7 +163,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 		if ctx.EventID == RecvfromEventID {
 			addrType = "src_addr"
 		}
-		if sockAddr, isStrMap := args[addrType].(map[string]string); isStrMap {
+		if sockAddr, isStrMap := args[addrType].(map[string]string); isStrMap && t.config.Output.ParseArguments {
 			var s string
 			for key, val := range sockAddr {
 				s += fmt.Sprintf("'%s': '%s',", key, val)
@@ -173,11 +173,11 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args[addrType] = s
 		}
 	case BpfEventID, SecurityBPFEventID:
-		if cmd, isInt32 := args["cmd"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if cmd, isInt32 := args["cmd"].(int32); isInt32 && t.config.Output.ParseArguments {
 			args["cmd"] = helpers.ParseBPFCmd(cmd)
 		}
 	case SecurityKernelReadFileEventID, SecurityPostReadFileEventID:
-		if readFileId, isInt32 := args["type"].(int32); isInt32 && !t.config.Output.RawArguments {
+		if readFileId, isInt32 := args["type"].(int32); isInt32 && t.config.Output.ParseArguments {
 			typeIdStr, err := ParseKernelReadFileId(readFileId)
 			if err == nil {
 				args["type"] = typeIdStr

--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -54,52 +54,8 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args[key] = fmt.Sprintf("0x%X", ptr)
 		}
 	}
+
 	switch ctx.EventID {
-	case SysEnterEventID, SysExitEventID, CapCapableEventID, CommitCredsEventID, SecurityFileOpenEventID:
-		//show syscall name instead of id
-		if id, isInt32 := args["syscall"].(int32); isInt32 && t.config.Output.ParseArguments {
-			if event, isKnown := EventsIDToEvent[id]; isKnown {
-				if event.Probes[0].attach == sysCall {
-					args["syscall"] = event.Probes[0].event
-				}
-			}
-		}
-		if ctx.EventID == CapCapableEventID {
-			if capability, isInt32 := args["cap"].(int32); isInt32 && t.config.Output.ParseArguments {
-				args["cap"] = helpers.ParseCapability(capability)
-			}
-		}
-		if ctx.EventID == SecurityFileOpenEventID {
-			if flags, isInt32 := args["flags"].(int32); isInt32 && t.config.Output.ParseArguments {
-				args["flags"] = helpers.ParseOpenFlags(uint32(flags))
-			}
-		}
-	case MmapEventID, MprotectEventID, PkeyMprotectEventID:
-		if prot, isInt32 := args["prot"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["prot"] = helpers.ParseMemProt(uint32(prot))
-		}
-	case PtraceEventID:
-		if req, isInt64 := args["request"].(int64); isInt64 && t.config.Output.ParseArguments {
-			args["request"] = helpers.ParsePtraceRequest(req)
-		}
-	case PrctlEventID:
-		if opt, isInt32 := args["option"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["option"] = helpers.ParsePrctlOption(opt)
-		}
-	case SocketEventID:
-		if dom, isInt32 := args["domain"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["domain"] = helpers.ParseSocketDomain(uint32(dom))
-		}
-		if typ, isInt32 := args["type"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["type"] = helpers.ParseSocketType(uint32(typ))
-		}
-	case SecuritySocketCreateEventID:
-		if dom, isInt32 := args["family"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["family"] = helpers.ParseSocketDomain(uint32(dom))
-		}
-		if typ, isInt32 := args["type"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["type"] = helpers.ParseSocketType(uint32(typ))
-		}
 	case ConnectEventID, AcceptEventID, Accept4EventID, BindEventID, GetsocknameEventID:
 		if sockAddr, isStrMap := args["addr"].(map[string]string); isStrMap {
 			var s string
@@ -130,32 +86,84 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			s = fmt.Sprintf("{%s}", s)
 			args["remote_addr"] = s
 		}
-	case AccessEventID, FaccessatEventID:
-		if mode, isInt32 := args["mode"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["mode"] = helpers.ParseAccessMode(uint32(mode))
-		}
-	case ExecveatEventID:
-		if flags, isInt32 := args["flags"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["flags"] = helpers.ParseExecFlags(uint32(flags))
-		}
-	case OpenEventID, OpenatEventID:
-		if flags, isInt32 := args["flags"].(int32); isInt32 && t.config.Output.ParseArguments {
-			args["flags"] = helpers.ParseOpenFlags(uint32(flags))
-		}
-	case MknodEventID, MknodatEventID, ChmodEventID, FchmodEventID, FchmodatEventID:
-		if mode, isUint32 := args["mode"].(uint32); isUint32 && t.config.Output.ParseArguments {
-			args["mode"] = helpers.ParseInodeMode(mode)
-		}
-	case SecurityInodeMknodEventID:
-		if mode, isUint16 := args["mode"].(uint16); isUint16 && t.config.Output.ParseArguments {
-			args["mode"] = helpers.ParseInodeMode(uint32(mode))
-		}
 	case MemProtAlertEventID:
 		if alert, isAlert := args["alert"].(alert); isAlert {
 			args["alert"] = PrintAlert(alert)
 		}
+	}
+
+	// EventIDs which are optionally parsed/enriched into human readable formats
+	if !t.config.Output.ParseArguments {
+		return nil
+	}
+	switch ctx.EventID {
+	case SysEnterEventID, SysExitEventID, CapCapableEventID, CommitCredsEventID, SecurityFileOpenEventID:
+		//show syscall name instead of id
+		if id, isInt32 := args["syscall"].(int32); isInt32 {
+			if event, isKnown := EventsIDToEvent[id]; isKnown {
+				if event.Probes[0].attach == sysCall {
+					args["syscall"] = event.Probes[0].event
+				}
+			}
+		}
+		if ctx.EventID == CapCapableEventID {
+			if capability, isInt32 := args["cap"].(int32); isInt32 {
+				args["cap"] = helpers.ParseCapability(capability)
+			}
+		}
+		if ctx.EventID == SecurityFileOpenEventID {
+			if flags, isInt32 := args["flags"].(int32); isInt32 {
+				args["flags"] = helpers.ParseOpenFlags(uint32(flags))
+			}
+		}
+	case MmapEventID, MprotectEventID, PkeyMprotectEventID:
+		if prot, isInt32 := args["prot"].(int32); isInt32 {
+			args["prot"] = helpers.ParseMemProt(uint32(prot))
+		}
+	case PtraceEventID:
+		if req, isInt64 := args["request"].(int64); isInt64 {
+			args["request"] = helpers.ParsePtraceRequest(req)
+		}
+	case PrctlEventID:
+		if opt, isInt32 := args["option"].(int32); isInt32 {
+			args["option"] = helpers.ParsePrctlOption(opt)
+		}
+	case SocketEventID:
+		if dom, isInt32 := args["domain"].(int32); isInt32 {
+			args["domain"] = helpers.ParseSocketDomain(uint32(dom))
+		}
+		if typ, isInt32 := args["type"].(int32); isInt32 {
+			args["type"] = helpers.ParseSocketType(uint32(typ))
+		}
+	case SecuritySocketCreateEventID:
+		if dom, isInt32 := args["family"].(int32); isInt32 {
+			args["family"] = helpers.ParseSocketDomain(uint32(dom))
+		}
+		if typ, isInt32 := args["type"].(int32); isInt32 {
+			args["type"] = helpers.ParseSocketType(uint32(typ))
+		}
+	case AccessEventID, FaccessatEventID:
+		if mode, isInt32 := args["mode"].(int32); isInt32 {
+			args["mode"] = helpers.ParseAccessMode(uint32(mode))
+		}
+	case ExecveatEventID:
+		if flags, isInt32 := args["flags"].(int32); isInt32 {
+			args["flags"] = helpers.ParseExecFlags(uint32(flags))
+		}
+	case OpenEventID, OpenatEventID:
+		if flags, isInt32 := args["flags"].(int32); isInt32 {
+			args["flags"] = helpers.ParseOpenFlags(uint32(flags))
+		}
+	case MknodEventID, MknodatEventID, ChmodEventID, FchmodEventID, FchmodatEventID:
+		if mode, isUint32 := args["mode"].(uint32); isUint32 {
+			args["mode"] = helpers.ParseInodeMode(mode)
+		}
+	case SecurityInodeMknodEventID:
+		if mode, isUint16 := args["mode"].(uint16); isUint16 {
+			args["mode"] = helpers.ParseInodeMode(uint32(mode))
+		}
 	case CloneEventID:
-		if flags, isUint64 := args["flags"].(uint64); isUint64 && t.config.Output.ParseArguments {
+		if flags, isUint64 := args["flags"].(uint64); isUint64 {
 			args["flags"] = helpers.ParseCloneFlags(flags)
 		}
 	case SendtoEventID, RecvfromEventID:
@@ -163,7 +171,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 		if ctx.EventID == RecvfromEventID {
 			addrType = "src_addr"
 		}
-		if sockAddr, isStrMap := args[addrType].(map[string]string); isStrMap && t.config.Output.ParseArguments {
+		if sockAddr, isStrMap := args[addrType].(map[string]string); isStrMap {
 			var s string
 			for key, val := range sockAddr {
 				s += fmt.Sprintf("'%s': '%s',", key, val)
@@ -173,11 +181,11 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args[addrType] = s
 		}
 	case BpfEventID, SecurityBPFEventID:
-		if cmd, isInt32 := args["cmd"].(int32); isInt32 && t.config.Output.ParseArguments {
+		if cmd, isInt32 := args["cmd"].(int32); isInt32 {
 			args["cmd"] = helpers.ParseBPFCmd(cmd)
 		}
 	case SecurityKernelReadFileEventID, SecurityPostReadFileEventID:
-		if readFileId, isInt32 := args["type"].(int32); isInt32 && t.config.Output.ParseArguments {
+		if readFileId, isInt32 := args["type"].(int32); isInt32 {
 			typeIdStr, err := ParseKernelReadFileId(readFileId)
 			if err == nil {
 				args["type"] = typeIdStr

--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -57,7 +57,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 	switch ctx.EventID {
 	case SysEnterEventID, SysExitEventID, CapCapableEventID, CommitCredsEventID, SecurityFileOpenEventID:
 		//show syscall name instead of id
-		if id, isInt32 := args["syscall"].(int32); isInt32 {
+		if id, isInt32 := args["syscall"].(int32); isInt32 && !t.config.Output.RawArguments {
 			if event, isKnown := EventsIDToEvent[id]; isKnown {
 				if event.Probes[0].attach == sysCall {
 					args["syscall"] = event.Probes[0].event
@@ -65,39 +65,39 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			}
 		}
 		if ctx.EventID == CapCapableEventID {
-			if capability, isInt32 := args["cap"].(int32); isInt32 {
+			if capability, isInt32 := args["cap"].(int32); isInt32 && !t.config.Output.RawArguments {
 				args["cap"] = helpers.ParseCapability(capability)
 			}
 		}
 		if ctx.EventID == SecurityFileOpenEventID {
-			if flags, isInt32 := args["flags"].(int32); isInt32 {
+			if flags, isInt32 := args["flags"].(int32); isInt32 && !t.config.Output.RawArguments {
 				args["flags"] = helpers.ParseOpenFlags(uint32(flags))
 			}
 		}
 	case MmapEventID, MprotectEventID, PkeyMprotectEventID:
-		if prot, isInt32 := args["prot"].(int32); isInt32 {
+		if prot, isInt32 := args["prot"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["prot"] = helpers.ParseMemProt(uint32(prot))
 		}
 	case PtraceEventID:
-		if req, isInt64 := args["request"].(int64); isInt64 {
+		if req, isInt64 := args["request"].(int64); isInt64 && !t.config.Output.RawArguments {
 			args["request"] = helpers.ParsePtraceRequest(req)
 		}
 	case PrctlEventID:
-		if opt, isInt32 := args["option"].(int32); isInt32 {
+		if opt, isInt32 := args["option"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["option"] = helpers.ParsePrctlOption(opt)
 		}
 	case SocketEventID:
-		if dom, isInt32 := args["domain"].(int32); isInt32 {
+		if dom, isInt32 := args["domain"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["domain"] = helpers.ParseSocketDomain(uint32(dom))
 		}
-		if typ, isInt32 := args["type"].(int32); isInt32 {
+		if typ, isInt32 := args["type"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["type"] = helpers.ParseSocketType(uint32(typ))
 		}
 	case SecuritySocketCreateEventID:
-		if dom, isInt32 := args["family"].(int32); isInt32 {
+		if dom, isInt32 := args["family"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["family"] = helpers.ParseSocketDomain(uint32(dom))
 		}
-		if typ, isInt32 := args["type"].(int32); isInt32 {
+		if typ, isInt32 := args["type"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["type"] = helpers.ParseSocketType(uint32(typ))
 		}
 	case ConnectEventID, AcceptEventID, Accept4EventID, BindEventID, GetsocknameEventID:
@@ -131,23 +131,23 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args["remote_addr"] = s
 		}
 	case AccessEventID, FaccessatEventID:
-		if mode, isInt32 := args["mode"].(int32); isInt32 {
+		if mode, isInt32 := args["mode"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["mode"] = helpers.ParseAccessMode(uint32(mode))
 		}
 	case ExecveatEventID:
-		if flags, isInt32 := args["flags"].(int32); isInt32 {
+		if flags, isInt32 := args["flags"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["flags"] = helpers.ParseExecFlags(uint32(flags))
 		}
 	case OpenEventID, OpenatEventID:
-		if flags, isInt32 := args["flags"].(int32); isInt32 {
+		if flags, isInt32 := args["flags"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["flags"] = helpers.ParseOpenFlags(uint32(flags))
 		}
 	case MknodEventID, MknodatEventID, ChmodEventID, FchmodEventID, FchmodatEventID:
-		if mode, isUint32 := args["mode"].(uint32); isUint32 {
+		if mode, isUint32 := args["mode"].(uint32); isUint32 && !t.config.Output.RawArguments {
 			args["mode"] = helpers.ParseInodeMode(mode)
 		}
 	case SecurityInodeMknodEventID:
-		if mode, isUint16 := args["mode"].(uint16); isUint16 {
+		if mode, isUint16 := args["mode"].(uint16); isUint16 && !t.config.Output.RawArguments {
 			args["mode"] = helpers.ParseInodeMode(uint32(mode))
 		}
 	case MemProtAlertEventID:
@@ -155,7 +155,7 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args["alert"] = PrintAlert(alert)
 		}
 	case CloneEventID:
-		if flags, isUint64 := args["flags"].(uint64); isUint64 {
+		if flags, isUint64 := args["flags"].(uint64); isUint64 && !t.config.Output.RawArguments {
 			args["flags"] = helpers.ParseCloneFlags(flags)
 		}
 	case SendtoEventID, RecvfromEventID:
@@ -173,11 +173,11 @@ func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
 			args[addrType] = s
 		}
 	case BpfEventID, SecurityBPFEventID:
-		if cmd, isInt32 := args["cmd"].(int32); isInt32 {
+		if cmd, isInt32 := args["cmd"].(int32); isInt32 && !t.config.Output.RawArguments {
 			args["cmd"] = helpers.ParseBPFCmd(cmd)
 		}
 	case SecurityKernelReadFileEventID, SecurityPostReadFileEventID:
-		if readFileId, isInt32 := args["type"].(int32); isInt32 {
+		if readFileId, isInt32 := args["type"].(int32); isInt32 && !t.config.Output.RawArguments {
 			typeIdStr, err := ParseKernelReadFileId(readFileId)
 			if err == nil {
 				args["type"] = typeIdStr

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -65,7 +65,7 @@ type OutputConfig struct {
 	ExecEnv        bool
 	RelativeTime   bool
 	ExecInfo       bool
-	RawArguments   bool
+	ParseArguments bool
 }
 
 type netProbe struct {

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -65,6 +65,7 @@ type OutputConfig struct {
 	ExecEnv        bool
 	RelativeTime   bool
 	ExecInfo       bool
+	RawArguments   bool
 }
 
 type netProbe struct {


### PR DESCRIPTION
This handles #461 

Based on conversation with Yaniv/Rafael we decided to make raw arguments opt-in, so they're parsed into strings by default (for all output formats). Raw arguments can be received by specifying `--output option:raw-arguments`. 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>