### PR TITLE
Bump to libbpfgo v0.2.3-libbpf-0.6.1 with libbpf 0.6.1

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -82,6 +82,19 @@ func main() {
 			}
 			cfg.Output = &output
 
+			// kernel lockdown check
+
+			lockdown, err := helpers.Lockdown()
+			if err != nil {
+				return err
+			}
+			if lockdown == helpers.CONFIDENTIALITY {
+				return fmt.Errorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs.")
+			}
+			if debug {
+				fmt.Fprintf(os.Stdout, "OSInfo: Security Lockdown is '%v'\n", lockdown)
+			}
+
 			// environment capabilities
 			selfCap, err := capabilities.Self()
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.2.3-libbpf-0.6.1.0.20220121171415-832e20b88009
+	github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0
+	github.com/aquasecurity/libbpfgo v0.2.3-libbpf-0.6.1.0.20220121171415-832e20b88009
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0 h1:Qecy9Qvj4TG0LK7sfuJWzd1QlwMozHo7H0AyZMGjLg8=
-github.com/aquasecurity/libbpfgo v0.2.2-libbpf-0.5.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.3-libbpf-0.6.1.0.20220121171415-832e20b88009 h1:jWRFYazvJ8i4ACsbjOkDkJ8QfBzesHH383IRlLid/VU=
+github.com/aquasecurity/libbpfgo v0.2.3-libbpf-0.6.1.0.20220121171415-832e20b88009/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.2.3-libbpf-0.6.1.0.20220121171415-832e20b88009 h1:jWRFYazvJ8i4ACsbjOkDkJ8QfBzesHH383IRlLid/VU=
 github.com/aquasecurity/libbpfgo v0.2.3-libbpf-0.6.1.0.20220121171415-832e20b88009/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1 h1:7Ezl6s7ftdV1S7JnBi/zgRR4Od3MtEx0GH21TmyFMAI=
+github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -86,7 +86,6 @@ func (t *Tracee) parseArgs(event *external.Event) error {
 		if reqArg := getEventArg(event, "request"); reqArg != nil {
 			if req, isInt64 := reqArg.Value.(int64); isInt64 {
 				ptraceRequestArgument, err := helpers.ParsePtraceRequestArgument(uint64(req))
-				// TODO: https://github.com/aquasecurity/libbpfgo/issues/108
 				ParseOrEmptyString(reqArg, ptraceRequestArgument, err)
 			}
 		}

--- a/tracee-ebpf/tracee/events_decoder.go
+++ b/tracee-ebpf/tracee/events_decoder.go
@@ -213,7 +213,11 @@ func readSockaddrFromBuff(buff io.Reader) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	res["sa_family"] = helpers.ParseSocketDomain(uint32(family))
+	socketDomainArg, err := helpers.ParseSocketDomainArgument(uint64(family))
+	if err != nil {
+		socketDomainArg = helpers.AF_UNSPEC
+	}
+	res["sa_family"] = socketDomainArg.String()
 	switch family {
 	case 1: // AF_UNIX
 		/*


### PR DESCRIPTION
- This is needed bump to solve https://github.com/aquasecurity/tracee/issues/295
- It contains fixes to breaking changes related to parseArgs
- https://github.com/aquasecurity/libbpfgo/issues/108 was discovered during this PR (should be resolved in the next libbpfgo version)