### PR TITLE
Prometheus support

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -38,7 +38,7 @@ probe_tracee_ebpf() {
 
         echo "INFO: probing tracee-ebpf capabilities..."
         timeout --preserve-status ${EBPF_PROBE_TIMEOUT} \
-            ${TRACEE_EBPF_EXE} --output=none \
+            ${TRACEE_EBPF_EXE} --metrics --output=none \
             --trace comm="nothing" 2>&1 > /dev/null 2>&1
         TRACEE_RET=$?
     fi
@@ -70,13 +70,13 @@ run_tracee_rules() {
     events=$($TRACEE_RULES_EXE --list-events)
 
     echo "INFO: starting tracee-ebpf..."
-    ${TRACEE_EBPF_EXE} --output=format:gob --output=option:parse-arguments --trace event=${events} --output=out-file:${TRACEE_PIPE} &
+    ${TRACEE_EBPF_EXE} --metrics --output=format:gob --output=option:parse-arguments --trace event=${events} --output=out-file:${TRACEE_PIPE} &
     tracee_ebpf_pid=$!
 
     # start tracee-rules
 
     echo "INFO: starting tracee-rules..."
-    $TRACEE_RULES_EXE --input-tracee=file:${TRACEE_PIPE} --input-tracee=format:gob $@
+    $TRACEE_RULES_EXE --metrics --input-tracee=file:${TRACEE_PIPE} --input-tracee=format:gob $@
     TRACEE_RET=$?
 }
 

--- a/cmd/tracee-ebpf/printer.go
+++ b/cmd/tracee-ebpf/printer.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aquasecurity/tracee/pkg/external"
+	"github.com/aquasecurity/tracee/tracee-ebpf/metrics"
 )
 
 type eventPrinter interface {
@@ -19,7 +20,7 @@ type eventPrinter interface {
 	// Preamble prints something before event printing begins (one time)
 	Preamble()
 	// Epilogue prints something after event printing ends (one time)
-	Epilogue(stats external.Stats)
+	Epilogue(stats metrics.Stats)
 	// Print prints a single event
 	Print(event external.Event)
 	// Error prints a single error
@@ -143,7 +144,7 @@ func (p tableEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p tableEventPrinter) Epilogue(stats external.Stats) {
+func (p tableEventPrinter) Epilogue(stats metrics.Stats) {
 	fmt.Println()
 	fmt.Fprintf(p.out, "End of events stream\n")
 	fmt.Fprintf(p.out, "Stats: %+v\n", stats)
@@ -191,7 +192,7 @@ func (p templateEventPrinter) Print(event external.Event) {
 	}
 }
 
-func (p templateEventPrinter) Epilogue(stats external.Stats) {}
+func (p templateEventPrinter) Epilogue(stats metrics.Stats) {}
 
 func (p templateEventPrinter) Close() {
 }
@@ -217,7 +218,7 @@ func (p jsonEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p jsonEventPrinter) Epilogue(stats external.Stats) {}
+func (p jsonEventPrinter) Epilogue(stats metrics.Stats) {}
 
 func (p jsonEventPrinter) Close() {
 }
@@ -250,7 +251,7 @@ func (p *gobEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p *gobEventPrinter) Epilogue(stats external.Stats) {}
+func (p *gobEventPrinter) Epilogue(stats metrics.Stats) {}
 
 func (p gobEventPrinter) Close() {
 }
@@ -272,6 +273,6 @@ func (p *ignoreEventPrinter) Error(err error) {
 	fmt.Fprintf(p.err, "%v\n", err)
 }
 
-func (p *ignoreEventPrinter) Epilogue(stats external.Stats) {}
+func (p *ignoreEventPrinter) Epilogue(stats metrics.Stats) {}
 
 func (p ignoreEventPrinter) Close() {}

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -40,6 +40,14 @@ The Go template can utilize helper functions from [Sprig].
 
 For example templates, see [tracee/cmd/tracee-rules/templates].
 
+## Prometheus
+
+Tracee is enabled for prometheus scraping by default. Scraping can be done through the following URLs:1
+1. `tracee-ebpf` can be scraped through `:3366/metrics`
+2. `tracee-rules` can be scraped through `:4466/metrics`
+
+The metrics addresses can be changed through running with the `metrics` and `metrics-addr` in the cli.
+
 ## Examples
 
 ### Raw JSON stdout

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/onsi/gomega v1.17.0
 	github.com/open-policy-agent/opa v0.35.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/testcontainers/testcontainers-go v0.12.0
@@ -28,7 +29,9 @@ require (
 	github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3 // indirect
 	github.com/Microsoft/hcsshim v0.8.16 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68 // indirect
 	github.com/containerd/containerd v1.5.0-beta.4 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
@@ -46,6 +49,7 @@ require (
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/moby/sys/mount v0.2.0 // indirect
@@ -57,6 +61,9 @@ require (
 	github.com/opencontainers/runc v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.29.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
@@ -517,6 +518,7 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -634,17 +636,20 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
+github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180110214958-89604d197083/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
+github.com/prometheus/common v0.29.0 h1:3jqPBvKT4OHAbje2Ql7KeaaSicDBCxMYwEJU1zRJceE=
 github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -655,6 +660,7 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -1,0 +1,31 @@
+package counter
+
+import "sync/atomic"
+
+type Counter int32
+
+func (c *Counter) Increment(amount ...int) {
+	sum := 1
+	if len(amount) > 0 {
+		sum = 0
+		for _, a := range amount {
+			sum = sum + a
+		}
+	}
+	atomic.AddInt32((*int32)(c), int32(sum))
+}
+
+func (c *Counter) Decrement(amount ...int) {
+	sum := -1
+	if len(amount) > 0 {
+		sum = 0
+		for _, a := range amount {
+			sum = sum - a
+		}
+	}
+	atomic.AddInt32((*int32)(c), int32(sum))
+}
+
+func (c *Counter) Read() int32 {
+	return atomic.LoadInt32((*int32)(c))
+}

--- a/pkg/counter/counter_test.go
+++ b/pkg/counter/counter_test.go
@@ -1,0 +1,44 @@
+package counter
+
+import "testing"
+
+func TestIncrement(t *testing.T) {
+	var c Counter = 0
+
+	c.Increment()
+
+	if c.Read() != 1 {
+		t.Errorf("Increment was incorrect, got %d, expected %d", c.Read(), 1)
+	}
+}
+
+func TestIncrementMultiple(t *testing.T) {
+	var c Counter = 0
+
+	c.Increment(1, 2, 3)
+	expected := 1 + 2 + 3
+
+	if c.Read() != int32(expected) {
+		t.Errorf("Increment was incorrect, got %d, expected %d", c.Read(), expected)
+	}
+}
+
+func TestDecrement(t *testing.T) {
+	var c Counter = 1
+
+	c.Decrement()
+
+	if c.Read() != 0 {
+		t.Errorf("Increment was incorrect, got %d, expected %d", c.Read(), 0)
+	}
+}
+
+func TestDecrementMultiple(t *testing.T) {
+	var c Counter = 1 + 2 + 3
+
+	c.Decrement(1, 2, 3)
+
+	if c.Read() != 0 {
+		t.Errorf("Increment was incorrect, got %d, expected %d", c.Read(), 0)
+	}
+}

--- a/pkg/external/external.go
+++ b/pkg/external/external.go
@@ -31,14 +31,6 @@ type Event struct {
 	Args                []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
 }
 
-type Stats struct {
-	EventCount  int
-	ErrorCount  int
-	LostEvCount int
-	LostWrCount int
-	LostNtCount int
-}
-
 // ToUnstructured returns a JSON compatible map with string, float, int, bool,
 // []interface{}, or map[string]interface{} children.
 //

--- a/tracee-ebpf/metrics/prometheus.go
+++ b/tracee-ebpf/metrics/prometheus.go
@@ -1,0 +1,60 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+//This function takes a pointer to a stats struct, it can be exported through the relevant .Stats() method
+func RegisterPrometheus(stats *Stats) error {
+	err := prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_ebpf",
+		Name:      "events_total",
+		Help:      "events collected by tracee-ebpf",
+	}, func() float64 { return float64(stats.EventCount.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_ebpf",
+		Name:      "lostevents_total",
+		Help:      "events lost in the submission buffer",
+	}, func() float64 { return float64(stats.LostEvCount.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_ebpf",
+		Name:      "write_lostevents_total",
+		Help:      "events lost in the write buffer",
+	}, func() float64 { return float64(stats.LostWrCount.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_ebpf",
+		Name:      "network_lostevents_total",
+		Help:      "events lost in the network buffer",
+	}, func() float64 { return float64(stats.LostNtCount.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_ebpf",
+		Name:      "errors_total",
+		Help:      "errors accumulated by tracee-ebpf",
+	}, func() float64 { return float64(stats.ErrorCount.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tracee-ebpf/metrics/stats.go
+++ b/tracee-ebpf/metrics/stats.go
@@ -1,0 +1,11 @@
+package metrics
+
+import "github.com/aquasecurity/tracee/pkg/counter"
+
+type Stats struct {
+	EventCount  counter.Counter
+	ErrorCount  counter.Counter
+	LostEvCount counter.Counter
+	LostWrCount counter.Counter
+	LostNtCount counter.Counter
+}

--- a/tracee-ebpf/tracee/events_pipeline.go
+++ b/tracee-ebpf/tracee/events_pipeline.go
@@ -160,7 +160,7 @@ func (t *Tracee) processEvents(ctx gocontext.Context, in <-chan *external.Event)
 
 				select {
 				case t.config.ChanEvents <- *event:
-					t.stats.eventCounter.Increment()
+					t.stats.EventCount.Increment()
 				case <-ctx.Done():
 					return
 				}
@@ -169,7 +169,7 @@ func (t *Tracee) processEvents(ctx gocontext.Context, in <-chan *external.Event)
 			for _, derivative := range derivatives {
 				select {
 				case t.config.ChanEvents <- derivative:
-					t.stats.eventCounter.Increment()
+					t.stats.EventCount.Increment()
 				case <-ctx.Done():
 					return
 				}
@@ -250,6 +250,6 @@ func MergeErrors(cs ...<-chan error) <-chan error {
 }
 
 func (t *Tracee) handleError(err error) {
-	t.stats.errorCounter.Increment()
+	t.stats.ErrorCount.Increment()
 	t.config.ChanErrors <- err
 }

--- a/tracee-ebpf/tracee/events_processor.go
+++ b/tracee-ebpf/tracee/events_processor.go
@@ -21,7 +21,7 @@ func (t *Tracee) processLostEvents() {
 		// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
 		// https://github.com/aquasecurity/libbpfgo/issues/122
 		if lost > 0 {
-			t.stats.lostEvCounter.Increment(int(lost))
+			t.stats.LostEvCount.Increment(int(lost))
 			t.config.ChanErrors <- fmt.Errorf("lost %d events", lost)
 		}
 	}

--- a/tracee-ebpf/tracee/net_events.go
+++ b/tracee-ebpf/tracee/net_events.go
@@ -168,7 +168,7 @@ func (t *Tracee) processNetEvents() {
 			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
 			// https://github.com/aquasecurity/libbpfgo/issues/122
 			if lost > 0 {
-				t.stats.lostNtCounter.Increment(int(lost))
+				t.stats.LostNtCount.Increment(int(lost))
 				t.config.ChanErrors <- fmt.Errorf("lost %d network events", lost)
 			}
 		}

--- a/tracee-ebpf/tracee/write_capture.go
+++ b/tracee-ebpf/tracee/write_capture.go
@@ -154,7 +154,7 @@ func (t *Tracee) processFileWrites() {
 			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
 			// https://github.com/aquasecurity/libbpfgo/issues/122
 			if lost > 0 {
-				t.stats.lostWrCounter.Increment(int(lost))
+				t.stats.LostWrCount.Increment(int(lost))
 				t.config.ChanErrors <- fmt.Errorf("lost %d write events", lost)
 			}
 		}

--- a/tracee-rules/metrics/prometheus.go
+++ b/tracee-rules/metrics/prometheus.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+//This function takes a pointer to a stats struct, it can be exported through the relevant .Stats() method
+func RegisterPrometheus(stats *Stats) error {
+	err := prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_rules",
+		Name:      "events_total",
+		Help:      "events ingested by tracee-rules",
+	}, func() float64 { return float64(stats.Events.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_rules",
+		Name:      "detections_total",
+		Help:      "detections made by tracee-rules",
+	}, func() float64 { return float64(stats.Detections.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Namespace: "tracee_rules",
+		Name:      "signatures_total",
+		Help:      "signatures loaded",
+	}, func() float64 { return float64(stats.Signatures.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tracee-rules/metrics/stats.go
+++ b/tracee-rules/metrics/stats.go
@@ -1,0 +1,9 @@
+package metrics
+
+import "github.com/aquasecurity/tracee/pkg/counter"
+
+type Stats struct {
+	Events     counter.Counter
+	Signatures counter.Counter
+	Detections counter.Counter
+}


### PR DESCRIPTION
* Adds prometheus metrics endpoint to tracee-ebpf cli enabled by flag (defaults to `:3366/metrics`)
* Adds prometheus metrics endpoint to tracee-rules cli enabled by flag (defaults to `:4466/metrics`)
* Adds engine stats
* Moves tracee-ebpf counter to it's own package (reused in engine stats)
* Adds metrics package which registers tracee-ebpf and tracee-rules stats to prometheus
* Move stats definition to metrics package (as part of stabilization #1250)

As part of #887 