### PR TITLE
chore: run tests in the pkg subdirectories

### DIFF
--- a/Makefile.one
+++ b/Makefile.one
@@ -496,7 +496,8 @@ test-tracee-ebpf: \
 		-tags $(GO_TAGS_EBPF) \
 		-v \
 		./tracee-ebpf/... \
-		./cmd/tracee-ebpf/...
+		./cmd/tracee-ebpf/... \
+		./pkg/...
 
 #
 # btfhub (expensive: only run if core obj changed)

--- a/tracee-ebpf/Makefile
+++ b/tracee-ebpf/Makefile
@@ -164,6 +164,7 @@ test: $(GO_SRC) $(LIBBPF_HEADERS) $(LIBBPF_OBJ)
 		-tags ebpf $(GOTEST_FLAGS) \
 		-v \
 		../cmd/tracee-ebpf/ \
+		../pkg/... \
 		./...
 
 else


### PR DESCRIPTION
We already have code under pkg that requires CGO flags
to compile and run. Therefore, we run them in the
test-tracee-ebpf target.

Resolves: #1369

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>