### PR TITLE
Use HTTPS link instead of SSH link for git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libbpf"]
 	path = 3rdparty/libbpf
-	url = git@github.com:libbpf/libbpf.git
+	url = https://github.com/libbpf/libbpf.git


### PR DESCRIPTION
Changed `libbpf` submodule link to use HTTPS instead of SSH so the `tracee` git repository can be cloned recursively even on machines that do not have an SSH public key registered on Github.