### PR TITLE
tracee-ebpf: add container cgroup ctime

### DIFF
--- a/tracee-ebpf/tracee/events_processor.go
+++ b/tracee-ebpf/tracee/events_processor.go
@@ -221,7 +221,7 @@ func (t *Tracee) processEvent(event *external.Event) error {
 		if err != nil {
 			return fmt.Errorf("error parsing cgroup_mkdir args: %v", err)
 		}
-		info, err := t.containers.CgroupUpdate(cgroupId, path)
+		info, err := t.containers.CgroupMkdir(cgroupId, path)
 		if err == nil && info.ContainerId == "" {
 			// If not a new container (no regex match) - remove from the bpf container_map
 			containers.RemoveFromBpfMap(t.bpfModule, cgroupId, "containers_map")


### PR DESCRIPTION
This PR adds cgroup ctime information which can be used to track containers start time.
    
Instead of using the WalkDir function to find a specific cgroup, this PR implements a recursive function that is more efficient as it
only stats a directory if its name has a given suffix. By doing so, performance is 5 times better than the use of WalkDir for this specific case.

In addition, this PR fixes the following issue (thanks @rafaeldtinoco for spotting this):
When container filter is set, we might treat essential events such as cgroup_mkdir as "false container positives".
Such events should be processed before checking for false positives.
This PR fixes this by placing the check for false positives after processing the events