### PR TITLE
tracee-ebpf: introduce event dependencies

### DIFF
--- a/tracee-ebpf/tracee/events_definitions.go
+++ b/tracee-ebpf/tracee/events_definitions.go
@@ -24,11 +24,16 @@ type probe struct {
 	fn     string
 }
 
+type dependency struct {
+	eventID int32
+}
+
 // EventDefinition is a struct describing an event configuration
 type EventDefinition struct {
 	ID32Bit        int32
 	Name           string
 	Probes         []probe
+	Dependencies   []dependency
 	EssentialEvent bool
 	Sets           []string
 	Params         []external.ArgMeta
@@ -5842,6 +5847,10 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "magic_write",
 		Probes:  []probe{}, Sets: []string{},
+		Dependencies: []dependency{
+			{eventID: VfsWriteEventID},
+			{eventID: VfsWritevEventID},
+		},
 		Params: []external.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "bytes", Name: "bytes"},
@@ -6090,7 +6099,12 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "socket_dup",
 		Probes:  []probe{},
-		Sets:    []string{},
+		Dependencies: []dependency{
+			{eventID: DupEventID},
+			{eventID: Dup2EventID},
+			{eventID: Dup3EventID},
+		},
+		Sets: []string{},
 		Params: []external.ArgMeta{
 			{Type: "int", Name: "oldfd"},
 			{Type: "int", Name: "newfd"},

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -270,17 +270,11 @@ func New(cfg Config) (*Tracee, error) {
 	for _, e := range t.config.Filter.EventsToTrace {
 		// Map value is true iff events requested by the user
 		t.eventsToTrace[e] = true
-	}
 
-	if t.eventsToTrace[MagicWriteEventID] {
-		setEssential(VfsWriteEventID)
-		setEssential(VfsWritevEventID)
-	}
-
-	if t.eventsToTrace[SocketDupEventID] {
-		setEssential(DupEventID)
-		setEssential(Dup2EventID)
-		setEssential(Dup3EventID)
+		// Some events depend on other events - mark those essential
+		for _, dependency := range EventsDefinitions[e].Dependencies {
+			setEssential(dependency.eventID)
+		}
 	}
 
 	// Compile final list of events to trace including essential events


### PR DESCRIPTION
Some events depend on other events to function properly.
Add a new field to event definition to declare those dependencies.
When an event is chosen by the user, set its dependencies essential.

This change will also help with the introduction of higher level events (#1310),
that are derived from other events received in userspace.