### PR TITLE
tracee-ebpf: introduce container id filter

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/flags-filter.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-filter.go
@@ -111,6 +111,10 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 		},
 		ContFilter:    &tracee.BoolFilter{},
 		NewContFilter: &tracee.BoolFilter{},
+		ContIDFilter: &tracee.ContIDFilter{
+			Equal:    []string{},
+			NotEqual: []string{},
+		},
 		RetFilter: &tracee.RetFilter{
 			Filters: make(map[int32]tracee.IntFilter),
 		},
@@ -194,6 +198,11 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 				filter.NewContFilter.Value = false
 				continue
 			}
+			err := filter.ContIDFilter.Parse(operatorAndValues)
+			if err != nil {
+				return tracee.Filter{}, err
+			}
+			continue
 		}
 
 		if strings.HasPrefix("event", filterName) {

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -73,7 +73,8 @@ func main() {
 			cfg.Filter = &filter
 
 			containerMode := (cfg.Filter.ContFilter.Enabled && cfg.Filter.ContFilter.Value) ||
-				(cfg.Filter.NewContFilter.Enabled && cfg.Filter.NewContFilter.Value)
+				(cfg.Filter.NewContFilter.Enabled && cfg.Filter.NewContFilter.Value) ||
+				cfg.Filter.ContIDFilter.Enabled
 
 			if checkCommandIsHelp(c.StringSlice("output")) {
 				fmt.Print(flags.OutputHelp())

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -293,17 +293,17 @@ func getCgroupPath(rootDir string, cgroupId uint64, subPath string) (string, err
 	return "", fs.ErrNotExist
 }
 
-// GetContainers provides a list of all added containers by their uuid.
-func (c *Containers) GetContainers() []string {
-	var conts []string
+// FindContainerCgroupID32LSB returns the 32 LSB of the Cgroup ID for a given container ID
+func (c *Containers) FindContainerCgroupID32LSB(containerID string) []uint32 {
+	var cgroupIDs []uint32
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()
-	for _, v := range c.cgroups {
-		if v.ContainerId != "" && v.expiresAt.IsZero() {
-			conts = append(conts, v.ContainerId)
+	for k, v := range c.cgroups {
+		if strings.HasPrefix(v.ContainerId, containerID) {
+			cgroupIDs = append(cgroupIDs, k)
 		}
 	}
-	return conts
+	return cgroupIDs
 }
 
 // GetCgroupInfo returns the Containers struct cgroupInfo data of a given cgroupId.

--- a/tracee-ebpf/tracee/tracee.bpf.c
+++ b/tracee-ebpf/tracee/tracee.bpf.c
@@ -220,6 +220,7 @@ Copyright (C) Aqua Security inc.
 #define CONFIG_PROC_TREE_FILTER         18
 #define CONFIG_CAPTURE_MODULES          19
 #define CONFIG_CGROUP_V1                20
+#define CONFIG_CGROUP_ID_FILTER         21
 
 // get_config(CONFIG_XXX_FILTER) returns 0 if not enabled
 #define FILTER_IN                       1
@@ -557,6 +558,7 @@ BPF_HASH(mnt_ns_filter, u64, u32);                      // filter events by moun
 BPF_HASH(pid_ns_filter, u64, u32);                      // filter events by pid namespace id
 BPF_HASH(uts_ns_filter, string_filter_t, u32);          // filter events by uts namespace name
 BPF_HASH(comm_filter, string_filter_t, u32);            // filter events by command name
+BPF_HASH(cgroup_id_filter, u32, u32);                   // filter events by cgroup id
 BPF_HASH(bin_args_map, u64, bin_args_t);                // persist args for send_bin funtion
 BPF_HASH(sys_32_to_64_map, u32, u32);                   // map 32bit to 64bit syscalls
 BPF_HASH(params_types_map, u32, u64);                   // encoded parameters types for event
@@ -1302,6 +1304,9 @@ static __always_inline int should_trace(context_t *context)
         return 0;
 
     if (!equality_filter_matches(CONFIG_PROC_TREE_FILTER, &process_tree_map, &context->pid))
+        return 0;
+
+    if (!equality_filter_matches(CONFIG_CGROUP_ID_FILTER, &cgroup_id_filter, &cgroup_id_lsb))
         return 0;
 
     // We passed all filters successfully

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -433,6 +433,7 @@ const (
 	configProcTreeFilter
 	configCaptureModules
 	configCgroupV1
+	configCgroupIdFilter
 )
 
 // Custom KernelConfigOption's to extend kernel_config helper support
@@ -595,6 +596,8 @@ func (t *Tracee) populateBPFMaps() error {
 	errmap["comm_filter"] = t.config.Filter.CommFilter.Set(t.bpfModule, "comm_filter", configCommFilter)
 	errmap["cont_filter"] = t.config.Filter.ContFilter.Set(t.bpfModule, configContFilter)
 	errmap["cont=new_filter"] = t.config.Filter.NewContFilter.Set(t.bpfModule, configNewContFilter)
+	errmap["cont_id_filter"] = t.config.Filter.ContIDFilter.Set(t.bpfModule, t.containers, "cgroup_id_filter", configCgroupIdFilter)
+
 	for k, v := range errmap {
 		if v != nil {
 			return fmt.Errorf("error setting %v filter: %v", k, v)


### PR DESCRIPTION
Add container id filter by mapping the container id to cgroup id and
using it to filter in kernel.

Close #255