### PR TITLE
enable tracing net_packet event

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/flags-capture.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-capture.go
@@ -72,7 +72,7 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 		} else if cap == "mem" {
 			capture.Mem = true
 		} else if strings.HasPrefix(cap, "net=") {
-			err := tracee.ParseIface(strings.TrimPrefix(cap, "net"), &capture.NetIfaces)
+			err := tracee.ParseIface(strings.TrimPrefix(cap, "net="), &capture.NetIfaces)
 			if err != nil {
 				return tracee.CaptureConfig{}, err
 			}

--- a/cmd/tracee-ebpf/internal/flags/flags-capture.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-capture.go
@@ -2,7 +2,6 @@ package flags
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,20 +72,9 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 		} else if cap == "mem" {
 			capture.Mem = true
 		} else if strings.HasPrefix(cap, "net=") {
-			iface := strings.TrimPrefix(cap, "net=")
-			if _, err := net.InterfaceByName(iface); err != nil {
-				return tracee.CaptureConfig{}, fmt.Errorf("invalid network interface: %s", iface)
-			}
-			found := false
-			// Check if we already have this interface
-			for _, item := range capture.NetIfaces {
-				if iface == item {
-					found = true
-					break
-				}
-			}
-			if !found {
-				capture.NetIfaces = append(capture.NetIfaces, iface)
+			err := tracee.ParseIface(strings.TrimPrefix(cap, "net"), &capture.NetIfaces)
+			if err != nil {
+				return tracee.CaptureConfig{}, err
 			}
 		} else if strings.HasPrefix(cap, "pcap:") {
 			netCaptureContext := strings.TrimPrefix(cap, "pcap:")

--- a/cmd/tracee-ebpf/internal/flags/flags-filter.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-filter.go
@@ -130,7 +130,7 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 			PIDs: make(map[uint32]bool),
 		},
 		EventsToTrace: []int32{},
-		NetFilter: &tracee.NetFilter{
+		NetFilter: &tracee.IfaceFilter{
 			InterfacesToTrace: []string{},
 		},
 	}
@@ -216,7 +216,7 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 		}
 
 		if strings.HasPrefix(filterName, "net") {
-			err := filter.NetFilter.Parse(operatorAndValues)
+			err := filter.NetFilter.Parse(strings.TrimPrefix(operatorAndValues, "="))
 			if err != nil {
 				return tracee.Filter{}, err
 			}

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -490,6 +490,9 @@ func printList() {
 	b.WriteString("____________  " + titleHeaderPadFirst + "____ " + titleHeaderPadSecond + "_________\n\n")
 	printEventGroup(&b, int(tracee.SysEnterEventID), int(tracee.MaxCommonEventID))
 	printEventGroup(&b, int(tracee.InitNamespacesEventID), int(tracee.MaxUserSpaceEventID))
+	b.WriteString("\n\nNetwork Events: " + titleHeaderPadFirst + "Sets:" + titleHeaderPadSecond + "Arguments:\n")
+	b.WriteString("____________  " + titleHeaderPadFirst + "____ " + titleHeaderPadSecond + "_________\n\n")
+	printEventGroup(&b, int(tracee.NetPacket), int(tracee.MaxNetEventEventID))
 	fmt.Println(b.String())
 }
 

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -492,7 +492,7 @@ func printList() {
 	printEventGroup(&b, int(tracee.InitNamespacesEventID), int(tracee.MaxUserSpaceEventID))
 	b.WriteString("\n\nNetwork Events: " + titleHeaderPadFirst + "Sets:" + titleHeaderPadSecond + "Arguments:\n")
 	b.WriteString("____________  " + titleHeaderPadFirst + "____ " + titleHeaderPadSecond + "_________\n\n")
-	printEventGroup(&b, int(tracee.NetPacket), int(tracee.MaxNetEventEventID))
+	printEventGroup(&b, int(tracee.NetPacket), int(tracee.MaxNetEventID))
 	fmt.Println(b.String())
 }
 

--- a/docs/tracee-ebpf/trace-options.md
+++ b/docs/tracee-ebpf/trace-options.md
@@ -196,3 +196,9 @@ trace all events that originated from bash or from one of the processes spawned 
 ```
 --trace comm=bash --trace follow
 ```
+
+trace the network events over a given interface name
+
+```
+-trace net=<iface>
+```

--- a/pkg/bufferdecoder/net_decoder.go
+++ b/pkg/bufferdecoder/net_decoder.go
@@ -8,7 +8,7 @@ import (
 
 type NetEventMetadata struct {
 	TimeStamp   uint64   `json:"timeStamp"`
-	NetEventId  uint32   `json:"netEventId"`
+	NetEventId  int32    `json:"netEventId"`
 	HostTid     uint32   `json:"hostTid"`
 	ProcessName [16]byte `json:"processName"`
 }
@@ -24,7 +24,7 @@ func (decoder *EbpfDecoder) DecodeNetEventMetadata(eventMetaData *NetEventMetada
 		return fmt.Errorf("can't read NetEventMetadata from buffer: buffer too short")
 	}
 	eventMetaData.TimeStamp = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+8])
