### PR TITLE
docs: use mkdocs macros plugin to specify version of tracee release artifacts

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:7.3.6
+FROM squidfunk/mkdocs-material:8.0.1
 
 RUN pip install mike
 RUN pip install mkdocs-macros-plugin

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,17 +21,25 @@ Before you proceed, make sure you follow the [minimum requirements for running T
 If running on __BTF enabled kernel__:
 
 ```bash
-docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -it aquasec/tracee:latest
+docker run --name tracee --rm -it --pid=host --cgroupns=host --privileged \
+  -v /tmp/tracee:/tmp/tracee \
+  aquasec/tracee:{{ git_tag_version[1:] }}
 ```
 
-> Note: Running with BTF requires access to the kernel configuration file. Depending on the linux distribution it can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
+!!! note
+    Running with BTF requires access to the kernel configuration file. Depending on the Linux distribution it can be in either `/proc/config.gz` (which docker mounts by default) or `/boot/config-$(uname -r)` (which must be mounted explicitly).
 
 If running on __BTF disabled kernel__:
 ```bash
-docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest
+docker run --name tracee --rm -it --pid=host --cgroupns=host --privileged \
+  -v /tmp/tracee:/tmp/tracee \
+  -v /lib/modules/:/lib/modules/:ro \
+  -v /usr/src:/usr/src:ro \
+  aquasec/tracee:{{ git_tag_version[1:] }}
 ```
 
-> Note: You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](install/headers.md) section for more info.
+!!! note
+    You may need to change the volume mounts for the kernel headers based on your setup. See [Linux Headers](install/headers.md) section for more info.
 
 This will run Tracee with default settings and start reporting detections to standard output.
 In order to simulate a suspicious behavior, you can run `strace ls` in another terminal, which will trigger the "Anti-Debugging" signature, which is loaded by default.
@@ -43,11 +51,16 @@ In some cases, you might want to leverage Tracee's eBPF event collection capabil
 ## Components
 
 Tracee is composed of the following sub-projects, which are hosted in the aquasecurity/tracee repository:
