### PR TITLE
test(smoke): wait for tracee pid file before sigs are triggered

### DIFF
--- a/cmd/tracee-rules/output.go
+++ b/cmd/tracee-rules/output.go
@@ -22,8 +22,8 @@ Time: {{ dateInZone "2006-01-02T15:04:05Z" (now) "UTC" }}
 Signature ID: {{ .SigMetadata.ID }}
 Signature: {{ .SigMetadata.Name }}
 Data: {{ .Data }}
-Command: {{ .Context.ProcessName }}
-Hostname: {{ .Context.HostName }}
+Command: {{ .Event.Payload.ProcessName }}
+Hostname: {{ .Event.Payload.HostName }}
 `
 
 func setupTemplate(inputTemplateFile string) (*template.Template, error) {

--- a/tests/tracee_test.go
+++ b/tests/tracee_test.go
@@ -1,16 +1,20 @@
-package main
+package tests
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -24,7 +28,7 @@ func runTraceeContainer(ctx context.Context, tempDir string) (*traceeContainer, 
 		Image:      *traceeImageRef,
 		Privileged: true,
 		BindMounts: map[string]string{ // container:host
-			tempDir:                tempDir,           // required for all
+			"/tmp":                 tempDir,           // required for all
 			"/etc/os-release-host": "/etc/os-release", // required for all
 			"/boot":                "/boot",           // required for all
 			"/usr/src":             "/usr/src",        // required for full
@@ -35,14 +39,21 @@ func runTraceeContainer(ctx context.Context, tempDir string) (*traceeContainer, 
 		},
 		Name:       "tracee",
 		AutoRemove: true,
-		WaitingFor: wait.NewLogStrategy("Loaded"),
+		// FIXME(danielpacak) It seems that the file written by tracee-ebpf to
+		// /tmp/tracee/out/tracee.pid is not a reliable readiness probe on its
+		// own. It still may happen that tests are flaky without waiting extra
+		// few seconds here.
+		// See https://github.com/aquasecurity/tracee/issues/1548 for more
+		// details.
+		WaitingFor: NewFileExistsStrategy(path.Join(tempDir, "/tracee/out/tracee.pid")).
+			WithExtraDelay(10 * time.Second),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed creating tracee container: %w", err)
 	}
 
 	return &traceeContainer{Container: container}, nil
@@ -61,7 +72,7 @@ func runTraceeTesterContainer(ctx context.Context, sigID string) (*traceeContain
 		Started:          true,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed creating tracee tester container: %w", err)
 	}
 
 	return &traceeContainer{Container: container}, nil
@@ -101,6 +112,10 @@ func parseSignatureIDs() []string {
 //            -tracee-tester-image-ref "aquasec/tracee-tester:latest" \
 //            -tracee-signatures "TRC-2,TRC-3"
 func TestTraceeSignatures(t *testing.T) {
+	// TODO Normally we should be using tempDir := t.TempDir() but all files
+	// created by tracee-ebpf and entrypoint.sh under /tmp/tracee/ are owned by
+	// the root user and cannot be automatically removed by the test Cleanup
+	// method.
 	tempDir := os.TempDir()
 	defer func() {
 		os.RemoveAll(tempDir)
@@ -111,23 +126,20 @@ func TestTraceeSignatures(t *testing.T) {
 			ctx := context.Background()
 
 			traceeContainer, err := runTraceeContainer(ctx, tempDir)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			defer traceeContainer.Terminate(ctx)
 
 			err = traceeContainer.StartLogProducer(ctx)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			defer traceeContainer.StopLogProducer()
 
-			traceeContainer.FollowOutput(errorLogConsumer(t))
+			traceeContainer.FollowOutput(ErrorLogConsumer(t))
 
 			traceeTesterContainer, err := runTraceeTesterContainer(ctx, sigID)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			defer traceeTesterContainer.Terminate(ctx)
 
 			traceeContainer.assertLogs(t, ctx, sigID)
@@ -157,11 +169,86 @@ func (f LogConsumerFunc) Accept(log testcontainers.Log) {
 	f(log)
 }
 
-// errorLogConsumer returns testcontainers.LogConsumer that prints container
+// ErrorLogConsumer returns testcontainers.LogConsumer that prints container
 // logs to the error log. Logs will be printed only if the test fails or the
 // -test.v flag is set.
-func errorLogConsumer(t *testing.T) LogConsumerFunc {
+func ErrorLogConsumer(t *testing.T) LogConsumerFunc {
 	return func(log testcontainers.Log) {
 		t.Logf("%s: %s", log.LogType, string(log.Content))
 	}
+}
+
+type FileExistsStrategy struct {
+	startupTimeout time.Duration
+	pollInterval   time.Duration
+	extraDelay     *time.Duration
+	path           string
+}
+
+// NewFileExistsStrategy constructs FileExistsStrategy with polling interval of
+// 100 milliseconds and startup timeout of 30 seconds by default.
+func NewFileExistsStrategy(path string) *FileExistsStrategy {
+	return &FileExistsStrategy{
+		startupTimeout: 30 * time.Second,
+		pollInterval:   100 * time.Millisecond,
+		path:           path,
+	}
+}
+
+// WithPollInterval can be used to override the default polling interval of 100
+// milliseconds.
+func (ws *FileExistsStrategy) WithPollInterval(pollInterval time.Duration) *FileExistsStrategy {
+	ws.pollInterval = pollInterval
+	return ws
+}
+
+// WithExtraDelay can be used to add an extra delay even if the file already
+// exists.
+func (ws *FileExistsStrategy) WithExtraDelay(extraDelay time.Duration) *FileExistsStrategy {
+	ws.extraDelay = &extraDelay
+	return ws
+}
+
+// WaitUntilReady implements wait.Strategy#WaitUntilReady by checking whether
+// the given file exists.
+func (ws *FileExistsStrategy) WaitUntilReady(ctx context.Context, _ wait.StrategyTarget) error {
+	ctx, cancelContext := context.WithTimeout(ctx, ws.startupTimeout)
+	defer cancelContext()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			exists, err := ws.exists()
+			if err != nil {
+				return err
+			}
+
+			log.Printf("Waiting for file %s (exists? %v)\n", ws.path, exists)
+
+			if exists {
+				if ws.extraDelay != nil {
+					log.Printf("Waiting extra %s\n", ws.extraDelay)
+					time.Sleep(*ws.extraDelay)
+				}
+				return nil
+			} else {
+				time.Sleep(ws.pollInterval)
+				continue
+			}
+
+		}
+	}
+}
+
+func (ws *FileExistsStrategy) exists() (bool, error) {
+	_, err := os.Stat(ws.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }


### PR DESCRIPTION
To mitigate loosing detections when tracee-ebpf is not
ready when we trigger detection.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>