### PR TITLE
protocol: encapsulate custom event headers

### DIFF
--- a/types/protocol/protocol.go
+++ b/types/protocol/protocol.go
@@ -7,7 +7,7 @@ type EventHeaders struct {
 	// Origin indicates whether Event originates from host or container.
 	Origin string
 	// Custom additional custom headers, nil most of the time
-	Custom map[string]string
+	custom map[string]string
 }
 
 //Event is a generic event that the Engine can process
@@ -16,17 +16,24 @@ type Event struct {
 	Payload interface{}
 }
 
-func (e Event) ContentType() string {
+func (e *Event) ContentType() string {
 	return e.Headers.ContentType
 }
 
-func (e Event) Origin() string {
+func (e *Event) Origin() string {
 	return e.Headers.Origin
 }
 
-func (e Event) Header(header string) string {
-	if e.Headers.Custom != nil {
-		return e.Headers.Custom[header]
+func (e *Event) Header(header string) string {
+	if e.Headers.custom != nil {
+		return e.Headers.custom[header]
 	}
 	return ""
+}
+
+func (e *Event) SetHeader(header string, value string) {
+	if e.Headers.custom == nil {
+		e.Headers.custom = make(map[string]string)
+	}
+	e.Headers.custom[header] = value
 }

--- a/types/protocol/protocol_test.go
+++ b/types/protocol/protocol_test.go
@@ -1,0 +1,24 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomHeaders(t *testing.T) {
+	evt := Event{
+		Headers: EventHeaders{},
+		Payload: "blah",
+	}
+
+	testHeader := "random-header"
+
+	assert.Equal(t, "", evt.Header(testHeader))
+
+	testHeaderInput := "test"
+
+	evt.SetHeader(testHeader, testHeaderInput)
+
+	assert.Equal(t, testHeaderInput, evt.Header(testHeader))
+}


### PR DESCRIPTION
In continuation of this from #1482:

> > In addition:
> > 
> > 1. in protocol.go we are exposing functions like `Origin`, `ContentType`, `Header` but the fields of `Event` and `EventHeaders` are also exported. What am I missing?
> > 2. in particular, `EventHeaders.Custom` is exported and a user might use the library wrongly and addressing to a `nil` `Custom` field causing a program crash/panic.
> 
> 1. The functions are there to ensure an abstracted access to those headers. IMO I'm perfectly fine with unexposing the headers and providing access only through receivers. However, that would complicate event building so maybe we can suffice using just the suggestion below (2)
> 2. Then as part of what I wrote above, at a minimum we could unexpose the`Custom` field and expose a `SetHeader` method

This PR unexports the new `Custom` field in `protocol.EventHeaders` and adds a method to set a custom header. This is done to ensure safe access to custom event headers.