-- [Tracee-eBPF](https://github.com/aquasecurity/tracee/tree/main/tracee-ebpf) - Linux Tracing and Forensics using eBPF
-- [Tracee-Rules](https://github.com/aquasecurity/tracee/tree/main/tracee-rules) - Runtime Security Detection Engine
+
+- [Tracee-eBPF](https://github.com/aquasecurity/tracee/tree/{{ git_tag_version }}/tracee-ebpf) - Linux Tracing and Forensics using eBPF
+- [Tracee-Rules](https://github.com/aquasecurity/tracee/tree/{{ git_tag_version }}/tracee-rules) - Runtime Security Detection Engine
 
 ---
 
-Tracee is an [Aqua Security](https://aquasec.com) open source project.  
+Tracee is an [Aqua Security] open source project.  
 Learn about our open source work and portfolio [here](https://www.aquasec.com/products/open-source-projects/).  
-Contact us about any matter by opening a GitHub Discussion [here](https://github.com/aquasecurity/tracee/discussions).
+Join the community, and talk to us about any matter in [GitHub Discussion] or [Slack].
+
+[Aqua Security]: https://aquasec.com
+[GitHub Discussion]: https://github.com/aquasecurity/tracee/discussions
+[Slack]: https://slack.aquasec.com

--- a/docs/install/ebpf-compilation.md
+++ b/docs/install/ebpf-compilation.md
@@ -30,7 +30,7 @@ Kernel version specific option:
 
 You can build the eBPF program in the following ways:
 
-1. Clone the repo (including submodules: `git clone --recursive https://github.com/aquasecurity/tracee.git`) and `make bpf`.
+1. Clone the repo (including submodules: `git clone --branch={{ git_tag_version }} --recursive https://github.com/aquasecurity/tracee.git`) and `make bpf`.
 2. `make bpf DOCKER=1` to build in a Docker container which includes all development tooling.
 
 Running this will produce a file called `tracee.bpf.$kernelversion.$traceeversion.o` under the `dist` directory.
@@ -50,7 +50,7 @@ If using Docker, the following `docker run` options demonstrate mounting a pre-c
 docker run --name tracee --rm --privileged -it \
   -v /path/in/host/tracee.bpf.123.o:/path/in/container/tracee.bpf.o \
   -e TRACEE_BPF_FILE=/path/in/container/tracee.bpf.o \
-  aquasec/tracee:slim
+  aquasec/tracee:slim-{{ git_tag_version[1:] }}
 ```
 
 If using Docker on a host without BTF enabled, the following `docker run` options demonstrate mounting of required kernel headers for building the bpf object at runtime:
@@ -60,7 +60,7 @@ docker run --name tracee --rm --privileged -it \
   -v /lib/modules/:/lib/modules/:ro \
   -v /usr/src:/usr/src:ro \
   -v /tmp/tracee:/tmp/tracee \
-  aquasec/tracee:latest
+  aquasec/tracee:{{ git_tag_version[1:] }}
 ```
 
 [Linux Headers]: ./headers.md

--- a/docs/install/headers.md
+++ b/docs/install/headers.md
@@ -7,6 +7,8 @@ In order to compile the kernel version specific eBPF object, Tracee needs some o
 
 Normally the files will be installed in `/lib/modules/${kernel_version}/build` which is where Tracee expects them. If you have the headers elsewhere, you can set the `KERN_HEADERS` environment variable with the correct location.
 
-> Note that it's important that the kernel headers match the exact version of the kernel you are running. To check the current kernel version, run the command `uname -r`. To install a specific kernel headers version append the version to the package name: `linux-headers-$(uname -r)`.
+!!! note
+    It's important that the kernel headers match the exact version of the kernel you are running. To check the current kernel version, run the command `uname -r`. To install a specific kernel headers version append the version to the package name: `linux-headers-$(uname -r)`.
 
-> Note that more often than not the kernel headers files contains filesystem links to other files in other directories. Therefore, when passing the kernel headers to Tracee docker container, make sure all the necessary directories are mounted. This is why the quickstart example mounts `/usr/src` in addition to `/lib/modules`.
+!!! warning
+    More often than not the kernel headers files contains filesystem links to other files in other directories. Therefore, when passing the kernel headers to Tracee docker container, make sure all the necessary directories are mounted. This is why the quickstart example mounts `/usr/src` in addition to `/lib/modules`.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -9,9 +9,9 @@ In the [deploy/kubernetes](https://github.com/aquasecurity/tracee/blob/main/depl
 To install Tracee with [Postee](https://github.com/aquasecurity/postee), simply run:
 
 ``` bash
-kubectl create -f \
-https://raw.githubusercontent.com/aquasecurity/postee/main/deploy/kubernetes/postee.yaml -f \
-https://raw.githubusercontent.com/aquasecurity/tracee/main/deploy/kubernetes/tracee-postee/tracee.yaml
+kubectl create \
+  -f https://raw.githubusercontent.com/aquasecurity/postee/main/deploy/kubernetes/postee.yaml \
+  -f https://raw.githubusercontent.com/aquasecurity/tracee/{{ git_tag_version }}/deploy/kubernetes/tracee-postee/tracee.yaml
 ```
 
 You can edit the configMap `postee-config` the was created, see an example configuration here: https://github.com/aquasecurity/postee/blob/main/cfg.yaml.
@@ -23,9 +23,9 @@ You can also use the [Postee UI](https://github.com/aquasecurity/postee#postee-u
 To install Tracee with [Falcosidekick](https://github.com/falcosecurity/falcosidekick), simply run:
 
 ``` bash
-kubectl create -f \
-https://raw.githubusercontent.com/aquasecurity/tracee/main/deploy/kubernetes/tracee-falcosidekick/falcosidekick.yaml -f \
-https://raw.githubusercontent.com/aquasecurity/tracee/main/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
+kubectl create \
+  -f https://raw.githubusercontent.com/aquasecurity/tracee/{{ git_tag_version }}/deploy/kubernetes/tracee-falcosidekick/falcosidekick.yaml \
+  -f https://raw.githubusercontent.com/aquasecurity/tracee/{{ git_tag_version }}/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
 ```
 
 You can edit the configMap `falcosidekick-config` the was created, see an example configuration here: https://github.com/falcosecurity/falcosidekick/blob/master/config_example.yaml

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -18,8 +18,8 @@ The following go templates are included in the Tracee container image and are av
 
 File name | Description | Content-Type | Source
 --- | --- | --- | ---
-falcosidekick.tmpl | For compatibility with [falcosidekick](https://github.com/falcosecurity/falcosidekick) | `application/json` | [source](https://github.com/aquasecurity/tracee/blob/main/tracee-rules/templates/falcosidekick.tmpl)
-rawjson.tmpl | Dumps the Finding object as raw JSON | `application/json` | [source](https://github.com/aquasecurity/tracee/blob/main/tracee-rules/templates/rawjson.tmpl)
+falcosidekick.tmpl | For compatibility with [falcosidekick] | `application/json` | [source](https://github.com/aquasecurity/tracee/blob/{{ git_tag_version }}/tracee-rules/templates/falcosidekick.tmpl)
+rawjson.tmpl | Dumps the Finding object as raw JSON | `application/json` | [source](https://github.com/aquasecurity/tracee/blob/{{ git_tag_version }}/tracee-rules/templates/rawjson.tmpl)
 
 
 ## Go Template Authoring
@@ -37,7 +37,7 @@ type Finding struct {
 
 The Go template can utilize helper functions from [Sprig](http://masterminds.github.io/sprig/).
 
-For example templates, see [tracee/tracee-rules/templates](https://github.com/aquasecurity/tracee/tree/main/tracee-rules/templates).
+For example templates, see [tracee/tracee-rules/templates](https://github.com/aquasecurity/tracee/tree/{{ git_tag_version }}/tracee-rules/templates).
 
 ## Examples
 
@@ -46,12 +46,16 @@ For example templates, see [tracee/tracee-rules/templates](https://github.com/aq
 The following example configures Tracee to output detections to stdout as raw JSON:
 
 ```bash
-docker run --rm --privileged --pid=host --cgroupns=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it aquasec/tracee --output-template /tracee/templates/rawjson.tmpl
+docker run --rm -it --privileged --pid=host --cgroupns=host \
+  -v /lib/modules/:/lib/modules/:ro \
+  -v /usr/src:/usr/src:ro \
+  -v /tmp/tracee:/tmp/tracee \
+  aquasec/tracee:{{ git_tag_version[1:] }} --output-template /tracee/templates/rawjson.tmpl
 ```
 
 ### falcosidekick webhook
 
-[falcosidekick](https://github.com/falcosecurity/falcosidekick) is a useful webhook server that can be configured to connect to various "outputs" such as: Slack, Mattermost, Teams, Datadog, Prometheus, StatsD, Email, Elasticsearch, Loki, PagerDuty, OpsGenie, and many more.
+[falcosidekick] is a useful webhook server that can be configured to connect to various "outputs" such as: Slack, Mattermost, Teams, Datadog, Prometheus, StatsD, Email, Elasticsearch, Loki, PagerDuty, OpsGenie, and many more.
 
 To use Tracee with falcosidekick:
 
@@ -61,14 +65,25 @@ To use Tracee with falcosidekick:
     1. See the the [falcosidekick Readme](https://github.com/falcosecurity/falcosidekick) for full documentation.
 3. Start Tracee while configuring it to post detections to the falcosidekick endpoint.
     1. If using Docker, you can use the simple [link](https://docs.docker.com/network/links/) flag to allow the containers to communicate
-	  2. Use the webhook flag to point to the falcosidekick container's endpoint
-	  3. Tracee ships with a built-in template for falcosidekick
+    2. Use the webhook flag to point to the falcosidekick container's endpoint
+    3. Tracee ships with a built-in template for falcosidekick
 
 
 ```bash
 # Start falcosidekick configured to post to Slack
-docker run --name falcosidekick -p 2801:2801 -e SLACK_WEBHOOKURL=https://hooks.slack.com/services/XXX/YYY/ZZZ falcosecurity/falcosidekick
+docker run --name falcosidekick -p 2801:2801 \
+  -e SLACK_WEBHOOKURL=https://hooks.slack.com/services/XXX/YYY/ZZZ \
+  falcosecurity/falcosidekick
 
 # Start Tracee, linking it to the falcosidekick container, and configuring it to call it on detections
-docker run --rm --privileged --pid=host --cgroupns=host -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -v /tmp/tracee:/tmp/tracee -it --link falcosidekick aquasec/tracee --webhook-template /tracee/templates/falcosidekick.tmpl --webhook-content-type application/json --webhook http://FALCOSIDEKICK:2801
+docker run --name tracee --rm -it --privileged --pid=host --cgroupns=host \
+  -v /lib/modules/:/lib/modules/:ro \
+  -v /usr/src:/usr/src:ro \
+  -v /tmp/tracee:/tmp/tracee \
+  --link falcosidekick aquasec/tracee:{{ git_tag_version[1:] }} \
+  --webhook-template /tracee/templates/falcosidekick.tmpl \
+  --webhook-content-type application/json \
+  --webhook http://FALCOSIDEKICK:2801
 ```
+
+[falcosidekick]: https://github.com/falcosecurity/falcosidekick

--- a/docs/tracee-ebpf/index.md
+++ b/docs/tracee-ebpf/index.md
@@ -9,7 +9,7 @@ In some cases, you might want to leverage Tracee's eBPF event collection capabil
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](../install/prerequisites.md).
 
 ```bash
-docker run --name tracee --rm --pid=host --cgroupns=host --privileged -it aquasec/tracee:latest trace
+docker run --name tracee --rm --pid=host --cgroupns=host --privileged -it aquasec/tracee:{{ git_tag_version[1:] }} trace
 ```
 
 Here we are running the same `aquasec/tracee` container, but with the `trace` sub-command, which will start just a raw trace (Tracee-eBPF), without the detection engine (Tracee-Rules). Here's a sample output of running with no additional arguments:
@@ -37,6 +37,7 @@ Each line is a single event collected by Tracee-eBPF, with the following informa
 ## Getting Tracee-eBPF
 
 You can obtain Tracee-eBPF in any of the following ways:
+
 1. Download from the [GitHub Releases](https://github.com/aquasecurity/tracee/releases) (`tracee.tar.gz`).
 2. Use the docker image from Docker Hub: `aquasec/tracee` with the `trace` sub-command.
 3. Build the executable from source using `make build`. For that you will need additional development tooling.


### PR DESCRIPTION
To preview changes run `make mkdocs-serve` and open http://localhost:8000 in you web browser.

![pin_version](https://user-images.githubusercontent.com/1322923/143479031-b68c4ea2-4fc2-434f-b641-133006f58c5c.png)

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>