### PR TITLE
events_pipeline: add queueEvents to cache pipeline events

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -70,7 +70,13 @@ run_tracee_rules() {
     events=$($TRACEE_RULES_EXE --list-events)
 
     echo "INFO: starting tracee-ebpf..."
-    ${TRACEE_EBPF_EXE} --metrics --output=format:gob --output=option:parse-arguments --trace event=${events} --output=out-file:${TRACEE_PIPE} &
+    ${TRACEE_EBPF_EXE} \
+        --metrics \
+        --output=format:gob \
+        --output=option:parse-arguments \
+        --output=option:cache-events \
+        --trace event=${events} \
+        --output=out-file:${TRACEE_PIPE} &
     tracee_ebpf_pid=$!
 
     # start tracee-rules

--- a/cmd/tracee-ebpf/internal/flags/flags-output.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-output.go
@@ -29,6 +29,7 @@ option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-hash,parse-ar
   exec-hash                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
   parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
   sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
+  cache-events                                     enable caching events to release perf-buffer pressure. This will decrease amount of event loss until cache is full.
 Examples:
   --output json                                            | output as json
   --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
@@ -92,6 +93,8 @@ func PrepareOutput(outputSlice []string) (tracee.OutputConfig, printerConfig, er
 				outcfg.ParseArguments = true
 			case "sort-events":
 				outcfg.EventsSorting = true
+			case "cache-events":
+				outcfg.EventsCaching = true
 			default:
 				return outcfg, printcfg, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -156,7 +156,7 @@ func main() {
 				return fmt.Errorf("failed preparing BPF object: %w", err)
 			}
 
-			cfg.ChanEvents = make(chan external.Event)
+			cfg.ChanEvents = make(chan external.Event, 10000) // TODO: sync buffer size with queueEventsBufferSize setup
 			cfg.ChanErrors = make(chan error)
 
 			t, err := tracee.New(cfg)

--- a/cmd/tracee-ebpf/main_test.go
+++ b/cmd/tracee-ebpf/main_test.go
@@ -1278,8 +1278,17 @@ func TestPrepareOutput(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			testName:    "option cache-events",
+			outputSlice: []string{"option:cache-events"},
+			expectedOutput: tracee.OutputConfig{
+				ParseArguments: true,
+				EventsCaching:  true,
+			},
+			expectedError: nil,
+		},
+		{
 			testName:    "all options",
-			outputSlice: []string{"option:stack-addresses", "option:detect-syscall", "option:exec-env", "option:exec-hash", "option:sort-events"},
+			outputSlice: []string{"option:stack-addresses", "option:detect-syscall", "option:exec-env", "option:exec-hash", "option:sort-events", "option:cache-events"},
 			expectedOutput: tracee.OutputConfig{
 				StackAddresses: true,
 				DetectSyscall:  true,
@@ -1287,6 +1296,7 @@ func TestPrepareOutput(t *testing.T) {
 				ExecHash:       true,
 				ParseArguments: true,
 				EventsSorting:  true,
+				EventsCaching:  true,
 			},
 			expectedError: nil,
 		},

--- a/tracee-ebpf/tracee/tracee.go
+++ b/tracee-ebpf/tracee/tracee.go
@@ -70,6 +70,7 @@ type OutputConfig struct {
 	ExecHash       bool
 	ParseArguments bool
 	EventsSorting  bool
+	EventsCaching  bool
 }
 
 type netProbe struct {


### PR DESCRIPTION
Currently tracee-rules has a throughput ratio of 1:4 (events consumed versus events being produced by tracee-ebpf). This requires tracee-ebpf to deal with this lag but, at the same time, the perf buffer events consumption cannot be left behind (or we might lose important events coming from kernel and miss signatures detections).

One way to solve this would be to increase the ChanEvents channel buffer size so, if events being printed weren't consumed as fast as they were being produced, the channel would cache them until they can be consumed, releasing the pressure over the perf buffer.

Unfortunately, only increasing the ChanEvents buffer wasn't enough to stop causing event losses. There is a need for a FIFO QUEUE in the pipeline, so events are cached and released according to speed of the end-of-pipeline consumption.

For now, this patch introduces in the pipeline a queue of up to 1 million events. This has proved to significantly reduce event losses during host load bursts, avoid signature detection losses.

It has been tested in a 2GB environment (and higher): memory allocation and de-allocation behaved well (~1GB consumption until the buffer was full, when events started being lost again, something that is expected).

New tracee-ebpf requirement: 2GB of ram minimum.

Until we know good default cache sizes, based on performance benchmarks of different host configurations, this option won't be enabled by default. Idea is, in near future, to give end user the power of controlling the size of this queue. It will be a game of how much memory you are willing to spend versus how many event loss you are able to accept.

Also, Future work might include queue watermarks advertisement for the eBPF programs. This way, based on the queue usage, eBPF programs might chose to send events (or not) based on their priorities. With that, the pressure over the perf buffer would be reduced as the cache is consumed.