### PR TITLE
Upgrade libbpfgo and libbpf for v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220228145039-5617016fe995
+	github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0
 	github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220228145039-5617016fe995 h1:yOyZr+Y+Ih0pmHAsxzLsOH7v9sDV6fWwSLPO2wEx11o=
-github.com/aquasecurity/libbpfgo v0.2.4-libbpf-0.6.1.0.20220228145039-5617016fe995/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
+github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0 h1:BpW7qxkveYXx8TCtvYWIvmliPqaTCz/IYs1i+Gyj0MQ=
+github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94 h1:8dNst7rq3V688n0CyVGy0aNV179s5jGfi6i+C8fCeh4=
 github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -346,12 +346,12 @@ Copyright (C) Aqua Security inc.
 #endif
 
 #define BPF_MAP(_name, _type, _key_type, _value_type, _max_entries)     \
-    struct bpf_map_def SEC("maps") _name = {                            \
-        .type = _type,                                                  \
-        .key_size = sizeof(_key_type),                                  \
-        .value_size = sizeof(_value_type),                              \
-        .max_entries = _max_entries,                                    \
-    };
+    struct {                                                            \
+        __uint(type, _type);                                            \
+        __uint(max_entries, _max_entries);                              \
+        __type(key, _key_type);                                         \
+        __type(value, _value_type);                                     \
+    } _name SEC(".maps");
 
 #define BPF_HASH(_name, _key_type, _value_type) \
     BPF_MAP(_name, BPF_MAP_TYPE_HASH, _key_type, _value_type, 10240)
@@ -372,13 +372,14 @@ Copyright (C) Aqua Security inc.
     BPF_MAP(_name, BPF_MAP_TYPE_PERF_EVENT_ARRAY, int, __u32, 1024)
 
 // stack traces: the value is 1 big byte array of the stack addresses
+typedef __u64 stack_trace_t[MAX_STACK_DEPTH];
 #define BPF_STACK_TRACE(_name, _max_entries)                            \
-    struct bpf_map_def SEC("maps") _name = {                            \
-        .type = BPF_MAP_TYPE_STACK_TRACE,                               \
-        .key_size = sizeof(u32),                                        \
-        .value_size = sizeof(size_t) * MAX_STACK_DEPTH,                 \
-        .max_entries = _max_entries,                                    \
-    };
+    struct {                                                            \
+        __uint(type, BPF_MAP_TYPE_STACK_TRACE);                         \
+        __uint(max_entries, _max_entries);                              \
+        __type(key, u32);                                               \
+        __type(value, stack_trace_t);                                   \
+    } _name SEC(".maps");
 
 #ifndef CORE
 #ifdef RHEL_RELEASE_CODE
@@ -3581,7 +3582,7 @@ int BPF_KPROBE(trace_tcp_connect)
     return net_map_update_or_delete_sock(ctx, DEBUG_NET_TCP_CONNECT, sk, data.context.host_tid);
 }
 
-static __always_inline u32 send_bin_helper(void* ctx, struct bpf_map_def *prog_array, int tail_call)
+static __always_inline u32 send_bin_helper(void* ctx, void *prog_array, int tail_call)
 {
     // Note: sending the data to the userspace have the following constraints:
     //

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -373,13 +373,8 @@ Copyright (C) Aqua Security inc.
 
 // stack traces: the value is 1 big byte array of the stack addresses
 typedef __u64 stack_trace_t[MAX_STACK_DEPTH];
-#define BPF_STACK_TRACE(_name, _max_entries)                            \
-    struct {                                                            \
-        __uint(type, BPF_MAP_TYPE_STACK_TRACE);                         \
-        __uint(max_entries, _max_entries);                              \
-        __type(key, u32);                                               \
-        __type(value, stack_trace_t);                                   \
-    } _name SEC(".maps");
+#define BPF_STACK_TRACE(_name, _max_entries) \
+    BPF_MAP(_name, BPF_MAP_TYPE_STACK_TRACE, u32, stack_trace_t, _max_entries)
 
 #ifndef CORE
 #ifdef RHEL_RELEASE_CODE


### PR DESCRIPTION
This currently causes a bunch of deprecated API warnings, so keeping this as a draft until I fix those issues, and mark libbpfgo v0.2.5-libbpf-v0.7.0 as an official release.

Info on the deprecated `bpf_map_def`:

- https://github.com/libbpf/libbpf/commit/d788cd57b54c179a657f823cbe56c868f6974924
- https://github.com/libbpf/libbpf/wiki/Libbpf:-the-road-to-v1.0#drop-support-for-legacy-bpf-map-declaration-syntax