### PR TITLE
tracee-ebpf: fix boot mount error

### DIFF
--- a/pkg/ebpf/initialization/kconfig.go
+++ b/pkg/ebpf/initialization/kconfig.go
@@ -40,5 +40,5 @@ func LoadKconfigValues(kc *helpers.KernelConfig, isDebug bool) (map[helpers.Kern
 			values[key] = kc.GetValue(key) // undefined, builtin OR module
 		}
 	}
-	return values, err
+	return values, nil
 }


### PR DESCRIPTION
#1532 fixed always failing tests issue, however, it didn't fix the root cause of the problem.
#1512 mistakenly returned an error when it failed to load kconfig values, instead of assuming values as was done before.
This PR fixes this.