### PR TITLE
Bugfix: Add warning docs for group exit flag about race conditions

### DIFF
--- a/tracee-ebpf/tracee/events_definitions.go
+++ b/tracee-ebpf/tracee/events_definitions.go
@@ -5722,7 +5722,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets:           []string{"default", "proc", "proc_life"},
 		Params: []external.ArgMeta{
 			{Type: "long", Name: "exit_code"},
-			// The filed value represents that all threads exited at the event time.
+			// The field value represents that all threads exited at the event time.
 			// Multiple exits of threads of the same process group at the same time could result that all threads exit
 			// events would have 'true' value in this field altogether.
 			{Type: "bool", Name: "process_group_exit"},

--- a/tracee-ebpf/tracee/events_definitions.go
+++ b/tracee-ebpf/tracee/events_definitions.go
@@ -5722,6 +5722,9 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets:           []string{"default", "proc", "proc_life"},
 		Params: []external.ArgMeta{
 			{Type: "long", Name: "exit_code"},
+			// The filed value represents that all threads exited at the event time.
+			// Multiple exits of threads of the same process group at the same time could result that all threads exit
+			// events would have 'true' value in this field altogether.
 			{Type: "bool", Name: "process_group_exit"},
 		},
 	},

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2510,6 +2510,8 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
     struct task_struct *task = data.task;
     struct signal_struct *signal = READ_KERN(task->signal);
     atomic_t live = READ_KERN(signal->live);
+    // This check could be true for multiple thread exits if the thread count was 0 when the hooks were triggered.
+    // This could happen for example if the threads performed exit in different CPUs simultaneously.
     if (live.counter == 0) {
         group_dead = true;
         if (proc_tree_filter_set) {


### PR DESCRIPTION
We noticed that the flag could have `true` value for multiple `sched_process_exit` events if they happen at almost the same because of concurrency issue (value used in the `do_exit` function in an atomic way, but we use the value afterwards so we are vulnerable to concurrent changes in the value).