### PR TITLE
docs: fix formatting on prerequisites page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ CMD_BATS ?= bats
 
 release_tools := $(CMD_DOCKER) $(CMD_GIT) $(CMD_CHECKSUM) $(CMD_GITHUB) $(CMD_TAR) $(CMP_CP)
 
+MKDOCS_IMAGE := aquasec/mkdocs-material:tracee
+MKDOCS_PORT := 8000
+
 # DOCKER variable is used by sub-makefiles to build their artifact in a container
 export DOCKER
 
@@ -112,3 +115,9 @@ clean:
 test-entrypoint: entrypoint.sh entrypoint_test.bats test/mocks/* test/bats-helpers.bash
 	@command -v $$BATS >/dev/null || (echo "missing required tool $$BATS"; false)
 	bats ./entrypoint_test.bats
+
+# Runs MkDocs dev server to preview the docs page before it is published.
+.PHONY: mkdocs-serve
+mkdocs-serve:
+	$(CMD_DOCKER) build -t $(MKDOCS_IMAGE) -f docs/Dockerfile docs
+	$(CMD_DOCKER) run --name mkdocs-serve --rm -v $(PWD):/docs -p $(MKDOCS_PORT):8000 $(MKDOCS_IMAGE)

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,4 @@
+FROM squidfunk/mkdocs-material:7.3.4
+
+RUN pip install mike
+RUN pip install mkdocs-macros-plugin

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -3,15 +3,21 @@
 * Linux kernel version >= 4.18
 
 One of the following:
-* BTF available under `/sys/kernel/btf/vmlinux` (see [libbpf CO-RE documentation](https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere) for more info)).
-* Linux kernel headers available under conventional location (see [Linux Headers](../headers) section for more info). In this case system libraries libelf and zlib are required as well.
-* Tracee's eBPF probe pre-compiled (see [eBPF compilation](install/ebpf-compilation.md) section for more info).
+
+* BTF available under `/sys/kernel/btf/vmlinux` (see [libbpf CO-RE documentation] for more info).
+* Linux kernel headers available under conventional location (see [Linux Headers](./headers.md) section for more info).
+  In this case system libraries libelf and zlib are required as well.
+* Tracee's eBPF probe pre-compiled (see [eBPF compilation](./ebpf-compilation.md) section for more info).
 
 # Permissions
 
-For using the eBPF Linux subsystem, Tracee needs to run with sufficient capabilities: 
+For using the eBPF Linux subsystem, Tracee needs to run with sufficient capabilities:
+
 * `CAP_SYS_RESOURCE` (to manage eBPF maps limits)
-* `CAP_BPF`+`CAP_PERFMON` which are available on recent kernels (>=5.8), or `CAP_SYS_ADMIN` on older kernels (to load and attach the eBPF programs).
-* On some environments (e.g. Ubuntu) `CAP_IPC_LOCK` might be required as well
+* `CAP_BPF`+`CAP_PERFMON` which are available on recent kernels (>=5.8), or `CAP_SYS_ADMIN` on older kernels (to load
+  and attach the eBPF programs).
+* On some environments (e.g. Ubuntu) `CAP_IPC_LOCK` might be required as well.
 
 Alternatively, run as `root` or with the `--privileged` flag of Docker.
+
+[libbpf CO-RE documentation]: https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere


### PR DESCRIPTION
### Before

![docs_prerequisites_before](https://user-images.githubusercontent.com/1322923/140734727-cb7add2c-5645-4593-8dd2-a0bcbb990b8e.png)

### After

![docs_prerequisites_after](https://user-images.githubusercontent.com/1322923/140734769-1a619b67-9612-4010-92f9-bc5391dfa581.png)

Also adding a convenient Make target to preview the documentation on http://localhost:8000 before it's published:

```console
$ make mkdocs-serve
docker build -t aquasec/mkdocs-material:tracee -f docs/Dockerfile docs
[+] Building 0.1s (7/7) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                           0.0s
 => => transferring dockerfile: 36B                                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/squidfunk/mkdocs-material:7.3.4                                                                                                     0.0s
 => [1/3] FROM docker.io/squidfunk/mkdocs-material:7.3.4                                                                                                                       0.0s
 => CACHED [2/3] RUN pip install mike                                                                                                                                          0.0s
 => CACHED [3/3] RUN pip install mkdocs-macros-plugin                                                                                                                          0.0s
 => exporting to image                                                                                                                                                         0.0s
 => => exporting layers                                                                                                                                                        0.0s
 => => writing image sha256:ed2fce93de0bd96a044530f85425d3eaddbda007c06938963f4a4d565eecdf69                                                                                   0.0s
 => => naming to docker.io/aquasec/mkdocs-material:tracee                                                                                                                      0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
docker run --name mkdocs-serve --rm -v /Users/dpacak/go/src/github.com/aquasecurity/tracee:/docs -p 8000:8000 aquasec/mkdocs-material:tracee
INFO     -  Building documentation...
WARNING  -  Config value: 'dev_addr'. Warning: The use of the IP address '0.0.0.0' suggests a production environment or the use of a proxy to connect to the MkDocs server. However, the MkDocs' server is intended for local development purposes only. Please use a third party production-ready server instead.
INFO     -  [macros] - Macros arguments: {'module_name': 'main', 'modules': [], 'include_dir': '', 'include_yaml': [], 'j2_block_start_string': '', 'j2_block_end_string': '', 'j2_variable_start_string': '', 'j2_variable_end_string': '', 'verbose': False}
INFO     -  [macros] - Extra variables (config file): ['generator', 'version']
INFO     -  [macros] - Extra filters (module): ['pretty']
INFO     -  Cleaning site directory
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - tracee-ebpf/override-os-needed-files.md
WARNING  -  A relative path to 'tracee-ebpf/override-os-needed-files' is included in the 'nav' configuration, which is not found in the documentation files
INFO     -  Documentation built in 0.93 seconds
INFO     -  [11:30:18] Serving on http://0.0.0.0:8000/tracee/
```

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>