### PR TITLE
Separate pcaps

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/flags-capture.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-capture.go
@@ -24,7 +24,7 @@ Possible options:
 dir:/path/to/dir                    path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
 profile                             creates a runtime profile of program executions and their metadata for forensics use.
 clear-dir                           clear the captured artifacts output dir before starting (default: false).
-pcap:[per-container|per-process]     capture separate pcap file based on container/process context (default: none - saving one pcap for the entire host).
+pcap:[per-container|per-process]    capture separate pcap file based on container/process context (default: none - saving one pcap for the entire host).
 
 Examples:
   --capture exec                                           | capture executed files into the default output directory

--- a/cmd/tracee-ebpf/internal/flags/flags-capture.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-capture.go
@@ -21,10 +21,10 @@ Possible options:
 [artifact:]mem                     capture memory regions that had write+execute (w+x) protection, and then changed to execute (x) only.
 [artifact:]net=interface           capture network traffic of the given interface. Only TCP/UDP protocols are currently supported.
 
-dir:/path/to/dir        			path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
-profile                 			creates a runtime profile of program executions and their metadata for forensics use.
-clear-dir               			clear the captured artifacts output dir before starting (default: false).
-net:[per-container|per-process]		capture separate pcap file based on container/process context (default: none - saving one pcap for the entire host).
+dir:/path/to/dir                    path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
+profile                             creates a runtime profile of program executions and their metadata for forensics use.
+clear-dir                           clear the captured artifacts output dir before starting (default: false).
+net:[per-container|per-process]     capture separate pcap file based on container/process context (default: none - saving one pcap for the entire host).
 
 Examples:
   --capture exec                                           | capture executed files into the default output directory

--- a/cmd/tracee-ebpf/internal/flags/flags-capture.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-capture.go
@@ -24,14 +24,14 @@ Possible options:
 dir:/path/to/dir                    path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
 profile                             creates a runtime profile of program executions and their metadata for forensics use.
 clear-dir                           clear the captured artifacts output dir before starting (default: false).
