### PR TITLE
feat: Enable sanity tests on each PR.

### DIFF
--- a/.github/wf2/pr-sanity.yaml
+++ b/.github/wf2/pr-sanity.yaml
@@ -1,0 +1,19 @@
+name: pr-sanity
+on:
+  pull_request:
+
+jobs:
+  sanity-test:
+    name: "Sanity Test"
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-20.04]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Run Tracee sanity tests
+        run: |
+          make sanity

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -1,0 +1,18 @@
+name: pr-sanity
+on:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ubuntu-20.04]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Run Tracee sanity tests
+        run: |
+          make sanity

--- a/.github/workflows/pr-sanity.yaml
+++ b/.github/workflows/pr-sanity.yaml
@@ -3,16 +3,21 @@ on:
   pull_request:
 
 jobs:
-  build-test:
+  sanity-test:
+    name: "Sanity Test"
     runs-on: ${{ matrix.os }}
     strategy:
-        matrix:
-            os: [ubuntu-20.04]
+      matrix:
+        os: [centos-8.2-linux-4.18]
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: Run Tracee sanity tests
-        run: |
-          make sanity
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Setup Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.16
+    - name: Run Tracee sanity tests
+      run: |
+        make sanity

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 
 ENV TINI_SUBREAPER=true
 
-ENTRYPOINT ["/sbin/tini", "-g", "--", "./entrypoint.sh"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -121,3 +121,8 @@ test-entrypoint: entrypoint.sh entrypoint_test.bats test/mocks/* test/bats-helpe
 mkdocs-serve:
 	$(CMD_DOCKER) build -t $(MKDOCS_IMAGE) -f docs/Dockerfile docs
 	$(CMD_DOCKER) run --name mkdocs-serve --rm -v $(PWD):/docs -p $(MKDOCS_PORT):8000 $(MKDOCS_IMAGE)
+
+.PHONY:
+sanity:
+	docker build -t tracee-test:latest .
+	cd tests && go test -v tracee_test.go

--- a/tests/tracee_test.go
+++ b/tests/tracee_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	waitTime                   = time.Second * 3
-	traceeDockerRunBTFEnabled  = `run --detach --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -t aquasec/tracee:latest`
-	traceeDockerRunBTFDisabled = `run --detach --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it aquasec/tracee:latest`
-	traceeDockerRunWithWebhook = `run --detach --name tracee --rm --pid=host --net=host --privileged -v /tmp/tracee:/tmp/tracee -t aquasec/tracee:latest --webhook=%s --webhook-template=%s --webhook-content-type=application/json`
+	waitTime                   = time.Second * 20
+	traceeDockerRunBTFEnabled  = `run --detach --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -t tracee-test:latest`
+	traceeDockerRunBTFDisabled = `run --detach --name tracee --rm --pid=host --privileged -v /tmp/tracee:/tmp/tracee -v /lib/modules/:/lib/modules/:ro -v /usr/src:/usr/src:ro -it tracee-test:latest`
+	traceeDockerRunWithWebhook = `run --detach --name tracee --rm --pid=host --net=host --privileged -v /tmp/tracee:/tmp/tracee -t tracee-test:latest --webhook=%s --webhook-template=%s --webhook-content-type=application/json`
 )
 
 func launchTracee(t *testing.T, traceeCmd string) string {


### PR DESCRIPTION
These tests exist today but aren't exercised. They have subjectively better value rather than unit testing the surface they touch.

**Motivation:**
While refactoring `tracee.go`, I noticed that we don't test input options to tracee in any way (more specifically, the `ActionFunc` for the cli framework).

```
=== RUN   TestLaunchTracee
=== RUN   TestLaunchTracee/BTF_enabled
    tracee_test.go:49: Launching Tracee container...
    tracee_test.go:49: Tracee container ID:  d203c40e30265c221e12429a800b25cd4c6ed131c8fe03d4d6e336f04c25a2b4
    tracee_test.go:55: Running strace [ls] ...
    tracee_test.go:61: Running docker [logs d203c40e30265c221e12429a800b25cd4c6ed131c8fe03d4d6e336f04c25a2b4] ...
    tracee_test.go:64: Asserting Logs...
    tracee_test.go:68: Terminating the Tracee container...
=== RUN   TestLaunchTracee/BTF_disabled
    tracee_test.go:73: Launching Tracee container...
    tracee_test.go:73: Tracee container ID:  5c16496d942c92c6d6f07854ec546c269b6151178990b701b80c2ea8ed01164e
    tracee_test.go:79: Running strace [ls] ...
    tracee_test.go:85: Running docker [logs 5c16496d942c92c6d6f07854ec546c269b6151178990b701b80c2ea8ed01164e] ...
    tracee_test.go:88: Asserting Logs...
    tracee_test.go:92: Terminating the Tracee container...
--- PASS: TestLaunchTracee (15.58s)
    --- PASS: TestLaunchTracee/BTF_enabled (7.75s)
    --- PASS: TestLaunchTracee/BTF_disabled (7.83s)
=== RUN   TestWebhookIntegration
    tracee_test.go:109: Launching Tracee container...
    tracee_test.go:109: Tracee container ID:  c245a35e8d3c34e8e24fdc41246c4f8ed57a6706e840598cd58c9ce79f2b4d84
    tracee_test.go:115: Running strace [ls] ...
    tracee_test.go:102: Asserting Logs...
    tracee_test.go:121: Running docker [logs c245a35e8d3c34e8e24fdc41246c4f8ed57a6706e840598cd58c9ce79f2b4d84] ...
    tracee_test.go:127: Terminating the Tracee container...
--- PASS: TestWebhookIntegration (7.20s)
PASS
ok      command-line-arguments  22.790s

```
Signed-off-by: Simar <simar@linux.com>