### PR TITLE
docs: add cgroupns=host docker option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,14 +25,14 @@ Before you proceed, make sure you follow the [minimum requirements for running T
 If running on __BTF enabled kernel__:
 
 ```bash
-docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
 ```
 
 > Note: Running with BTF requires access to the kernel configuration file. Depending on the linux distribution it can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
 
 If running on __BTF disabled kernel__:
 ```bash
-docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
 ```
 
 > Note: You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](https://aquasecurity.github.io/tracee/install/headers.md) section for more info.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,14 +21,14 @@ Before you proceed, make sure you follow the [minimum requirements for running T
 If running on __BTF enabled kernel__:
 
 ```bash
-docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
 ```
 
 > Note: Running with BTF requires access to the kernel configuration file. Depending on the linux distribution it can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
 
 If running on __BTF disabled kernel__:
 ```bash
-docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
 ```
 
 > Note: You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](install/headers.md) section for more info.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -46,7 +46,7 @@ For example templates, see [tracee/tracee-rules/templates](https://github.com/aq
 The following example configures Tracee to output detections to stdout as raw JSON:
 
 ```bash
-docker run --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it aquasec/tracee --output-template /tracee/templates/rawjson.tmpl
+docker run --rm --privileged --pid=host --cgroupns=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it aquasec/tracee --output-template /tracee/templates/rawjson.tmpl
 ```
 
 ### falcosidekick webhook
@@ -70,5 +70,5 @@ To use Tracee with falcosidekick:
 docker run --name falcosidekick -p 2801:2801 -e SLACK_WEBHOOKURL=https://hooks.slack.com/services/XXX/YYY/ZZZ falcosecurity/falcosidekick
 
 # Start Tracee, linking it to the falcosidekick container, and configuring it to call it on detections
-docker run --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it --link falcosidekick aquasec/tracee --webhook-template /tracee/templates/falcosidekick.tmpl --webhook-content-type application/json --webhook http://FALCOSIDEKICK:2801
+docker run --rm --privileged --pid=host --cgroupns=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it --link falcosidekick aquasec/tracee --webhook-template /tracee/templates/falcosidekick.tmpl --webhook-content-type application/json --webhook http://FALCOSIDEKICK:2801
 ```

--- a/docs/tracee-ebpf/index.md
+++ b/docs/tracee-ebpf/index.md
@@ -9,7 +9,7 @@ In some cases, you might want to leverage Tracee's eBPF event collection capabil
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](../install/prerequisites.md).
 
 ```bash
-docker run --name tracee --rm --privileged -it aquasec/tracee:latest trace
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -it aquasec/tracee:latest trace
 ```
 
 Here we are running the same `aquasec/tracee` container, but with the `trace` sub-command, which will start just a raw trace (Tracee-eBPF), without the detection engine (Tracee-Rules). Here's a sample output of running with no additional arguments:

--- a/tracee-ebpf/Dockerfile
+++ b/tracee-ebpf/Dockerfile
@@ -18,9 +18,9 @@ FROM alpine as slim
 RUN apk --no-cache update && apk --no-cache add libc6-compat elfutils-dev
 
 # If running on a BTF enabled kernel:
-# docker run --name tracee --rm --privileged -it aquasec/tracee:latest
+# docker run --name tracee --pid=host --cgroupns=host --rm --privileged -it aquasec/tracee:latest
 # If running on a BTF disabled kernel, you must mount linux headers:
-# docker run --name tracee --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee aquasec/tracee
+# docker run --name tracee --pid=host --cgroupns=host --rm --privileged --pid=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee aquasec/tracee
 FROM $BASE
 WORKDIR /tracee
 COPY --from=build /tracee/dist/tracee-ebpf ./

--- a/tracee-ebpf/Readme.md
+++ b/tracee-ebpf/Readme.md
@@ -13,7 +13,7 @@ The full documentation of Tracee's eBPF tracing is available at [https://aquasec
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](https://aquasecurity.github.io/tracee/dev/install/prerequisites/).
 
 ```bash
-docker run --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest trace
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest trace
 ```
 
 Here we are running the same `aquasec/tracee` container, but with the `trace` sub-command, which will start just a raw trace (Tracee-eBPF), without the detection engine (Tracee-Rules). Here's a sample output of running with no additional arguments:


### PR DESCRIPTION
To identify existing containers, `--cgroupns=host` should be provided to the `docker run` command