### PR TITLE
tracee-ebpf: enable apple M1

### DIFF
--- a/tracee-ebpf/tracee/events_config.go
+++ b/tracee-ebpf/tracee/events_config.go
@@ -126,7 +126,7 @@ var EventsIDToEvent = map[int32]EventConfig{
 	ShmatEventID:                  {ID: ShmatEventID, ID32Bit: sys32shmat, Name: "shmat", Probes: []probe{{event: "shmat", attach: sysCall, fn: "shmat"}}, Sets: []string{"syscalls", "ipc", "ipc_shm"}},
 	ShmctlEventID:                 {ID: ShmctlEventID, ID32Bit: sys32shmctl, Name: "shmctl", Probes: []probe{{event: "shmctl", attach: sysCall, fn: "shmctl"}}, Sets: []string{"syscalls", "ipc", "ipc_shm"}},
 	DupEventID:                    {ID: DupEventID, ID32Bit: sys32dup, Name: "dup", Probes: []probe{{event: "dup", attach: sysCall, fn: "dup"}}, Sets: []string{"default", "syscalls", "fs", "fs_fd_ops"}},
-	Dup2EventID:                   {ID: Dup2EventID, ID32Bit: sys32dup2, Name: "dup2", Probes: []probe{{event: "dup2", attach: sysCall, fn: "dup2"}}, Sets: []string{"default", "syscalls", "fs", "fs_fd_ops"}},
+	Dup2EventID:                   {ID: Dup2EventID, ID32Bit: sys32dup2, Name: "dup2", Probes: []probe{{event: "dup2", attach: sysCall, fn: "dup2"}}, Sets: []string{"syscalls", "fs", "fs_fd_ops"}},
 	PauseEventID:                  {ID: PauseEventID, ID32Bit: sys32pause, Name: "pause", Probes: []probe{{event: "pause", attach: sysCall, fn: "pause"}}, Sets: []string{"syscalls", "signals"}},
 	NanosleepEventID:              {ID: NanosleepEventID, ID32Bit: sys32nanosleep, Name: "nanosleep", Probes: []probe{{event: "nanosleep", attach: sysCall, fn: "nanosleep"}}, Sets: []string{"syscalls", "time", "time_timer"}},
 	GetitimerEventID:              {ID: GetitimerEventID, ID32Bit: sys32getitimer, Name: "getitimer", Probes: []probe{{event: "getitimer", attach: sysCall, fn: "getitimer"}}, Sets: []string{"syscalls", "time", "time_timer"}},

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -3053,12 +3053,15 @@ int BPF_KPROBE(trace_security_socket_connect)
         save_to_submit_buf(&data, (void *)address, sizeof(struct sockaddr_in6), 1);
     }
     else if (sa_fam == AF_UNIX) {
+#if defined(__TARGET_ARCH_x86) // TODO: this is broken in arm64 (issue: #1129)
         if (addr_len <= sizeof(struct sockaddr_un)) {
             struct sockaddr_un sockaddr = {};
             bpf_probe_read(&sockaddr, addr_len, (void *)address);
             save_to_submit_buf(&data, (void *)&sockaddr, sizeof(struct sockaddr_un), 1);
         }
-        else save_to_submit_buf(&data, (void *)address, sizeof(struct sockaddr_un), 1);
+        else
+#endif
+            save_to_submit_buf(&data, (void *)address, sizeof(struct sockaddr_un), 1);
     }
 
     return events_perf_submit(&data, SECURITY_SOCKET_CONNECT, 0);
@@ -3170,12 +3173,15 @@ int BPF_KPROBE(trace_security_socket_bind)
         }
     }
     else if (sa_fam == AF_UNIX) {
+#if defined(__TARGET_ARCH_x86) // TODO: this is broken in arm64 (issue: #1129)
         if (addr_len <= sizeof(struct sockaddr_un)) {
             struct sockaddr_un sockaddr = {};
             bpf_probe_read(&sockaddr, addr_len, (void *)address);
             save_to_submit_buf(&data, (void *)&sockaddr, sizeof(struct sockaddr_un), 1);
         }
-        else save_to_submit_buf(&data, (void *)address, sizeof(struct sockaddr_un), 1);
+        else
+#endif
+            save_to_submit_buf(&data, (void *)address, sizeof(struct sockaddr_un), 1);
     }
 
     if (connect_id.port) {


### PR DESCRIPTION
Fixes: 1208
Mitigates: 1129

- Remove Dup2EventID from the default set (unsupported by arm64)

- Revert fix made by 48654aa ("fix sockaddr struct overflow and change
  error message") only in arm64, as its verifier isn't passing that
  change. Added as a TODO to fix issue: #1129.