### PR TITLE
don't alert for fileless runc on host

### DIFF
--- a/tracee-rules/signatures/rego/fileless_execution.rego
+++ b/tracee-rules/signatures/rego/fileless_execution.rego
@@ -17,7 +17,7 @@ __rego_metadoc__ := {
 eventSelectors := [
     {
         "source": "tracee",
-        "name": "security_bprm_check"
+        "name": "sched_process_exec"
     }
 ]
 
@@ -27,13 +27,24 @@ tracee_selected_events[eventSelector] {
 
 
 tracee_match {
-    input.eventName == "security_bprm_check"
+    input.eventName == "sched_process_exec"
     pathname = helpers.get_tracee_argument("pathname")
     startswith(pathname, "memfd:")
+
+    not startswith(pathname, "memfd:runc")
+    input.containerId == ""
 }
 
 tracee_match {
-    input.eventName == "security_bprm_check"
+    input.eventName == "sched_process_exec"
+    pathname = helpers.get_tracee_argument("pathname")
+    startswith(pathname, "memfd:")
+
+    input.containerId != ""
+}
+
+tracee_match {
+    input.eventName == "sched_process_exec"
     pathname = helpers.get_tracee_argument("pathname")
     startswith(pathname, "/dev/shm")
 }

--- a/tracee-rules/signatures/rego/fileless_execution_test.rego
+++ b/tracee-rules/signatures/rego/fileless_execution_test.rego
@@ -2,8 +2,9 @@ package tracee.TRC_5
 
 test_match_1 {
     tracee_match with input as {
-        "eventName": "security_bprm_check",
+        "eventName": "sched_process_exec",
         "argsNum": 1,
+        "containerId": "someContainer",
         "args": [
             {
                 "name": "pathname",
@@ -15,8 +16,51 @@ test_match_1 {
 
 test_match_2 {
     tracee_match with input as {
-        "eventName": "security_bprm_check",
+        "eventName": "sched_process_exec",
         "argsNum": 1,
+        "containerId": "someContainer",
+        "args": [
+            {
+                "name": "pathname",
+                "value": "memfd:runc"
+            }
+        ]
+    }
+}
+
+test_match_3 {
+    tracee_match with input as {
+        "eventName": "sched_process_exec",
+        "argsNum": 1,
+        "containerId": "",
+        "args": [
+            {
+                "name": "pathname",
+                "value": "memfd://something/something"
+            }
+        ]
+    }
+}
+
+test_match_4 {
+    not tracee_match with input as {
+        "eventName": "sched_process_exec",
+        "argsNum": 1,
+        "containerId": "",
+        "args": [
+            {
+                "name": "pathname",
+                "value": "memfd:runc"
+            }
+        ]
+    }
+}
+
+test_match_5 {
+    tracee_match with input as {
+        "eventName": "sched_process_exec",
+        "argsNum": 1,
+        "containerId": "someContainer",
         "args": [
             {
                 "name": "pathname",
@@ -28,8 +72,9 @@ test_match_2 {
 
 test_match_wrong_pathname {
     not tracee_match with input as {
-        "eventName": "security_bprm_check",
+        "eventName": "sched_process_exec",
         "argsNum": 1,
+        "containerId": "someContainer",
         "args": [
             {
                 "name": "pathname",


### PR DESCRIPTION
when on host there's a legitimate case of memfd:runc being run. don't alert for this case.