### PR TITLE
decoding: cast SlimCred to trace.SlimCred

### DIFF
--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -93,7 +93,7 @@ func ReadArgFromBuff(ebpfMsgDecoder *EbpfDecoder, params []trace.ArgMeta) (trace
 	case credT:
 		var data SlimCred
 		err = ebpfMsgDecoder.DecodeSlimCred(&data)
-		res = data
+		res = trace.SlimCred(data) //here we cast to trace.SlimCred to ensure we send the public interface and not bufferdecoder.SlimCred
 	case strT:
 		res, err = readStringFromBuff(ebpfMsgDecoder)
 	case strArrT:


### PR DESCRIPTION
This fixes an issue with gob encoding where `trace.SlimCred` was registered but when we parse the SlimCred argument it's parsed as `bufferdecoder.SlimCred`.

The fix simply adds a cast after the decoding, which should break on compile time if either of the contracts change.