### PR TITLE
tracee-ebpf: fix container filters

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/flags-filter.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-filter.go
@@ -172,8 +172,6 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 		}
 
 		if strings.HasPrefix("container", f) || (strings.HasPrefix("!container", f) && len(f) > 1) {
-			filter.NewPidFilter.Enabled = true
-			filter.NewPidFilter.Value = true
 			err := filter.ContFilter.Parse(f)
 			if err != nil {
 				return tracee.Filter{}, err
@@ -183,8 +181,6 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 
 		if strings.HasPrefix("container", filterName) {
 			if operatorAndValues == "=new" {
-				filter.NewPidFilter.Enabled = true
-				filter.NewPidFilter.Value = true
 				filter.NewContFilter.Enabled = true
 				filter.NewContFilter.Value = true
 				continue
@@ -192,8 +188,6 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 			if operatorAndValues == "!=new" {
 				filter.ContFilter.Enabled = true
 				filter.ContFilter.Value = true
-				filter.NewPidFilter.Enabled = true
-				filter.NewPidFilter.Value = true
 				filter.NewContFilter.Enabled = true
 				filter.NewContFilter.Value = false
 				continue

--- a/cmd/tracee-ebpf/main_test.go
+++ b/cmd/tracee-ebpf/main_test.go
@@ -644,10 +644,7 @@ func TestPrepareFilter(t *testing.T) {
 					Greater:  tracee.GreaterNotSetUint,
 					Is32Bit:  true,
 				},
-				NewPidFilter: &tracee.BoolFilter{
-					Value:   true,
-					Enabled: true,
-				},
+				NewPidFilter: &tracee.BoolFilter{},
 				MntNSFilter: &tracee.UintFilter{
 					Equal:    []uint64{},
 					NotEqual: []uint64{},
@@ -700,10 +697,7 @@ func TestPrepareFilter(t *testing.T) {
 					Greater:  tracee.GreaterNotSetUint,
 					Is32Bit:  true,
 				},
-				NewPidFilter: &tracee.BoolFilter{
-					Value:   true,
-					Enabled: true,
-				},
+				NewPidFilter: &tracee.BoolFilter{},
 				MntNSFilter: &tracee.UintFilter{
 					Equal:    []uint64{},
 					NotEqual: []uint64{},

--- a/tracee-ebpf/tracee/events_pipeline.go
+++ b/tracee-ebpf/tracee/events_pipeline.go
@@ -155,7 +155,7 @@ func (t *Tracee) processEvents(ctx gocontext.Context, in <-chan *external.Event)
 				continue
 			}
 
-			if (t.config.Filter.ContFilter.Enabled || t.config.Filter.NewContFilter.Enabled) && event.ContainerID == "" {
+			if (t.config.Filter.ContFilter.Value || t.config.Filter.NewContFilter.Enabled) && event.ContainerID == "" {
 				// Don't trace false container positives -
 				// a container filter is set by the user, but this event wasn't originated in a container.
 				// Although kernel filters shouldn't submit such events, we do this check to be on the safe side.


### PR DESCRIPTION
Currently we don't trace existing container processes when a container
filter is set. This behavior is due to using the NewPidFilter when
a container filter is set. As we now use cgroups to identify
containers (and not by checking that pid != host_pid like we used to),
we can remove this extra filter to trace existing container processes
as expected by the filter.

While at it, fix the "!container" filter which currently doesn't work as the events are identified as false container positives.

Fix #1436