### PR TITLE
add ctime to security_file_open and fix variable type

### DIFF
--- a/tracee-ebpf/tracee/consts.go
+++ b/tracee-ebpf/tracee/consts.go
@@ -953,7 +953,7 @@ var EventsIDToParams = map[int32][]external.ArgMeta{
 	CgroupMkdirEventID:            {{Type: "u64", Name: "cgroup_id"}, {Type: "const char*", Name: "cgroup_path"}},
 	CgroupRmdirEventID:            {{Type: "u64", Name: "cgroup_id"}, {Type: "const char*", Name: "cgroup_path"}},
 	SecurityBprmCheckEventID:      {{Type: "const char*", Name: "pathname"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}},
-	SecurityFileOpenEventID:       {{Type: "const char*", Name: "pathname"}, {Type: "int", Name: "flags"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "int", Name: "syscall"}},
+	SecurityFileOpenEventID:       {{Type: "const char*", Name: "pathname"}, {Type: "int", Name: "flags"}, {Type: "dev_t", Name: "dev"}, {Type: "unsigned long", Name: "inode"}, {Type: "unsigned long", Name: "ctime"}, {Type: "int", Name: "syscall"}},
 	SecurityInodeUnlinkEventID:    {{Type: "const char*", Name: "pathname"}},
 	SecuritySocketCreateEventID:   {{Type: "int", Name: "family"}, {Type: "int", Name: "type"}, {Type: "int", Name: "protocol"}, {Type: "int", Name: "kern"}},
 	SecuritySocketListenEventID:   {{Type: "int", Name: "sockfd"}, {Type: "struct sockaddr*", Name: "local_addr"}, {Type: "int", Name: "backlog"}},

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -892,7 +892,7 @@ static __always_inline unsigned long get_inode_nr_from_file(struct file *file)
     return READ_KERN(f_inode->i_ino);
 }
 
-static __always_inline unsigned long get_ctime_nanosec_from_file(struct file *file)
+static __always_inline u64 get_ctime_nanosec_from_file(struct file *file)
 {
     struct inode *f_inode = READ_KERN(file->f_inode);
     struct timespec64 ts = READ_KERN(f_inode->i_ctime);

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2457,7 +2457,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     struct file* file = get_file_ptr_from_bprm(bprm);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
-    unsigned long ctime = get_ctime_nanosec_from_file(file);
+    u64 ctime = get_ctime_nanosec_from_file(file);
 
     // bprm->mm is null at this point (set by begin_new_exec()), and task->mm is already initialized
     struct mm_struct *mm = get_mm_from_task(task);
@@ -2487,7 +2487,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     save_to_submit_buf(&data, &s_dev, sizeof(dev_t), 4);
     save_to_submit_buf(&data, &inode_nr, sizeof(unsigned long), 5);
     save_to_submit_buf(&data, &invoked_from_kernel, sizeof(int), 6);
-    save_to_submit_buf(&data, &ctime, sizeof(unsigned long), 7);
+    save_to_submit_buf(&data, &ctime, sizeof(u64), 7);
 
     return events_perf_submit(&data, SCHED_PROCESS_EXEC, 0);
 }
@@ -2684,15 +2684,17 @@ int BPF_KPROBE(trace_security_file_open)
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
     void *file_path = get_path_str(GET_FIELD_ADDR(file->f_path));
+    u64 ctime = get_ctime_nanosec_from_file(file);
 
     save_str_to_buf(&data, file_path, 0);
     save_to_submit_buf(&data, (void*)GET_FIELD_ADDR(file->f_flags), sizeof(int), 1);
     save_to_submit_buf(&data, &s_dev, sizeof(dev_t), 2);
     save_to_submit_buf(&data, &inode_nr, sizeof(unsigned long), 3);
+    save_to_submit_buf(&data, &ctime, sizeof(u64), 4);
     if (get_config(CONFIG_SHOW_SYSCALL)) {
         syscall_data_t *sys = bpf_map_lookup_elem(&syscall_data_map, &data.context.host_tid);
         if (sys) {
-            save_to_submit_buf(&data, (void*)&sys->id, sizeof(int), 4);
+            save_to_submit_buf(&data, (void*)&sys->id, sizeof(int), 5);
         }
     }
 


### PR DESCRIPTION
Add ctime of the opened file to `security_file_open`.
The type was fixed from `unsigned long` to `u64` because it resulted in parsing errors of following argument.
This issue wasn't noticed because there are no arguments after the `ctime` argument of `sched_process_exec`.