### PR TITLE
Fix links in documentation

### DIFF
--- a/docs/rules-authoring.md
+++ b/docs/rules-authoring.md
@@ -9,7 +9,7 @@ Create a `.rego` file in the rules directory that has the following Rego Rules (
 2. `tracee_selected_events`: A *set* rule that defines the event selectors.
 3. `tracee_match`: A *boolean* or a *document* rule that defines the logic of the signature. If bool is "returned", a true evaluation will generate a Finding with no data. If a document is "returned", any non-empty evaluation will generate a Finding with the returned document as the Finding's "Data".
 
-See [tracee/signatures/rego] for example Rego signatures.
+See [signatures/rego] for example Rego signatures.
 
 ## Golang Rules
 
@@ -21,9 +21,9 @@ Tracee exports a `Signature` interface that you can implement. We use [Go Plugin
 4. Compile using goplugins `go build -buildmode=plugin -o yourplugin.so yoursource.go`.
 5. Place the resulting compiled file in the rules directory, and it will be automatically discovered by Tracee.
 
-See [tracee/signatures/golang/examples] for example Go signatures.
+See [signatures/golang/examples] for example Go signatures.
 
 [Open Policy Agent]: https://github.com/open-policy-agent/opa/
 [Go Plugins]: https://golang.org/pkg/plugin/
-[tracee/signatures/rego]: https://github.com/aquasecurity/tracee/tree/{{ git.tag }}/signatures/rego
-[tracee/signatures/golang/examples]: https://github.com/aquasecurity/tracee/tree/{{ git.tag }}/signatures/golang/examples
+[signatures/rego]: https://github.com/aquasecurity/tracee/tree/{{ git.tag }}/signatures/rego
+[signatures/golang/examples]: https://github.com/aquasecurity/tracee/tree/{{ git.tag }}/signatures/golang/examples


### PR DESCRIPTION
#1489 reported a few different issues with broken links in documentation. #1497 fixed some of them, this fixes the rest.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>