### PR TITLE
test(smoke): follow tracee container logs and print them out to error log

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -173,6 +173,7 @@ jobs:
           make -f Makefile.one install-bpf-nocore
       - name: Run tests
         run: |
+          docker image pull aquasec/tracee-tester:latest
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
             -tracee-image-ref "tracee-nocore:latest" \
             -tracee-tester-image-ref "aquasec/tracee-tester:latest" \
@@ -208,6 +209,7 @@ jobs:
           make -f builder/Makefile.tracee-container build-alpine-tracee-core-btfhub
       - name: Run tests
         run: |
+          docker image pull aquasec/tracee-tester:latest
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
             -tracee-image-ref "tracee-btfhub:latest" \
             -tracee-tester-image-ref "aquasec/tracee-tester:latest" \

--- a/.github/workflows/scheduled-signatures-test.yaml
+++ b/.github/workflows/scheduled-signatures-test.yaml
@@ -32,6 +32,7 @@ jobs:
           make -f Makefile.one install-bpf-nocore
       - name: Run tests
         run: |
+          docker image pull aquasec/tracee-tester:latest
           go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
             -tracee-image-ref "tracee-nocore:latest" \
             -tracee-tester-image-ref "aquasec/tracee-tester:latest"


### PR DESCRIPTION
Gives some insights into (failing) tests run in the CI workflow

