### PR TITLE
tracee-ebpf: fix container removal in cgroup v1

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -5900,6 +5900,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Params: []trace.ArgMeta{
 			{Type: "u64", Name: "cgroup_id"},
 			{Type: "const char*", Name: "cgroup_path"},
+			{Type: "u32", Name: "hierarchy_id"},
 		},
 	},
 	SecurityBprmCheckEventID: {


### PR DESCRIPTION
Container removal didn't take into account cgroup hierarchy id, unlike
cgroupMkdir (container creation).
Under cgroup v1 environments, this might cause running containers to be
removed before they are actually removed. In case another container has
the same cgroup id, but in another cgroup hierarchy, the removal of such
a container will also remove the first one.

Fix this by updating the container maps for only one cgroup hierarchy (cpuset).

Close #1534