### PR TITLE
Load kallsyms values

### DIFF
--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -29,6 +29,7 @@ capabilities:
 * Load and Attach eBPF programs:
     1. `CAP_BPF`+`CAP_PERFMON` for recent kernels (>=5.8)
     2. or `CAP_SYS_ADMIN` for older kernels
+* `CAP_SYSLOG` (to access kernel symbols through /proc/kallsyms)
 * On some environments (e.g. Ubuntu) `CAP_IPC_LOCK` might be required as well.
 
 > Alternatively, run as `root` or with the `--privileged` flag of Docker.

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -22,8 +22,12 @@ type probe struct {
 	fn     string
 }
 
-type dependency struct {
+type eventDependency struct {
 	eventID int32
+}
+
+type dependencies struct {
+	events   []eventDependency // Events required to be loaded and/or submitted for the event to happen
 }
 
 // EventDefinition is a struct describing an event configuration
@@ -31,7 +35,7 @@ type EventDefinition struct {
 	ID32Bit        int32
 	Name           string
 	Probes         []probe
-	Dependencies   []dependency
+	Dependencies   dependencies
 	EssentialEvent bool
 	Sets           []string
 	Params         []trace.ArgMeta
@@ -5860,9 +5864,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "magic_write",
 		Probes:  []probe{}, Sets: []string{},
-		Dependencies: []dependency{
-			{eventID: VfsWriteEventID},
-			{eventID: VfsWritevEventID},
+		Dependencies: dependencies{
+			events: []eventDependency{{VfsWriteEventID}, {VfsWritevEventID}},
 		},
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
@@ -6127,10 +6130,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "socket_dup",
 		Probes:  []probe{},
-		Dependencies: []dependency{
-			{eventID: DupEventID},
-			{eventID: Dup2EventID},
-			{eventID: Dup3EventID},
+		Dependencies: dependencies{
+			events: []eventDependency{{DupEventID}, {Dup2EventID}, {Dup3EventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6154,8 +6155,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "container_create",
 		Probes:  []probe{},
-		Dependencies: []dependency{
-			{eventID: CgroupMkdirEventID},
+		Dependencies: dependencies{
+			events: []eventDependency{{CgroupMkdirEventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6168,8 +6169,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "container_remove",
 		Probes:  []probe{},
-		Dependencies: []dependency{
-			{eventID: CgroupRmdirEventID},
+		Dependencies: dependencies{
+			events: []eventDependency{{CgroupRmdirEventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6189,11 +6190,10 @@ var EventsDefinitions = map[int32]EventDefinition{
 		},
 	},
 	NetPacket: {
-		ID32Bit:      sys32undefined,
-		Name:         "net_packet",
-		Probes:       []probe{},
-		Dependencies: []dependency{},
-		Sets:         []string{},
+		ID32Bit: sys32undefined,
+		Name:    "net_packet",
+		Probes:  []probe{},
+		Sets:    []string{},
 		Params: []trace.ArgMeta{
 			{Type: "external.PktMeta", Name: "metadata"},
 		},

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -28,6 +28,7 @@ type eventDependency struct {
 
 type dependencies struct {
 	events   []eventDependency // Events required to be loaded and/or submitted for the event to happen
+	ksymbols []string
 }
 
 // EventDefinition is a struct describing an event configuration

--- a/pkg/ebpf/initialization/ksymbols.go
+++ b/pkg/ebpf/initialization/ksymbols.go
@@ -1,0 +1,15 @@
+package initialization
+
+import "github.com/aquasecurity/libbpfgo/helpers"
+
+var globalSymbolOwner = "system"
+
+// ValidateKsymbolsTable check if the addresses in the table are valid by checking a specific symbol address.
+// The reason for the addresses to be invalid is if the capabilities required to read the kallsyms file are not given.
+// The chosen symbol used here is "current_task" because it is used by all supported kernel versions and shouldn't be 0.
+func ValidateKsymbolsTable(ksyms *helpers.KernelSymbolTable) bool {
+	if sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "current_task"); err != nil || sym.Address == 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/ebpf/initialization/ksymbols.go
+++ b/pkg/ebpf/initialization/ksymbols.go
@@ -1,8 +1,37 @@
 package initialization
 
-import "github.com/aquasecurity/libbpfgo/helpers"
+import (
+	"github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/libbpfgo/helpers"
+	"unsafe"
+)
 
+var maxKsymNameLen = 64 // Most match the constant in the bpf code
 var globalSymbolOwner = "system"
+
+func LoadKallsymsValues(ksymsTable *helpers.KernelSymbolTable, ksymbols []string) map[string]*helpers.KernelSymbol {
+	kallsymsMap := make(map[string]*helpers.KernelSymbol)
+	for _, name := range ksymbols {
+		symbol, err := ksymsTable.GetSymbolByName(globalSymbolOwner, name)
+		if err == nil {
+			kallsymsMap[name] = symbol
+		}
+	}
+	return kallsymsMap
+}
+
+func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helpers.KernelSymbol) error {
+	for ksymName, value := range ksymbols {
+		key := make([]byte, maxKsymNameLen)
+		copy(key, ksymName)
+		address := value.Address
+		err := bpfKsymsMap.Update(unsafe.Pointer(&key[0]), unsafe.Pointer(&address))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // ValidateKsymbolsTable check if the addresses in the table are valid by checking a specific symbol address.
 // The reason for the addresses to be invalid is if the capabilities required to read the kallsyms file are not given.


### PR DESCRIPTION
Load symbols from /proc/kallsyms to BPF map.
The first commit is a patch until the loading of kallsyms will be merged into libbpfgo, so please only review the second commit.
This is a first step needed for #1357.

Fix #1505