### PR TITLE
fix container pcaps not being closed

### DIFF
--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -182,10 +182,8 @@ func (t *Tracee) getPcapContextFromTid(hostTid uint32) (processPcapId, procinfo.
 			return pcapContext, procinfo.ProcessCtx{}, fmt.Errorf("unable to get ProcessCtx of hostTid %d to generate pcap context: %v", networkThread.HostPid, err)
 		}
 		pcapContext = t.getProcessPcapContext(networkProcess.HostPid, networkProcess.Comm, uint64(networkProcess.StartTime), contID)
-		return pcapContext, networkThread, nil
 	} else if t.config.Capture.NetPerContainer {
 		pcapContext = t.getContainerPcapContext(contID)
-		return pcapContext, networkThread, nil
 	}
 
 	return pcapContext, networkThread, nil


### PR DESCRIPTION
fixes #1544.

in `cgroup_rmdir` event, get the container id from the tracee Containers map. use this container id to get the pcap context, and close properly.

this approach forces getting the pcap context using the `container id`, and not the `hostTid` - therefore, created `getContainerPcapContext` func (and also `getProcessPcapContext`, `getHostPcapContext`) and generalized `getPcapContext`.