### PR TITLE
fix help on output flags

### DIFF
--- a/docs/tracee-ebpf/output.md
+++ b/docs/tracee-ebpf/output.md
@@ -39,5 +39,5 @@ output as the provided go template
 output to `/my/out` and errors to `/my/err`
 
 ```
---output out-file:/my/out err-file:/my/err
+--output out-file:/my/out --output err-file:/my/err
 ```

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -382,7 +382,7 @@ option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-hash,parse-ar
 Examples:
   --output json                                            | output as json
   --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
-  --output out-file:/my/out err-file:/my/err               | output to /my/out and errors to /my/err
+  --output out-file:/my/out --output err-file:/my/err      | output to /my/out and errors to /my/err
   --output none                                            | ignore events output
 
 Use this flag multiple times to choose multiple output options


### PR DESCRIPTION
in the help string it is mentioned that several output flags can be provided in sequence, specifically the out-file and err-file flags:
```

Examples:
  --output json                                            | output as json
  --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
  --output out-file:/my/out err-file:/my/err               | output to /my/out and errors to /my/err
  --output none                                            | ignore events output

Use this flag multiple times to choose multiple output options

```
Although it states that the flag should be provided multiple times the example shows differently.