### PR TITLE
fix(deps): use OPA v0.35.0 in builder config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CMD_GO ?= go
 CMD_GREP ?= grep
 CMD_CAT ?= cat
 CMD_MD5 ?= md5sum
-CMD_OPA ?= opa # https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64
+CMD_OPA ?= opa # https://github.com/open-policy-agent/opa/releases/download/v0.35.0/opa_linux_amd64
 
 .check_%:
 #

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -63,7 +63,7 @@ RUN apk --no-cache update && \
     apk --no-cache add sudo curl && \
     apk --no-cache add libelf zlib && \
     apk --no-cache add libc6-compat && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.35.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 #

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -22,7 +22,7 @@ RUN apk --no-cache update && \
     apk --no-cache add elfutils-dev && \
     apk --no-cache add libelf-static && \
     apk --no-cache add zlib-static && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.35.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -21,7 +21,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y linux-headers-generic && \
     apt-get install -y libelf-dev && \
     apt-get install -y zlib1g-dev && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.35.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo

--- a/packaging/Dockerfile.fedora-packaging
+++ b/packaging/Dockerfile.fedora-packaging
@@ -25,7 +25,7 @@ RUN yum update -y && \
     yum install -y elfutils-libelf-devel && \
     yum install -y zlib-devel && \
     yum install -y rpm-build && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.35.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo

--- a/packaging/Dockerfile.ubuntu-packaging
+++ b/packaging/Dockerfile.ubuntu-packaging
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y build-essential devscripts ubuntu-dev-tools && \
     apt-get install -y debhelper dh-exec dpkg-dev pkg-config && \
     apt-get install -y software-properties-common && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.33.1/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.35.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo


### PR DESCRIPTION
We've declared OPA v0.35.0 in go.mod, but we are
using v0.33.1 throughout builder config files.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>