### PR TITLE
tracee-ebpf: add event to detect hooked syscalls

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -61,10 +61,26 @@ func main() {
 			// for the rest of execution, use this debug mode value
 			debug := flags.DebugModeEnabled()
 
+			// OS release information
+
+			OSInfo, err := helpers.GetOSInfo()
+			if err != nil {
+				if debug {
+					fmt.Fprintf(os.Stderr, "OSInfo: warning: os-release file could not be found\n(%v)\n", err) // only to be enforced when BTF needs to be downloaded, later on
+					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", helpers.OS_KERNEL_RELEASE, OSInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE))
+				}
+			} else if debug {
+				for k, v := range OSInfo.GetOSReleaseAllFieldValues() {
+					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", k, v)
+				}
+			}
+
 			cfg := tracee.Config{
 				PerfBufferSize:     c.Int("perf-buffer-size"),
 				BlobPerfBufferSize: c.Int("blob-perf-buffer-size"),
 				Debug:              debug,
+				OsConfig:           OSInfo,
+
 			}
 
 			cacheSlice := c.StringSlice("cache")
@@ -160,20 +176,6 @@ func main() {
 				if debug {
 					fmt.Fprintf(os.Stderr, "KConfig: warning: could not check enabled kconfig features\n(%v)\n", err)
 					fmt.Fprintf(os.Stderr, "KConfig: warning: assuming kconfig values, might have unexpected behavior\n")
-				}
-			}
-
-			// OS release information
-
-			OSInfo, err := helpers.GetOSInfo()
-			if err != nil {
-				if debug {
-					fmt.Fprintf(os.Stderr, "OSInfo: warning: os-release file could not be found\n(%v)\n", err) // only to be enforced when BTF needs to be downloaded, later on
-					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", helpers.OS_KERNEL_RELEASE, OSInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE))
-				}
-			} else if debug {
-				for k, v := range OSInfo.GetOSReleaseAllFieldValues() {
-					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", k, v)
 				}
 			}
 

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -79,8 +79,7 @@ func main() {
 				PerfBufferSize:     c.Int("perf-buffer-size"),
 				BlobPerfBufferSize: c.Int("blob-perf-buffer-size"),
 				Debug:              debug,
-				OsConfig:           OSInfo,
-
+				OSInfo:             OSInfo,
 			}
 
 			cacheSlice := c.StringSlice("cache")

--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -221,6 +221,24 @@ func (decoder *EbpfDecoder) DecodeIntArray(msg []int32, size uint32) error {
 	return nil
 }
 
+// DecodeUint64Array translate from the decoder buffer, starting from the decoder cursor, to msg, size * 8 bytes (in order to get int64).
+func (decoder *EbpfDecoder) DecodeUint64Array(msg *[]uint64) error {
+	var arrLen uint8
+	err := decoder.DecodeUint8(&arrLen)
+	if err != nil {
+		return fmt.Errorf("error reading ulong array number of elements: %v", err)
+	}
+	for i := 0; i < int(arrLen); i++ {
+		var element uint64
+		err := decoder.DecodeUint64(&element)
+		if err != nil {
+			return fmt.Errorf("can't read element %d uint64 from buffer: %s", i, err)
+		}
+		*msg = append(*msg, element)
+	}
+	return nil
+}
+
 // DecodeSlimCred translates data from the decoder buffer, starting from the decoder cursor, to SlimCred struct.
 func (decoder *EbpfDecoder) DecodeSlimCred(slimCred *SlimCred) error {
 	offset := decoder.cursor

--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -34,6 +34,7 @@ const (
 	u16T
 	credT
 	intArr2T
+	uint64ArrT
 )
 
 // These types don't match the ones defined in the ebpf code since they are not being used by syscalls arguments.
@@ -154,6 +155,14 @@ func ReadArgFromBuff(ebpfMsgDecoder *EbpfDecoder, params []trace.ArgMeta) (trace
 			return argMeta, nil, fmt.Errorf("error reading int elements: %v", err)
 		}
 		res = intArray
+	case uint64ArrT:
+		ulongArray := make([]uint64, 0, 0)
+		err := ebpfMsgDecoder.DecodeUint64Array(&ulongArray)
+		if err != nil {
+			return argMeta, nil, fmt.Errorf("error reading ulong elements: %v", err)
+		}
+		res = ulongArray
+
 	default:
 		// if we don't recognize the arg type, we can't parse the rest of the buffer
 		return argMeta, nil, fmt.Errorf("error unknown arg type %v", argType)
@@ -202,6 +211,8 @@ func GetParamType(paramType string) ArgType {
 		return credT
 	case "umode_t":
 		return u16T
+	case "unsigned long[]":
+		return uint64ArrT
 	default:
 		// Default to pointer (printed as hex) for unsupported types
 		return pointerT

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -110,3 +110,12 @@ type SlimCred struct {
 func (s SlimCred) GetSizeBytes() uint32 {
 	return 80
 }
+
+type HookedSyscallData struct {
+	SyscallName string
+	ModuleOwner string
+}
+type SymbolData struct {
+	SymbolName    string
+	SymbolAddress string
+}

--- a/pkg/ebpf/events_amd64.go
+++ b/pkg/ebpf/events_amd64.go
@@ -905,3 +905,24 @@ const (
 	sys32process_mrelease             int32 = 448
 	sys32undefined                    int32 = 10000
 )
+
+var syscallsToCheck = []int{
+	0,   // read
+	1,   // write
+	2,   // open
+	3,   // close
+	16,  // ioctl
+	41,  // socket
+	44,  // sendto
+	45,  // recvfrom
+	46,  // sendmsg
+	47,  // recvmsg
+	59,  // execve
+	62,  // kill
+	78,  // getdents
+	101, // ptrace
+	217, // getdents64
+	257, // openat
+	321, // bpf
+	322, // execveat
+}

--- a/pkg/ebpf/events_arm64.go
+++ b/pkg/ebpf/events_arm64.go
@@ -965,3 +965,22 @@ const (
 	sys32fadvise64
 	sys32sync_file_range
 )
+
+var syscallsToCheck = []int{
+	29,  // ioctl
+	56,  // openat
+	57,  // close
+	61,  // getdents64
+	63,  // read
+	64,  // write
+	117, // ptrace
+	129, // kill
+	198, // socket
+	281, // execveat
+	206, // sendto
+	207, // recvfrom
+	211, // sendmsg
+	212, // recvmsg
+	221, // execve
+	280, // bpf
+}

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -95,6 +95,7 @@ const (
 	ContainerCreateEventID
 	ContainerRemoveEventID
 	ExistingContainerEventID
+	DetectHookedSyscallsEventID
 	MaxUserSpaceEventID
 )
 

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -6300,4 +6300,26 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "u64", Name: "proc_ops_addr"},
 		},
 	},
+	PrintSyscallTableEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "print_syscall_table",
+		Probes: []probe{
+			{event: "security_file_ioctl", attach: kprobe, fn: "trace_tracee_trigger_event"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "unsigned long[]", Name: "syscalls_addresses"},
+		},
+	},
+	DetectHookedSyscallsEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "detect_hooked_syscalls",
+		Dependencies: []dependency{
+			{eventID: PrintSyscallTableEventID},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "HookedSyscallData[]", Name: "hooked_syscalls"},
+		},
+	},
 }

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -6308,7 +6308,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "security_file_ioctl", attach: kprobe, fn: "trace_tracee_trigger_event"},
 		},
