### PR TITLE
builder: container images: slim and full

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -139,7 +139,6 @@ jobs:
           severity: "CRITICAL"
           exit-code: "1"
 
-
   # smoke-test-noncore job is using TRC-2 (Anti-Debugging) signature and tracee
   # non CO-RE container image to run a quick smoke test on each PR.
   #
@@ -165,9 +164,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           opa-version: ${{ env.OPA_VERSION }}
-      - name: Build tracee-nocore
+      - name: Build tracee image (full w/out BTFHUB)
         run: |
-          make -f builder/Makefile.tracee-container build-alpine-tracee-nocore
+          BTFHUB=0 make -f builder/Makefile.tracee-container build-tracee-full
       - name: Install BPF
         run: |
           make -f Makefile.one install-bpf-nocore
@@ -175,7 +174,7 @@ jobs:
         run: |
           docker image pull aquasec/tracee-tester:latest
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
-            -tracee-image-ref "tracee-nocore:latest" \
+            -tracee-image-ref "tracee:full" \
             -tracee-tester-image-ref "aquasec/tracee-tester:latest" \
             -tracee-signatures "TRC-2"
 
@@ -204,17 +203,16 @@ jobs:
       - name: Built tracee BPF
         run: |
           make -f Makefile.one bpf-core
-      - name: Build tracee-core-btfhub
+      - name: Build tracee image (slim w/ BTFHUB)
         run: |
-          make -f builder/Makefile.tracee-container build-alpine-tracee-core-btfhub
+          BTFHUB=1 make -f builder/Makefile.tracee-container build-tracee
       - name: Run tests
         run: |
           docker image pull aquasec/tracee-tester:latest
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
-            -tracee-image-ref "tracee-btfhub:latest" \
+            -tracee-image-ref "tracee:latest" \
             -tracee-tester-image-ref "aquasec/tracee-tester:latest" \
             -tracee-signatures "TRC-2"
-
 
   # deprecated-verify-tracee-ebpf and deprecated-verify-tracee-rules jobs are
   # supposed to be removed once we fully migrate to Makefile.one and get rid of

--- a/.github/workflows/scheduled-signatures-test.yaml
+++ b/.github/workflows/scheduled-signatures-test.yaml
@@ -24,9 +24,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           opa-version: ${{ env.OPA_VERSION }}
-      - name: Build tracee-nocore
+      - name: Build tracee image (slim w/ BTFHUB)
         run: |
-          make -f builder/Makefile.tracee-container build-alpine-tracee-nocore
+          BTFHUB=1 make -f builder/Makefile.tracee-container build-tracee
       - name: Install BPF
         run: |
           make -f Makefile.one install-bpf-nocore
@@ -34,5 +34,5 @@ jobs:
         run: |
           docker image pull aquasec/tracee-tester:latest
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
-            -tracee-image-ref "tracee-nocore:latest" \
+            -tracee-image-ref "tracee:latest" \
             -tracee-tester-image-ref "aquasec/tracee-tester:latest"

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -58,6 +58,7 @@ USER root
 # install base environment
 
 RUN apk --no-cache update && \
+    apk --no-cache add coreutils && \
     apk --no-cache add sudo curl && \
     apk --no-cache add libelf zlib && \
     apk --no-cache add libc6-compat && \
@@ -98,7 +99,9 @@ COPY . /tracee
 RUN make -f Makefile.one clean && \
     BTFHUB=$BTFHUB make -f Makefile.one tracee-ebpf && \
     make -f Makefile.one tracee-rules && \
-    make -f Makefile.one rules
+    make -f Makefile.one rules && \
+    rm -rf ./3rdparty/btfhub/ && \
+    rm -rf ./3rdparty/btfhub-archive/
 
 #
 # tracee-core (tracee-base as base)

--- a/builder/Makefile.tracee-container
+++ b/builder/Makefile.tracee-container
@@ -37,32 +37,27 @@ CMD_DOCKER ?= docker
 .PHONY: help
 help:
 	@echo ""
