### PR TITLE
tracee-ebpf: a new Makefile

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,6 +52,13 @@ jobs:
         run: |
           make -C tracee-ebpf/ all DOCKER=1
           make -C tracee-ebpf/ test DOCKER=1
+      - name: Test Single Makefile tracee-ebpf
+        run: |
+          rm -rf tracee-ebpf/dist
+          rm -rf dist
+          make -f Makefile.one tracee-ebpf
+          make -f Makefile.one clean
+          make -f Makefile.one test-tracee-ebpf
   test-tracee-rules:
     name: Test tracee-rules
     needs:
@@ -73,6 +80,17 @@ jobs:
       - name: Test tracee-rules in Docker
         run: |
           make -C tracee-rules/ test DOCKER=1
+      - name: Test Single Makefile tracee-rules
+        run: |
+          rm -rf tracee-rules/dist
+          rm -rf dist
+          make -f Makefile.one tracee-rules
+          make -f Makefile.one clean
+          make -f Makefile.one rules
+          make -f Makefile.one clean
+          make -f Makefile.one test-tracee-rules
+          make -f Makefile.one clean
+          make -f Makefile.one test-rules
   release-snapshot:
     name: Release Snapshot
     needs:

--- a/Makefile.one
+++ b/Makefile.one
@@ -1,0 +1,468 @@
+.PHONY: all
+all:
+	$(MAKE) env
+	$(MAKE) reqs
+	$(MAKE) tracee-ebpf tracee-rules rules
+
+# make
+
+PARALLEL = $(shell $(CMD_GREP) -c ^processor /proc/cpuinfo)
+
+NORM_MAKE = make -j$(PARALLEL)
+
+MAKE = make -f Makefile.one
+MAKEFLAGS += --no-print-directory
+MAKEFLAGS += -j$(PARALLEL)
+
+# tools
+
+CMD_GIT ?= git
+CMD_CLANG ?= clang
+CMD_LLC ?= llc
+CMD_STRIP ?= llvm-strip
+CMD_RM ?= rm
+CMD_INSTALL ?= install
+CMD_MKDIR ?= mkdir
+CMD_PKGCONFIG ?= pkg-config
+CMD_GO ?= go
+CMD_GREP ?= grep
+CMD_OPA ?= opa # https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64
+
+check_%:
+	@command -v $* >/dev/null || (echo "missing required tool $*" ; exit 1)
+
+# libs
+
+LIB_ELF ?= libelf
+LIB_ZLIB ?= zlib
+
+checklib_%:
+	@$(CMD_PKGCONFIG) --silence-errors --validate $* 2>/dev/null || \
+		(echo "missing lib $*" ; exit 1)
+
+# version
+
+LAST_GIT_TAG ?= $(shell $(CMD_GIT) describe --tags --match 'v*' 2>/dev/null)
+VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(LAST_GIT_TAG))
+
+# environment
+
+UNAME_M := $(shell uname -m)
+UNAME_R := $(shell uname -r)
+
+ifeq ($(UNAME_M),x86_64)
+   ARCH = x86_64
+   LINUX_ARCH = x86
+   GO_ARCH = amd64
+endif
+
+ifeq ($(UNAME_M),aarch64)
+   ARCH = arm64
+   LINUX_ARCH = arm64
+   GO_ARCH = arm64
+endif
+
+.PHONY: env
+env:
+	@echo ---------------------------------------
+	@echo "Makefile Environment:"
+	@echo ---------------------------------------
+	@echo "PARALLEL                 $(PARALLEL)"
+	@echo ---------------------------------------
+	@echo "CMD_CLANG                $(CMD_CLANG)"
+	@echo "CMD_GIT                  $(CMD_GIT)"
+	@echo "CMD_GO                   $(CMD_GO)"
+	@echo "CMD_GREP                 $(CMD_GREP)"
+	@echo "CMD_INSTALL              $(CMD_INSTALL)"
+	@echo "CMD_LLC                  $(CMD_LLC)"
+	@echo "CMD_MKDIR                $(CMD_MKDIR)"
+	@echo "CMD_OPA                  $(CMD_OPA)"
+	@echo "CMD_PKGCONFIG            $(CMD_PKGCONFIG)"
+	@echo "CMD_RM                   $(CMD_RM)"
+	@echo "CMD_STRIP                $(CMD_STRIP)"
+	@echo ---------------------------------------
+	@echo "LIB_ELF                  $(LIB_ELF)"
+	@echo "LIB_ZLIB                 $(LIB_ZLIB)"
+	@echo ---------------------------------------
+	@echo "VERSION                  $(VERSION)"
+	@echo "LAST_GIT_TAG             $(LAST_GIT_TAG)"
+	@echo "BPF_NOCORE_TAG           $(BPF_NOCORE_TAG)"
+	@echo ---------------------------------------
+	@echo "UNAME_M                  $(UNAME_M)"
+	@echo "UNAME_R                  $(UNAME_R)"
+	@echo "ARCH                     $(ARCH)"
+	@echo "LINUX_ARCH               $(LINUX_ARCH)"
+	@echo ---------------------------------------
+	@echo "OUTPUT_DIR               $(OUTPUT_DIR)"
+	@echo ---------------------------------------
+	@echo "KERN_RELEASE             $(KERN_RELEASE)"
+	@echo "KERN_BUILD_PATH          $(KERN_BUILD_PATH)"
+	@echo "KERN_SRC_PATH            $(KERN_SRC_PATH)"
+	@echo ---------------------------------------
+	@echo "LIBBPF_CFLAGS            $(LIBBPF_CFLAGS)"
+	@echo "LIBBPF_LDLAGS            $(LIBBPF_LDFLAGS)"
+	@echo "LIBBPF_SRC               $(LIBBPF_SRC)"
+	@echo ---------------------------------------
+	@echo "STATIC                   $(STATIC)"
+	@echo ---------------------------------------
+	@echo "BPF_VCPU                 $(BPF_VCPU)"
+	@echo "TRACEE_EBPF_OBJ_SRC      $(TRACEE_EBPF_OBJ_SRC)"
+	@echo ---------------------------------------
+	@echo "GO_ARCH                  $(GO_ARCH)"
+	@echo "GO_TAGS_EBPF             $(GO_TAGS_EBPF)"
+	@echo "GO_TAGS_RULES            $(GO_TAGS_RULES)"
+	@echo ---------------------------------------
+	@echo "CUSTOM_CGO_CFLAGS        $(CUSTOM_CGO_CFLAGS)"
+	@echo "CUSTOM_CGO_LDFLAGS       $(CUSTOM_CGO_LDFLAGS)"
+	@echo "CGO_EXT_LDFLAGS_EBPF     $(CGO_EXT_LDFLAGS_EBPF)"
+	@echo "CGO_EXT_LDFLAGS_RULES    $(CGO_EXT_LDFLAGS_RULES)"
+	@echo ---------------------------------------
+	@echo "GO_ENV_EBPF              $(GO_ENV_EBPF)"
+	@echo "GO_ENV_RULES             $(GO_ENV_RULES)"
+	@echo ---------------------------------------
+	@echo "TRACEE_EBPF_SRC          $(TRACEE_EBPF_SRC)"
+	@echo ---------------------------------------
+	@echo "GOSIGNATURES_DIR         $(GOSIGNATURES_DIR)"
+	@echo "GOSIGNATURES_SRC         $(GOSIGNATURES_SRC)"
+	@echo ---------------------------------------
+	@echo "REGO_SIGNATURES_DIR      $(REGO_SIGNATURES_DIR)"
+	@echo "REGO_SIGNATURES_SRC      $(REGO_SIGNATURES_SRC)"
+	@echo ---------------------------------------
+
+# usage
+
+.PHONY: help
+help:
+	@echo ""
+	@echo "$ make env                  # show makefile environment/variables"
+	@echo "$ make reqs                 # verify build requirements"
+	@echo ""
+	@echo "# build"
+	@echo ""
+	@echo "$ make all                  # build tracee-ebpf, tracee-rules & rules"
+	@echo "$ make bpf-core             # build ./dist/tracee.bpf.core.o"
+	@echo "$ make bpf-nocore           # build ./dist/tracee.bpf.XXX.o"
+	@echo "$ make tracee-ebpf          # build ./dist/tracee-ebpf"
+	@echo "$ make tracee-rules         # build ./dist/tracee-rules"
+	@echo "$ make rules                # build ./dist/rules"
+	@echo ""
+	@echo "# clean"
+	@echo ""
+	@echo "$ make clean                # wipe ./dist/"
+	@echo "$ make clean-bpf-core       # wipe ./dist/tracee.bpf.core.o"
+	@echo "$ make clean-bpf-nocore     # wipe ./dist/tracee.bpf.XXX.o"
+	@echo "$ make clean-tracee-ebpf    # wipe ./dist/tracee-ebpf"
+	@echo "$ make clean-tracee-rules   # wipe ./dist/tracee-rules"
+	@echo "$ make clean-rules          # wipe ./dist/rules"
+	@echo ""
+	@echo "# test"
+	@echo ""
+	@echo "$ make test                 # run all go & opa tests"
+	@echo "$ make test-tracee-ebpf     # go test tracee-ebpf"
+	@echo "$ make test-tracee-rules    # go test tracee-rules"
+	@echo "$ make test-rules           # opa test (tracee-rules)"
+	@echo ""
+
+# variables
+
+BPF_VCPU = v2
+
+# requirements
+
+.PHONY: reqs_cmds
+reqs_cmds: \
+	check_$(CMD_GIT) \
+	check_$(CMD_CLANG) \
+	check_$(CMD_LLC) \
+	check_$(CMD_STRIP) \
+	check_$(CMD_RM) \
+	check_$(CMD_GREP) \
+	check_$(CMD_INSTALL) \
+	check_$(CMD_MKDIR) \
+	check_$(CMD_PKGCONFIG) \
+	check_$(CMD_GO) \
+	check_$(CMD_OPA)
+
+.PHONY: reqs_libs
+reqs_libs: \
+	checklib_$(LIB_ELF) \
+	checklib_$(LIB_ZLIB)
+
+.PHONY: reqs
+reqs:
+	$(MAKE) reqs_cmds
+	$(MAKE) reqs_libs
+
+# output dir
+
+OUTPUT_DIR = ./dist
+
+$(OUTPUT_DIR):
+	$(CMD_MKDIR) -p $@
+	$(CMD_MKDIR) -p $@/libbpf
+	$(CMD_MKDIR) -p $@/libbpf/obj
+
+# bundle
+
+.PHONY: $(OUTPUT_DIR)/tracee.bpf
+$(OUTPUT_DIR)/tracee.bpf:
+	$(CMD_MKDIR) -p $@
+	$(CMD_INSTALL) -m 0640 ./tracee-ebpf/3rdparty/include/* $@
+	$(CMD_INSTALL) -m 0640 $(OUTPUT_DIR)/libbpf/bpf/*.h $@
+	$(CMD_INSTALL) -m 0640 $(TRACEE_EBPF_OBJ_SRC) $@
+
+#
+# libbpf
+#
+
+LIBBPF_CFLAGS =
+LIBBPF_LDLAGS =
+LIBBPF_SRC = ./tracee-ebpf/3rdparty/libbpf/src
+
+$(OUTPUT_DIR)/libbpf/libbpf.a: $(LIBBPF_SRC) $(wildcard $(LIBBPF_SRC)/*.[ch]) | $(OUTPUT_DIR)
+	CC="$(CMD_CLANG)" \
+		CFLAGS="$(LIBBPF_CFLAGS)" \
+		LD_FLAGS="$(LIBBPF_LDFLAGS)" \
+		$(NORM_MAKE) -C $(LIBBPF_SRC) \
+		BUILD_STATIC_ONLY=1 \
+		DESTDIR=$(abspath ./$(OUTPUT_DIR)/libbpf/) \
+		OBJDIR=$(abspath ./$(OUTPUT_DIR)/libbpf/obj) \
+		INCLUDEDIR= LIBDIR= UAPIDIR= prefix= libdir= \
+		install install_uapi_headers
+
+$(LIBBPF_SRC):
+ifeq ($(wildcard $@), )
+	$(CMD_GIT) submodule update --init --recursive
+endif
+
+#
+# non co-re ebpf
+#
+
+TRACEE_EBPF_OBJ_SRC = ./tracee-ebpf/tracee/tracee.bpf.c
+
+KERN_RELEASE ?= $(UNAME_R)
+KERN_BUILD_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),/lib/modules/$(KERN_RELEASE)/build)
+KERN_SRC_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),$(if $(wildcard /lib/modules/$(KERN_RELEASE)/source),/lib/modules/$(KERN_RELEASE)/source,$(KERN_BUILD_PATH)))
+
+BPF_NOCORE_TAG = $(subst .,_,$(KERN_RELEASE)).$(subst .,_,$(VERSION))
+
+.PHONY: bpf-nocore
+bpf-nocore: $(OUTPUT_DIR)/tracee.bpf.$(BPF_NOCORE_TAG).o
+
+$(OUTPUT_DIR)/tracee.bpf.$(BPF_NOCORE_TAG).o: $(OUTPUT_DIR)/libbpf/libbpf.a \
+	$(TRACEE_EBPF_OBJ_SRC)
+	$(MAKE) $(OUTPUT_DIR)/tracee.bpf
+	$(CMD_CLANG) -S -nostdinc \
+		-D__TARGET_ARCH_$(LINUX_ARCH) \
+		-D__BPF_TRACING__ \
+		-D__KERNEL__ \
+		-include $(KERN_SRC_PATH)/include/linux/kconfig.h \
+		-I $(KERN_SRC_PATH)/arch/$(LINUX_ARCH)/include \
+		-I $(KERN_SRC_PATH)/arch/$(LINUX_ARCH)/include/uapi \
+		-I $(KERN_BUILD_PATH)/arch/$(LINUX_ARCH)/include/generated \
+		-I $(KERN_BUILD_PATH)/arch/$(LINUX_ARCH)/include/generated/uapi \
+		-I $(KERN_SRC_PATH)/include \
+		-I $(KERN_BUILD_PATH)/include \
+		-I $(KERN_SRC_PATH)/include/uapi \
+		-I $(KERN_BUILD_PATH)/include/generated \
+		-I $(KERN_BUILD_PATH)/include/generated/uapi \
+		-I$(OUTPUT_DIR)/tracee.bpf \
+		-Wunused \
+		-Wall \
+		-Wno-frame-address \
+		-Wno-unused-value \
+		-Wno-unknown-warning-option \
+		-Wno-pragma-once-outside-header \
+		-Wno-pointer-sign \
+		-Wno-gnu-variable-sized-type-not-at-end \
+		-Wno-deprecated-declarations \
+		-Wno-compare-distinct-pointer-types \
+		-Wno-address-of-packed-member \
+		-fno-stack-protector \
+		-fno-jump-tables \
+		-fno-unwind-tables \
+		-fno-asynchronous-unwind-tables \
+		-xc -O2 -g -emit-llvm \
+		-c $(TRACEE_EBPF_OBJ_SRC) \
+		-o $(@:.o=.ll)
+	$(CMD_LLC) \
+		-march=bpf -mcpu=$(BPF_VCPU) \
+		-filetype=obj \
+		-o $@ \
+		$(@:.o=.ll)
+	$(CMD_RM) $(@:.o=.ll)
+
+.PHONY: clean-bpf-nocore
+clean-bpf-nocore:
+	$(CMD_RM) -rf $(OUTPUT_DIR)/tracee.bpf.$(BPF_NOCORE_TAG).o
+
+#
+# co-re ebpf
+#
+
+TRACEE_EBPF_OBJ_CORE_HEADERS = $(shell find tracee-ebpf -name *.h ! -iregex '.*3rdparty.*')
+
+.PHONY: bpf-core
+bpf-core: $(OUTPUT_DIR)/tracee.bpf.core.o
+
+$(OUTPUT_DIR)/tracee.bpf.core.o: $(OUTPUT_DIR)/libbpf/libbpf.a \
+	$(TRACEE_EBPF_OBJ_SRC) \
+	$(TRACEE_EBPF_OBJ_CORE_HEADERS)
+	$(MAKE) $(OUTPUT_DIR)/tracee.bpf
+	$(CMD_CLANG) \
+		-D__TARGET_ARCH_$(LINUX_ARCH) \
+		-D__BPF_TRACING__ \
+		-DCORE \
+		-I./tracee-ebpf/tracee/co-re/ \
+		-I$(OUTPUT_DIR)/tracee.bpf \
+		-target bpf \
+		-O2 -g \
+		-target bpf -march=bpf -mcpu=$(BPF_VCPU) \
+		-c $(TRACEE_EBPF_OBJ_SRC) \
+		-o $@
+
+.PHONY: clean-bpf-core
+clean-bpf-core:
+	$(CMD_RM) -rf $(OUTPUT_DIR)/tracee.bpf.core.o
+
+#
+# tracee-ebpf
+#
+
+STATIC ?= 0
+GO_TAGS_EBPF = core,ebpf
+CGO_EXT_LDFLAGS_EBPF =
+
+ifeq ($(STATIC), 1)
+    CGO_EXT_LDFLAGS_EBPF += -static
+    GO_TAGS_EBPF := $(GO_TAGS_EBPF),netgo
+endif
+
+CUSTOM_CGO_CFLAGS = "-I$(abspath $(OUTPUT_DIR)/libbpf)"
+CUSTOM_CGO_LDFLAGS = "-lelf -lz $(abspath $(OUTPUT_DIR)/libbpf/libbpf.a)"
+
+GO_ENV_EBPF =
+GO_ENV_EBPF += GOOS=linux
+GO_ENV_EBPF += CC=$(CMD_CLANG)
+GO_ENV_EBPF += GOARCH=$(GO_ARCH)
+GO_ENV_EBPF += CGO_CFLAGS=$(CUSTOM_CGO_CFLAGS)
+GO_ENV_EBPF += CGO_LDFLAGS=$(CUSTOM_CGO_LDFLAGS)
+
+TRACEE_EBPF_SRC=$(shell find ./tracee-ebpf/ -type f -name '*.go' ! -name '*_test.go')
+
+.PHONY: tracee-ebpf
+tracee-ebpf: $(OUTPUT_DIR)/tracee-ebpf
+
+$(OUTPUT_DIR)/tracee-ebpf: $(OUTPUT_DIR)/tracee.bpf.core.o $(TRACEE_EBPF_SRC) ./embedded-ebpf.go
+	$(GO_ENV_EBPF) $(CMD_GO) build \
+		-tags $(GO_TAGS_EBPF) \
+		-ldflags="-w \
+			-extldflags \"$(CGO_EXT_LDFLAGS_EBPF)\" \
+			-X main.version=\"$(VERSION)\" \
+			" \
+		-v -o $@ ./tracee-ebpf
+
+.PHONY: clean-tracee-ebpf
+clean-tracee-ebpf:
+	$(CMD_RM) -rf $(OUTPUT_DIR)/tracee-ebpf
+
+.PHONY: test-tracee-ebpf
+test-tracee-ebpf: $(OUTPUT_DIR)/tracee.bpf.core.o
+	$(GO_ENV_EBPF) $(CMD_GO) test \
+		-tags $(GO_TAGS_EBPF) \
+		-v ./tracee-ebpf/...
+
+#
+# tracee-rules
+#
+
+STATIC ?= 0
+GO_TAGS_RULES =
+CGO_EXT_LDFLAGS_RULES =
+
+ifeq ($(STATIC), 1)
+    CGO_EXT_LDFLAGS_RULES += -static
+    GO_TAGS_RULES := netgo
+endif
+
+GO_ENV_RULES =
+GO_ENV_RULES += GOOS=linux
+GO_ENV_RULES += CC=$(CMD_CLANG)
+GO_ENV_RULES += GOARCH=$(GO_ARCH)
+GO_ENV_RULES += CGO_CFLAGS=
+GO_ENV_RULES += CGO_LDFLAGS=
+
+TRACEE_RULES_SRC=$(shell find ./tracee-rules/ -type f -name '*.go')
+
+.PHONY: tracee-rules
+tracee-rules: $(OUTPUT_DIR)/tracee-rules
+
+$(OUTPUT_DIR)/tracee-rules: $(TRACEE_RULES_SRC) | $(OUTPUT_DIR)
+	$(GO_ENV_RULES) $(CMD_GO) build \
+		-tags $(GO_TAGS_RULES) \
+		-ldflags="-w \
+			-extldflags \"$(CGO_EXT_LDFLAGS_RULES)\" \
+			" \
+		-v -o $@ ./tracee-rules
+
+.PHONY: clean-tracee-rules
+clean-tracee-rules:
+	$(CMD_RM) -rf $(OUTPUT_DIR)/tracee-rules
+
+.PHONY: test-tracee-rules
+test-tracee-rules:
+	$(GO_ENV_RULES) $(CMD_GO) test \
+		-tags $(GO_TAGS_RULES) \
+		-v ./tracee-rules/...
+
+# rules
+
+GOSIGNATURES_DIR ?= signatures/golang
+GOSIGNATURES_SRC :=	$(shell find $(GOSIGNATURES_DIR) \
+			-type f \
+			-name '*.go' \
+			! -name '*_test.go' \
+			! -path '$(GOSIGNATURES_DIR)/examples/*' \
+			)
+
+REGO_SIGNATURES_DIR ?= signatures/rego
+REGO_SIGNATURES_SRC :=	$(shell find $(REGO_SIGNATURES_DIR) \
+			-type f \
+			-name '*.rego' \
+			! -name '*_test.rego' \
+			! -path '$(REGO_SIGNATURES_DIR)/examples/*' \
+			)
+
+.PHONY: rules
+rules: $(OUTPUT_DIR)/rules
+
+$(OUTPUT_DIR)/rules: $(GOSIGNATURES_SRC) $(REGO_SIGNATURES_SRC) | $(OUTPUT_DIR)
+	mkdir -p $@
+	$(GO_ENV_RULES) $(CMD_GO) build \
+		--buildmode=plugin \
+		-o $@/builtin.so \
+		$(GOSIGNATURES_SRC)
+	$(CMD_INSTALL) -m 0640 $(REGO_SIGNATURES_SRC) $@
+
+.PHONY: clean-rules
+clean-rules:
+	$(CMD_RM) -rf $(OUTPUT_DIR)/rules
+
+.PHONY: test-rules
+test-rules:
+	$(CMD_OPA) test $(REGO_SIGNATURES_DIR) --verbose
+
+# test
+
+.PHONY: test
+test:
+	$(MAKE) test-tracee-ebpf
+	$(MAKE) test-tracee-rules
+	$(MAKE) test-rules
+
+# clean
+
+.PHONY: clean
+clean:
+	$(CMD_RM) -rf $(OUTPUT_DIR)

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -1,0 +1,31 @@
+FROM alpine:3.15
+
+ARG uid=1000
+ARG gid=1000
+
+RUN apk --no-cache update && \
+    apk --no-cache add sudo coreutils findutils && \
+    apk --no-cache add bash git curl && \
+    apk --no-cache add musl-dev libc6-compat && \
+    apk --no-cache add llvm clang go make gcc && \
+    apk --no-cache add linux-headers && \
+    apk --no-cache add elfutils-dev && \
+    apk --no-cache add libelf-static && \
+    apk --no-cache add zlib-static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    chmod 755 /usr/bin/opa
+
+RUN export uid=$uid gid=$gid && \
+    mkdir -p /home/tracee && \
+    echo "tracee:x:${uid}:${gid}:Tracee,,,:/home/tracee:/bin/bash" >> /etc/passwd && \
+    echo "tracee:x:${gid}:" >> /etc/group && \
+    echo "tracee ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/tracee && \
+    chmod 0440 /etc/sudoers.d/tracee && \
+    chown ${uid}:${gid} -R /home/tracee && \
+    echo "export PS1=\"\u@\h[\w]$ \"" > /home/tracee/.bashrc && \
+    echo "alias ls=\"ls --color\"" >> /home/tracee/.bashrc && \
+    ln -s /home/tracee/.bashrc /home/tracee/.profile
+
+USER tracee
+ENV HOME /home/tracee
+WORKDIR /tracee

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -1,0 +1,30 @@
+FROM ubuntu:hirsute
+
+ARG uid=1000
+ARG gid=1000
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y sudo coreutils bash git curl && \
+    apt-get install -y llvm clang golang make gcc && \
+    apt-get install -y linux-headers-generic && \
+    apt-get install -y libelf-dev && \
+    apt-get install -y zlib1g-dev && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    chmod 755 /usr/bin/opa
+
+RUN export uid=$uid gid=$gid && \
+    mkdir -p /home/tracee && \
+    echo "tracee:x:${uid}:${gid}:Tracee,,,:/home/tracee:/bin/bash" >> /etc/passwd && \
+    echo "tracee:x:${gid}:" >> /etc/group && \
+    echo "tracee::99999:0:99999:7:::" >> /etc/shadow && \
+    echo "tracee ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/tracee && \
+    chmod 0440 /etc/sudoers.d/tracee && \
+    chown ${uid}:${gid} -R /home/tracee && \
+    echo "export PS1=\"\u@\h[\w]$ \"" > /home/tracee/.bashrc && \
+    echo "alias ls=\"ls --color\"" >> /home/tracee/.bashrc && \
+    ln -s /home/tracee/.bashrc /home/tracee/.profile
+
+USER tracee
+ENV HOME /home/tracee
+WORKDIR /tracee

--- a/builder/Makefile.docker
+++ b/builder/Makefile.docker
@@ -1,0 +1,133 @@
+.PHONY: all
+all:
+
+# tools
+
+MAKEFLAGS += --no-print-directory
+
+# tools
+
+CMD_DOCKER ?= docker
+
+check_%:
+	@command -v $* >/dev/null || (echo "missing required tool $*" ; exit 1)
+
+# usage
+
+.PHONY: help
+help:
+	@echo ""
+	@echo "To create an alpine-tracee-make container:"
+	@echo ""
+	@echo "    $ make -f builder/Makefile.docker alpine-prepare"
+	@echo ""
+	@echo "To create an ubuntu-tracee-make container:"
+	@echo ""
+	@echo "    $ make -f builder/Makefile.docker ubuntu-prepare"
+	@echo ""
+	@echo "To execute an alpine-tracee-make shell:"
+	@echo ""
+	@echo "    $ make -f builder/Makefile.docker alpine-shell"
+	@echo ""
+	@echo "To execute an ubuntu-tracee-make shell:"
+	@echo ""
+	@echo "    $ make -f builder/Makefile.docker ubuntu-shell"
+	@echo ""
+	@echo "Examples:"
+	@echo ""
+	@echo "    $ make -f builder/Makefile.docker ubuntu-make ARG=\"clean\""
+	@echo "    $ make -f builder/Makefile.docker ubuntu-make ARG=\"bpf-core\""
+	@echo "    $ make -f builder/Makefile.docker ubuntu-make ARG=\"tracee-ebpf\""
+	@echo ""
+	@echo "Tell tracee-make to do STATIC builds:"
+	@echo ""
+	@echo "    $ STATIC=0 make -f builder/Makefile.docker alpine-make ARG=\"tracee-ebpf\""
+	@echo "    $ STATIC=1 make -f builder/Makefile.docker alpine-make ARG=\"tracee-ebpf\""
+	@echo ""
+
+# requirements
+
+.PHONY: check_tree
+check_tree:
+	@if [ ! -d ./builder ]; then \
+		echo "you must be in the root directory"; \
+		exit 1; \
+	fi
+
+# create tracee-make
+
+UID = $(shell id -u)
+GID = $(shell id -g)
+PWD = $(shell pwd)
+
+ALPINE_MAKE_CONTNAME = alpine-tracee-make
+ALPINE_MAKE_DOCKERFILE = $(abspath $(shell find -name Dockerfile.alpine-tracee-make))
+
+.PHONY: alpine-prepare
+alpine-prepare: check_$(CMD_DOCKER) | check_tree
+	$(CMD_DOCKER) build \
+		-f $(ALPINE_MAKE_DOCKERFILE) \
+		-t $(ALPINE_MAKE_CONTNAME):latest \
+		--build-arg uid=$(UID) \
+		--build-arg gid=$(GID) \
+		.
+
+UBUNTU_MAKE_CONTNAME = ubuntu-tracee-make
+UBUNTU_MAKE_DOCKERFILE = $(abspath $(shell find -name Dockerfile.ubuntu-tracee-make))
+
+.PHONY: ubuntu-prepare
+ubuntu-prepare: check_$(CMD_DOCKER) | check_tree
+	$(CMD_DOCKER) build \
+		-f $(UBUNTU_MAKE_DOCKERFILE) \
+		-t $(UBUNTU_MAKE_CONTNAME):latest \
+		--build-arg uid=$(UID) \
+		--build-arg gid=$(GID) \
+		.
+
+# tracee-make's shell
+
+ifeq ($(STATIC), 1)
+    DOCKER_RUN_ENV = -e STATIC=1
+endif
+
+DOCKER_RUN_ARGS = run --rm --pid=host --privileged \
+		-v /etc/os-release:/etc/os-release-host:ro \
+		-v $(PWD):/tracee \
+		-v /lib/modules:/lib/modules:ro \
+		-v /usr/src:/usr/src:ro \
+		-v /tmp/tracee:/tmp/tracee \
+		-e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
+		$(DOCKER_RUN_ENV)
+
+.PHONY: alpine-shell
+alpine-shell: check_$(CMD_DOCKER) | check_tree
+	$(CMD_DOCKER) $(DOCKER_RUN_ARGS) \
+		-it $(ALPINE_MAKE_CONTNAME) \
+		/bin/bash
+
+.PHONY: ubuntu-shell
+ubuntu-shell: check_$(CMD_DOCKER) | check_tree
+	$(CMD_DOCKER) $(DOCKER_RUN_ARGS) \
+		-it $(UBUNTU_MAKE_CONTNAME) \
+		/bin/bash
+
+# tracee-make replacing make
+
+.PHONY: alpine-make
+alpine-make: check_$(CMD_DOCKER) | check_tree
+ifneq ($(ARG),)
+	$(CMD_DOCKER) $(DOCKER_RUN_ARGS) \
+		-it $(ALPINE_MAKE_CONTNAME) \
+		$(MAKE) -f Makefile.one $(ARG)
+endif
+
+.PHONY: ubuntu-make
+ubuntu-make: check_$(CMD_DOCKER) | check_tree
+ifneq ($(ARG),)
+	$(CMD_DOCKER) $(DOCKER_RUN_ARGS) \
+		-it $(UBUNTU_MAKE_CONTNAME) \
+		$(MAKE) -f Makefile.one $(ARG)
+endif
+
+.PHONY: clean
+clean:

--- a/builder/README-containers.md
+++ b/builder/README-containers.md
@@ -1,0 +1,79 @@
+## Instructions on how to use the 'tracee-make' docker container
+
+> Here you will find an explanation about what
+> [Makefile.docker](./Makefile.docker) does "under the hood".
+
+### To create **tracee-make** container:
+
+Create an alpine based docker container (musl based):
+
+```
+$ docker build -f Dockerfile.alpine-tracee-make \
+    -t alpine-tracee-make:latest \
+    --build-arg uid=$UID \
+    --build-arg gid=$GID \
+    .
+```
+
+OR create an ubuntu based docker container (glibc based):
+
+```
+$ docker build -f Dockerfile.ubuntu-tracee-make \
+    -t ubuntu-tracee-make:latest \
+    --build-arg uid=$UID \
+    --build-arg gid=$GID \
+    .
+```
+
+> You may generate static (STATIC=1) or dynamic (STATIC=0) binaries. Be aware
+> that, if not static, your binaries will depend on either `musl` or `glibc`,
+> based on the distro you picked as the builder distro.
+
+> If you chose to build your binaries with STATIC=1, then you'll have something
+> close to an **universal** binary, able to run in different distros.
+
+### To exec the 'tracee-make' shell:
+
+Use your newly-generated build environment:
+
+```
+$ docker run --rm --pid=host --privileged \
+    -v $(pwd):/tracee \
+    --entrypoint=/bin/bash \
+    -it xxxx-tracee-make
+```
+
+```
+tracee@b7c4c3ea733e[/tracee]$ make -f Makefile.one clean
+tracee@b7c4c3ea733e[/tracee]$ make -f Makefile.one all
+tracee@b7c4c3ea733e[/tracee]$ sudo ./dist/tracee-ebpf --debug --trace 'event!=sched*'
+```
+
+> Where xxxx is the distro you've picked as builder distro ('alpine' or
+> 'ubuntu').
+
+You may also mount your host kernel headers to build non-CORE tracee-ebpf:
+
+```
+$ docker run --rm --pid=host --privileged \
+    -v $(pwd):/tracee \
+    -v /lib/modules:/lib/modules:ro \
+    -v /usr/src:/usr/src:ro \
+    -v /tmp/tracee:/tmp/tracee \
+    -it xxxx-tracee-make /bin/bash
+```
+
+### To use 'tracee-make' as replacement for the make tool:
+
+```
+$ docker run --rm --pid=host --privileged \
+    -v $(pwd):/tracee \
+    -v /lib/modules:/lib/modules:ro \
+    -v /usr/src:/usr/src:ro \
+    -v /tmp/tracee:/tmp/tracee \
+    -it xxxx-tracee-make \
+    make -f Makefile.one [clean|core|all|test|...]
+```
+
+> Where xxxx is the distro you've picked as builder distro ('alpine' or
+> 'ubuntu').

--- a/builder/README.md
+++ b/builder/README.md
@@ -1,0 +1,111 @@
+## Instructions on how to use **Makefile.docker**
+
+In order to have a controlled building environment for tracee, tracee provides
+a [Makefile.docker](./Makefile.docker) file that allows you to create and use
+docker controlled environments to build & test `tracee-ebpf` and
+`tracee-rules`.
+
+### Creating a builder container
+
+We're maintaining 2 different docker builder distros: **Alpine** and
+**Ubuntu**. The reason for that is that Alpine is based in the
+[musl](https://en.wikipedia.org/wiki/Musl) C standard library while Ubuntu uses
+[glibc](https://en.wikipedia.org/wiki/Glibc). By doing that we can always be
+sure that the project builds (and executes) correctly in both environments.
+
+> The best way to build a generic, and portable across different distributions,
+> binary is to use STATIC=1 environment variable while executing "make".
+
+Both distributions also maintain, to each of their released versions, one
+default toolchain and this is good for testing builds (as we can test multiple
+toolchain versions,activelly supported/maintained, by having different
+Dockerfile flavors only changing the distro version).
+
+To create an **alpine-tracee-make** container:
+
+```
+$ make -f builder/Makefile.docker alpine-prepare
+```
+
+OR to create an **ubuntu-tracee-make** container:
+
+```
+$ make -f builder/Makefile.docker ubuntu-prepare
+```
+
+### Executing a builder shell
+
+Execute an **alpine-tracee-make** shell:
+
+```
+$ make -f builder/Makefile.docker alpine-shell
+```
+
+OR execute an **ubuntu-tracee-make** shell:
+
+```
+$ make -f builder/Makefile.docker ubuntu-shell
+```
+
+### Executing compiled binaries inside builder shell
+
+Execute **any** build commands inside picked builder shell:
+
+```
+tracee@402fbaa94e7f[/tracee]$ make -f Makefile.one clean
+tracee@402fbaa94e7f[/tracee]$ make -f Makefile.one bpf-core
+tracee@402fbaa94e7f[/tracee]$ make -f Makefile.one tracee-ebpf
+tracee@402fbaa94e7f[/tracee]$ make -f Makefile.one tracee-rules
+tracee@402fbaa94e7f[/tracee]$ make -f Makefile.one rules
+tracee@402fbaa94e7f[/tracee]$ make -f Makefile.one bpf-nocore
+...
+```
+
+Execute `tracee-ebpf`:
+
+```
+tracee@402fbaa94e7f[/tracee]$ sudo ./dist/tracee-ebpf --debug --trace 'event!=sched*'
+```
+
+and `tracee-rules` from inside builder shell:
+
+```
+tracee@402fbaa94e7f[/tracee]$ sudo ./dist/tracee-ebpf -o format:gob | \
+    ./dist/tracee-rules --input-tracee file:stdin --input-tracee format:gob
+```
+
+> Do not mix the 2 **tracee-make** environments. If you compile `tracee-ebpf`,
+> `tracee-rules`, or `rules` targets, inside **alpine** **tracee-make** env,
+> then make sure to execute the given cmdlines in **alpine**. Same happens to
+> the **ubuntu** `tracee-make` environment.
+
+> **Note**: compiling `tracee-rules` with STATIC=1 won't allow you to use
+> golang based signatures:
+>
+> ```
+> 2021/12/13 13:27:21 error opening plugin /tracee/dist/rules/builtin.so: plugin.Open("/tracee/dist/rules/builtin.so"): Dynamic loading not supported
+> ```
+
+### Running `tracee-make` as the MAKE tool
+
+You may also want to execute the **tracee-make** docker container as a
+replacement to the `make` command:
+
+```
+$ make -f builder/Makefile.docker xxxx-make ARG="clean"
+$ make -f builder/Makefile.docker xxxx-make ARG="bpf-core"
+$ make -f builder/Makefile.docker xxxx-make ARG="tracee-ebpf"
+```
+
+And even tell **tracee-make** to do STATIC builds:
+
+```
+$ STATIC=0 make -f builder/Makefile.docker xxxx-make ARG="tracee-ebpf"
+$ STATIC=1 make -f builder/Makefile.docker xxxx-make ARG="tracee-ebpf"
+```
+
+> where xxxx might be 'alpine' or 'ubuntu'
+
+## More information
+
+Read [MORE](README-containers.md) on how to use 'tracee-make' container.

--- a/embedded-ebpf.go
+++ b/embedded-ebpf.go
@@ -1,0 +1,12 @@
+//go:build ebpf
+// +build ebpf
+
+package tracee
+
+import (
+	"embed"
+)
+
+//go:embed "dist/tracee.bpf/*"
+//go:embed "dist/tracee.bpf.core.o"
+var BPFBundleInjected embed.FS

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -61,7 +61,11 @@ build: $(OUT_BIN)
 go_env := GOOS=linux GOARCH=$(ARCH:x86_64=amd64) CC=$(CMD_CLANG) CGO_CFLAGS="-I $(abspath $(LIBBPF_HEADERS))" CGO_LDFLAGS="$(abspath $(LIBBPF_OBJ))"
 ifndef DOCKER
 $(OUT_BIN): $(LIBBPF_HEADERS) $(LIBBPF_OBJ) $(OUT_BPF_CORE) $(filter-out *_test.go,$(GO_SRC)) $(BPF_BUNDLE) | $(OUT_DIR)
-	$(go_env) go build -tags netgo -v -o $(OUT_BIN) \
+	# workaround until Makefile.one becomes standard
+	mkdir -p ../dist/
+	cp -rfp ./dist/* ../dist/
+	# end of workaround
+	$(go_env) go build -tags ebpf,netgo -v -o $(OUT_BIN) \
 	-ldflags "-w -extldflags \"$(CGO_EXT_LDFLAGS)\" -X main.version=$(VERSION)"
 else
 $(OUT_BIN): $(DOCKER_BUILDER) | $(OUT_DIR)
@@ -85,6 +89,10 @@ bpf_bundle_dir := $(OUT_DIR)/tracee.bpf
 $(BPF_BUNDLE): $(BPF_SRC) $(LIBBPF_HEADERS)/bpf $(BPF_HEADERS)
 	mkdir -p $(bpf_bundle_dir)
 	cp $$(find $^ -type f) $(bpf_bundle_dir)
+	# workaround until Makefile.one becomes standard
+	mkdir -p ../dist/
+	cp -rf $(bpf_bundle_dir) ../dist/
+	# end of workaround
 
 .PHONY: bpf
 bpf: $(OUT_BPF) $(OUT_BPF_CORE)
@@ -154,7 +162,8 @@ endif
 .PHONY: test
 ifndef DOCKER
 test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
-	$(go_env)	go test $(GOTEST_FLAGS) -v ./...
+	$(go_env)	go test -tags ebpf $(GOTEST_FLAGS) -v ./...
+
 else
 test: $(DOCKER_BUILDER)
 	$(call docker_builder_make,$@)

--- a/tracee-ebpf/main.go
+++ b/tracee-ebpf/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"embed"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/libbpfgo/helpers"
+	embed "github.com/aquasecurity/tracee"
 	"github.com/aquasecurity/tracee/pkg/external"
 	"github.com/aquasecurity/tracee/tracee-ebpf/tracee"
 	"github.com/syndtr/gocapability/capability"
@@ -27,10 +27,6 @@ var debug bool
 var traceeInstallPath string
 var buildPolicy string
 
-// These vars are supposed to be injected at build time
-//go:embed "dist/tracee.bpf/*"
-//go:embed "dist/tracee.bpf.core.o"
-var bpfBundleInjected embed.FS
 var version string
 
 func main() {
@@ -1122,7 +1118,7 @@ func getBPFObjectPath() (string, error) {
 }
 
 func unpackCOREBinary() ([]byte, error) {
-	b, err := bpfBundleInjected.ReadFile("dist/tracee.bpf.core.o")
+	b, err := embed.BPFBundleInjected.ReadFile("dist/tracee.bpf.core.o")
 	if err != nil {
 		return nil, err
 	}
@@ -1137,7 +1133,7 @@ func unpackCOREBinary() ([]byte, error) {
 // unpackBPFBundle unpacks the bundle into the provided directory
 func unpackBPFBundle(dir string) error {
 	basePath := "dist/tracee.bpf"
-	files, err := bpfBundleInjected.ReadDir(basePath)
+	files, err := embed.BPFBundleInjected.ReadDir(basePath)
 	if err != nil {
 		return fmt.Errorf("error reading embedded bpf bundle: %s", err.Error())
 	}
@@ -1148,7 +1144,7 @@ func unpackBPFBundle(dir string) error {
 		}
 		defer outFile.Close()
 
-		f, err := bpfBundleInjected.Open(filepath.Join(basePath, f.Name()))
+		f, err := embed.BPFBundleInjected.Open(filepath.Join(basePath, f.Name()))
 		if err != nil {
 			return fmt.Errorf("error opening bpf bundle file: %s", err.Error())
 		}

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -267,7 +267,7 @@ func (engine *Engine) LoadSignature(signature types.Signature) (string, error) {
 func (engine *Engine) UnloadSignature(signatureId string) error {
 	var signature types.Signature
 	engine.signaturesMutex.RLock()
-	for sig, _ := range engine.signatures {
+	for sig := range engine.signatures {
 		metadata, _ := sig.GetMetadata()
 		if metadata.ID == signatureId {
 			signature = sig

--- a/tracee-rules/input_test.go
+++ b/tracee-rules/input_test.go
@@ -102,7 +102,7 @@ func TestSetupTraceeJSONInputSource(t *testing.T) {
 		{
 			testName: "one event",
 			events: []tracee.Event{
-				tracee.Event{
+				{
 					EventName: "Yankees are the best team in baseball",
 				},
 			},
@@ -111,10 +111,10 @@ func TestSetupTraceeJSONInputSource(t *testing.T) {
 		{
 			testName: "two events",
 			events: []tracee.Event{
-				tracee.Event{
+				{
 					EventName: "Yankees are the best team in baseball",
 				},
-				tracee.Event{
+				{
 					EventName: "I hate the Red Sox",
 				},
 			},
@@ -183,7 +183,7 @@ func TestSetupTraceeGobInputSource(t *testing.T) {
 		{
 			testName: "one event",
 			events: []tracee.Event{
-				tracee.Event{
+				{
 					EventName: "Yankees are the best team in baseball",
 				},
 			},
@@ -192,10 +192,10 @@ func TestSetupTraceeGobInputSource(t *testing.T) {
 		{
 			testName: "two events",
 			events: []tracee.Event{
-				tracee.Event{
+				{
 					EventName: "Yankees are the best team in baseball",
 				},
-				tracee.Event{
+				{
 					EventName: "I hate the Red Sox so much",
 				},
 			},
@@ -204,13 +204,13 @@ func TestSetupTraceeGobInputSource(t *testing.T) {
 		{
 			testName: "three events",
 			events: []tracee.Event{
-				tracee.Event{
+				{
 					EventName: "Yankees are the best team in baseball",
 				},
-				tracee.Event{
+				{
 					EventName: "I hate the Red Sox so much",
 				},
-				tracee.Event{
+				{
 					EventName: "Aaron Judge is my idol",
 				},
 			},

--- a/tracee-rules/regosig/aio_test.go
+++ b/tracee-rules/regosig/aio_test.go
@@ -48,11 +48,11 @@ func TestAio_GetSelectedEvents(t *testing.T) {
 	}
 
 	assert.Equal(t, map[types.SignatureEventSelector]bool{
-		types.SignatureEventSelector{
+		{
 			Source: "tracee",
 			Name:   "ptrace",
 		}: true,
-		types.SignatureEventSelector{
+		{
 			Source: "tracee",
 			Name:   "execve",
 		}: true,


### PR DESCRIPTION
**tracee: a new makefile is born**

Original Makefile will be kept until all targets, release process and
docker container functionalities are in place. The new Makefile(s) are
meant to be used by:

    $ make -f Makefile.new <target>

> **Note:** DO NOT mix usage of ./Makefile, ./tracee-ebpf/Makefile &
> ./tracee-rules/Makefile with ./Makefile.one. Make sure to wipe all
> "dist" directories before using Makefile.one.

The new Makefile targets are: (fix this)

    $ make all                  # build tracee-ebpf, tracee-rules & rules

    $ make env                  # show makefile environment/variables
    $ make reqs                 # verify build requirements

    # build

    $ make core                 # build ./dist/tracee.bpf.core.o
    $ make non-core             # build ./dist/tracee.bpf.XXX.o
    $ make tracee-ebpf          # build ./dist/tracee-ebpf
    $ make tracee-rules         # build ./dist/tracee-rules
    $ make rules                # build ./dist/rules

    # clean

    $ make clean                # wipe ./dist/
    $ make clean-core           # wipe ./dist/tracee.bpf.core.o
    $ make clean-non-core       # wipe ./dist/tracee.bpf.XXX.o
    $ make clean-tracee-ebpf    # wipe ./dist/tracee-ebpf
    $ make clean-tracee-rules   # wipe ./dist/tracee-rules
    $ make clean-rules          # wipe ./dist/rules

    # test

    $ make test                 # run all go & opa tests
    $ make tracee-ebpf-test     # go test tracee-ebpf
    $ make tracee-rules-test    # go test tracee-rules
    $ make test-rules           # opa test (tracee-rules)

----

**REASON**

The advantage of new Makefiles is that all the build targets have correct dependencies and new compilations only occur if you remove the targets OR change related source files.

Another advantage is to split the DOCKER building logic from the OS building one (further changes).