### PR TITLE
close pcap files instead of just deleting from mapping

### DIFF
--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -20,8 +20,8 @@ import (
 )
 
 type netPcap struct {
-	FileObj *os.File
-	Writer  *pcapgo.NgWriter
+	FileObj os.File
+	Writer  pcapgo.NgWriter
 }
 
 type netInfo struct {
@@ -138,7 +138,7 @@ func (t *Tracee) createPcapFile(pcapContext processPcapId) (netPcap, error) {
 		return netPcap{}, err
 	}
 
-	pcap := netPcap{pcapFile, pcapWriter}
+	pcap := netPcap{*pcapFile, *pcapWriter}
 	t.netCapture.SetPcapWriter(pcapContext, pcap)
 
 	return pcap, nil


### PR DESCRIPTION
solves #1529.

introducing new struct `netPcap` to hold both the writer, and the file object. this way, on netExit, we can access the file object and close it (note: flushing the ngWriter is adviced before closing the underline file).

also, changed name of Tracee struct field: netPcap to netCapture.