### PR TITLE
refactor: tests for Go signatures

### DIFF
--- a/tracee-rules/signatures/golang/export.go
+++ b/tracee-rules/signatures/golang/export.go
@@ -4,7 +4,7 @@ import "github.com/aquasecurity/tracee/tracee-rules/types"
 
 // ExportedSignatures fulfills the goplugins contract required by the rule-engine
 // this is a list of signatures that this plugin exports
-var ExportedSignatures []types.Signature = []types.Signature{
+var ExportedSignatures = []types.Signature{
 	&stdioOverSocket{},
 	&K8sApiConnection{},
 }

--- a/tracee-rules/signatures/golang/stdio_over_socket_test.go
+++ b/tracee-rules/signatures/golang/stdio_over_socket_test.go
@@ -1,16 +1,36 @@
 package main
 
 import (
-	tracee "github.com/aquasecurity/tracee/tracee-ebpf/external"
 	"testing"
 
+	tracee "github.com/aquasecurity/tracee/tracee-ebpf/external"
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStdioOverSocket(t *testing.T) {
-	SigTests := []signaturestest.SigTest{
+	noFindings := map[string]types.Finding{}
+	md := types.SignatureMetadata{
+		ID:          "TRC-1",
+		Version:     "0.1.0",
+		Name:        "Standard Input/Output Over Socket",
+		Description: "Redirection of process's standard input/output to socket",
+		Tags:        []string{"linux", "container"},
+		Properties: map[string]interface{}{
+			"Severity":     3,
+			"MITRE ATT&CK": "Persistence: Server Software Component",
+		},
+	}
+
+	testCases := []struct {
+		Name     string
+		Events   []types.Event
+		Findings map[string]types.Finding
+	}{
 		{
+			Name: "A",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -49,9 +69,37 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: true,
+			Findings: map[string]types.Finding{
+				"TRC-1": {
+					Data: map[string]interface{}{
+						"fd":   0,
+						"ip":   "10.225.0.2",
+						"port": "53",
+					},
+					SigMetadata: md,
+					Context: tracee.Event{
+						ProcessID: 45,
+						EventName: "dup2",
+						Args: []tracee.Argument{
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "oldfd",
+								},
+								Value: int32(5),
+							},
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "newfd",
+								},
+								Value: int32(0),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
+			Name: "B",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -90,9 +138,37 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: true,
+			Findings: map[string]types.Finding{
+				"TRC-1": {
+					Data: map[string]interface{}{
+						"fd":   0,
+						"ip":   "10.225.0.2",
+						"port": "53",
+					},
+					SigMetadata: md,
+					Context: tracee.Event{
+						ProcessID: 45,
+						EventName: "dup2",
+						Args: []tracee.Argument{
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "oldfd",
+								},
+								Value: int32(5),
+							},
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "newfd",
+								},
+								Value: int32(0),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
+			Name: "C",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -126,9 +202,32 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: true,
+			Findings: map[string]types.Finding{
+				"TRC-1": {
+					Data: map[string]interface{}{
+						"fd":   1,
+						"ip":   "10.225.0.2",
+						"port": "53",
+					},
+					Context: tracee.Event{
+						ProcessID:   45,
+						EventName:   "dup",
+						ReturnValue: 1,
+						Args: []tracee.Argument{
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "oldfd",
+								},
+								Value: int32(5),
+							},
+						},
+					},
+					SigMetadata: md,
+				},
+			},
 		},
 		{
+			Name: "D",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -173,9 +272,43 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: true,
+			Findings: map[string]types.Finding{
+				"TRC-1": {
+					Data: map[string]interface{}{
+						"fd":   0,
+						"ip":   "10.225.0.2",
+						"port": "53",
+					},
+					Context: tracee.Event{
+						ProcessID: 45,
+						EventName: "dup3",
+						Args: []tracee.Argument{
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "oldfd",
+								},
+								Value: int32(5),
+							},
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "newfd",
+								},
+								Value: int32(0),
+							},
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "flags",
+								},
+								Value: "SOMEFLAGS",
+							},
+						},
+					},
+					SigMetadata: md,
+				},
+			},
 		},
 		{
+			Name: "E",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -196,9 +329,10 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: false,
+			Findings: noFindings,
 		},
 		{
+			Name: "F",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -249,9 +383,10 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: false,
+			Findings: noFindings,
 		},
 		{
+			Name: "G",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -290,9 +425,10 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: false,
+			Findings: noFindings,
 		},
 		{
+			Name: "H",
 			Events: []types.Event{
 				tracee.Event{
 					ProcessID: 45,
@@ -331,21 +467,48 @@ func TestStdioOverSocket(t *testing.T) {
 					},
 				},
 			},
-			Expect: true,
+			Findings: map[string]types.Finding{
+				"TRC-1": {
+					Data: map[string]interface{}{
+						"fd":   0,
+						"ip":   "2001:67c:1360:8001::2f",
+						"port": "443",
+					},
+					Context: tracee.Event{
+						ProcessID: 45,
+						EventName: "dup2",
+						Args: []tracee.Argument{
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "oldfd",
+								},
+								Value: int32(5),
+							},
+							{
+								ArgMeta: tracee.ArgMeta{
+									Name: "newfd",
+								},
+								Value: int32(0),
+							},
+						},
+					},
+					SigMetadata: md,
+				},
+			},
 		},
 	}
 
