### PR TITLE
tracee-ebpf: add MemProtAlert type to external package

### DIFF
--- a/tracee-ebpf/external/external.go
+++ b/tracee-ebpf/external/external.go
@@ -204,3 +204,30 @@ type SlimCred struct {
 	CapBounding    uint64 /* capability bounding set */
 	CapAmbient     uint64 /* Ambient capability set */
 }
+
+// Message is an enum of possible messages that can be sent by an event to pass some extra information about the event.
+type MemProtAlert uint32
+
+const (
+	ProtAlertUnknown MemProtAlert = iota
+	ProtAlertMmapWX
+	ProtAlertMprotectToX
+	ProtAlertMprotectXToWX
+	ProtAlertMprotectWXToX
+	ProtAlertLast
+)
+
+func (alert MemProtAlert) String() string {
+	switch alert {
+	case ProtAlertMmapWX:
+		return "Mmaped region with W+E permissions!"
+	case ProtAlertMprotectToX:
+		return "Protection changed to Executable!"
+	case ProtAlertMprotectXToWX:
+		return "Protection changed from E to W+E!"
+	case ProtAlertMprotectWXToX:
+		return "Protection changed from W+E to E!"
+	default:
+		return "Unknown alert"
+	}
+}

--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -23,17 +23,13 @@ func Print16BytesSliceIP(in []byte) string {
 	return ip.String()
 }
 
-func (t *Tracee) prepareArgs(ctx *context, args map[string]interface{}) error {
+func (t *Tracee) parseArgs(ctx *context, args map[string]interface{}) error {
 	for key, arg := range args {
 		if ptr, isUintptr := arg.(uintptr); isUintptr {
 			args[key] = fmt.Sprintf("0x%X", ptr)
 		}
 	}
 
-	// EventIDs which are optionally parsed/enriched into human readable formats
-	if !t.config.Output.ParseArguments {
-		return nil
-	}
 	switch ctx.EventID {
 	case MemProtAlertEventID:
 		if alert, isUint32 := args["alert"].(uint32); isUint32 {

--- a/tracee-ebpf/tracee/argprinters_test.go
+++ b/tracee-ebpf/tracee/argprinters_test.go
@@ -21,23 +21,3 @@ func TestPrint16BytesSliceIP(t *testing.T) {
 	expectedIP := "2001:db8:85a3::8a2e:370:7334"
 	assert.Equal(t, expectedIP, ip)
 }
-
-func TestPrintAlert(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    alert
-		expected string
-	}{
-		{"SecurityAlert1", alert{Msg: 1}, "Mmaped region with W+E permissions!"},
-		{"SecurityAlert2", alert{Msg: 2}, "Protection changed to Executable!"},
-		{"SecurityAlert3", alert{Msg: 3}, "Protection changed from E to W+E!"},
-		{"SecurityAlert4", alert{Msg: 4}, "Protection changed from W+E to E!"},
-		{"AlertNotDefined", alert{Msg: 5}, "5"},
-		{"AlertNotDefinedWithPayload", alert{Msg: 6, Payload: 1, Ts: 1628094500}, "6 Saving data to bin.1628094500"},
-	}
-
-	for _, tc := range testCases {
-		actual := PrintAlert(tc.input)
-		assert.Equal(t, tc.expected, actual, tc.name)
-	}
-}

--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -110,7 +110,6 @@ const (
 	strT
 	strArrT
 	sockAddrT
-	alertT
 	bytesT
 	u16T
 	credT
@@ -941,7 +940,7 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	CapCapableEventID:             {{Type: "int", Name: "cap"}, {Type: "int", Name: "syscall"}},
 	VfsWriteEventID:               {{Type: "const char*", Name: "pathname"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "size_t", Name: "count"}, {Type: "off_t", Name: "pos"}},
 	VfsWritevEventID:              {{Type: "const char*", Name: "pathname"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "unsigned long", Name: "vlen"}, {Type: "off_t", Name: "pos"}},
-	MemProtAlertEventID:           {{Type: "alert_t", Name: "alert"}},
+	MemProtAlertEventID:           {{Type: "u32", Name: "alert"}},
 	CommitCredsEventID:            {{Type: "slim_cred_t", Name: "old_cred"}, {Type: "slim_cred_t", Name: "new_cred"}, {Type: "int", Name: "syscall"}},
 	SwitchTaskNSEventID:           {{Type: "pid_t", Name: "pid"}, {Type: "u32", Name: "new_mnt"}, {Type: "u32", Name: "new_pid"}, {Type: "u32", Name: "new_uts"}, {Type: "u32", Name: "new_ipc"}, {Type: "u32", Name: "new_net"}, {Type: "u32", Name: "new_cgroup"}},
 	MagicWriteEventID:             {{Type: "const char*", Name: "pathname"}, {Type: "bytes", Name: "bytes"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}},

--- a/tracee-ebpf/tracee/events.go
+++ b/tracee-ebpf/tracee/events.go
@@ -78,10 +78,13 @@ func (t *Tracee) processEvents(done <-chan struct{}) error {
 		if !t.eventsToTrace[ctx.EventID] {
 			continue
 		}
-		err = t.prepareArgs(&ctx, args)
-		if err != nil {
-			t.handleError(err)
-			continue
+
+		if t.config.Output.ParseArguments {
+			err = t.parseArgs(&ctx, args)
+			if err != nil {
+				t.handleError(err)
+				continue
+			}
 		}
 
 		// Add stack trace if needed

--- a/tracee-ebpf/tracee/events_decoder.go
+++ b/tracee-ebpf/tracee/events_decoder.go
@@ -12,14 +12,6 @@ import (
 	"github.com/aquasecurity/tracee/tracee-ebpf/external"
 )
 
-// alert struct encodes a security alert message with a timestamp
-// it is used to unmarshal binary data and therefore should match (bit by bit) to the `alert_t` struct in the ebpf code.
-type alert struct {
-	Ts      uint64
-	Msg     uint32
-	Payload uint8
-}
-
 func readArgFromBuff(dataBuff io.Reader, params []external.ArgMeta) (external.ArgMeta, interface{}, error) {
 	var err error
 	var res interface{}
@@ -63,10 +55,6 @@ func readArgFromBuff(dataBuff io.Reader, params []external.ArgMeta) (external.Ar
 		res = uintptr(data)
 	case sockAddrT:
 		res, err = readSockaddrFromBuff(dataBuff)
-	case alertT:
-		var data alert
-		err = binary.Read(dataBuff, binary.LittleEndian, &data)
-		res = data
 	case credT:
 		var data external.SlimCred
 		err = binary.Read(dataBuff, binary.LittleEndian, &data)

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -429,8 +429,6 @@ func getParamType(paramType string) argType {
 		return bytesT
 	case "int[2]":
 		return intArr2T
-	case "alert_t":
-		return alertT
 	case "slim_cred_t":
 		return credT
 	case "umode_t":


### PR DESCRIPTION
Not too long ago we had "security-alerts" as part of tracee-ebpf (until #1114 removed it).
"alerts" where messages sent by an eBPF event as an extra argument, to pass some information about a security alert.
Introduce MemProtAlert in the external package, so it can be used by tracee-ebpf consumers

This will also allow us to expose "alerts" as raw arguments (related #1123 )