### PR TITLE
Upgrade dependencies

### DIFF
--- a/tracee-ebpf/go.mod
+++ b/tracee-ebpf/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/aquasecurity/tracee/tracee-ebpf/external => ./external/
 
 require (
-	github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210910045113-64a32faceb3c
+	github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0
 	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210903145311-dfdb5d66613f
 	github.com/google/gopacket v1.1.19
 	github.com/stretchr/testify v1.7.0

--- a/tracee-ebpf/go.sum
+++ b/tracee-ebpf/go.sum
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210910045113-64a32faceb3c h1:VdquJTWJxJaRK+4Egx6EMIb2mb1ipLxR+OC/3msWgwg=
-github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210910045113-64a32faceb3c/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0 h1:Qecy9Qvj4TG0LK7sfuJWzd1QlwMozHo7H0AyZMGjLg8=
+github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -868,7 +868,12 @@ func (t *Tracee) initBPF() error {
 			case kretprobe:
 				_, err = prog.AttachKretprobe(probe.event)
 			case tracepoint:
-				_, err = prog.AttachTracepoint(probe.event)
+				tpEvent := strings.Split(probe.event, ":")
+				if len(tpEvent) != 2 {
+					err = fmt.Errorf("tracepoint must be in 'category:name' format")
+				} else {
+					_, err = prog.AttachTracepoint(probe.event, probe.event)
+				}
 			case rawTracepoint:
 				tpEvent := strings.Split(probe.event, ":")[1]
 				_, err = prog.AttachRawTracepoint(tpEvent)

--- a/tracee-rules/go.mod
+++ b/tracee-rules/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210922213431-07969faccea0
+	github.com/aquasecurity/tracee/tracee-ebpf/external v0.6.4
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/tracee-rules/go.sum
+++ b/tracee-rules/go.sum
@@ -54,8 +54,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210922213431-07969faccea0 h1:W2asvJ+Zh4ybmNhjySSgy0O53RDaDH373qCp87jPWbg=
-github.com/aquasecurity/tracee/tracee-ebpf/external v0.0.0-20210922213431-07969faccea0/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
+github.com/aquasecurity/tracee/tracee-ebpf/external v0.6.4 h1:9OHivG3zVP4Etd7IHMEc4LFQE1w6o3SsQK98VmhVkrU=
+github.com/aquasecurity/tracee/tracee-ebpf/external v0.6.4/go.mod h1:C6aED/3HEi4aKSyjtCBWC//7EDXVlV/cQAdDgSbF1eM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=


### PR DESCRIPTION
This upgrades:

- libbpf to v0.5.0
- libbpfgo to v0.2.2-libbpf-0.5.0 (and fixed breaking change)
- tracee-ebpf/external to v0.6.4