-net:[per-container|per-process]     capture separate pcap file based on container/process context (default: none - saving one pcap for the entire host).
+pcap:[per-container|per-process]     capture separate pcap file based on container/process context (default: none - saving one pcap for the entire host).
 
 Examples:
   --capture exec                                           | capture executed files into the default output directory
   --capture exec --capture dir:/my/dir --capture clear-dir | delete /my/dir/out and then capture executed files into it
   --capture write=/usr/bin/* --capture write=/etc/*        | capture files that were written into anywhere under /usr/bin/ or /etc/
   --capture profile                                        | capture executed files and create a runtime profile in the output directory
-  --capture net=eth0 --capture net:per-container           | capture network traffic of eth0, and save pcap for each container
+  --capture net=eth0 --capture pcap:per-container           | capture network traffic of eth0, and save pcap for each container
   --capture exec --output none                             | capture executed files into the default output directory not printing the stream of events
 
 Use this flag multiple times to choose multiple capture options
@@ -87,14 +87,14 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 			if !found {
 				capture.NetIfaces = append(capture.NetIfaces, iface)
 			}
-		} else if strings.HasPrefix(cap, "net:") {
-			netCaptureContext := strings.TrimPrefix(cap, "net:")
+		} else if strings.HasPrefix(cap, "pcap:") {
+			netCaptureContext := strings.TrimPrefix(cap, "pcap:")
 			if netCaptureContext == "per-container" {
 				netCapturePerContainer = true
 			} else if netCaptureContext == "per-process" {
 				netCapturePerProcess = true
 			} else {
-				return tracee.CaptureConfig{}, fmt.Errorf("invalid network capture option: %s. accepted options - net:per-container or net:per-process", netCaptureContext)
+				return tracee.CaptureConfig{}, fmt.Errorf("invalid network capture option: %s. accepted options - pcap:per-container or pcap:per-process", netCaptureContext)
 			}
 		} else if cap == "clear-dir" {
 			clearDir = true
@@ -118,7 +118,7 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 	}
 
 	if netCapturePerContainer && netCapturePerProcess {
-		return tracee.CaptureConfig{}, fmt.Errorf("invalid capture flags: can't use both net:per-container and net:per-process capture options")
+		return tracee.CaptureConfig{}, fmt.Errorf("invalid capture flags: can't use both pcap:per-container and pcap:per-process capture options")
 	}
 	capture.NetPerContainer = netCapturePerContainer
 	capture.NetPerProcess = netCapturePerProcess

--- a/cmd/tracee-ebpf/internal/flags/flags-capture.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-capture.go
@@ -31,7 +31,8 @@ Examples:
   --capture exec --capture dir:/my/dir --capture clear-dir | delete /my/dir/out and then capture executed files into it
   --capture write=/usr/bin/* --capture write=/etc/*        | capture files that were written into anywhere under /usr/bin/ or /etc/
   --capture profile                                        | capture executed files and create a runtime profile in the output directory
-  --capture net=eth0 --capture pcap:per-container           | capture network traffic of eth0, and save pcap for each container
+  --capture net=eth0                                       | capture network traffic of eth0
+  --capture net=eth0 --capture pcap:per-container          | capture network traffic of eth0, and save pcap for each container
   --capture exec --output none                             | capture executed files into the default output directory not printing the stream of events
 
 Use this flag multiple times to choose multiple capture options

--- a/docs/tracee-ebpf/capture.md
+++ b/docs/tracee-ebpf/capture.md
@@ -23,8 +23,8 @@ CLI Option | Description
 `profile` | creates a runtime profile of program executions and their metadata for forensics use.
 `dir:/path/to/dir` | path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
 `clear-dir` | clear the captured artifacts output dir before starting (default: false).
-`net:per-container` | when capturing network packets, save pcap per container
-`net:per-process` | when capturing network packets, save pcap per process
+`pcap:per-container` | when capturing network packets, save pcap per container
+`pcap:per-process` | when capturing network packets, save pcap per process
 
 (Use this flag multiple times to choose multiple capture options)
 
@@ -58,7 +58,7 @@ Capture pcap files
 
 ```
 --capture net=enp0s3
---capture net=enp0s3 --capture net:per-container
+--capture net=enp0s3 --capture pcap:per-container
 ```
 
 Creates a runtime profile of program executions and their metadata for forensics use. The profiles created can be compared among executions to identify if there is any difference. For example, [use it as a github action to identify if any new process was executed since the last pipeline](https://github.com/aquasecurity/tracee-action), useful for supply chain security.

--- a/docs/tracee-ebpf/capture.md
+++ b/docs/tracee-ebpf/capture.md
@@ -23,6 +23,8 @@ CLI Option | Description
 `profile` | creates a runtime profile of program executions and their metadata for forensics use.
 `dir:/path/to/dir` | path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
 `clear-dir` | clear the captured artifacts output dir before starting (default: false).
+`net:per-container` | when capturing network packets, save pcap per container
+`net:per-process` | when capturing network packets, save pcap per process
 
 (Use this flag multiple times to choose multiple capture options)
 
@@ -56,6 +58,7 @@ Capture pcap files
 
 ```
 --capture net=enp0s3
+--capture net=enp0s3 --capture net:per-container
 ```
 
 Creates a runtime profile of program executions and their metadata for forensics use. The profiles created can be compared among executions to identify if there is any difference. For example, [use it as a github action to identify if any new process was executed since the last pipeline](https://github.com/aquasecurity/tracee-action), useful for supply chain security.

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -213,6 +213,7 @@ Copyright (C) Aqua Security inc.
 #define OPT_DEBUG_NET                   (1 << 5)
 #define OPT_CAPTURE_MODULES             (1 << 6)
 #define OPT_CGROUP_V1                   (1 << 7)
+#define OPT_PROCESS_INFO                (1 << 8)
 
 #define FILTER_UID_ENABLED              (1 << 0)
 #define FILTER_UID_OUT                  (1 << 1)
@@ -2414,13 +2415,17 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     struct task_struct *parent = (struct task_struct*)ctx->args[0];
     struct task_struct *child = (struct task_struct*)ctx->args[1];
 
+    u64 start_time = get_task_start_time(child);
+
     // note: v5.4 verifier does not like using (process_context_t *) from &data->context
-    process_context_t process = {};
-    __builtin_memcpy(&process, &data.context, sizeof(process_context_t));
-    process.tid = get_task_ns_pid(child);
-    process.host_tid = get_task_host_pid(child);
-    process.start_time = get_task_start_time(child);
-    bpf_map_update_elem(&process_context_map, &process.host_tid, &process, BPF_ANY);
+    if (data.options & OPT_PROCESS_INFO) {
+        process_context_t process = {};
+        __builtin_memcpy(&process, &data.context, sizeof(process_context_t));
+        process.tid = get_task_ns_pid(child);
+        process.host_tid = get_task_host_pid(child);
+        process.start_time = start_time;
+        bpf_map_update_elem(&process_context_map, &process.host_tid, &process, BPF_ANY);
+    }
 
     int parent_pid = get_task_host_pid(parent);
     int child_pid = get_task_host_pid(child);
@@ -2447,22 +2452,24 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
         bpf_map_update_elem(&new_pids_map, &child_pid, &child_pid, BPF_ANY);
     }
 
-    int parent_ns_pid = get_task_ns_pid(parent);
-    int parent_ns_tgid = get_task_ns_tgid(parent);
-    int child_ns_pid = get_task_ns_pid(child);
-    int child_ns_tgid = get_task_ns_tgid(child);
+    if (event_chosen(SCHED_PROCESS_FORK) || data.options & OPT_PROCESS_INFO) {
+        int parent_ns_pid = get_task_ns_pid(parent);
+        int parent_ns_tgid = get_task_ns_tgid(parent);
+        int child_ns_pid = get_task_ns_pid(child);
+        int child_ns_tgid = get_task_ns_tgid(child);
 
-    save_to_submit_buf(&data, (void*)&parent_pid, sizeof(int), 0);
-    save_to_submit_buf(&data, (void*)&parent_ns_pid, sizeof(int), 1);
-    save_to_submit_buf(&data, (void*)&parent_tgid, sizeof(int), 2);
-    save_to_submit_buf(&data, (void*)&parent_ns_tgid, sizeof(int), 3);
-    save_to_submit_buf(&data, (void*)&child_pid, sizeof(int), 4);
-    save_to_submit_buf(&data, (void*)&child_ns_pid, sizeof(int), 5);
-    save_to_submit_buf(&data, (void*)&child_tgid, sizeof(int), 6);
-    save_to_submit_buf(&data, (void*)&child_ns_tgid, sizeof(int), 7);
-    save_to_submit_buf(&data, (void*)&process.start_time, sizeof(u64), 8);
+        save_to_submit_buf(&data, (void*)&parent_pid, sizeof(int), 0);
+        save_to_submit_buf(&data, (void*)&parent_ns_pid, sizeof(int), 1);
+        save_to_submit_buf(&data, (void*)&parent_tgid, sizeof(int), 2);
+        save_to_submit_buf(&data, (void*)&parent_ns_tgid, sizeof(int), 3);
+        save_to_submit_buf(&data, (void*)&child_pid, sizeof(int), 4);
+        save_to_submit_buf(&data, (void*)&child_ns_pid, sizeof(int), 5);
+        save_to_submit_buf(&data, (void*)&child_tgid, sizeof(int), 6);
+        save_to_submit_buf(&data, (void*)&child_ns_tgid, sizeof(int), 7);
+        save_to_submit_buf(&data, (void*)&start_time, sizeof(u64), 8);
 
-    events_perf_submit(&data, SCHED_PROCESS_FORK, 0);
+        events_perf_submit(&data, SCHED_PROCESS_FORK, 0);
+    }
 
     return 0;
 }
@@ -2499,10 +2506,11 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     // We passed all filters (in should_trace()) - add this pid to traced pids set
     bpf_map_update_elem(&traced_pids_map, &data.context.host_tid, &data.context.host_tid, BPF_ANY);
 
-    process_context_t *process = bpf_map_lookup_elem(&process_context_map, &data.context.host_tid);
-    if (process != NULL) {
-        __builtin_memcpy(process->comm, data.context.comm, TASK_COMM_LEN);
-        bpf_map_update_elem(&process_context_map, &data.context.host_tid, process, BPF_ANY);
+    if (data.options & OPT_PROCESS_INFO) {
+        process_context_t *process = bpf_map_lookup_elem(&process_context_map, &data.context.host_tid);
+        if (process != NULL) {
+            __builtin_memcpy(process->comm, data.context.comm, TASK_COMM_LEN);
+        }
     }
 
     struct task_struct *task = (struct task_struct *)ctx->args[0];
@@ -2550,19 +2558,23 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     // 2. fdpath                  - generated filename for execveat (after
     //                              resolving dirfd)
 
-    save_str_to_buf(&data, (void *)filename, 0);
-    save_str_to_buf(&data, file_path, 1);
-    save_args_str_arr_to_buf(&data, (void *)arg_start, (void *)arg_end, argc, 2);
-    if (data.options & OPT_EXEC_ENV) {
-        save_args_str_arr_to_buf(&data, (void *)env_start, (void *)env_end, envc, 3);
-    }
-    save_to_submit_buf(&data, &s_dev, sizeof(dev_t), 4);
-    save_to_submit_buf(&data, &inode_nr, sizeof(unsigned long), 5);
-    save_to_submit_buf(&data, &invoked_from_kernel, sizeof(int), 6);
-    save_to_submit_buf(&data, &ctime, sizeof(u64), 7);
-    save_to_submit_buf(&data, &stdin_type, sizeof(unsigned short), 8);
+    if (event_chosen(SCHED_PROCESS_EXEC) || data.options & OPT_PROCESS_INFO) {
+        save_str_to_buf(&data, (void *)filename, 0);
+        save_str_to_buf(&data, file_path, 1);
+        save_args_str_arr_to_buf(&data, (void *)arg_start, (void *)arg_end, argc, 2);
+        if (data.options & OPT_EXEC_ENV) {
+            save_args_str_arr_to_buf(&data, (void *)env_start, (void *)env_end, envc, 3);
+        }
+        save_to_submit_buf(&data, &s_dev, sizeof(dev_t), 4);
+        save_to_submit_buf(&data, &inode_nr, sizeof(unsigned long), 5);
+        save_to_submit_buf(&data, &invoked_from_kernel, sizeof(int), 6);
+        save_to_submit_buf(&data, &ctime, sizeof(u64), 7);
+        save_to_submit_buf(&data, &stdin_type, sizeof(unsigned short), 8);
 
-    return events_perf_submit(&data, SCHED_PROCESS_EXEC, 0);
+        events_perf_submit(&data, SCHED_PROCESS_EXEC, 0);
+    }
+
+    return 0;
 }
 
 // include/trace/events/sched.h:
@@ -2581,7 +2593,9 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
     bpf_map_delete_elem(&traced_pids_map, &data.context.host_tid);
     bpf_map_delete_elem(&new_pids_map, &data.context.host_tid);
     bpf_map_delete_elem(&syscall_data_map, &data.context.host_tid);
-    bpf_map_delete_elem(&process_context_map, &data.context.host_tid);
+    if (data.options & OPT_PROCESS_INFO) {
+        bpf_map_delete_elem(&process_context_map, &data.context.host_tid);
+    }
 
     int proc_tree_filter_set = get_config(CONFIG_FILTERS) & FILTER_PROC_TREE_ENABLED;
 
@@ -2603,10 +2617,14 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
 
     long exit_code = get_task_exit_code(data.task);
 
-    save_to_submit_buf(&data, (void*)&exit_code, sizeof(long), 0);
-    save_to_submit_buf(&data, (void*)&group_dead, sizeof(bool), 1);
+    if (event_chosen(SCHED_PROCESS_EXIT) || data.options & OPT_PROCESS_INFO) {
+        save_to_submit_buf(&data, (void*)&exit_code, sizeof(long), 0);
+        save_to_submit_buf(&data, (void*)&group_dead, sizeof(bool), 1);
 
-    return events_perf_submit(&data, SCHED_PROCESS_EXIT, 0);
+        events_perf_submit(&data, SCHED_PROCESS_EXIT, 0);
+    }
+
+    return 0;
 }
 
 // include/trace/events/sched.h:

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2593,9 +2593,7 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
     bpf_map_delete_elem(&traced_pids_map, &data.context.host_tid);
     bpf_map_delete_elem(&new_pids_map, &data.context.host_tid);
     bpf_map_delete_elem(&syscall_data_map, &data.context.host_tid);
-    if (data.options & OPT_PROCESS_INFO) {
-        bpf_map_delete_elem(&process_context_map, &data.context.host_tid);
-    }
+    bpf_map_delete_elem(&process_context_map, &data.context.host_tid);
 
     int proc_tree_filter_set = get_config(CONFIG_FILTERS) & FILTER_PROC_TREE_ENABLED;
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2440,23 +2440,21 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
         bpf_map_update_elem(&new_pids_map, &child_pid, &child_pid, BPF_ANY);
     }
 
-    if (event_chosen(SCHED_PROCESS_FORK)) {
-        int parent_ns_pid = get_task_ns_pid(parent);
-        int parent_ns_tgid = get_task_ns_tgid(parent);
-        int child_ns_pid = get_task_ns_pid(child);
-        int child_ns_tgid = get_task_ns_tgid(child);
+    int parent_ns_pid = get_task_ns_pid(parent);
+    int parent_ns_tgid = get_task_ns_tgid(parent);
+    int child_ns_pid = get_task_ns_pid(child);
+    int child_ns_tgid = get_task_ns_tgid(child);
 
-        save_to_submit_buf(&data, (void*)&parent_pid, sizeof(int), 0);
-        save_to_submit_buf(&data, (void*)&parent_ns_pid, sizeof(int), 1);
-        save_to_submit_buf(&data, (void*)&parent_tgid, sizeof(int), 2);
-        save_to_submit_buf(&data, (void*)&parent_ns_tgid, sizeof(int), 3);
-        save_to_submit_buf(&data, (void*)&child_pid, sizeof(int), 4);
-        save_to_submit_buf(&data, (void*)&child_ns_pid, sizeof(int), 5);
-        save_to_submit_buf(&data, (void*)&child_tgid, sizeof(int), 6);
-        save_to_submit_buf(&data, (void*)&child_ns_tgid, sizeof(int), 7);
+    save_to_submit_buf(&data, (void*)&parent_pid, sizeof(int), 0);
+    save_to_submit_buf(&data, (void*)&parent_ns_pid, sizeof(int), 1);
+    save_to_submit_buf(&data, (void*)&parent_tgid, sizeof(int), 2);
+    save_to_submit_buf(&data, (void*)&parent_ns_tgid, sizeof(int), 3);
+    save_to_submit_buf(&data, (void*)&child_pid, sizeof(int), 4);
+    save_to_submit_buf(&data, (void*)&child_ns_pid, sizeof(int), 5);
+    save_to_submit_buf(&data, (void*)&child_tgid, sizeof(int), 6);
+    save_to_submit_buf(&data, (void*)&child_ns_tgid, sizeof(int), 7);
 
-        events_perf_submit(&data, SCHED_PROCESS_FORK, 0);
-    }
+    events_perf_submit(&data, SCHED_PROCESS_FORK, 0);
 
     return 0;
 }

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -405,7 +405,7 @@ typedef struct event_context {
 } context_t;
 
 typedef struct process_context {
-    u64 start_time;                // Timestamp
+    u64 start_time;                // thread's start time
     u64 cgroup_id;
     u32 pid;                       // PID as in the userspace term
     u32 tid;                       // TID as in the userspace term

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -255,6 +255,7 @@ struct task_struct {
 	struct task_struct *       group_leader;
 	struct pid *               thread_pid;
 	struct list_head           thread_group;
+	u64                        start_time;
 	const struct cred  *       real_cred;
 	char                       comm[16];
 	struct files_struct *      files;

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -5697,6 +5697,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "int", Name: "child_ns_tid"},
 			{Type: "int", Name: "child_pid"},
 			{Type: "int", Name: "child_ns_pid"},
+			{Type: "unsigned long", Name: "start_time"},
 		},
 	},
 	SchedProcessExecEventID: {

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -142,18 +142,18 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 	case SchedProcessExecEventID:
 		//update the process tree
 		processData := procinfo.ProcessCtx{
-			StartTime:   event.Timestamp,
+			StartTime:     event.Timestamp,
 			ProcStartTime: event.Timestamp,
-			ContainerID: event.ContainerID,
-			Pid:         uint32(event.ProcessID),
-			Tid:         uint32(event.ThreadID),
-			Ppid:        uint32(event.ParentProcessID),
-			HostTid:     uint32(event.HostThreadID),
-			HostPid:     uint32(event.HostProcessID),
-			HostPpid:    uint32(event.HostParentProcessID),
-			Uid:         uint32(event.UserID),
-			MntId:       uint32(event.MountNS),
-			PidId:       uint32(event.PIDNS)}
+			ContainerID:   event.ContainerID,
+			Pid:           uint32(event.ProcessID),
+			Tid:           uint32(event.ThreadID),
+			Ppid:          uint32(event.ParentProcessID),
+			HostTid:       uint32(event.HostThreadID),
+			HostPid:       uint32(event.HostProcessID),
+			HostPpid:      uint32(event.HostParentProcessID),
+			Uid:           uint32(event.UserID),
+			MntId:         uint32(event.MountNS),
+			PidId:         uint32(event.PIDNS)}
 		err := t.FillProcessStartTime(&processData)
 		if err != nil {
 			t.handleError(err)
@@ -283,18 +283,18 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			return err
 		}
 		processData := procinfo.ProcessCtx{
-			StartTime:   event.Timestamp,
+			StartTime:     event.Timestamp,
 			ProcStartTime: event.Timestamp,
-			ContainerID: event.ContainerID,
-			Pid:         uint32(pid),
-			Tid:         uint32(tid),
-			Ppid:        uint32(ppid),
-			HostTid:     uint32(hostTid),
-			HostPid:     uint32(hostPid),
-			HostPpid:    uint32(hostPpid),
-			Uid:         uint32(event.UserID),
-			MntId:       uint32(event.MountNS),
-			PidId:       uint32(event.PIDNS)}
+			ContainerID:   event.ContainerID,
+			Pid:           uint32(pid),
+			Tid:           uint32(tid),
+			Ppid:          uint32(ppid),
+			HostTid:       uint32(hostTid),
+			HostPid:       uint32(hostPid),
+			HostPpid:      uint32(hostPpid),
+			Uid:           uint32(event.UserID),
+			MntId:         uint32(event.MountNS),
+			PidId:         uint32(event.PIDNS)}
 		err = t.FillProcessStartTime(&processData)
 		if err != nil {
 			t.handleError(err)

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -142,10 +142,10 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 	case SchedProcessExecEventID:
 		//update the process tree with correct comm name
 		if t.config.ProcessTree {
-			processData, err := t.procInfo.GetElement(event.HostThreadID)
+			processData, err := t.procInfo.GetElement(event.HostProcessID)
 			if err == nil {
 				processData.Comm = event.ProcessName
-				t.procInfo.UpdateElement(event.HostThreadID, processData)
+				t.procInfo.UpdateElement(event.HostProcessID, processData)
 			}
 		}
 

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -94,10 +94,10 @@ func (t *Tracee) shouldProcessEvent(ctx *bufferdecoder.Context, args []trace.Arg
 }
 
 func (t *Tracee) deleteProcInfoDelayed(hostTid int) {
-	// wait a second before deleting from the map - because there might events coming in the context of this process,
+	// wait 5 seconds before deleting from the map - because there might events coming in the context of this process,
 	// after we receive its sched_process_exit. this mainly happens from network events, because these events come from
 	// the netChannel, and there might be a race condition between this channel and the eventsChannel.
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 5)
 	t.procInfo.DeleteElement(hostTid)
 }
 

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -141,7 +141,7 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 
 	case SchedProcessExecEventID:
 		//update the process tree with correct comm name
-		if t.config.ProcessTree {
+		if t.config.ProcessInfo {
 			processData, err := t.procInfo.GetElement(event.HostProcessID)
 			if err == nil {
 				processData.Comm = event.ProcessName
@@ -239,7 +239,7 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			return err
 		}
 	case SchedProcessExitEventID:
-		if t.config.ProcessTree {
+		if t.config.ProcessInfo {
 			if t.config.Capture.NetPerProcess {
 				pcapContext, _, err := t.getPcapContext(uint32(event.HostThreadID))
 				if err == nil {
@@ -250,7 +250,7 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			go t.deleteProcInfoDelayed(event.HostThreadID)
 		}
 	case SchedProcessForkEventID:
-		if t.config.ProcessTree {
+		if t.config.ProcessInfo {
 			hostTid, err := getEventArgInt32Val(event, "child_tid")
 			if err != nil {
 				return err

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -93,7 +93,7 @@ func (t *Tracee) shouldProcessEvent(ctx *bufferdecoder.Context, args []trace.Arg
 	return true
 }
 
-func (t *Tracee) deleteFromProcessTree(hostTid int) {
+func (t *Tracee) deleteProcInfoDelayed(hostTid int) {
 	// wait a second before deleting from the map - because there might events coming in the context of this process,
 	// after we receive its sched_process_exit. this mainly happens from network events, because these events come from
 	// the netChannel, and there might be a race condition between this channel and the eventsChannel.
@@ -256,7 +256,7 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			}
 		}
 
-		go t.deleteFromProcessTree(event.HostThreadID)
+		go t.deleteProcInfoDelayed(event.HostThreadID)
 	case SchedProcessForkEventID:
 		hostTid, err := getEventArgInt32Val(event, "child_tid")
 		if err != nil {

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -5,8 +5,6 @@ import (
 	gocontext "context"
 	"encoding/binary"
 	"fmt"
-	"github.com/google/gopacket/layers"
-	"github.com/google/gopacket/pcapgo"
 	"math"
 	"os"
 	"path"
@@ -18,6 +16,8 @@ import (
 	"github.com/aquasecurity/tracee/pkg/procinfo"
 	"github.com/aquasecurity/tracee/types/trace"
 	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
 )
 
 type EventMeta struct {

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
+	"inet.af/netaddr"
 	"math"
 	"os"
 	"path"
@@ -177,7 +178,7 @@ func (t *Tracee) getPcapContext(hostTid uint32, comm string) (processPcapId, pro
 	return packetContext, networkThread, nil
 }
 
-func (t *Tracee) processNetEvents() {
+func (t *Tracee) processNetEvents(ctx gocontext.Context) {
 	// Todo: add stats for network packets (in epilog)
 	for {
 		select {

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -198,10 +198,8 @@ func (t *Tracee) processNetEvents(ctx gocontext.Context) {
 				evtMeta.TimeStamp += t.bootTime
 			}
 
-			packetContext, networkThread, err := t.getPcapContext(uint32(evtMeta.HostTid))
-			if err != nil {
-				t.handleError(err)
-			}
+			// continue without checking for error, as packetContext will be valid anyway
+			packetContext, networkThread, _ := t.getPcapContext(uint32(evtMeta.HostTid))
 
 			if evtMeta.NetEventId == NetPacket {
 				captureData, err := parseCaptureData(payloadBytes)

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -33,32 +33,32 @@ type CaptureData struct {
 	InterfaceIndex uint32 `json:"if_index"`
 }
 
-type traceeNet struct {
+type netInfo struct {
 	mtx           sync.Mutex
 	pcapWriters   map[processPcapId]*pcapgo.NgWriter
 	ngIfacesIndex map[int]int
 }
 
-func (tn *traceeNet) GetPcapWriter(id processPcapId) (*pcapgo.NgWriter, bool) {
-	tn.mtx.Lock()
-	defer tn.mtx.Unlock()
+func (ni *netInfo) GetPcapWriter(id processPcapId) (*pcapgo.NgWriter, bool) {
+	ni.mtx.Lock()
+	defer ni.mtx.Unlock()
 
-	writer, exists := tn.pcapWriters[id]
+	writer, exists := ni.pcapWriters[id]
 	return writer, exists
 }
 
-func (tn *traceeNet) PutPcapWriter(id processPcapId, writer *pcapgo.NgWriter) {
-	tn.mtx.Lock()
-	defer tn.mtx.Unlock()
+func (ni *netInfo) SetPcapWriter(id processPcapId, writer *pcapgo.NgWriter) {
+	ni.mtx.Lock()
+	defer ni.mtx.Unlock()
 
-	tn.pcapWriters[id] = writer
+	ni.pcapWriters[id] = writer
 }
 
-func (tn *traceeNet) DeletePcapWriter(id processPcapId) {
-	tn.mtx.Lock()
-	defer tn.mtx.Unlock()
+func (ni *netInfo) DeletePcapWriter(id processPcapId) {
+	ni.mtx.Lock()
+	defer ni.mtx.Unlock()
 
-	delete(tn.pcapWriters, id)
+	delete(ni.pcapWriters, id)
 }
 
 type processPcapId struct {
@@ -69,7 +69,6 @@ type processPcapId struct {
 }
 
 func (t *Tracee) createPcapsDirPath(pcapContext processPcapId) (string, error) {
-
 	pcapsDirPath := path.Join(t.config.Capture.OutputPath, pcapContext.contID)
 	err := os.MkdirAll(pcapsDirPath, os.ModePerm)
 	if err != nil {
@@ -80,7 +79,6 @@ func (t *Tracee) createPcapsDirPath(pcapContext processPcapId) (string, error) {
 }
 
 func (t *Tracee) getPcapFilePath(pcapContext processPcapId) (string, error) {
-
 	pcapsDirPath, err := t.createPcapsDirPath(pcapContext)
 	if err != nil {
 		return "", err
@@ -97,7 +95,6 @@ func (t *Tracee) getPcapFilePath(pcapContext processPcapId) (string, error) {
 }
 
 func (t *Tracee) createPcapFile(pcapContext processPcapId) error {
-
 	pcapFilePath, err := t.getPcapFilePath(pcapContext)
 	if err != nil {
 		return fmt.Errorf("error getting pcap file path: %v", err)
@@ -141,7 +138,7 @@ func (t *Tracee) createPcapFile(pcapContext processPcapId) error {
 	if err != nil {
 		return err
 	}
-	t.netPcap.PutPcapWriter(pcapContext, pcapWriter)
+	t.netPcap.SetPcapWriter(pcapContext, pcapWriter)
 
 	return nil
 }
@@ -153,7 +150,6 @@ func (t *Tracee) netExit(pcapContext processPcapId) {
 }
 
 func (t *Tracee) getPcapContext(hostTid uint32) (processPcapId, procinfo.ProcessCtx, error) {
-
 	networkThread, err := t.getProcessCtx(hostTid)
 	if err != nil {
 		return processPcapId{}, procinfo.ProcessCtx{}, err

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
-	"inet.af/netaddr"
 	"math"
 	"os"
 	"path"

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -8,10 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -28,7 +26,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/metrics"
 	"github.com/aquasecurity/tracee/pkg/procinfo"
 	"github.com/aquasecurity/tracee/types/trace"
-	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 	lru "github.com/hashicorp/golang-lru"
 	"golang.org/x/sys/unix"
@@ -60,6 +57,8 @@ type CaptureConfig struct {
 	Mem             bool
 	Profile         bool
 	NetIfaces       []string
+	NetPerContainer bool
+	NetPerProcess   bool
 }
 
 type OutputConfig struct {
@@ -174,9 +173,7 @@ type Tracee struct {
 	pidsInMntns       bucketscache.BucketsCache //record the first n PIDs (host) in each mount namespace, for internal usage
 	StackAddressesMap *bpf.BPFMap
 	tcProbe           []netProbe
-	pcapWriter        *pcapgo.NgWriter
-	pcapFile          *os.File
-	ngIfacesIndex     map[int]int
+	netPcap           traceeNet
 	containers        *containers.Containers
 	procInfo          *procinfo.ProcInfo
 	eventsSorter      *sorting.EventsChronologicalSorter
@@ -303,58 +300,16 @@ func New(cfg Config) (*Tracee, error) {
 		return nil, fmt.Errorf("error creating output path: %v", err)
 	}
 
-	if t.config.Capture.NetIfaces != nil {
-		pcapFile, err := os.Create(path.Join(t.config.Capture.OutputPath, "capture.pcap"))
+	t.netPcap.ngIfacesIndex = make(map[int]int)
+	for idx, iface := range t.config.Capture.NetIfaces {
+		netIface, err := net.InterfaceByName(iface)
 		if err != nil {
-			return nil, fmt.Errorf("error creating pcap file: %v", err)
+			return nil, fmt.Errorf("invalid network interface: %s", iface)
 		}
-		t.pcapFile = pcapFile
-
-		t.ngIfacesIndex = make(map[int]int)
-		for idx, iface := range t.config.Capture.NetIfaces {
-			netIface, err := net.InterfaceByName(iface)
-			if err != nil {
-				return nil, fmt.Errorf("invalid network interface: %s", iface)
-			}
-			// Map real network interface index to NgInterface index
-			t.ngIfacesIndex[netIface.Index] = idx
-		}
-
-		ngIface := pcapgo.NgInterface{
-			Name:       t.config.Capture.NetIfaces[0],
-			Comment:    "tracee tc capture",
-			Filter:     "",
-			LinkType:   layers.LinkTypeEthernet,
-			SnapLength: uint32(math.MaxUint16),
-		}
-
-		pcapWriter, err := pcapgo.NewNgWriterInterface(t.pcapFile, ngIface, pcapgo.NgWriterOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		for _, iface := range t.config.Capture.NetIfaces[1:] {
-			ngIface = pcapgo.NgInterface{
-				Name:       iface,
-				Comment:    "tracee tc capture",
-				Filter:     "",
-				LinkType:   layers.LinkTypeEthernet,
-				SnapLength: uint32(math.MaxUint16),
-			}
-
-			_, err := pcapWriter.AddInterface(ngIface)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		// Flush the header
-		err = pcapWriter.Flush()
-		if err != nil {
-			return nil, err
-		}
-		t.pcapWriter = pcapWriter
+		// Map real network interface index to NgInterface index
+		t.netPcap.ngIfacesIndex[netIface.Index] = idx
 	}
+	t.netPcap.pcapWriters = make(map[processPcapId]*pcapgo.NgWriter)
 
 	// Get reference to stack trace addresses map
 	StackAddressesMap, err := t.bpfModule.GetMap("stack_addresses")
@@ -988,8 +943,24 @@ func (t *Tracee) writeProfilerStats(wr io.Writer) error {
 	return nil
 }
 
-func (t *Tracee) getProcessCtx(hostTid int) (procinfo.ProcessCtx, error) {
-	processCtx, err := t.procInfo.GetElement(hostTid)
+func (t *Tracee) FillProcessStartTime(ctx *procinfo.ProcessCtx) error {
+
+	// default value for process start time
+	ctx.ProcStartTime = ctx.StartTime
+
+	if ctx.HostTid != ctx.HostPid {
+		process, err := t.getProcessCtx(ctx.HostPid)
+		if err != nil {
+			return err
+		}
+		ctx.ProcStartTime = process.StartTime
+	}
+
+	return nil
+}
+
+func (t *Tracee) getProcessCtx(hostTid uint32) (procinfo.ProcessCtx, error) {
+	processCtx, err := t.procInfo.GetElement(int(hostTid))
 	if err == nil {
 		return processCtx, nil
 	} else {
@@ -1002,7 +973,11 @@ func (t *Tracee) getProcessCtx(hostTid int) (procinfo.ProcessCtx, error) {
 			return processCtx, err
 		}
 		processCtx, err = procinfo.ParseProcessContext(processCtxBpfMap, t.containers)
-		t.procInfo.UpdateElement(hostTid, processCtx)
+		err = t.FillProcessStartTime(&processCtx)
+		if err != nil {
+			return processCtx, err
+		}
+		t.procInfo.UpdateElement(int(hostTid), processCtx)
 		return processCtx, err
 	}
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -46,6 +46,7 @@ type Config struct {
 	KernelConfig       *helpers.KernelConfig
 	ChanEvents         chan trace.Event
 	ChanErrors         chan error
+	ProcessTree        bool
 }
 
 type CaptureConfig struct {
@@ -369,6 +370,7 @@ const (
 	optDebugNet
 	optCaptureModules
 	optCgroupV1
+	optProcessInfo
 )
 
 // filters config should match defined values in ebpf code
@@ -424,6 +426,10 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	}
 	if t.containers.IsCgroupV1() {
 		cOptVal = cOptVal | optCgroupV1
+	}
+	if t.config.Capture.NetIfaces != nil || t.config.Debug {
+		cOptVal = cOptVal | optProcessInfo
+		t.config.ProcessTree = true
 	}
 
 	return cOptVal

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -943,22 +943,6 @@ func (t *Tracee) writeProfilerStats(wr io.Writer) error {
 	return nil
 }
 
-func (t *Tracee) FillProcessStartTime(ctx *procinfo.ProcessCtx) error {
-
-	// default value for process start time
-	ctx.ProcStartTime = ctx.StartTime
-
-	if ctx.HostTid != ctx.HostPid {
-		process, err := t.getProcessCtx(ctx.HostPid)
-		if err != nil {
-			return err
-		}
-		ctx.ProcStartTime = process.StartTime
-	}
-
-	return nil
-}
-
 func (t *Tracee) getProcessCtx(hostTid uint32) (procinfo.ProcessCtx, error) {
 	processCtx, err := t.procInfo.GetElement(int(hostTid))
 	if err == nil {
@@ -973,10 +957,6 @@ func (t *Tracee) getProcessCtx(hostTid uint32) (procinfo.ProcessCtx, error) {
 			return processCtx, err
 		}
 		processCtx, err = procinfo.ParseProcessContext(processCtxBpfMap, t.containers)
-		err = t.FillProcessStartTime(&processCtx)
-		if err != nil {
-			return processCtx, err
-		}
 		t.procInfo.UpdateElement(int(hostTid), processCtx)
 		return processCtx, err
 	}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -46,7 +46,7 @@ type Config struct {
 	KernelConfig       *helpers.KernelConfig
 	ChanEvents         chan trace.Event
 	ChanErrors         chan error
-	ProcessTree        bool
+	ProcessInfo        bool
 }
 
 type CaptureConfig struct {
@@ -174,7 +174,7 @@ type Tracee struct {
 	pidsInMntns       bucketscache.BucketsCache //record the first n PIDs (host) in each mount namespace, for internal usage
 	StackAddressesMap *bpf.BPFMap
 	tcProbe           []netProbe
-	netPcap           traceeNet
+	netPcap           netInfo
 	containers        *containers.Containers
 	procInfo          *procinfo.ProcInfo
 	eventsSorter      *sorting.EventsChronologicalSorter
@@ -429,7 +429,7 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	}
 	if t.config.Capture.NetIfaces != nil || t.config.Debug {
 		cOptVal = cOptVal | optProcessInfo
-		t.config.ProcessTree = true
+		t.config.ProcessInfo = true
 	}
 
 	return cOptVal

--- a/pkg/procinfo/procinfo.go
+++ b/pkg/procinfo/procinfo.go
@@ -16,17 +16,18 @@ import (
 )
 
 type ProcessCtx struct {
-	StartTime   int
-	ContainerID string
-	Pid         uint32
-	Tid         uint32
-	Ppid        uint32
-	HostTid     uint32
-	HostPid     uint32
-	HostPpid    uint32
-	Uid         uint32
-	MntId       uint32
-	PidId       uint32
+	StartTime     int // start time of the thread
+	ProcStartTime int // start time of the process
+	ContainerID   string
+	Pid           uint32
+	Tid           uint32
+	Ppid          uint32
+	HostTid       uint32
+	HostPid       uint32
+	HostPpid      uint32
+	Uid           uint32
+	MntId         uint32
+	PidId         uint32
 }
 
 type ProcInfo struct {
@@ -189,6 +190,13 @@ func NewProcessInfo() (*ProcInfo, error) {
 		if err != nil {
 			continue
 		}
+
+		processStatusFile := fmt.Sprintf("/proc/%d/status", pid)
+		processStartTime, err := getFileCtime(processStatusFile)
+		if err != nil {
+			continue
+		}
+
 		taskDir, err := os.Open(fmt.Sprintf("/proc/%d/task", pid))
 		if err != nil {
 			continue
@@ -214,6 +222,7 @@ func NewProcessInfo() (*ProcInfo, error) {
 				continue
 			}
 			processStatus.ContainerID = containerId
+			processStatus.ProcStartTime = processStartTime
 			p.UpdateElement(int(processStatus.HostTid), processStatus)
 		}
 	}


### PR DESCRIPTION
add options to separate captured pcap files by their process context.
two output options were added: 
 - separating by hostPid
 - separating by containerId

in tracee output folder, the captured pcaps would be captured under the containerId folder ("host" is used when containerId from process context is empty), in this format:
 - separating by hostPid:
        <tracee_out>/host/<process_name>_<process_id>_<process_start_time>.pcap
 - separating by containerId:
        <tracee_out>/<containerId>/captured.pcap
- user didn't choose separating the pcaps:
        <tracee_out>/host/captured.pcap


more details about how we separate:

instead of have one pcapWriter for tracee, we now have a map of pcapWriters, where the key is packetContext. packetContext is generated for each packet, and depends on whether the user chose to separate pcap by process_id, container_id, or not separate at all.  with every packet we get the hostTid from the kernel, and the packetContext is generated using the process context from the processTree map.
in order to maintain this map, we would want to delete on process_exit/cotainer_exit (when the user didn't choose to separate, there is only one value in this map, and it shouldn't be deleted). in order to do that, i have added two network event, which will go through the net_events channel - NetProcessExit and NetContainerExit.
note: we might have packets coming after the process had already exited - therefore i delete from the pcapWriters map with a delay of 1 second. also, for the same reason, i delete from processTree with delay of 1 second, as the net_events relay on this map to generate packetContext.