### PR TITLE
418corefixes

### DIFF
--- a/tracee-ebpf/tracee/co-re/struct_flavors.h
+++ b/tracee-ebpf/tracee/co-re/struct_flavors.h
@@ -3,6 +3,8 @@
 
 #pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
 
+// (struct kernfs_node *)->id was union kernfs_node_id before 5.5
+
 union kernfs_node_id {
     struct {
         u32 ino;
@@ -27,17 +29,19 @@ struct kernfs_node___rh8 {
     };
 };
 
+// commit bf9765145b85 ("sock: Make sk_protocol a 16-bit value")
+
 struct sock___old {
-    struct sock_common      __sk_common;
-    unsigned int            __sk_flags_offset[0];
-    unsigned int            sk_padding : 1,
-                            sk_kern_sock : 1,
-                            sk_no_check_tx : 1,
-                            sk_no_check_rx : 1,
-                            sk_userlocks : 4,
-                            sk_protocol  : 8,
-                            sk_type      : 16;
-    u16                     sk_gso_max_segs;
+    struct sock_common  __sk_common;
+    unsigned int        __sk_flags_offset[0];
+    unsigned int        sk_padding : 1,
+                        sk_kern_sock : 1,
+                        sk_no_check_tx : 1,
+                        sk_no_check_rx : 1,
+                        sk_userlocks : 4,
+                        sk_protocol  : 8,
+                        sk_type      : 16;
+    u16                 sk_gso_max_segs;
 };
 
 #pragma clang attribute pop

--- a/tracee-ebpf/tracee/co-re/struct_flavors.h
+++ b/tracee-ebpf/tracee/co-re/struct_flavors.h
@@ -44,6 +44,27 @@ struct sock___old {
     u16                 sk_gso_max_segs;
 };
 
+// support bpf_core_type_exists((task struct)->pids) for kernels < 5.0
+
+enum pid_type
+{
+    PIDTYPE_PID,
+    PIDTYPE_PGID,
+    PIDTYPE_SID,
+    PIDTYPE_MAX,
+    __PIDTYPE_TGID
+};
+
+struct pid_link
+{
+    struct hlist_node node;
+    struct pid *pid;
+};
+
+struct task_struct___older_v50 {
+    struct pid_link pids[PIDTYPE_MAX];
+};
+
 #pragma clang attribute pop
 
 #endif

--- a/tracee-ebpf/tracee/co-re/struct_flavors.h
+++ b/tracee-ebpf/tracee/co-re/struct_flavors.h
@@ -5,15 +5,26 @@
 
 union kernfs_node_id {
     struct {
-        u32     ino;
-        u32     generation;
+        u32 ino;
+        u32 generation;
     };
-    u64         id;
+    u64 id;
 };
 
-struct kernfs_node___old {
-    const char            *name;
-    union kernfs_node_id  id;
+struct kernfs_node___older_v55 {
+    const char *name;
+    union kernfs_node_id id;
+};
+
+struct kernfs_node___rh8 {
+    const char *name;
+    union {
+        u64 id;
+        struct {
+            union kernfs_node_id id;
+        } rh_kabi_hidden_172;
+        union { };
+    };
 };
 
 struct sock___old {


### PR DESCRIPTION
The following comment: https://github.com/aquasecurity/tracee/issues/1171#issuecomment-985966743 summarizes the whys of this PR.
---

commit bf6ff44 (HEAD -> 418corefixes, rafaeldtinoco/418corefixes)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Dec 3 11:27:09 2021

    tracee-ebpf: turn CO-RE v4.18 and beyond compatible

    Fixes: #1171

    For the VANILLA v4.18 (and beyond) kernels, we need the following 3
    commits backported, together with this patch, in order to have tracee
    eBPF object loaded correctly.

    commit 0962590e5533
    Author: Daniel Borkmann <daniel@iogearbox.net>
    Date:   Wed Oct 31 23:05:52 2018

        bpf: fix partial copy of map_ptr when dst is scalar

    commit e4f8d81c738d
    Author: Steven Rostedt (VMware) <rostedt@goodmis.org>
    Date:   Mon Jul 9 21:48:54 2018

        cgroup/tracing: Move taking of spin lock out of trace event handlers

    commit f7cf25b2026d
    Author: Alexei Starovoitov <ast@kernel.org>
    Date:   Sat Jun 15 12:12:17 2019 -0700

        bpf: track spill/fill of constants

    There is no v4.18 stable tree, so there is no way to propose those
    patches to upstream. Nevertheless, it is important to mention here so
    someone needing v4.18 kernel is able to compile it with the 3 mentioned
    patches - and possibly other dependencies - and this patch to tracee.

    The v4.19 (stable tree: linux-4.19.y branch) kernel already contains the
    needed fixes and doesn't need changes to have tracee CO-RE object
    running.
    
---

commit 902f242
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Dec 3 11:05:54 2021

    tracee-ebpf: comments for co-re type flavors

    - add comments to flavored types
    - adjust spaces & tabs according to project source style

---

commit 646dcf2
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Dec 3 10:58:04 2021

    tracee-ebpf: fix kernfs_node CORE access in RHEL8

    Fixes: #1171

    RHEL8 4.18 kernels have a different kernfs_node struct. You can see the
    name rh_kabi_hiddenXXX which is part of the RH KABI abstraction header
    (an attempt of RH to keep KABI compatible between their back-ports):

    struct kernfs_node {
            atomic_t count;
            atomic_t active;
            struct kernfs_node *parent;
            const char *name;
            struct rb_node rb;
            const void *ns;
            unsigned int hash;
            union {
                    struct kernfs_elem_dir dir;
                    struct kernfs_elem_symlink symlink;
                    struct kernfs_elem_attr attr;
            };
            void *priv;
            union {
                    u64 id;
                    struct {
                            union kernfs_node_id id;
                    } rh_kabi_hidden_172;
                    union {         };
            };
            short unsigned int flags;
            umode_t mode;
            struct kernfs_iattrs *iattr;
    };

    while the regular v4.18 struct is:

    struct kernfs_node {
            atomic_t count;
            atomic_t active;
            struct kernfs_node *parent;
            const char *name;
            struct rb_node rb;
            const void *ns;
            unsigned int hash;
            union {
                    struct kernfs_elem_dir dir;
                    struct kernfs_elem_symlink symlink;
                    struct kernfs_elem_attr attr;
            };
            void *priv;
            union kernfs_node_id id;
            short unsigned int flags;
            umode_t mode;
            struct kernfs_iattrs *iattr;
    };

    One way of dealing with this would be to pass to tracee.bpf the current
    running OS distro and kernel version and use branches to decide which
    struct flavor to use.. but we cannot do that because of the dead branch
    bug of v5.4 kernel.

    RHEL8 4.18 kernel is also very different from vanilla 4.18 kernel.

    Another example is the

    struct pid_link {
            struct hlist_node node;
            struct pid *pid;
    };

    not existing in RHEL8 and the task_struct of RHEL8 having:

    struct task_struct {
    ...
        struct pid *thread_pid;
    ...
    }

    Based on that, type the type/field checks are better than version checks
    because most of the times it will do the right thing (if the type we
    want exists we declare it as a flavor).