-	@echo "To generate tracee container(s):"
+	@echo "To generate tracee containers:"
 	@echo ""
-	@echo "    $$ make -f builder/Makefile.tracee-container build-alpine-tracee-core"
-	@echo "    $$ make -f builder/Makefile.tracee-container build-alpine-tracee-core-btfhub"
-	@echo "    $$ make -f builder/Makefile.tracee-container build-alpine-tracee-nocore"
+	@echo "    $$ make -f builder/Makefile.tracee-container build-tracee"
+	@echo "    $$ make -f builder/Makefile.tracee-container build-tracee-full"
 	@echo ""
-	@echo "To execute tracee container(s):"
+	@echo "To execute tracee containers:"
 	@echo ""
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-core"
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-core-btfhub"
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-nocore"
+	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee"
+	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee-ebpf"
 	@echo ""
-	@echo "To execute tracee-ebpf container(s):"
-	@echo ""
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-core"
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-core-btfhub"
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-nocore"
+	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee-full"
+	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee-ebpf-full"
 	@echo ""
 	@echo "Note: You may provide \"run\" arguments using the ARG variable."
 	@echo ""
 	@echo "Example:"
 	@echo ""
-	@echo "    $$ make -f builder/Makefile.tracee-container build-alpine-tracee-core-btfhub"
+	@echo "    $$ make -f builder/Makefile.tracee-container build-tracee"
 	@echo ""
-	@echo "    $$ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-core \ "
-	@echo "          ARG=\"--debug -trace event!='sched*'\" "
+	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee-ebpf-full \ "
+	@echo "          ARG=\"--debug -trace comm=bash --trace follow'\" "
 	@echo ""
 
 #
@@ -78,137 +73,110 @@ help:
 	fi
 
 #
-# create tracee (tracee-ebpf + tracee-rules + rules)
+# create tracee & tracee-full
 #
 
-ALPINE_TRACEE_CORE_CONTNAME = tracee
-ALPINE_TRACEE_CORE_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
+# BTFHUB is not set by default, but both of the official images, slim and full,
+# should be built with BTFHUB=1. This will maximize chances of end user using
+# the slim image AND also allow end user to pick the full image for all use
+# cases (if that is what one wants).
+ifeq ($(BTFHUB),)
+BTFHUB=0
+endif
 
-.PHONY: build-alpine-tracee-core
-build-alpine-tracee-core: \
+# TODO: change BTFHUB=1 for the pull request
+
+TRACEE_CONT_NAME = tracee:latest
+TRACEE_FULL_CONT_NAME = tracee:full
+
+TRACEE_CONT_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
+
+.PHONY: build-tracee
+build-tracee: \
 	| .check_$(CMD_DOCKER) \
 	.check_tree
 #
 	$(CMD_DOCKER) build \
-		-f $(ALPINE_TRACEE_CORE_DOCKERFILE) \
-		-t $(ALPINE_TRACEE_CORE_CONTNAME):latest \
-		--build-arg=BTFHUB=0 \
+		-f $(TRACEE_CONT_DOCKERFILE) \
+		-t $(TRACEE_CONT_NAME) \
+		--build-arg=BTFHUB=$(BTFHUB) \
 		--build-arg=FLAVOR=tracee-core \
 		.
 
-ALPINE_TRACEE_CORE_BTFHUB_CONTNAME = tracee-btfhub
-ALPINE_TRACEE_CORE_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
-
-.PHONY: build-alpine-tracee-core-btfhub
-build-alpine-tracee-core-btfhub: \
+.PHONY: build-tracee-full
+build-tracee-full: \
 	| .check_$(CMD_DOCKER) \
 	.check_tree
 #
 	$(CMD_DOCKER) build \
