### PR TITLE
tracee-ebpf: use cgroup id for container id resolution

### DIFF
--- a/tracee-ebpf/printer.go
+++ b/tracee-ebpf/printer.go
@@ -90,13 +90,13 @@ func (p tableEventPrinter) Init() error { return nil }
 func (p tableEventPrinter) Preamble() {
 	if p.verbose {
 		if p.containerMode {
-			fmt.Fprintf(p.out, "%-16s %-16s %-16s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "MNT_NS", "PID_NS", "UID", "COMM", "PID/host", "TID/host", "PPID/host", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "MNT_NS", "PID_NS", "UID", "COMM", "PID/host", "TID/host", "PPID/host", "RET", "EVENT", "ARGS")
 		} else {
-			fmt.Fprintf(p.out, "%-16s %-16s %-16s %-12s %-12s %-6s %-16s %-7s %-7s %-7s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "MNT_NS", "PID_NS", "UID", "COMM", "PID", "TID", "PPID", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12s %-12s %-6s %-16s %-7s %-7s %-7s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "MNT_NS", "PID_NS", "UID", "COMM", "PID", "TID", "PPID", "RET", "EVENT", "ARGS")
 		}
 	} else {
 		if p.containerMode {
-			fmt.Fprintf(p.out, "%-16s %-16s %-16s %-6s %-16s %-15s %-15s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "UID", "COMM", "PID/host", "TID/host", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out, "%-16s %-13s %-6s %-16s %-15s %-15s %-16s %-20s %s", "TIME", "CONTAINER_ID", "UID", "COMM", "PID/host", "TID/host", "RET", "EVENT", "ARGS")
 		} else {
 			fmt.Fprintf(p.out, "%-16s %-6s %-16s %-7s %-7s %-16s %-20s %s", "TIME", "UID", "COMM", "PID", "TID", "RET", "EVENT", "ARGS")
 		}
@@ -110,15 +110,21 @@ func (p tableEventPrinter) Print(event external.Event) {
 		ut = ut.UTC()
 	}
 	timestamp := fmt.Sprintf("%02d:%02d:%02d:%06d", ut.Hour(), ut.Minute(), ut.Second(), ut.Nanosecond()/1000)
+
+	containerId := event.ContainerID
+	if len(containerId) > 12 {
+		containerId = containerId[:12]
+	}
+
 	if p.verbose {
 		if p.containerMode {
-			fmt.Fprintf(p.out, "%-16s %-16s %-16s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, event.HostName, event.ContainerID, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ParentProcessID, event.ParentProcessID, event.ReturnValue, event.EventName)
+			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, event.HostName, containerId, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ParentProcessID, event.ParentProcessID, event.ReturnValue, event.EventName)
 		} else {
-			fmt.Fprintf(p.out, "%-16s %-16s %-16s %-12d %-12d %-6d %-16s %-7d %-7d %-7d %-16d %-20s ", timestamp, event.HostName, event.ContainerID, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.ThreadID, event.ParentProcessID, event.ReturnValue, event.EventName)
+			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12d %-12d %-6d %-16s %-7d %-7d %-7d %-16d %-20s ", timestamp, event.HostName, containerId, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.ThreadID, event.ParentProcessID, event.ReturnValue, event.EventName)
 		}
 	} else {
 		if p.containerMode {
-			fmt.Fprintf(p.out, "%-16s %-16s %-16s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, event.HostName, event.ContainerID, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ReturnValue, event.EventName)
+			fmt.Fprintf(p.out, "%-16s %-13s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, containerId, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ReturnValue, event.EventName)
 		} else {
 			fmt.Fprintf(p.out, "%-16s %-6d %-16s %-7d %-7d %-16d %-20s ", timestamp, event.UserID, event.ProcessName, event.ProcessID, event.ThreadID, event.ReturnValue, event.EventName)
 		}

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -41,6 +41,7 @@ const (
 	configDebugNet
 	configProcTreeFilter
 	configCaptureModules
+	configCgroupV1
 )
 
 const (

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -165,6 +165,8 @@ const (
 	SwitchTaskNSEventID
 	MagicWriteEventID
 	CgroupAttachTaskEventID
+	CgroupMkdirEventID
+	CgroupRmdirEventID
 	SecurityBprmCheckEventID
 	SecurityFileOpenEventID
 	SecurityInodeUnlinkEventID
@@ -568,7 +570,9 @@ var EventsIDToEvent = map[int32]EventConfig{
 	CommitCredsEventID:            {ID: CommitCredsEventID, ID32Bit: sys32undefined, Name: "commit_creds", Probes: []probe{{event: "commit_creds", attach: kprobe, fn: "trace_commit_creds"}}, Sets: []string{}},
 	SwitchTaskNSEventID:           {ID: SwitchTaskNSEventID, ID32Bit: sys32undefined, Name: "switch_task_ns", Probes: []probe{{event: "switch_task_namespaces", attach: kprobe, fn: "trace_switch_task_namespaces"}}, Sets: []string{}},
 	MagicWriteEventID:             {ID: MagicWriteEventID, ID32Bit: sys32undefined, Name: "magic_write", Probes: []probe{}, Sets: []string{}},
-	CgroupAttachTaskEventID:       {ID: CgroupAttachTaskEventID, ID32Bit: sys32undefined, Name: "cgroup_attach_task", Probes: []probe{{event: "cgroup:cgroup_attach_task", attach: rawTracepoint, fn: "tracepoint__cgroup__cgroup_attach_task"}}, EssentialEvent: true, Sets: []string{}},
+	CgroupAttachTaskEventID:       {ID: CgroupAttachTaskEventID, ID32Bit: sys32undefined, Name: "cgroup_attach_task", Probes: []probe{{event: "cgroup:cgroup_attach_task", attach: rawTracepoint, fn: "tracepoint__cgroup__cgroup_attach_task"}}, Sets: []string{}},
+	CgroupMkdirEventID:            {ID: CgroupMkdirEventID, ID32Bit: sys32undefined, Name: "cgroup_mkdir", Probes: []probe{{event: "cgroup:cgroup_mkdir", attach: rawTracepoint, fn: "tracepoint__cgroup__cgroup_mkdir"}}, EssentialEvent: true, Sets: []string{}},
+	CgroupRmdirEventID:            {ID: CgroupRmdirEventID, ID32Bit: sys32undefined, Name: "cgroup_rmdir", Probes: []probe{{event: "cgroup:cgroup_rmdir", attach: rawTracepoint, fn: "tracepoint__cgroup__cgroup_rmdir"}}, EssentialEvent: true, Sets: []string{}},
 	SecurityBprmCheckEventID:      {ID: SecurityBprmCheckEventID, ID32Bit: sys32undefined, Name: "security_bprm_check", Probes: []probe{{event: "security_bprm_check", attach: kprobe, fn: "trace_security_bprm_check"}}, Sets: []string{"default", "lsm_hooks", "proc", "proc_life"}},
 	SecurityFileOpenEventID:       {ID: SecurityFileOpenEventID, ID32Bit: sys32undefined, Name: "security_file_open", Probes: []probe{{event: "security_file_open", attach: kprobe, fn: "trace_security_file_open"}}, Sets: []string{"default", "lsm_hooks", "fs", "fs_file_ops"}},
 	SecurityInodeUnlinkEventID:    {ID: SecurityInodeUnlinkEventID, ID32Bit: sys32undefined, Name: "security_inode_unlink", Probes: []probe{{event: "security_inode_unlink", attach: kprobe, fn: "trace_security_inode_unlink"}}, Sets: []string{"default", "lsm_hooks", "fs", "fs_file_ops"}},
@@ -944,7 +948,9 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	CommitCredsEventID:            {{Type: "slim_cred_t", Name: "old_cred"}, {Type: "slim_cred_t", Name: "new_cred"}, {Type: "int", Name: "syscall"}},
 	SwitchTaskNSEventID:           {{Type: "pid_t", Name: "pid"}, {Type: "u32", Name: "new_mnt"}, {Type: "u32", Name: "new_pid"}, {Type: "u32", Name: "new_uts"}, {Type: "u32", Name: "new_ipc"}, {Type: "u32", Name: "new_net"}, {Type: "u32", Name: "new_cgroup"}},
 	MagicWriteEventID:             {{Type: "const char*", Name: "pathname"}, {Type: "bytes", Name: "bytes"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}},
-	CgroupAttachTaskEventID:       {{Type: "const char*", Name: "cgroup_path"}},
+	CgroupAttachTaskEventID:       {{Type: "const char*", Name: "cgroup_path"}, {Type: "const char*", Name: "comm"}, {Type: "pid_t", Name: "pid"}},
+	CgroupMkdirEventID:            {{Type: "u64", Name: "cgroup_id"}, {Type: "const char*", Name: "cgroup_path"}},
+	CgroupRmdirEventID:            {{Type: "u64", Name: "cgroup_id"}, {Type: "const char*", Name: "cgroup_path"}},
 	SecurityBprmCheckEventID:      {{Type: "const char*", Name: "pathname"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}},
 	SecurityFileOpenEventID:       {{Type: "const char*", Name: "pathname"}, {Type: "int", Name: "flags"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "syscall"}},
 	SecurityInodeUnlinkEventID:    {{Type: "const char*", Name: "pathname"}},

--- a/tracee-ebpf/tracee/events.go
+++ b/tracee-ebpf/tracee/events.go
@@ -16,6 +16,7 @@ import (
 // keep the 1-byte 'Argnum' as the final parameter before the padding (if padding is needed).
 type context struct {
 	Ts       uint64
+	CgroupID uint64
 	Pid      uint32
 	Tid      uint32
 	Ppid     uint32
@@ -27,7 +28,6 @@ type context struct {
 	PidID    uint32
 	Comm     [16]byte
 	UtsName  [16]byte
-	ContID   [16]byte
 	EventID  int32
 	Retval   int64
 	StackID  uint32
@@ -117,7 +117,7 @@ func (t *Tracee) processEvents(done <-chan struct{}) error {
 			PIDNS:               int(ctx.PidID),
 			ProcessName:         string(bytes.TrimRight(ctx.Comm[:], "\x00")),
 			HostName:            string(bytes.TrimRight(ctx.UtsName[:], "\x00")),
-			ContainerID:         string(bytes.TrimRight(ctx.ContID[:], "\x00")),
+			ContainerID:         t.containers.GetContainerId(ctx.CgroupID),
 			EventID:             int(ctx.EventID),
 			EventName:           EventsIDToEvent[int32(ctx.EventID)].Name,
 			ArgsNum:             int(ctx.Argnum),

--- a/tracee-ebpf/tracee/events_processor.go
+++ b/tracee-ebpf/tracee/events_processor.go
@@ -202,6 +202,24 @@ func (t *Tracee) processEvent(ctx *context, args map[string]interface{}, argMeta
 
 	case SocketEventID:
 		removeSocketTailOnce.Do(t.removeSocketTail)
+
+	case CgroupMkdirEventID:
+		cgroupId, ok := args["cgroup_id"].(uint64)
+		if !ok {
+			return fmt.Errorf("error parsing cgroup_mkdir args")
+		}
+		path, ok := args["cgroup_path"].(string)
+		if !ok {
+			return fmt.Errorf("error parsing cgroup_mkdir args")
+		}
+		t.containers.CgroupUpdate(cgroupId, path)
+
+	case CgroupRmdirEventID:
+		cgroupId, ok := args["cgroup_id"].(uint64)
+		if !ok {
+			return fmt.Errorf("error parsing cgroup_rmdir args")
+		}
+		t.containers.CgroupRemove(cgroupId)
 	}
 
 	return nil


### PR DESCRIPTION
This PR changes the way we extract container id for events.

The current solution has several problems:
1. Container id is saved per process, wasting memory.
2. Container id is only 12 chars long, while the full container id (64 chars long) might be required.
3. Bpf code is responsible for extracting container id from a cgroup name (we now check, for example, if cgroup name has "docker-" prefix, but this doesn't always work, e.g. with podman)
4. Regexes used during container id map initialization don't match the container ids we extract in runtime (as bpf code can't handle regexes)

To solve these problems, let's move to use cgroup id to get a container id:
1. In the context of every event, send task's cgroup id (instead of 12 chars container id)
2. Add a new map in userspace that maps cgroup id to container id
3. Update this map on init with existing containers by knowing that the lower 32 bits of the cgroup_id are actually the inode number in the cgroupfs entry
4. Add two new events (tracepoints) to track cgroup creation/removal: cgroup_mkdir and cgroup_rmdir
5. Using these two events, update cgroup to container id map in runtime if a match to a known container runtime is found
6. Use cgroup_id as an index to the map to get the container id of a given event

close #473
fix #958