### PR TITLE
tracee-ebpf: fix cap_capable when using CO-RE

### DIFF
--- a/tracee-ebpf/tracee/co-re/missing_definitions.h
+++ b/tracee-ebpf/tracee/co-re/missing_definitions.h
@@ -172,6 +172,10 @@
 #define S_ISGID  0002000
 #define S_ISVTX  0001000
 
+#define CAP_OPT_NONE 0x0
+#define CAP_OPT_NOAUDIT 0b10
+#define CAP_OPT_INSETID 0b100
+
 static inline bool ipv6_addr_any(const struct in6_addr *a)
 {
     return (a->in6_u.u6_addr32[0] | a->in6_u.u6_addr32[1] | a->in6_u.u6_addr32[2] | a->in6_u.u6_addr32[3]) == 0;

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -2942,8 +2942,6 @@ int BPF_KPROBE(trace_switch_task_namespaces)
 SEC("kprobe/cap_capable")
 int BPF_KPROBE(trace_cap_capable)
 {
-    int audit;
-
     event_data_t data = {};
     if (!init_event_data(&data, ctx))
         return 0;
@@ -2951,18 +2949,10 @@ int BPF_KPROBE(trace_cap_capable)
     if (!should_trace(&data.context))
         return 0;
 
-    //const struct cred *cred = (const struct cred *)PT_REGS_PARM1(ctx);
-    //struct user_namespace *targ_ns = (struct user_namespace *)PT_REGS_PARM2(ctx);
     int cap = PT_REGS_PARM3(ctx);
     int cap_opt = PT_REGS_PARM4(ctx);
 
-  #ifdef CAP_OPT_NONE
-    audit = (cap_opt & 0b10) == 0;
-  #else
-    audit = cap_opt;
-  #endif
-
-    if (audit == 0)
+    if (cap_opt & CAP_OPT_NOAUDIT)
         return 0;
 
     save_to_submit_buf(&data, (void*)&cap, sizeof(int), 0);


### PR DESCRIPTION
Add missing cap_opts definition in CO-RE to fix cap_capable event which
didn't monitor the requested capabilities correctly.

Fix #1341