```console
$ go test -v -run "TestTraceeSignatures" ./tests/tracee_test.go \
    -tracee-image-ref "tracee-nocore:latest" \
    -tracee-tester-image-ref "aquasec/tracee-tester:latest" \
    -tracee-signatures "TRC-2"
=== RUN   TestTraceeSignatures
=== RUN   TestTraceeSignatures/tracee-nocore:latest/TRC-2
2022/02/04 14:23:41 Starting container id: eb7dfe6d44e3 image: testcontainers/ryuk:0.3.3
2022/02/04 14:23:41 Waiting for container id eb7dfe6d44e3 image: testcontainers/ryuk:0.3.3
2022/02/04 14:23:41 Container is ready id: eb7dfe6d44e3 image: testcontainers/ryuk:0.3.3
2022/02/04 14:23:41 Starting container id: 3c40da3e1a92 image: tracee-nocore:latest
2022/02/04 14:23:41 Waiting for container id 3c40da3e1a92 image: tracee-nocore:latest
2022/02/04 14:23:54 Container is ready id: 3c40da3e1a92 image: tracee-nocore:latest
    tracee_test.go:161: STDOUT: rm -rf ./dist
    tracee_test.go:161: STDOUT: rm -rf .*.md5
    tracee_test.go:161: STDOUT: rm -rf .check*
    tracee_test.go:161: STDOUT: CC="clang" \
    tracee_test.go:161: STDOUT: 	CFLAGS="" \
    tracee_test.go:161: STDOUT: 	LD_FLAGS="" \
    tracee_test.go:161: STDOUT: 	make -j2 \
    tracee_test.go:161: STDOUT: 	-C ./3rdparty/libbpf/src \
    tracee_test.go:161: STDOUT: 	BUILD_STATIC_ONLY=1 \
    tracee_test.go:161: STDOUT: 	DESTDIR=/tracee/src/dist/libbpf \
    tracee_test.go:161: STDOUT: 	OBJDIR=/tracee/src/dist/libbpf/obj \
    tracee_test.go:161: STDOUT: 	INCLUDEDIR= LIBDIR= UAPIDIR= prefix= libdir= \
    tracee_test.go:161: STDOUT: 	install install_uapi_headers
    tracee_test.go:161: STDOUT:   MKDIR    /tracee/src/dist/libbpf/obj/staticobjs
    tracee_test.go:161: STDOUT:   INSTALL  bpf.h libbpf.h btf.h libbpf_common.h libbpf_legacy.h xsk.h bpf_helpers.h bpf_helper_defs.h bpf_tracing.h bpf_endian.h bpf_core_read.h skel_internal.h libbpf_version.h
    tracee_test.go:161: STDOUT:   INSTALL  ../include/uapi/linux/bpf.h ../include/uapi/linux/bpf_common.h ../include/uapi/linux/btf.h
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/bpf.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/btf.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/libbpf.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/libbpf_errno.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/netlink.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/nlattr.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/str_error.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/libbpf_probes.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/bpf_prog_linfo.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/xsk.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/btf_dump.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/hashmap.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/ringbuf.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/strset.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/linker.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/gen_loader.o
    tracee_test.go:161: STDOUT:   CC       /tracee/src/dist/libbpf/obj/staticobjs/relo_core.o
    tracee_test.go:161: STDOUT:   INSTALL  /tracee/src/dist/libbpf/obj/libbpf.pc
    tracee_test.go:161: STDOUT:   AR       /tracee/src/dist/libbpf/obj/libbpf.a
    tracee_test.go:161: STDOUT:   INSTALL  /tracee/src/dist/libbpf/obj/libbpf.a
    tracee_test.go:161: STDOUT: make -f Makefile.one ./dist/tracee.bpf
    tracee_test.go:161: STDOUT: clang -S -nostdinc \
    tracee_test.go:161: STDOUT: 	-D__TARGET_ARCH_x86 \
    tracee_test.go:161: STDOUT: 	-D__BPF_TRACING__ \
    tracee_test.go:161: STDOUT: 	-D__KERNEL__ \
    tracee_test.go:161: STDOUT: 	-include /lib/modules/5.4.0-90-generic/build/include/linux/kconfig.h \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/arch/x86/include \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/arch/x86/include/uapi \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/arch/x86/include/generated \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/arch/x86/include/generated/uapi \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/include \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/include \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/include/uapi \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/include/generated \
    tracee_test.go:161: STDOUT: 	-I /lib/modules/5.4.0-90-generic/build/include/generated/uapi \
    tracee_test.go:161: STDOUT: 	-I./dist/tracee.bpf \
    tracee_test.go:161: STDOUT: 	-Wunused \
    tracee_test.go:161: STDOUT: 	-Wall \
    tracee_test.go:161: STDOUT: 	-Wno-frame-address \
    tracee_test.go:161: STDOUT: 	-Wno-unused-value \
    tracee_test.go:161: STDOUT: 	-Wno-unknown-warning-option \
    tracee_test.go:161: STDOUT: 	-Wno-pragma-once-outside-header \
    tracee_test.go:161: STDOUT: 	-Wno-pointer-sign \
    tracee_test.go:161: STDOUT: 	-Wno-gnu-variable-sized-type-not-at-end \
    tracee_test.go:161: STDOUT: 	-Wno-deprecated-declarations \
    tracee_test.go:161: STDOUT: 	-Wno-compare-distinct-pointer-types \
    tracee_test.go:161: STDOUT: 	-Wno-address-of-packed-member \
    tracee_test.go:161: STDOUT: 	-fno-stack-protector \
    tracee_test.go:161: STDOUT: 	-fno-jump-tables \
    tracee_test.go:161: STDOUT: 	-fno-unwind-tables \
    tracee_test.go:161: STDOUT: 	-fno-asynchronous-unwind-tables \
    tracee_test.go:161: STDOUT: 	-xc -O2 -g -emit-llvm \
    tracee_test.go:161: STDOUT: 	-c ./tracee-ebpf/tracee/tracee.bpf.c \
    tracee_test.go:161: STDOUT: 	-o dist/tracee.bpf.5_4_0-90-generic.v0_7_0-123-gc0d1993.ll
    tracee_test.go:161: STDOUT: llc \
    tracee_test.go:161: STDOUT: 	-march=bpf -mcpu=v2 \
    tracee_test.go:161: STDOUT: 	-filetype=obj \
    tracee_test.go:161: STDOUT: 	-o dist/tracee.bpf.5_4_0-90-generic.v0_7_0-123-gc0d1993.o \
    tracee_test.go:161: STDOUT: 	dist/tracee.bpf.5_4_0-90-generic.v0_7_0-123-gc0d1993.ll
    tracee_test.go:161: STDOUT: rm dist/tracee.bpf.5_4_0-90-generic.v0_7_0-123-gc0d1993.ll
    tracee_test.go:161: STDOUT: starting tracee-ebpf...
    tracee_test.go:161: STDOUT: starting tracee-rules...
    tracee_test.go:161: STDOUT: Loaded 14 signature(s): [TRC-1 TRC-13 TRC-2 TRC-14 TRC-3 TRC-11 TRC-9 TRC-4 TRC-5 TRC-12 TRC-8 TRC-6 TRC-10 TRC-7]
2022/02/04 14:23:54 Starting container id: 9a4456267b62 image: aquasec/tracee-tester:latest
2022/02/04 14:23:55 Container is ready id: 9a4456267b62 image: aquasec/tracee-tester:latest
    tracee_test.go:161: STDOUT:
    tracee_test.go:161: STDOUT: *** Detection ***
    tracee_test.go:161: STDOUT: Time: 2022-02-04T14:23:56Z
    tracee_test.go:161: STDOUT: Signature ID: TRC-2
    tracee_test.go:161: STDOUT: Signature: Anti-Debugging
    tracee_test.go:161: STDOUT: Data: map[]
    tracee_test.go:161: STDOUT: Command: strace
    tracee_test.go:161: STDOUT: Hostname: 9a4456267b62
--- PASS: TestTraceeSignatures (24.63s)
    --- PASS: TestTraceeSignatures/tracee-nocore:latest/TRC-2 (24.63s)
PASS
ok  	command-line-arguments	24.641s
```