-	eventMetaData.NetEventId = binary.LittleEndian.Uint32(decoder.buffer[offset+8 : offset+12])
+	eventMetaData.NetEventId = int32(binary.LittleEndian.Uint32(decoder.buffer[offset+8 : offset+12]))
 	eventMetaData.HostTid = binary.LittleEndian.Uint32(decoder.buffer[offset+12 : offset+16])
 	copy(eventMetaData.ProcessName[:], bytes.TrimRight(decoder.buffer[offset+16:offset+32], "\x00"))
 
@@ -33,8 +33,8 @@ func (decoder *EbpfDecoder) DecodeNetEventMetadata(eventMetaData *NetEventMetada
 }
 
 type NetCaptureData struct {
-	PacketLength   uint32 `json:"pkt_len"`
-	InterfaceIndex uint32 `json:"if_index"`
+	PacketLength     uint32 `json:"pkt_len"`
+	ConfigIfaceIndex uint32 `json:"if_index"`
 }
 
 func (NetCaptureData) GetSizeBytes() uint32 {
@@ -48,7 +48,7 @@ func (decoder *EbpfDecoder) DecodeNetCaptureData(netCaptureData *NetCaptureData)
 		return fmt.Errorf("can't read NetCaptureData from buffer: buffer too short")
 	}
 	netCaptureData.PacketLength = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
