### PR TITLE
tracee-ebpf: remove mem_prot_alert dependencies

### DIFF
--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -276,11 +276,6 @@ func New(cfg Config) (*Tracee, error) {
 		setEssential(VfsWritevEventID)
 	}
 
-	if t.eventsToTrace[MemProtAlertEventID] {
-		setEssential(MmapEventID)
-		setEssential(MprotectEventID)
-	}
-
 	if t.eventsToTrace[SocketDupEventID] {
 		setEssential(DupEventID)
 		setEssential(Dup2EventID)


### PR DESCRIPTION
mem_prot_alert event no longer depends on mmap and mprotect events as we now save syscall args anyway.
Remove these dependencies