### PR TITLE
btfhub.sh: allow skipping initial fetch

### DIFF
--- a/3rdparty/btfhub.sh
+++ b/3rdparty/btfhub.sh
@@ -7,6 +7,9 @@
 #
 # It uses the 2 repositories to generate tailored BTF files, according to
 # latest CO-RE object file, so those files can be embedded in tracee Go binary.
+#
+# Note: You may opt out from fetching repositories changes in the beginning of
+# the execution by exporting SKIP_FETCH=1 env variable.
 
 BASEDIR=$(dirname "${0}") ; cd ${BASEDIR}/../ ; BASEDIR=$(pwd) ; cd ${BASEDIR}
 
@@ -58,7 +61,7 @@ branch_clean() {
 
 CMDS="rsync git cp rm mv"
 for cmd in ${CMDS}; do
-	command -v $cmd 2>&1 >/dev/null || die "cmd ${cmd} not found"
+    command -v $cmd 2>&1 >/dev/null || die "cmd ${cmd} not found"
 done
 
 [ ! -f ${TRACEE_BPF_CORE} ] && die "tracee CO-RE obj not found"
@@ -66,8 +69,10 @@ done
 [ ! -d ${BTFHUB_DIR} ] && git clone "${BTFHUB_REPO}" ${BTFHUB_DIR}
 [ ! -d ${BTFHUB_ARCH_DIR} ] && git clone "${BTFHUB_ARCH_REPO}" ${BTFHUB_ARCH_DIR}
 
-branch_clean ${BTFHUB_DIR}
-branch_clean ${BTFHUB_ARCH_DIR}
+if [ -z ${SKIP_FETCH} ]; then
+    branch_clean ${BTFHUB_DIR}
+    branch_clean ${BTFHUB_ARCH_DIR}
+fi
 
 cd ${BTFHUB_DIR}
 


### PR DESCRIPTION
btfhub-archive caching will be performed by github actions. Allow a way to skip the initial fetching logic (unneeded for the PR checks).

@danielpacak let me know if this suits our needs for the PR checks. I can make changes if you need something else.