-		-f $(ALPINE_TRACEE_CORE_DOCKERFILE) \
-		-t $(ALPINE_TRACEE_CORE_BTFHUB_CONTNAME):latest \
-		--build-arg=BTFHUB=1 \
-		--build-arg=FLAVOR=tracee-core \
-		.
-
-ALPINE_TRACEE_NOCORE_CONTNAME = tracee-nocore
-ALPINE_TRACEE_NOCORE_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
-
-.PHONY: build-alpine-tracee-nocore
-build-alpine-tracee-nocore: \
-	| .check_$(CMD_DOCKER) \
-	.check_tree
-#
-	$(CMD_DOCKER) build \
-		-f $(ALPINE_TRACEE_NOCORE_DOCKERFILE) \
-		-t $(ALPINE_TRACEE_NOCORE_CONTNAME):latest \
-		--build-arg=BTFHUB=0 \
+		-f $(TRACEE_CONT_DOCKERFILE) \
+		-t $(TRACEE_FULL_CONT_NAME) \
+		--build-arg=BTFHUB=$(BTFHUB) \
 		--build-arg=FLAVOR=tracee-nocore \
 		.
 
 #
-# run tracee (tracee-ebpf + tracee-rules)
+# run tracee and tracee-full
 #
 
 DOCKER_RUN_ARGS = run --rm --pid=host --privileged \
 		-v /etc/os-release:/etc/os-release-host:ro \
-		-v $(PWD):/tracee \
-		-v /lib/modules:/lib/modules:ro \
-		-v /usr/src:/usr/src:ro \
 		-v /sys/kernel/security:/sys/kernel/security:ro \
-		-e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host
+		-e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
+		-v /tmp/tracee:/tmp/tracee:rw
 
-.PHONY: run-alpine-tracee-core
-run-alpine-tracee-core: \
+DOCKER_RUN_ARGS_FULL = $(DOCKER_RUN_ARGS) \
+		-v /lib/modules:/lib/modules:ro \
+		-v /usr/src:/usr/src:ro
+
+.PHONY: run-tracee
+run-tracee: \
 	| .check_$(CMD_DOCKER) \
 	.check_tree
 #
 	$(CMD_DOCKER) \
 		$(DOCKER_RUN_ARGS) \
 		-e TRACEE_EBPF_ONLY=0 \
-		--rm -it $(ALPINE_TRACEE_CORE_CONTNAME) \
+		--rm -it $(TRACEE_CONT_NAME) \
 		$(ARG)
 
-.PHONY: run-alpine-tracee-core-btfhub
-run-alpine-tracee-core-btfhub: \
+.PHONY: run-tracee-full
+run-tracee-full: \
 	| .check_$(CMD_DOCKER) \
 	.check_tree
 #
 	$(CMD_DOCKER) \
-		$(DOCKER_RUN_ARGS) \
-		-e TRACEE_EBPF_ONLY=0 \
-		--rm -it $(ALPINE_TRACEE_CORE_BTFHUB_CONTNAME) \
-		$(ARG)
-
-.PHONY: run-alpine-tracee-nocore
-run-alpine-tracee-nocore: \
-	| .check_$(CMD_DOCKER) \
-	.check_tree
-#
-	$(CMD_DOCKER) \
-		$(DOCKER_RUN_ARGS) \
+		$(DOCKER_RUN_ARGS_FULL) \
 		-e TRACEE_EBPF_ONLY=0 \
 		-e FORCE_CORE=0 \
-		--rm -it $(ALPINE_TRACEE_NOCORE_CONTNAME) \
+		--rm -it $(TRACEE_FULL_CONT_NAME) \
 		$(ARG)
 
 #
-# run tracee-ebpf only
+# run tracee-ebpf or tracee-ebpf-full
 #
 
-.PHONY: run-alpine-tracee-ebpf-core
-run-alpine-tracee-ebpf-core: \
+.PHONY: run-tracee-ebpf
+run-tracee-ebpf: \
 	| .check_$(CMD_DOCKER) \
 	.check_tree
 #
 	$(CMD_DOCKER) \
 		$(DOCKER_RUN_ARGS) \
 		-e TRACEE_EBPF_ONLY=1 \