-		Sets: []string{},
+		Dependencies: dependencies{ksymbols: []string{"sys_call_table"}},
+		Sets:         []string{},
 		Params: []trace.ArgMeta{
 			{Type: "unsigned long[]", Name: "syscalls_addresses"},
 		},
@@ -6316,9 +6317,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 	DetectHookedSyscallsEventID: {
 		ID32Bit: sys32undefined,
 		Name:    "detect_hooked_syscalls",
-		Dependencies: []dependency{
-			{eventID: FinitModuleEventID},
-			{eventID: PrintSyscallTableEventID},
+		Dependencies: dependencies{
+			events: []eventDependency{{eventID: FinitModuleEventID}, {eventID: PrintSyscallTableEventID}, {eventID: InitModuleEventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -85,6 +85,7 @@ const (
 	CallUsermodeHelperEventID
 	DirtyPipeSpliceEventID
 	DebugfsCreateFile
+	PrintSyscallTableEventID
 	MaxCommonEventID
 )
 

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -6317,6 +6317,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "detect_hooked_syscalls",
 		Dependencies: []dependency{
+			{eventID: FinitModuleEventID},
 			{eventID: PrintSyscallTableEventID},
 		},
 		Sets: []string{},

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -2,11 +2,11 @@ package ebpf
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/types/trace"
-	"strings"
 )
 
 // deriveFn is a function prototype for a function that receives an event as
@@ -25,6 +25,9 @@ func (t *Tracee) initEventDerivationMap() error {
 		},
 		CgroupRmdirEventID: {
 			ContainerRemoveEventID: deriveContainerRemoved(t),
+		},
+		PrintSyscallTableEventID: {
+			DetectHookedSyscallsEventID: deriveDetectHookedSyscall(t),
 		},
 	}
 
@@ -121,12 +124,15 @@ func deriveContainerRemoved(t *Tracee) deriveFn {
 }
 
 func deriveDetectHookedSyscall(t *Tracee) deriveFn {
-	return func(event trace.Event)  (trace.Event, bool, error) {
+	return func(event trace.Event) (trace.Event, bool, error) {
 		syscallsAdresses, err := getEventArgUlongArrVal(&event, "syscalls_addresses")
 		if err != nil {
 			return trace.Event{}, false, fmt.Errorf("error parsing syscalls_numbers arg: %v", err)
 		}
-		hookedSyscallData := t.ParseHookedAddresses(syscallsAdresses)
+		hookedSyscallData, err := analyzeHookedAddresses(syscallsAdresses, t.config.OSInfo, t.kernelSymbols)
+		if err != nil {
+			return trace.Event{}, false, fmt.Errorf("error parsing analyzing hooked syscalls adresses arg: %v", err)
+		}
 		de := event
 		de.EventID = int(DetectHookedSyscallsEventID)
 		de.EventName = "hooked_syscalls"
@@ -139,43 +145,36 @@ func deriveDetectHookedSyscall(t *Tracee) deriveFn {
 	}
 }
 
-func (t *Tracee) ParseHookedAddresses(addresses []uint64) []bufferdecoder.HookedSyscallData {
+func analyzeHookedAddresses(addresses []uint64, OsConfig *helpers.OSInfo, kernelSymbols *helpers.KernelSymbolTable) ([]bufferdecoder.HookedSyscallData, error) {
 	hookedSyscallData := make([]bufferdecoder.HookedSyscallData, 0, 0)
 	for idx, syscallsAdress := range addresses {
-		InTextSegment, err := t.kernelSymbols.TextSegmentContains(syscallsAdress)
+		InTextSegment, err := kernelSymbols.TextSegmentContains(syscallsAdress)
 		if err != nil {
 			continue
 		}
 		if !InTextSegment {
-			hookingFunction := t.ParseSymbol(syscallsAdress)
-			arch := t.config.OsConfig.GetOSReleaseFieldValue(helpers.OS_ARCH)
+			hookingFunction := parseSymbol(syscallsAdress, kernelSymbols)
 			var syscallNumber int32
-			if strings.Compare(arch, "x86_64") == 0 {
-				if idx > len(syscallsToCheckX86) {
-					continue
-				}
-				syscallNumber = int32(syscallsToCheckX86[idx])
-			} else {
-				if idx > len(syscallsToCheckArm) {
-					continue
-				}
-				syscallNumber = int32(syscallsToCheckArm[idx])
+			if idx > len(syscallsToCheck) {
+				return nil, fmt.Errorf("syscall inedx out of the syscalls to check list %v", err)
 			}
+			syscallNumber = int32(syscallsToCheck[idx])
 			event, found := EventsDefinitions[syscallNumber]
-			var hookedSyscall bufferdecoder.HookedSyscallData
+			var hookedSyscallName string
 			if found {
-				hookedSyscall = bufferdecoder.HookedSyscallData{event.Name, hookingFunction.Owner}
+				hookedSyscallName = event.Name
 			} else {
-				hookedSyscall = bufferdecoder.HookedSyscallData{fmt.Sprint(syscallNumber), hookingFunction.Owner}
+				hookedSyscallName = fmt.Sprint(syscallNumber)
 			}
-			hookedSyscallData = append(hookedSyscallData, hookedSyscall)
+			hookedSyscallData = append(hookedSyscallData, bufferdecoder.HookedSyscallData{hookedSyscallName, hookingFunction.Owner})
+
 		}
 	}
-	return hookedSyscallData
+	return hookedSyscallData, nil
 }
 
-func (t *Tracee) ParseSymbol(address uint64) *helpers.KernelSymbol {
-	hookingFunction, err := t.kernelSymbols.GetSymbolByAddr(address)
+func parseSymbol(address uint64, table *helpers.KernelSymbolTable) *helpers.KernelSymbol {
+	hookingFunction, err := table.GetSymbolByAddr(address)
 	if err != nil {
 		hookingFunction = &helpers.KernelSymbol{}
 		hookingFunction.Owner = "hidden"

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -3,7 +3,10 @@ package ebpf
 import (
 	"fmt"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/types/trace"
+	"strings"
 )
 
 // deriveFn is a function prototype for a function that receives an event as
@@ -115,4 +118,69 @@ func deriveContainerRemoved(t *Tracee) deriveFn {
 
 		return trace.Event{}, false, nil
 	}
+}
+
+func deriveDetectHookedSyscall(t *Tracee) deriveFn {
+	return func(event trace.Event)  (trace.Event, bool, error) {
+		syscallsAdresses, err := getEventArgUlongArrVal(&event, "syscalls_addresses")
+		if err != nil {
+			return trace.Event{}, false, fmt.Errorf("error parsing syscalls_numbers arg: %v", err)
+		}
+		hookedSyscallData := t.ParseHookedAddresses(syscallsAdresses)
+		de := event
+		de.EventID = int(DetectHookedSyscallsEventID)
+		de.EventName = "hooked_syscalls"
+		de.ReturnValue = 0
+		de.Args = []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "hooked_syscalls", Type: "hookedSyscallData[]"}, Value: hookedSyscallData},
+		}
+		de.ArgsNum = 1
+		return de, true, nil
+	}
+}
+
+func (t *Tracee) ParseHookedAddresses(addresses []uint64) []bufferdecoder.HookedSyscallData {
+	hookedSyscallData := make([]bufferdecoder.HookedSyscallData, 0, 0)
+	for idx, syscallsAdress := range addresses {
+		InTextSegment, err := t.kernelSymbols.TextSegmentContains(syscallsAdress)
+		if err != nil {
+			continue
+		}
+		if !InTextSegment {
+			hookingFunction := t.ParseSymbol(syscallsAdress)
+			arch := t.config.OsConfig.GetOSReleaseFieldValue(helpers.OS_ARCH)
+			var syscallNumber int32
+			if strings.Compare(arch, "x86_64") == 0 {
+				if idx > len(syscallsToCheckX86) {
+					continue
+				}
+				syscallNumber = int32(syscallsToCheckX86[idx])
+			} else {
+				if idx > len(syscallsToCheckArm) {
+					continue
+				}
+				syscallNumber = int32(syscallsToCheckArm[idx])
+			}
+			event, found := EventsDefinitions[syscallNumber]
+			var hookedSyscall bufferdecoder.HookedSyscallData
+			if found {
+				hookedSyscall = bufferdecoder.HookedSyscallData{event.Name, hookingFunction.Owner}
+			} else {
+				hookedSyscall = bufferdecoder.HookedSyscallData{fmt.Sprint(syscallNumber), hookingFunction.Owner}
+			}
+			hookedSyscallData = append(hookedSyscallData, hookedSyscall)
+		}
+	}
+	return hookedSyscallData
+}
+
+func (t *Tracee) ParseSymbol(address uint64) *helpers.KernelSymbol {
+	hookingFunction, err := t.kernelSymbols.GetSymbolByAddr(address)
+	if err != nil {
+		hookingFunction = &helpers.KernelSymbol{}
+		hookingFunction.Owner = "hidden"
+	}
+	hookingFunction.Owner = strings.TrimPrefix(hookingFunction.Owner, "[")
+	hookingFunction.Owner = strings.TrimSuffix(hookingFunction.Owner, "]")
+	return hookingFunction
 }

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -334,7 +334,11 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 		}
 		t.containers.CgroupRemove(cgroupId, hId)
 
+	// in case FinitModule and IinitModule occurs it means that kernel module loaded, then we will want to check if it hooked the syscall table
 	case FinitModuleEventID:
+		t.invokeIoctlTriggeredEvents()
+
+	case InitModuleEventID:
 		t.invokeIoctlTriggeredEvents()
 	}
 

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -333,6 +333,9 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			return fmt.Errorf("error parsing cgroup_mkdir args: %w", err)
 		}
 		t.containers.CgroupRemove(cgroupId, hId)
+
+	case FinitModuleEventID:
+		t.invokeIoctlTriggeredEvents()
 	}
 
 	return nil

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -364,6 +364,19 @@ func getEventArgUint64Val(event *trace.Event, argName string) (uint64, error) {
 	return 0, fmt.Errorf("argument %s not found", argName)
 }
 
+func getEventArgUlongArrVal(event *trace.Event, argName string) ([]uint64, error) {
+	for _, arg := range event.Args {
+		if arg.Name == argName {
+			val, ok := arg.Value.([]uint64)
+			if !ok {
+				return nil, fmt.Errorf("argument %s is not of type ulong array", argName)
+			}
+			return val, nil
+		}
+	}
+	return nil, fmt.Errorf("argument %s not found", argName)
+}
+
 func getEventArgUint32Val(event *trace.Event, argName string) (uint32, error) {
 	for _, arg := range event.Args {
 		if arg.Name == argName {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -49,6 +49,7 @@ type Config struct {
 	ChanEvents         chan trace.Event
 	ChanErrors         chan error
 	ProcessInfo        bool
+	OsConfig           *helpers.OSInfo
 }
 
 type CaptureConfig struct {
@@ -783,6 +784,32 @@ func (t *Tracee) populateBPFMaps() error {
 				return err
 			}
 		}
+		if e == PrintSyscallTableEventID {
+			hookedSyscallsMap, err := t.bpfModule.GetMap("syscalls_to_check_map")
+			if err != nil {
+				return err
+			}
+			/* the hookedSyscallsMap store first the syscall table address then the syscall numbers, like that:
+			 * [sys_call_table symbol address][syscall num #1][syscall num #2][syscall num #3]...
+			 * with that, we can fetch the syscall address by accessing the syscall table in the syscall number index
+			 */
+			key := int(0)
+			syscallTableSymbol, err := t.kernelSymbols.GetSymbolByName("system", "sys_call_table")
+			syscallTableAddress := syscallTableSymbol.Address
+			errs = append(errs, hookedSyscallsMap.Update(unsafe.Pointer(&key), unsafe.Pointer(&syscallTableAddress)))
+			arch := t.config.OsConfig.GetOSReleaseFieldValue(helpers.OS_ARCH)
+			syscallList := getSyscallList(arch)
+			// the map should look like [syscall_table][syscall number 1][syscall number 2][syscall number 3]...
+			for idx, val := range syscallList {
+				key = idx + 1
+				errs = append(errs, hookedSyscallsMap.Update(unsafe.Pointer(&(key)), unsafe.Pointer(&val)))
+			}
+			for _, err := range errs {
+				if err != nil {
+					return err
+				}
+			}
+		}
 	}
 	if len(t.netInfo.ifaces) > 0 {
 		networkConfingMap, err := t.bpfModule.GetMap("network_config") // u32, int
@@ -800,6 +827,55 @@ func (t *Tracee) populateBPFMaps() error {
 	}
 
 	return nil
+}
+
+var syscallsToCheckX86 = []int{
+	0,   // read
+	1,   // write
+	2,   // open
+	3,   // close
+	41,  // socket
+	44,  // sendto
+	45,  // recvfrom
+	46,  // sendmsg
+	47,  // recvmsg
+	59,  // execve
+	62,  // kill
+	78,  // getdents
+	101, // ptrace
+	217, // getdents64
+	321, // bpf
+	322, // execveat
+	16,  // ioctl
+	257, // openat
+}
+
+var syscallsToCheckArm = []int{
+	63, // read
+	64, // write
+	// open (not present)
+	57,  // close
+	29,  // ioctl
+	198, // socket
+	221, // execve
+	129, // kill
+	// getdents (not present)
+	117, // ptrace
+	61,  // getdents64
+	280, // bpf
+	281, // execveat
+	56,  // openat
+	206, // sendto
+	207, // recvfrom
+	211, // sendmsg
+	212, // recvmsg
+}
+
+func getSyscallList(arch string) []int {
+	if strings.Compare(arch, "x86_64") == 0 {
+		return syscallsToCheckX86
+	}
+	return syscallsToCheckArm
 }
 
 func (t *Tracee) attachTcProg(ifaceName string, attachPoint bpf.TcAttachPoint, progName string) (*bpf.TcHook, error) {
@@ -1135,6 +1211,7 @@ func (t *Tracee) getProcessCtx(hostTid uint32) (procinfo.ProcessCtx, error) {
 // Run starts the trace. it will run until ctx is cancelled
 func (t *Tracee) Run(ctx gocontext.Context) error {
 	t.invokeInitEvents()
+	t.invokeIoctlTriggeredEvents()
 	t.eventsPerfMap.Start()
 	t.fileWrPerfMap.Start()
 	t.netPerfMap.Start()
@@ -1271,4 +1348,18 @@ func findInList(element string, list *[]string) (int, error) {
 		}
 	}
 	return 0, fmt.Errorf("element: %s dosent found\n", element)
+}
+
+const IoctlFetchSyscalls int = 65 // randomly picked number for ioctl cmd
+
+func (t *Tracee) invokeIoctlTriggeredEvents() {
+	// invoke DetectHookedSyscallsEvent
+	if t.eventsToTrace[PrintSyscallTableEventID] {
+		ptmx, err := os.OpenFile(t.config.Capture.OutputPath, os.O_RDONLY, 444)
+		if err != nil {
+			return
+		}
+		syscall.Syscall(syscall.SYS_IOCTL, ptmx.Fd(), uintptr(IoctlFetchSyscalls), 0)
+		ptmx.Close()
+	}
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1354,7 +1354,7 @@ const IoctlFetchSyscalls int = 65 // randomly picked number for ioctl cmd
 
 func (t *Tracee) invokeIoctlTriggeredEvents() {
 	// invoke DetectHookedSyscallsEvent
-	if t.eventsToTrace[PrintSyscallTableEventID] {
+	if t.eventsToTrace[PrintSyscallTableEventID] || t.eventsToTrace[DetectHookedSyscallsEventID] {
 		ptmx, err := os.OpenFile(t.config.Capture.OutputPath, os.O_RDONLY, 444)
 		if err != nil {
 			return


### PR DESCRIPTION
Hi
this is a fixed version of #1222 PR, 
Its solves #1257 
I put it now as Draft until it will pass a CR  (:

**how it works:**
A special ioctl cmd is executed during tracee initialization. This
special ioctl cmd tells eBPF kprobe function that it should look the
syscalls table for a list of given syscalls and their addresses.

By checking runtime syscall handlers addresses, it is possible to know
if the handlers were hijacked by a kernel module, for example. They way
way it works is this: if the syscall handler address is not in kernel
text segment boundaries, it means it is not part of running kernel
(likely a hook somewhere else).
