### PR TITLE
change to conitine instead exit while error occurs

### DIFF
--- a/tracee-ebpf/tracee/process_tree.go
+++ b/tracee-ebpf/tracee/process_tree.go
@@ -160,15 +160,16 @@ func NewProcessTree() (*ProcessTree, error) {
 			taskStatus := fmt.Sprintf("/proc/%d/task/%v/status", pid, task)
 			data, err := ioutil.ReadFile(taskStatus)
 			if err != nil {
+				// process might have exited - ignore this task
 				continue
 			}
 			processStatus, err := parseProcStatus(data, taskStatus)
 			if err != nil {
-				return nil, err
+				continue
 			}
 			containerId, err := containers.GetContainerIdFromTaskDir(taskDir)
 			if err != nil {
-				return nil, err
+				continue
 			}
 			processStatus.ContainerID = containerId
 			p.processTreeMap[int(processStatus.HostTid)] = processStatus


### PR DESCRIPTION
solves #1366 
by changing the return to continue while error occurs .
if you want i can also remove the error check in the creation of Tracee to verify it never crush on that case 