### PR TITLE
tracee-ebpf: add existing_containers event

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -373,6 +373,19 @@ func (c *Containers) GetCgroupInfo(cgroupId uint64) CgroupInfo {
 	return cgroupInfo
 }
 
+// GetContainers provides a list of all existing containers.
+func (c *Containers) GetContainers() []CgroupInfo {
+	var conts []CgroupInfo
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+	for _, v := range c.cgroups {
+		if v.ContainerId != "" && v.expiresAt.IsZero() {
+			conts = append(conts, v)
+		}
+	}
+	return conts
+}
+
 // CgroupExists checks if there is a cgroupInfo data of a given cgroupId.
 func (c *Containers) CgroupExists(cgroupId uint64) bool {
 	c.mtx.RLock()

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -84,6 +84,7 @@ const (
 	InitNamespacesEventID int32 = iota + 2000
 	ContainerCreateEventID
 	ContainerRemoveEventID
+	ExistingContainerEventID
 	MaxUserSpaceEventID
 )
 
@@ -6165,6 +6166,17 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Params: []external.ArgMeta{
 			{Type: "const char*", Name: "runtime"},
 			{Type: "const char*", Name: "container_id"},
+		},
+	},
+	ExistingContainerEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "existing_container",
+		Probes:  []probe{},
+		Sets:    []string{},
+		Params: []external.ArgMeta{
+			{Type: "const char*", Name: "runtime"},
+			{Type: "const char*", Name: "container_id"},
+			{Type: "unsigned long", Name: "ctime"},
 		},
 	},
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1009,7 +1009,7 @@ func (t *Tracee) getProcessCtx(hostTid int) (procinfo.ProcessCtx, error) {
 
 // Run starts the trace. it will run until ctx is cancelled
 func (t *Tracee) Run(ctx gocontext.Context) error {
-	t.invokeInitNamespacesEvent()
+	t.invokeInitEvents()
 	t.eventsPerfMap.Start()
 	t.fileWrPerfMap.Start()
 	t.netPerfMap.Start()
@@ -1118,10 +1118,16 @@ func (t *Tracee) updateFileSHA() {
 	}
 }
 
-func (t *Tracee) invokeInitNamespacesEvent() {
+func (t *Tracee) invokeInitEvents() {
 	if t.eventsToTrace[InitNamespacesEventID] {
 		systemInfoEvent, _ := CreateInitNamespacesEvent()
 		t.config.ChanEvents <- systemInfoEvent
 		t.stats.EventCount.Increment()
+	}
+	if t.eventsToTrace[ExistingContainerEventID] {
+		for _, e := range t.CreateExistingContainersEvents() {
+			t.config.ChanEvents <- e
+			t.stats.EventCount.Increment()
+		}
 	}
 }

--- a/pkg/ebpf/user_mode_events.go
+++ b/pkg/ebpf/user_mode_events.go
@@ -62,3 +62,25 @@ func fetchInitNamespaces() map[string]uint32 {
 	}
 	return initNamespacesMap
 }
+
+func (t *Tracee) CreateExistingContainersEvents() []external.Event {
+	var events []external.Event
+	def := EventsDefinitions[ExistingContainerEventID]
+	for _, info := range t.containers.GetContainers() {
+		args := []external.Argument{
+			{ArgMeta: def.Params[0], Value: info.Runtime},
+			{ArgMeta: def.Params[1], Value: info.ContainerId},
+			{ArgMeta: def.Params[2], Value: info.Ctime.UnixNano()},
+		}
+		existingContainerEvent := external.Event{
+			Timestamp:   int(time.Now().UnixNano()),
+			ProcessName: "tracee-ebpf",
+			EventID:     int(ExistingContainerEventID),
+			EventName:   EventsDefinitions[ExistingContainerEventID].Name,
+			ArgsNum:     len(args),
+			Args:        args,
+		}
+		events = append(events, existingContainerEvent)
+	}
+	return events
+}


### PR DESCRIPTION
This PR adds existing_containers event that lists all the containers which were present once tracee started.
Using this information in combination of the runtime `container_create` event it is now possible to have the complete picture of the containers running in the system, which can then be used by tracee-rules.

Once #1278 will be completed, we can remove this event and pass this information as part of the new tracee-ebpf to tracee-rules protocol.