### PR TITLE
tracee-ebpf: remove cap_capable from the default set

### DIFF
--- a/tracee-ebpf/tracee/events_definitions.go
+++ b/tracee-ebpf/tracee/events_definitions.go
@@ -5766,7 +5766,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "cap_capable", attach: kprobe, fn: "trace_cap_capable"},
 		},
-		Sets: []string{"default"},
+		Sets: []string{},
 		Params: []external.ArgMeta{
 			{Type: "int", Name: "cap"},
 			{Type: "int", Name: "syscall"},


### PR DESCRIPTION
After fixing #1341 it seems that cap_capable event is too noisy.
Remove it from the default set.