### PR TITLE
libbpfgo: bump to commit 5e89006 to include fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1
+	github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220126150855-5e890064f075
 	github.com/aquasecurity/tracee/types v0.0.0-20220124150039-d317caa9cf09
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:C
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1 h1:7Ezl6s7ftdV1S7JnBi/zgRR4Od3MtEx0GH21TmyFMAI=
 github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220126150855-5e890064f075 h1:BqrItxwk9rA2c/TpY8zuKIreHh8KAtLe3uz6TcSQf9E=
+github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220126150855-5e890064f075/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/aquasecurity/tracee/types v0.0.0-20220124150039-d317caa9cf09 h1:K4gNDoBv3drfz7tD2cbD0hwkjRJcVxI3ii15jTuQxcw=
 github.com/aquasecurity/tracee/types v0.0.0-20220124150039-d317caa9cf09/go.mod h1:E3pyWcV82nrIKQLXvWCNlNJYRbjC3AyTBe2AxOQBdxE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
libbpfgo recently added 2 needed fixes:

commit 5e89006 ("libbpfgo: use perf_buffer__new new API and fix style") and commit 5d2336e ("kprobe: remove legacy kprobes and unneeded includes").

Together they fix a panic happening in main branch:

    $ sudo ./dist/tracee-ebpf
    TIME             UID    COMM             PID     TID...
    fatal error: unexpected signal during runtime execution
    [signal SIGSEGV: segmentation violation code=0x2 addr=...

whenever libbpf executes perf_buffer__new() using the old, and deprecated, prototype. This change makes sure that libbpfgo will always call perf_buffer__new() using the new prototype.

Fix: #1383