### PR TITLE
update fileless_execution

### DIFF
--- a/signatures/rego/fileless_execution.rego
+++ b/signatures/rego/fileless_execution.rego
@@ -48,3 +48,9 @@ tracee_match {
     pathname = helpers.get_tracee_argument("pathname")
     startswith(pathname, "/dev/shm")
 }
+
+tracee_match {
+    input.eventName == "sched_process_exec"
+    pathname = helpers.get_tracee_argument("pathname")
+    startswith(pathname, "/run/shm")
+}

--- a/signatures/rego/fileless_execution_test.rego
+++ b/signatures/rego/fileless_execution_test.rego
@@ -70,6 +70,20 @@ test_match_5 {
     }
 }
 
+test_match_6 {
+    tracee_match with input as {
+        "eventName": "sched_process_exec",
+        "argsNum": 1,
+        "containerId": "someContainer",
+        "args": [
+            {
+                "name": "pathname",
+                "value": "/run/shm/something"
+            }
+        ]
+    }
+}
+
 test_match_wrong_pathname {
     not tracee_match with input as {
         "eventName": "sched_process_exec",


### PR DESCRIPTION
add /run/shm to Fileless Execution, and here is my reference (https://linuxsecurity.com/features/fileless-malware-on-linux)