### PR TITLE
update mkdocs version dependency

### DIFF
--- a/.github/workflows/mkdocs-dev.yaml
+++ b/.github/workflows/mkdocs-dev.yaml
@@ -24,7 +24,7 @@ jobs:
           pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
           pip install mike
           pip install mkdocs-macros-plugin
-          pip install git+https://github.com/itaysk/mkdocs-macro-gitsemver
+          pip install git+https://github.com/itaysk/mkdocs-macros-gittagversion
         env:
           GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
       - name: Setup Git

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -25,7 +25,7 @@ jobs:
           pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
           pip install mike
           pip install mkdocs-macros-plugin
-          pip install git+https://github.com/itaysk/mkdocs-macro-gitsemver
+          pip install git+https://github.com/itaysk/mkdocs-macros-gittagversion
         env:
           GH_TOKEN: ${{ secrets.MKDOCS_AQUA_BOT }}
       - name: Setup Git

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -2,4 +2,4 @@ FROM squidfunk/mkdocs-material:7.3.6
 
 RUN pip install mike
 RUN pip install mkdocs-macros-plugin
-RUN pip install git+https://github.com/itaysk/mkdocs-macro-gitsemver
+RUN pip install git+https://github.com/itaysk/mkdocs-macros-gittagversion

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,4 +45,4 @@ extra:
 plugins:
   - search
   - macros:
-      modules: ["mkdocs_macros_gitsemver"]
+      modules: ["mkdocs_macros_gittagversion"]


### PR DESCRIPTION
the repo was renamed according to mkdocs-macros recommendation (macro->macros) and also to better reflect the variable (any version, not just semver)

can be used like `{{ git_tag_version }}`