### PR TITLE
limit number of open pcap using lru.Cache

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -340,7 +340,12 @@ func New(cfg Config) (*Tracee, error) {
 		t.Close()
 		return nil, fmt.Errorf("error creating output path: %v", err)
 	}
-	t.netInfo.pcapWriters = make(map[processPcapId]netPcap)
+
+	t.netInfo.pcapWriters, err = lru.NewWithEvict(openPcapsLimit, t.netInfo.PcapWriterOnEvict)
+	if err != nil {
+		t.Close()
+		return nil, err
+	}
 
 	// Get reference to stack trace addresses map
 	StackAddressesMap, err := t.bpfModule.GetMap("stack_addresses")


### PR DESCRIPTION
using lru.Cache as the map of the opened pcapWriters. a callback is called whenever a key is removed from this cache (due to LRU, or specifically remove due to process/container exit), enabling us to close the FD.

i set the limit to be 512 - just an arbitrary number that seems to me as good enough to let tracee use 1024-512 FDs, and also not having the overhead of opening an already existing pcap too many times.

if there are any other things to consider here - please let me know!