### PR TITLE
Makefile: add types module testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -572,7 +572,8 @@ test-tracee-rules: \
 		-v \
 		./cmd/tracee-rules/... \
 		./pkg/rules/...
-
+	cd ./types; $(CMD_GO) test -v ./...
+	cd ..
 #
 # rules
 #


### PR DESCRIPTION
Solves #1509

This PR:
1. Adds a script(`test-types`) to test the `types` module since it was missing from tests.
2. Adds `test-types` to `make test`.
3. Adds a job to verify types in the PR github workflow.