### PR TITLE
parseArgs: replace Sprintf with string concat

### DIFF
--- a/tracee-ebpf/tracee/argprinters.go
+++ b/tracee-ebpf/tracee/argprinters.go
@@ -2,6 +2,7 @@ package tracee
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/external"
@@ -10,7 +11,7 @@ import (
 func (t *Tracee) parseArgs(event *external.Event) error {
 	for i := range event.Args {
 		if ptr, isUintptr := event.Args[i].Value.(uintptr); isUintptr {
-			event.Args[i].Value = fmt.Sprintf("0x%X", ptr)
+			event.Args[i].Value = "0x" + strconv.FormatUint(uint64(ptr), 16)
 		}
 	}
 


### PR DESCRIPTION
# The fix

Simply change the way in which pointer arguments are parsed into a hex string in `parseArgs`. `fmt.Sprintf`, due to it's need to support many types of operations, can be less performant than using more specific operations. In this case, simply replacing `Sprintf` with a string concatenation conversion functions removes this code path bottleneck.

# Performance analysis

First a flame graph comparison:
 
With Sprintf:
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/22661609/154547722-f93e9378-000d-4584-bd89-f926dfe206ed.png">
Without:
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/22661609/154547759-13882e2f-ec12-4e5d-bd65-88b75819591e.png">

Note the cpu percentage decrease in processEvents at the top of the screenshots (which should translate to gains in other places, hopefully in more time for event processing and signature handling).

In addition i've performed a benchmark between these two functions:

```
package tohex

import (
	"fmt"
	"strconv"
)

func SprintFToHex(val uintptr) string {
	return fmt.Sprintf("0x%X", val)
}

func ConcatToHex(val uintptr) string {
	return "0x" + strconv.FormatUint(uint64(val), 16)
}
```

And the results show a x2 efficiency increase in the second function:

```
il.ar.tal.gr@ILNadavSt tohex % go test -bench=.
goos: darwin
goarch: arm64
pkg: tohex
BenchmarkSprintf-8      19122786                62.52 ns/op
BenchmarkConcat-8       37810806                31.38 ns/op
PASS
ok      tohex   3.864s
il.ar.tal.gr@ILNadavSt tohex % go test -bench=.
goos: darwin
goarch: arm64
pkg: tohex
BenchmarkSprintf-8      17953947                62.43 ns/op
BenchmarkConcat-8       37373716                31.63 ns/op
PASS
ok      tohex   2.522s
```

With these two demonstrations I think it is clear that this PR will increase performance of this code path (which I assume is pretty frequent)