-	for _, st := range SigTests {
-		sig := stdioOverSocket{}
-		st.Init(&sig)
-		for _, e := range st.Events {
-			err := sig.OnEvent(e)
-			if err != nil {
-				t.Error(err, st)
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			holder := signaturestest.FindingsHolder{}
+			sig := stdioOverSocket{}
+			sig.Init(holder.OnFinding)
+
+			for _, e := range tc.Events {
+				err := sig.OnEvent(e)
+				require.NoError(t, err)
 			}
-		}
-		if st.Expect != st.Status {
-			t.Error("unExpected result", st)
-		}
+			assert.Equal(t, tc.Findings, holder.GroupBySigID())
+		})
 	}
 }

--- a/tracee-rules/signatures/rego/regosig/aio_test.go
+++ b/tracee-rules/signatures/rego/regosig/aio_test.go
@@ -8,6 +8,7 @@ import (
 
 	tracee "github.com/aquasecurity/tracee/tracee-ebpf/external"
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/rego/regosig"
+	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/stretchr/testify/assert"
@@ -270,7 +271,7 @@ func AioOnEventSpec(t *testing.T, target string, partial bool) {
 			)
 			require.NoError(t, err)
 
-			holder := &findingsHolder{}
+			holder := &signaturestest.FindingsHolder{}
 			err = sig.Init(holder.OnFinding)
 			require.NoError(t, err)
 

--- a/tracee-rules/signatures/rego/regosig/common_test.go
+++ b/tracee-rules/signatures/rego/regosig/common_test.go
@@ -1,9 +1,5 @@
 package regosig_test
 
-import (
-	"github.com/aquasecurity/tracee/tracee-rules/types"
-)
-
 const (
 	testRegoCodeBoolean = `package tracee.TRC_BOOL
 
@@ -90,28 +86,3 @@ tracee_match = res {
 }
 `
 )
-
-// findingsHolder is a utility struct that defines types.SignatureHandler callback method
-// and holds types.Finding values received as the callback's argument.
-type findingsHolder struct {
-	values []types.Finding
-}
-
-func (h *findingsHolder) OnFinding(f types.Finding) {
-	h.values = append(h.values, f)
-}
-
-func (h *findingsHolder) GroupBySigID() map[string]types.Finding {
-	r := make(map[string]types.Finding)
-	for _, v := range h.values {
-		r[v.SigMetadata.ID] = v
-	}
-	return r
-}
-
-func (h *findingsHolder) FirstValue() *types.Finding {
-	if len(h.values) == 0 {
-		return nil
-	}
-	return &h.values[0]
-}

--- a/tracee-rules/signatures/rego/regosig/traceerego_test.go
+++ b/tracee-rules/signatures/rego/regosig/traceerego_test.go
@@ -9,6 +9,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/tracee-ebpf/external"
 	"github.com/aquasecurity/tracee/tracee-rules/engine"
 	"github.com/aquasecurity/tracee/tracee-rules/signatures/rego/regosig"
+	"github.com/aquasecurity/tracee/tracee-rules/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/tracee-rules/types"
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/stretchr/testify/assert"
@@ -332,7 +333,7 @@ func OnEventSpec(t *testing.T, target string, partial bool) {
 			sig, err := regosig.NewRegoSignature(target, partial, tc.regoCode)
 			require.NoError(t, err)
 
-			holder := &findingsHolder{}
+			holder := &signaturestest.FindingsHolder{}
 			err = sig.Init(holder.OnFinding)
 			require.NoError(t, err)
 

--- a/tracee-rules/signatures/signaturestest/signaturestest.go
+++ b/tracee-rules/signatures/signaturestest/signaturestest.go
@@ -1,32 +1,31 @@
 package signaturestest
 
-import "github.com/aquasecurity/tracee/tracee-rules/types"
+import (
+	"github.com/aquasecurity/tracee/tracee-rules/types"
+)
 
-// SigTest is a utility to test signatures
-type SigTest struct {
-	// Events are a series of events that the signature will be tested with (in the provided order)
-	Events []types.Event
-	// CB provide a callback for this test case only if you want to check the Finding result
-	// if providing your own callback, make sure to call SetStatus from it
-	CB types.SignatureHandler
-	// Expect declares if we expect the signature to match for this event
-	Expect bool
-	// Status shows if the signatures has matched
-	Status bool
+// FindingsHolder is a utility struct that defines types.SignatureHandler
+// callback method and holds types.Finding values received as the callback's
+// argument in memory.
+type FindingsHolder struct {
+	Values []types.Finding
 }
 
-func (st *SigTest) Init(sig types.Signature) {
-	st.Status = false
-	if st.CB != nil {
-		sig.Init(func(res types.Finding) {
-			st.SetStatus(res)
-			st.CB(res)
-		})
-	} else {
-		sig.Init(st.SetStatus)
+func (h *FindingsHolder) OnFinding(f types.Finding) {
+	h.Values = append(h.Values, f)
+}
+
+func (h *FindingsHolder) GroupBySigID() map[string]types.Finding {
+	r := make(map[string]types.Finding)
+	for _, v := range h.Values {
+		r[v.SigMetadata.ID] = v
 	}
+	return r
 }
 
-func (st *SigTest) SetStatus(res types.Finding) {
-	st.Status = true
+func (h *FindingsHolder) FirstValue() *types.Finding {
+	if len(h.Values) == 0 {
+		return nil
+	}
+	return &h.Values[0]
 }


### PR DESCRIPTION
The signaturetest.SigTest struct doesn't support meaningful assertions
because it has only boolean properties to indicate findings.

Use signaturetest.FindingHolder instead that keeps all findings
in memory and along with helper methods allows flexible
assertions (with testify).

Resolves: #925

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>