### PR TITLE
Buffered signature channels

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -111,7 +111,7 @@ func main() {
 
 			config := engine.Config{
 				ParsedEvents:        c.Bool("rego-enable-parsed-events"),
-				SignatureBufferSize: c.Int(signatureBufferFlag),
+				SignatureBufferSize: c.Uint(signatureBufferFlag),
 			}
 			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, config)
 			if err != nil {
@@ -183,7 +183,7 @@ func main() {
 				Name:  "list-events",
 				Usage: "print a list of events that currently loaded signatures require",
 			},
-			&cli.IntFlag{
+			&cli.UintFlag{
 				Name:  signatureBufferFlag,
 				Usage: "size of the event channel's buffer consumed by signatures",
 				Value: 1000,

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -19,6 +19,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	signatureBufferFlag = "sig-buffer"
+)
+
 func main() {
 	app := &cli.App{
 		Name:  "tracee-rules",
@@ -106,7 +110,8 @@ func main() {
 			}
 
 			config := engine.Config{
-				ParsedEvents: c.Bool("rego-enable-parsed-events"),
+				ParsedEvents:        c.Bool("rego-enable-parsed-events"),
+				SignatureBufferSize: c.Int(signatureBufferFlag),
 			}
 			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, config)
 			if err != nil {
@@ -177,6 +182,11 @@ func main() {
 			&cli.BoolFlag{
 				Name:  "list-events",
 				Usage: "print a list of events that currently loaded signatures require",
+			},
+			&cli.IntFlag{
+				Name:  signatureBufferFlag,
+				Usage: "size of the event channel's buffer consumed by signatures",
+				Value: 1000,
 			},
 		},
 	}

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -104,7 +104,11 @@ func main() {
 			if err != nil {
 				return err
 			}
-			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, c.Bool("rego-enable-parsed-events"))
+
+			config := engine.Config{
+				ParsedEvents: c.Bool("rego-enable-parsed-events"),
+			}
+			e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, config)
 			if err != nil {
 				return fmt.Errorf("constructing engine: %w", err)
 			}

--- a/tracee-rules/benchmark/benchmark_test.go
+++ b/tracee-rules/benchmark/benchmark_test.go
@@ -98,7 +98,9 @@ func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 				s, err := bc.sigFunc()
 				require.NoError(b, err, bc.name)
 
-				e, err := engine.NewEngine([]types.Signature{s}, inputs, output, os.Stderr, bc.preparedEvents)
+				e, err := engine.NewEngine([]types.Signature{s}, inputs, output, os.Stderr, engine.Config{
+					ParsedEvents: bc.preparedEvents,
+				})
 				require.NoError(b, err, "constructing engine")
 				b.StartTimer()
 
@@ -153,7 +155,9 @@ func BenchmarkEngineWithMultipleSignatures(b *testing.B) {
 				inputs := ProduceEventsInMemory(inputEventsCount)
 				output := make(chan types.Finding, inputEventsCount*len(sigs))
 
-				e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, bc.preparedEvents)
+				e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, engine.Config{
+					ParsedEvents: bc.preparedEvents,
+				})
 				require.NoError(b, err, "constructing engine")
 				b.StartTimer()
 
@@ -213,7 +217,7 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 					b.StopTimer()
 					inputs := ProduceEventsInMemory(inputEventsCount)
 					output := make(chan types.Finding, inputEventsCount*len(sigs))
-					e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, false)
+					e, err := engine.NewEngine(sigs, inputs, output, os.Stderr, engine.Config{})
 					require.NoError(b, err, "constructing engine")
 					b.StartTimer()
 

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -22,7 +22,7 @@ const ALL_EVENT_TYPES = "*"
 // Config defines the engine's configurable values
 type Config struct {
 	ParsedEvents        bool
-	SignatureBufferSize int
+	SignatureBufferSize uint
 }
 
 // Engine is a rule-engine that can process events coming from a set of input sources against a set of loaded signatures, and report the signatures' findings

