### PR TITLE
tests: mount /boot for smoke tests

### DIFF
--- a/tests/tracee_test.go
+++ b/tests/tracee_test.go
@@ -26,6 +26,7 @@ func runTraceeContainer(ctx context.Context, tempDir string) (*traceeContainer, 
 		BindMounts: map[string]string{ // container:host
 			tempDir:                tempDir,           // required for all
 			"/etc/os-release-host": "/etc/os-release", // required for all
+			"/boot":                "/boot",           // required for all
 			"/usr/src":             "/usr/src",        // required for full
 			"/lib/modules":         "/lib/modules",    // required for full
 		},


### PR DESCRIPTION
Tests always fail with:
`error creating Tracee: could not read /boot/config-5.11.0-1028-azure: stat /boot/config-5.11.0-1028-azure: no such file or directory\n`

Fix this