-		--rm -it $(ALPINE_TRACEE_CORE_CONTNAME) \
+		--rm -it $(TRACEE_CONT_NAME) \
 		$(ARG)
 
-.PHONY: run-alpine-tracee-ebpf-core-btfhub
-run-alpine-tracee-ebpf-core-btfhub: \
+.PHONY: run-tracee-ebpf-full
+run-tracee-ebpf-full: \
 	| .check_$(CMD_DOCKER) \
 	.check_tree
 #
 	$(CMD_DOCKER) \
-		$(DOCKER_RUN_ARGS) \
-		-e TRACEE_EBPF_ONLY=1 \
-		--rm -it $(ALPINE_TRACEE_CORE_BTFHUB_CONTNAME) \
-		$(ARG)
-
-
-.PHONY: run-alpine-tracee-ebpf-nocore
-run-alpine-tracee-ebpf-nocore: \
-	| .check_$(CMD_DOCKER) \
-	.check_tree
-#
-	$(CMD_DOCKER) \
-		$(DOCKER_RUN_ARGS) \
+		$(DOCKER_RUN_ARGS_FULL) \
 		-e TRACEE_EBPF_ONLY=1 \
 		-e FORCE_CORE=0 \
-		--rm -it $(ALPINE_TRACEE_NOCORE_CONTNAME) \
+		--rm -it $(TRACEE_FULL_CONT_NAME) \
 		$(ARG)
 
 #

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -393,7 +393,13 @@ func prepareBpfObject(config *tracee.Config, kConfig *helpers.KernelConfig, OSIn
 		fmt.Printf("BPF: trying non CO-RE eBPF at %s\n", bpfFilePath)
 	}
 	if bpfBytes, err = ioutil.ReadFile(bpfFilePath); err != nil {
-		return err
+		// tell entrypoint that eBPF non CO-RE obj compilation is needed
+		fmt.Printf("BPF: %v\n", err)
+		fmt.Printf("BPF: ATTENTION:\n")
+		fmt.Printf("BPF: It seems tracee-ebpf can't load CO-RE eBPF obj and could not find\n")
+		fmt.Printf("BPF: the non CO-RE object in %s. You may build a non CO-RE eBPF\n", traceeInstallPath)
+		fmt.Printf("BPF: obj by using the source tree and executing \"make install-bpf-nocore\".\n")
+		os.Exit(2)
 	}
 
 out:

--- a/docs/building/containers.md
+++ b/docs/building/containers.md
@@ -8,97 +8,71 @@
 
 ## Generating Tracee containers
 
-Tracee containers come in **3 flavors**:
+Tracee containers come in **2 flavors**:
 