-	netCaptureData.InterfaceIndex = binary.LittleEndian.Uint32(decoder.buffer[offset+4 : offset+8])
+	netCaptureData.ConfigIfaceIndex = binary.LittleEndian.Uint32(decoder.buffer[offset+4 : offset+8])
 
 	decoder.cursor += int(netCaptureData.GetSizeBytes())
 	return nil

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4394,13 +4394,14 @@ static __always_inline int tc_probe(struct __sk_buff *skb, bool ingress) {
     // host_tid (u32), comm (16 bytes), packet len (u32), and ifindex (u32)
     size_t pkt_size = PACKET_MIN_SIZE;
 
-    if (get_iface_config(skb->ifindex) & TRACE_IFACE){
+    int iface_conf = get_iface_config(skb->ifindex);
+    if (iface_conf & TRACE_IFACE){
         pkt_size = sizeof(pkt);
         pkt.src_port = __bpf_ntohs(pkt.src_port);
         pkt.dst_port = __bpf_ntohs(pkt.dst_port);
     }
 
-    if (get_iface_config(skb->ifindex) & CAPTURE_IFACE){
+    if (iface_conf & CAPTURE_IFACE){
         flags |= (u64)skb->len << 32;
     }
     bpf_perf_event_output(skb, &net_events, flags, &pkt, pkt_size);

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -207,6 +207,9 @@ Copyright (C) Aqua Security inc.
 #define CONFIG_FILTERS                  2
 #define CONFIG_CGROUP_V1_HID            3
 
+#define CAPTURE_IFACE                   (1 << 0)
+#define TRACE_IFACE                     (1 << 1)
+
 #define OPT_SHOW_SYSCALL                (1 << 0)
 #define OPT_EXEC_ENV                    (1 << 1)
 #define OPT_CAPTURE_FILES               (1 << 2)
@@ -261,6 +264,8 @@ Copyright (C) Aqua Security inc.
 #define CONTAINER_EXISTED               1         // container existed before tracee was started
 #define CONTAINER_CREATED               2         // new cgroup path created
 #define CONTAINER_STARTED               3         // a process in the cgroup executed a new binary
+
+#define PACKET_MIN_SIZE                 40
 
 #ifndef CORE
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)  // lower values in old kernels (instr lim is 4096)
@@ -587,6 +592,7 @@ BPF_HASH(sys_32_to_64_map, u32, u32);                   // map 32bit to 64bit sy
 BPF_HASH(params_types_map, u32, u64);                   // encoded parameters types for event
 BPF_HASH(process_tree_map, u32, u32);                   // filter events by the ancestry of the traced process
 BPF_HASH(process_context_map, u32, process_context_t);  // holds the process_context data for every tid
+BPF_HASH(network_config, u32, int);                     // holds the network config for each iface
 BPF_LRU_HASH(sock_ctx_map, u64, net_ctx_ext_t);         // socket address to process context
 BPF_LRU_HASH(network_map, local_net_id_t, net_ctx_t);   // network identifier to process context
 BPF_ARRAY(config_map, u32, 4);                          // various configurations
@@ -1379,6 +1385,15 @@ static __always_inline int event_chosen(u32 key)
 static __always_inline buf_t* get_buf(int idx)
 {
     return bpf_map_lookup_elem(&bufs, &idx);
+}
+
+static __always_inline int get_iface_config(int ifindex)
+{
+    int *config  = bpf_map_lookup_elem(&network_config, &ifindex);
+    if (config == NULL)
+        return 0;
+
+    return *config;
 }
 
 static __always_inline void set_buf_off(int buf_idx, u32 new_off)
@@ -4373,19 +4388,22 @@ static __always_inline int tc_probe(struct __sk_buff *skb, bool ingress) {
     //
     // See bpf_skb_event_output in net/core/filter.c.
     u64 flags = BPF_F_CURRENT_CPU;
-    flags |= (u64)skb->len << 32;
-    if (event_chosen(NET_PACKET)){
+
+    // If net_packet event wasn't chosen, only send the minimal required data to save the
+    // packet. This will be the timestamp (u64), net event_id (u32),
+    // host_tid (u32), comm (16 bytes), packet len (u32), and ifindex (u32)
+    size_t pkt_size = PACKET_MIN_SIZE;
+
+    if (get_iface_config(skb->ifindex) & TRACE_IFACE){
+        pkt_size = sizeof(pkt);
         pkt.src_port = __bpf_ntohs(pkt.src_port);
         pkt.dst_port = __bpf_ntohs(pkt.dst_port);
-        bpf_perf_event_output(skb, &net_events, flags, &pkt, sizeof(pkt));
-    }
-    else {
-        // If not debugging, only send the minimal required data to save the
-        // packet. This will be the timestamp (u64), net event_id (u32),
-        // host_tid (u32), comm (16 bytes), packet len (u32), and ifindex (u32)
-        bpf_perf_event_output(skb, &net_events, flags, &pkt, 40);
     }
 
+    if (get_iface_config(skb->ifindex) & CAPTURE_IFACE){
+        flags |= (u64)skb->len << 32;
+    }
+    bpf_perf_event_output(skb, &net_events, flags, &pkt, pkt_size);
     return TC_ACT_UNSPEC;
 }
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -192,14 +192,15 @@ Copyright (C) Aqua Security inc.
 #define HIDDEN_INODES                   1033
 #define MAX_EVENT_ID                    1034
 
-#define NET_PACKET                      0
-#define DEBUG_NET_SECURITY_BIND         1
-#define DEBUG_NET_UDP_SENDMSG           2
-#define DEBUG_NET_UDP_DISCONNECT        3
-#define DEBUG_NET_UDP_DESTROY_SOCK      4
-#define DEBUG_NET_UDPV6_DESTROY_SOCK    5
-#define DEBUG_NET_INET_SOCK_SET_STATE   6
-#define DEBUG_NET_TCP_CONNECT           7
+#define NET_PACKET                      4000
+
+#define DEBUG_NET_SECURITY_BIND         5000
+#define DEBUG_NET_UDP_SENDMSG           5001
+#define DEBUG_NET_UDP_DISCONNECT        5002
+#define DEBUG_NET_UDP_DESTROY_SOCK      5003
+#define DEBUG_NET_UDPV6_DESTROY_SOCK    5004
+#define DEBUG_NET_INET_SOCK_SET_STATE   5005
+#define DEBUG_NET_TCP_CONNECT           5006
 
 #define CONFIG_TRACEE_PID               0
 #define CONFIG_OPTIONS                  1
@@ -4260,6 +4261,7 @@ static __always_inline int tc_probe(struct __sk_buff *skb, bool ingress) {
 
     struct ethhdr *eth = (void *)head;
     net_packet_t pkt = {0};
+    pkt.event_id = NET_PACKET;
     pkt.ts = bpf_ktime_get_ns();
     pkt.len = skb->len;
     pkt.ifindex = skb->ifindex;
@@ -4372,7 +4374,7 @@ static __always_inline int tc_probe(struct __sk_buff *skb, bool ingress) {
     // See bpf_skb_event_output in net/core/filter.c.
     u64 flags = BPF_F_CURRENT_CPU;
     flags |= (u64)skb->len << 32;
-    if (get_config(CONFIG_OPTIONS) & OPT_DEBUG_NET){
+    if (event_chosen(NET_PACKET)){
         pkt.src_port = __bpf_ntohs(pkt.src_port);
         pkt.dst_port = __bpf_ntohs(pkt.dst_port);
         bpf_perf_event_output(skb, &net_events, flags, &pkt, sizeof(pkt));

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -86,9 +86,14 @@ const (
 	MaxUserSpaceEventID
 )
 
+const Unique32BitSyscallsStartID = 3000
+
 const (
-	NetPacket uint32 = iota
-	DebugNetSecurityBind
+	NetPacket int32 = iota + 4000
+	MaxNetEventEventID
+)
+const (
+	DebugNetSecurityBind int32 = iota + 5000
 	DebugNetUdpSendmsg
 	DebugNetUdpDisconnect
 	DebugNetUdpDestroySock
@@ -96,8 +101,6 @@ const (
 	DebugNetInetSockSetState
 	DebugNetTcpConnect
 )
-
-const Unique32BitSyscallsStartID = 3000
 
 var EventsDefinitions = map[int32]EventDefinition{
 	ReadEventID: {
@@ -6177,6 +6180,16 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "const char*", Name: "runtime"},
 			{Type: "const char*", Name: "container_id"},
 			{Type: "unsigned long", Name: "ctime"},
+		},
+	},
+	NetPacket: {
+		ID32Bit:      sys32undefined,
+		Name:         "net_packet",
+		Probes:       []probe{},
+		Dependencies: []dependency{},
+		Sets:         []string{"net_events"},
+		Params: []external.ArgMeta{
+			{Type: "external.PktMeta", Name: "metadata"},
 		},
 	},
 }

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -94,7 +94,7 @@ const (
 )
 
 const (
-	CaptureIface int32 = iota + 1
+	CaptureIface int32 = 1 << iota
 	TraceIface
 )
 

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -90,8 +90,14 @@ const Unique32BitSyscallsStartID = 3000
 
 const (
 	NetPacket int32 = iota + 4000
-	MaxNetEventEventID
+	MaxNetEventID
 )
+
+const (
+	CaptureIface int32 = iota + 1
+	TraceIface
+)
+
 const (
 	DebugNetSecurityBind int32 = iota + 5000
 	DebugNetUdpSendmsg
@@ -6187,8 +6193,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:         "net_packet",
 		Probes:       []probe{},
 		Dependencies: []dependency{},
-		Sets:         []string{"net_events"},
-		Params: []external.ArgMeta{
+		Sets:         []string{},
+		Params: []trace.ArgMeta{
 			{Type: "external.PktMeta", Name: "metadata"},
 		},
 	},

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -55,6 +55,7 @@ type Filter struct {
 	ArgFilter         *ArgFilter
 	ProcessTreeFilter *ProcessTreeFilter
 	Follow            bool
+	InterfaceToTrace  []string
 }
 
 type UintFilter struct {

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -56,7 +56,7 @@ type Filter struct {
 	ArgFilter         *ArgFilter
 	ProcessTreeFilter *ProcessTreeFilter
 	Follow            bool
-	NetFilter         *NetFilter
+	NetFilter         *IfaceFilter
 }
 
 type UintFilter struct {
@@ -646,16 +646,16 @@ func (filter *ContIDFilter) FilterOut() bool {
 	}
 }
 
-type NetFilter struct {
+type IfaceFilter struct {
 	InterfacesToTrace []string
 }
 
-func (filter *NetFilter) Parse(operatorAndValues string) error {
+func (filter *IfaceFilter) Parse(operatorAndValues string) error {
 	return ParseIface(operatorAndValues, &filter.InterfacesToTrace)
 }
 
 func ParseIface(operatorAndValues string, ifacesList *[]string) error {
-	ifaces := strings.Split(strings.TrimPrefix(operatorAndValues, "="), ",")
+	ifaces := strings.Split(operatorAndValues, ",")
 	for _, iface := range ifaces {
 		if _, err := net.InterfaceByName(iface); err != nil {
 			return fmt.Errorf("invalid network interface: %s", iface)

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -260,7 +260,6 @@ func (t *Tracee) processNetEvents(ctx gocontext.Context) {
 					}
 				}
 
-				ifaceName = t.netInfo.ifaces[int(netCaptureData.ConfigIfaceIndex)].Name
 				ifaceIdx, err = t.getCapturedIfaceIdx(ifaceName)
 				if ifaceIdx >= 0 && err == nil {
 					// capture the packet

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -843,7 +843,7 @@ func (t *Tracee) initBPF() error {
 		return err
 	}
 
-	if t.config.Capture.NetIfaces != nil || t.config.Debug {
+	if t.config.Capture.NetIfaces != nil || t.eventsToTrace[NetPacket] {
 		for _, iface := range t.config.Capture.NetIfaces {
 			ingressHook, err := t.attachTcProg(iface, bpf.BPFTcIngress, "tc_ingress")
 			if err != nil {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -87,7 +87,7 @@ func (tc Config) Validate() error {
 		if _, ok := EventsDefinitions[e]; !ok {
 			return fmt.Errorf("invalid event to trace: %d", e)
 		}
-		if strings.Compare(EventsDefinitions[e].Name, EventsDefinitions[NetPacket].Name) == 0 {
+		if e == NetPacket {
 			if len(tc.Filter.NetFilter.InterfacesToTrace) == 0 {
 				return fmt.Errorf("missing interface for net event: %s, please add -t net=<iface>", EventsDefinitions[e].Name)
 			}


### PR DESCRIPTION
Hi 
this PR solves #1514 
by separate the `net_packet` to new numbering of events which will be only for network events and adding the `net` option flag to the `-trace`  flag