--- a/tracee-rules/engine/engine.go
+++ b/tracee-rules/engine/engine.go
@@ -60,7 +60,7 @@ func NewEngine(sigs []types.Signature, sources EventSources, output chan types.F
 	engine.signaturesMutex.Unlock()
 	for _, sig := range sigs {
 		engine.signaturesMutex.Lock()
-		engine.signatures[sig] = make(chan types.Event)
+		engine.signatures[sig] = make(chan types.Event, engine.config.SignatureBufferSize)
 		engine.signaturesMutex.Unlock()
 		meta, err := sig.GetMetadata()
 		if err != nil {
@@ -244,7 +244,7 @@ func (engine *Engine) LoadSignature(signature types.Signature) (string, error) {
 		// signature already exists
 		return metadata.ID, nil
 	}
-	c := make(chan types.Event)
+	c := make(chan types.Event, engine.config.SignatureBufferSize)
 	engine.signatures[signature] = c
 
 	// insert in engine.signaturesIndex map

--- a/tracee-rules/engine/engine_test.go
+++ b/tracee-rules/engine/engine_test.go
@@ -68,7 +68,7 @@ func TestConsumeSources(t *testing.T) {
 		expectedNumEvents int
 		expectedError     string
 		expectedEvent     interface{}
-		enableParsedEvent bool
+		config            Config
 	}{
 		{
 			name: "happy path - with one matching selector, parsed event enabled",
@@ -100,7 +100,9 @@ func TestConsumeSources(t *testing.T) {
 				ProcessID: 2, ParentProcessID: 1, Args: []external.Argument{{ArgMeta: external.ArgMeta{Name: "pathname", Type: ""}, Value: "/proc/self/mem"}},
 				EventName: "test_event",
 			},
-			enableParsedEvent: true,
+			config: Config{
+				ParsedEvents: true,
+			},
 		},
 		{
 			name: "happy path - with one matching selector",
@@ -378,7 +380,7 @@ func TestConsumeSources(t *testing.T) {
 
 			var gotNumEvents int
 			tc.inputSignature.onEvent = func(event types.Event) error {
-				if tc.enableParsedEvent {
+				if tc.config.ParsedEvents {
 					assert.Equal(t, tc.expectedEvent, event.(ParsedEvent).Event, tc.name)
 				} else {
 					assert.Equal(t, tc.expectedEvent, event.(external.Event), tc.name)
@@ -387,7 +389,7 @@ func TestConsumeSources(t *testing.T) {
 				return nil
 			}
 
-			e, err := NewEngine(sigs, inputs, outputChan, logger, tc.enableParsedEvent)
+			e, err := NewEngine(sigs, inputs, outputChan, logger, tc.config)
 			require.NoError(t, err, "constructing engine")
 			go func() {
 				e.Start(done)
@@ -446,7 +448,7 @@ func TestGetSelectedEvents(t *testing.T) {
 			},
 		},
 	}
-	e, err := NewEngine(sigs, EventSources{Tracee: make(chan types.Event)}, make(chan types.Finding), &bytes.Buffer{}, false)
+	e, err := NewEngine(sigs, EventSources{Tracee: make(chan types.Event)}, make(chan types.Finding), &bytes.Buffer{}, Config{})
 	require.NoError(t, err, "constructing engine")
 	se := e.GetSelectedEvents()
 	expected := []types.SignatureEventSelector{


### PR DESCRIPTION
During the performance testing that @mtcherni95 and I are doing, we've found that one of tracee-rule's bottlenecks (especially when running with low cpu constraints) is blocked channels on sending and receiving. We've also measured high times spent in `runtime.futex`, which is related to the channel blocking as I will demonstrate.

This PR enables configuring the event channels buffers that stream to signatures in tracee-rules. The default value set in the CLI is 1000. This should decrease the channel blocking overhead when some signatures receive many events, and reduce time in context switching between the signature go routines.

The PR also introduces a `Config` struct for the tracee-rules engine.

First, the case of unbuffered channels: 

Currently, signatures in the rules engine are implemented as a map between signatures and channels of events they receive. These channels are hard coded to be unbuffered. Here i've attached a flame graph of this case and a `top` table of cpu time spent:
![image](https://user-images.githubusercontent.com/22661609/152140604-64ea25af-89a6-4237-8340-570ba6fa6e44.png)
![image](https://user-images.githubusercontent.com/22661609/152140643-55088403-3ff3-46d5-85aa-54ddf9dc4c51.png)

As we can see in this case much time is spent in `runtime.futex` and the chanrecv and chansend functions take 7.85% and 7.05% of cpu time respectively, cumulating in 14.95% of cpu time.

This isn't the case for buffered channels (set to 1000):
![image](https://user-images.githubusercontent.com/22661609/152140909-f01bf1fe-af77-4f23-8b7d-024a4cd7e879.png)
Here we can see a drop in chanrecv and chansend time with 4.77% and 3.82% of cpu time respectively adding up to 8.59% of cpu time.

And for the top graph a differential pprof between the cases:
![image](https://user-images.githubusercontent.com/22661609/152141041-4de7ad0d-cb52-48ba-bdb5-4d55790972c7.png)

As we can see here there was a flat drop of 10.73% of cpu time on context switching. This means buffering the channels, as done in this pr, overall freed up 19.32% of cpu time.

I've also attached the relevant pprofs here: 
[0buffer.pb.gz](https://github.com/aquasecurity/tracee/files/7985815/0buffer.pb.gz)
[1000buffer.pb.gz](https://github.com/aquasecurity/tracee/files/7985816/1000buffer.pb.gz)