-* `tracee`: default [CO-RE eBPF](https://nakryiko.com/posts/bpf-portability-and-co-re/) tracee (portable).
-
-  ```
-  $ make -f builder/Makefile.tracee-container build-alpine-tracee-core
-  ```
-
-* `tracee-btfhub`: CO-RE eBPF tracee with [older kernels support](https://github.com/aquasecurity/btfhub/blob/main/docs/supported-distros.md).
+* `tracee:latest`
 
   ```
-  $ make -f builder/Makefile.tracee-container build-alpine-tracee-core-btfhub
+  $ BTFHUB={0,1} make -f builder/Makefile.tracee-container build-tracee
   ```
 
-* `tracee-nocore`: non CO-RE eBPF binary (eBPF code is compiled before the run).
+* `tracee:full`
 
   ```
-  $ make -f builder/Makefile.tracee-container build-alpine-tracee-nocore
+  $ BTFHUB={0,1} make -f builder/Makefile.tracee-container build-tracee-full
   ```
 
-At the end you will end up with 3 docker images built. Example:
+> Note: BTFHUB=1 adds support to some [older kernels](https://github.com/aquasecurity/btfhub/blob/main/docs/supported-distros.md)
+> so user doesn't need to build specific non CO-RE eBPF objects to them.
 
-```
-$ docker image ls
-REPOSITORY           TAG       IMAGE ID       CREATED        SIZE
-tracee-btfhub        latest    1612003190b7   11 hours ago   73.6MB
-tracee-nocore        latest    cc8eba17fd76   11 hours ago   1.19GB
-tracee               latest    11dd16c3bda3   11 hours ago   72.1MB
-```
+## Running Tracee containers
 
-Then, you may chose to run the container images through the cmdline, or to use
-the same Makefile.tracee-container file with targets that will run it for you.
+Containers are supposed to be executed through docker cmdline directly, from the
+official built images. Nevertheless, during the image building process, it may
+be usefull to execute them with correct arguments to see if they're working.
 
-## Executing Tracee containers
+User may execute built containers through `Makefile.tracee-container` file with
+the "run" targets:
 
-You may chose to generate container images locally or not. You're able to run
-the containers images, with correct/needed docker arguments, through the
-Makefile.tracee-container file.
-
-* To run the `tracee` container:
+* To run the `tracee:latest` container:
 
   ```
-  $ make -f builder/Makefile.tracee-container run-alpine-tracee-core
+  $ make -f builder/Makefile.tracee-container run-tracee
   ```
 
-* To run the `tracee-btfhub` container:
+* To run the `tracee:full` container:
 
   ```
-  $ make -f builder/Makefile.tracee-container run-alpine-tracee-core-btfhub
+  $ make -f builder/Makefile.tracee-container run-tracee-full
   ```
 
-* To run the `tracee-nocore` container:
-
-  ```
-  $ make -f builder/Makefile.tracee-container run-alpine-tracee-nocore
-  ```
-
-> You may provide arguments to tracee through the `ARG` variable to the Makefile:
+> Note: tracee-ebpf arguments are passed through the ARG="" variable
 >
 > ```
-> $ make -f builder/Makefile.tracee-container run-alpine-tracee-core ARG="--debug"
+> $ make -f builder/Makefile.tracee-container run-tracee ARG="--help"
 > ```
 
-## Executing `tracee-ebpf` only
+## Running Tracee-eBPF only
 
-Generated tracee containers allow you to run **tracee**, as a complete solution
-(tracee-ebpf passes events to tracee-rules and tracee-rules process events
-based on existing signatures) OR to run **tracee-ebpf** only, as an
-introspection tool.
+Generated containers allow user to run **tracee**, as a complete security
+solution (tracee-ebpf passes events to tracee-rules & tracee-rules process
+events based on existing security signatures) OR to run **tracee-ebpf** only,
+as an introspection tool.
 
-* To run the `tracee` container with `tracee-ebpf` only:
-
-  ```
-  $ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-core
-  ```
-
-* To run the `tracee-btfhub` container with `tracee-ebpf` only:
+* To run the `tracee:latest` container with `tracee-ebpf` only:
 
   ```
-  $ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-core-btfhub
+  $ make -f builder/Makefile.tracee-container run-tracee-ebpf
   ```
 
-* To run the `tracee-nocore` container with `tracee-ebpf` only:
+* To run the `tracee:full` container with `tracee-ebpf` only:
 
   ```
-  $ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-nocore
+  $ make -f builder/Makefile.tracee-container run-tracee-ebpf-full
   ```
 
-> You may provide arguments to tracee-ebpf through the `ARG` variable to the
-> Makefile:
+> Note: tracee-ebpf arguments are passed through the ARG="" variable
 >
 > ```
-> $ make -f builder/Makefile.tracee-container run-alpine-tracee-ebpf-core ARG="--debug"
+> $ make -f builder/Makefile.tracee-container run-tracee-ebpf ARG="--debug"
 > ```

--- a/docs/building/containers.md
+++ b/docs/building/containers.md
@@ -10,7 +10,7 @@
 
 Tracee containers come in **2 flavors**:
 
-* `tracee:latest`
+* `tracee:latest` (CO-RE enabled embedded tracee bpf object)
 
   ```
   $ BTFHUB={0,1} make -f builder/Makefile.tracee-container build-tracee

--- a/docs/building/containers.md
+++ b/docs/building/containers.md
@@ -16,7 +16,7 @@ Tracee containers come in **2 flavors**:
   $ BTFHUB={0,1} make -f builder/Makefile.tracee-container build-tracee
   ```
 
-* `tracee:full`
+* `tracee:full` (Contains tracee bpf source code and compiler tool chain) 
 
   ```
   $ BTFHUB={0,1} make -f builder/Makefile.tracee-container build-tracee-full

--- a/tests/tracee_test.go
+++ b/tests/tracee_test.go
@@ -26,8 +26,8 @@ func runTraceeContainer(ctx context.Context, tempDir string) (*traceeContainer, 
 		BindMounts: map[string]string{ // container:host
 			tempDir:                tempDir,           // required for all
 			"/etc/os-release-host": "/etc/os-release", // required for all
-			"/usr/src":             "/usr/src",        // required for -nocore
-			"/lib/modules":         "/lib/modules",    // required for -nocore
+			"/usr/src":             "/usr/src",        // required for full
+			"/lib/modules":         "/lib/modules",    // required for full
 		},
 		Env: map[string]string{
 			"LIBBPFGO_OSRELEASE_FILE": "/etc/os-release-host",
@@ -69,7 +69,7 @@ func runTraceeTesterContainer(ctx context.Context, sigID string) (*traceeContain
 var (
 	testerImageRef = flag.String("tracee-tester-image-ref", "docker.io/aquasec/tracee-tester:latest",
 		"tracee tester container image reference")
-	traceeImageRef = flag.String("tracee-image-ref", "tracee-nocore:latest",
+	traceeImageRef = flag.String("tracee-image-ref", "tracee:full",
 		"tracee container image reference")
 	signatureIDs = flag.String("tracee-signatures", "TRC-2,TRC-3,TRC-4,TRC-5,TRC-7,TRC-8,TRC-9,TRC-10,TRC-11,TRC-12,TRC-14",
 		"comma-separated list of tracee signature identifiers")
@@ -96,7 +96,7 @@ func parseSignatureIDs() []string {
 // non CO-RE, and CO-RE with custom BTFHub support.
 //
 //     go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
-//            -tracee-image-ref "tracee-nocore:latest" \
+//            -tracee-image-ref "tracee:full" \
 //            -tracee-tester-image-ref "aquasec/tracee-tester:latest" \
 //            -tracee-signatures "TRC-2,TRC-3"
 func TestTraceeSignatures(t *testing.T) {


### PR DESCRIPTION
```
This commit is the result of a broader discussion regarding how we
should distribute tracee and how CO-RE and non CO-RE feature, and wording,
should be handled.

We, now, will have the following container images:

- tracee:latest
- tracee:full

And they are generated by:

- make -f builder/Makefile.tracee-container build-tracee
- make -f builder/Makefile.tracee-container build-tracee-full

And might be tested by:

- make -f builder/Makefile.tracee-container run-tracee
- make -f builder/Makefile.tracee-container run-tracee-full

  Obs: images need to be built before run targets are executed.

Both images can run:

- tracee-eBPF with CO-RE
- tracee-eBPF with CO-RE + BTFHub (tailored BTF files)
- tracee-eBPF non CO-RE (from /tmp/tracee non CO-RE eBPF obj)

So, one may built the non CO-RE object by using:

- make -f builder/Makefile.tracee-container run-tracee-full

and subsequent calls to the smaller image will work:

- make -f builder/Makefile.tracee-container run-tracee

  Obs: makefile automatically shares /tmp/tracee so this can be true.

The full image is different because:

- it contains tracee src code, tools and compilers
- it builds /tmp/tracee/xxx.bpf.o non CO-RE eBPF obj, if needed

  Obs: One can use the full image to generate needed non CO-RE obj and
       distribute it through different nodes, with same kernel, in order
       to run the smaller (slim) image on them.
```