### PR TITLE
tracee-ebpf: filter containers using cgroup id

### DIFF
--- a/tracee-ebpf/tracee/events_processor.go
+++ b/tracee-ebpf/tracee/events_processor.go
@@ -212,7 +212,11 @@ func (t *Tracee) processEvent(ctx *context, args map[string]interface{}, argMeta
 		if !ok {
 			return fmt.Errorf("error parsing cgroup_mkdir args")
 		}
-		t.containers.CgroupUpdate(cgroupId, path)
+		info, err := t.containers.CgroupUpdate(cgroupId, path)
+		if err == nil && info.ContainerId == "" {
+			// If not a new container (no regex match) - remove from the bpf container_map
+			t.containers.RemoveFromBpfMap(t.bpfModule, cgroupId)
+		}
 
 	case CgroupRmdirEventID:
 		cgroupId, ok := args["cgroup_id"].(uint64)

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -573,6 +573,9 @@ func (t *Tracee) populateBPFMaps() error {
 		}
 	}
 
+	// Populate containers_map with existing containers
+	t.containers.PopulateBpfMap(t.bpfModule)
+
 	// Initialize tail calls program array
 	errs = make([]error, 0)
 	errs = append(errs, t.initTailCall(tailVfsWrite, "prog_array", "trace_ret_vfs_write_tail"))


### PR DESCRIPTION
Currently, to filter a container in the bpf code we use "pid != host_pid", and to identify a NEW container we look for pid 1 in a new pid namespace.
These checks are not always true (e.g. pid=host or containers that share pid namespace).

This PR introduces a new way to identify containers in the bpf code using cgroup ids.
To do this, the following algorithm is used:
1. Introduce a new (bpf) containers_map with a key of cgroup_id (lower 32 bits) and value of CONTAINER_EXISTED, CONTAINER_CREATED, CONTAINER_STARTED
2. Update containers_map on init with existing containers (CONTAINER_EXISTED)
3. Update containers_map when a new cgroup is created (CONTAINER_CREATED)
4. If a cgroup path is not of a new container (checked by userspace when a cgroup_mkdir event is received) - remove it from the bpf container_map
5. Update containers_map when a process of a newly created cgroup (CONTAINER_CREATED) has executed a binary (CONTAINER_STARTED)
6. Identifying a container process can then be done by using the cgroup id to check in containers_map if the state is either CONTAINER_EXISTED or CONTAINER_STARTED
7. Identifying a process of a new container can be done by checking if the state is CONTAINER_STARTED
8. We can then remove the check "pid != host_pid" that is used to identify a container with a check of existing cgroup_id in the bpf containers_map
9. Use cgroup_rmdir to delete cgroup_id from the bpf map

By doing this change, we will also be able to address the following issues in future PRs:
1. #676 - We will be able to have a new container_started EVENT which will also include the container runtime extracted from the cgroup name (e.g. docker/containerd/podman)
2. #255 - We will be able to create container id filters in kernel (by mapping container id to cgroup id)