### PR TITLE
templates: change rawjson.tmpl to be backwards compatible

### DIFF
--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -250,3 +250,70 @@ HostName: foobar.local
 
 	}
 }
+
+func TestJsonTemplateV1(t *testing.T) {
+	testCases := []struct {
+		testName     string
+		finding      detect.Finding
+		expectedJson string
+	}{
+		{
+			testName: "convert finding to v1",
+			finding: detect.Finding{
+				Data: map[string]interface{}{
+					"a": 123,
+					"b": "c",
+					"d": true,
+					"f": map[string]string{
+						"123": "456",
+						"foo": "bar",
+					},
+				},
+				Event: trace.Event{
+					ProcessID:   21312,
+					Timestamp:   1321321,
+					UserID:      0,
+					ContainerID: "abbc123",
+					EventName:   "execve",
+				}.ToProtocol(),
+				SigMetadata: detect.SignatureMetadata{
+					ID:          "TRC-1",
+					Version:     "0.1.0",
+					Name:        "Standard Input/Output Over Socket",
+					Description: "Redirection of process's standard input/output to socket",
+					Tags:        []string{"linux", "container"},
+					Properties: map[string]interface{}{
+						"Severity":     3,
+						"MITRE ATT&CK": "Persistence: Server Software Component",
+					},
+				},
+			},
+			expectedJson: `{
+				"Data": {
+					"a":123,"b":"c","d":true,"f":{"123":"456","foo":"bar"}
+				},
+				"Context":{
+					"timestamp":1321321,"processorId":0,"processId":21312,"threadId":0,"parentProcessId":0,"hostProcessId":0,"hostThreadId":0,"hostParentProcessId":0,"userId":0,"mountNamespace":0,"pidNamespace":0,"processName":"","hostName":"","containerId":"abbc123","eventId":"0","eventName":"execve","argsNum":0,"returnValue":0,"stackAddresses":null,"args":null
+				},
+				"SigMetadata":{
+					"ID":"TRC-1","Version":"0.1.0","Name":"Standard Input/Output Over Socket","Description":"Redirection of process's standard input/output to socket","Tags":["linux","container"],"Properties":{"MITRE ATT\u0026CK":"Persistence: Server Software Component","Severity":3}
+				}
+			}`,
+		},
+	}
+
+	jsonTemplate, err := setupTemplate("templates/rawjson.tmpl")
+
+	require.NoError(t, err)
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			//pass finding through template and compare to a v1 json
+			var buf bytes.Buffer
+			jsonTemplate.Execute(&buf, tc.finding)
+
+			assert.JSONEq(t, tc.expectedJson, buf.String())
+		})
+	}
+
+}

--- a/cmd/tracee-rules/templates/rawjson.tmpl
+++ b/cmd/tracee-rules/templates/rawjson.tmpl
@@ -1,1 +1,1 @@
-{{ toJson . }}
+{"Data":{{ toJson .Data }},"Context":{{ toJson .Event.Payload }},"SigMetadata":{{ toJson .SigMetadata }}}


### PR DESCRIPTION
Some users have reported a breaking change when we changed `Finding.Context` to `Finding.Event.Payload`.

This PR updates the `rawjson.tmpl` to be backwards compatible with to the previous struct(from 0.6.5). Later json templates need to be versioned appropriately (A discussion on this will be opened in the near future).