### PR TITLE
change the libbpfgo to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220126150855-5e890064f075
+	github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220228145039-5617016fe995
 	github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220126150855-5e890064f075 h1:BqrItxwk9rA2c/TpY8zuKIreHh8KAtLe3uz6TcSQf9E=
-github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220126150855-5e890064f075/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220228145039-5617016fe995 h1:yOyZr+Y+Ih0pmHAsxzLsOH7v9sDV6fWwSLPO2wEx11o=
+github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220228145039-5617016fe995/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94 h1:8dNst7rq3V688n0CyVGy0aNV179s5jGfi6i+C8fCeh4=
 github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
Hi 

I just added to `libbpfgo` a helper that enables to hold all the kernel symbols.

This update will help #1508, #1222, and #1195 
I just update `go.mod` and `go.sum` files to use the last commit of `libbpfgo`
solves #1520 