### PR TITLE
fix: k8s tracee manifests

### DIFF
--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -20,7 +20,7 @@ spec:
       - image: aquasec/tracee:latest
         imagePullPolicy: Always
         args:
-          - --webhook http://postee-svc:8080 --webhook-template ./templates/rawjson.tmpl --webhook-content-type application/json
+          - --webhook http://postee-svc:8082 --webhook-template ./templates/rawjson.tmpl --webhook-content-type application/json
         name: tracee
         securityContext:
           privileged: true

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -13,7 +13,7 @@ To install Tracee with [Postee](https://github.com/aquasecurity/postee), simply 
 ``` bash
 kubectl create \
   -f https://raw.githubusercontent.com/aquasecurity/postee/main/deploy/kubernetes/postee.yaml \
-  -f https://raw.githubusercontent.com/aquasecurity/tracee/{{ git.tag }}/deploy/kubernetes/tracee-postee/tracee.yaml
+  -f https://raw.githubusercontent.com/aquasecurity/tracee/main/deploy/kubernetes/tracee-postee/tracee.yaml
 ```
 
 You can edit the configMap `postee-config` the was created, see an example configuration here: https://github.com/aquasecurity/postee/blob/main/cfg.yaml.

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -13,7 +13,7 @@ To install Tracee with [Postee](https://github.com/aquasecurity/postee), simply 
 ``` bash
 kubectl create \
   -f https://raw.githubusercontent.com/aquasecurity/postee/main/deploy/kubernetes/postee.yaml \
-  -f https://raw.githubusercontent.com/aquasecurity/tracee/main/deploy/kubernetes/tracee-postee/tracee.yaml
+  -f https://raw.githubusercontent.com/aquasecurity/tracee/{{ git.tag }}/deploy/kubernetes/tracee-postee/tracee.yaml
 ```
 
 You can edit the configMap `postee-config` the was created, see an example configuration here: https://github.com/aquasecurity/postee/blob/main/cfg.yaml.


### PR DESCRIPTION
the Postee k8s was updated to use the http port with [8082](https://github.com/aquasecurity/postee/blob/main/deploy/kubernetes/postee.yaml#L97)