### PR TITLE
chore(ci): skip building aquasec/tracee-tester:latest container image

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -165,9 +165,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           opa-version: ${{ env.OPA_VERSION }}
-      - name: Buld tracee-tester image
-        run: |
-          make -f tests/Makefile docker-build-tracee-tester
       - name: Build tracee-nocore
         run: |
           make -f builder/Makefile.tracee-container build-alpine-tracee-nocore
@@ -209,9 +206,6 @@ jobs:
       - name: Build tracee-core-btfhub
         run: |
           make -f builder/Makefile.tracee-container build-alpine-tracee-core-btfhub
-      - name: Buld tracee-tester image
-        run: |
-          make -f tests/Makefile docker-build-tracee-tester
       - name: Run tests
         run: |
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \

--- a/.github/workflows/publish-tracee-tester.yaml
+++ b/.github/workflows/publish-tracee-tester.yaml
@@ -9,11 +9,11 @@ on:
       tag:
         description: "Name and optionally a tag in the 'name:tag' format"
         default: "aquasec/tracee-tester:latest"
-        required: false
+        required: true
 jobs:
-  deploy:
-    name: Deploy the latest documentation
-    runs-on: ubuntu-18.04
+  publish:
+    name: Publish tracee-tester Image
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout main
         uses: actions/checkout@v2

--- a/.github/workflows/scheduled-signatures-test.yaml
+++ b/.github/workflows/scheduled-signatures-test.yaml
@@ -24,9 +24,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           opa-version: ${{ env.OPA_VERSION }}
-      - name: Buld tracee-tester image
-        run: |
-          make -f tests/Makefile docker-build-tracee-tester
       - name: Build tracee-nocore
         run: |
           make -f builder/Makefile.tracee-container build-alpine-tracee-nocore

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,0 @@
-# TODO Delete this Makefile once we publish aquasec/tracee-tester:latest to DockerHub.
-docker-build-tracee-tester:
-	docker image build --tag aquasec/tracee-tester:latest tests/tracee-tester


### PR DESCRIPTION
We've already published aquasec/tracee-tester:latest to [DockerHub](https://hub.docker.com/r/aquasec/tracee-tester) so we can just use it for testing.