### PR TITLE
hooks detections:  file operations hooking under /proc

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -50,6 +50,20 @@ func main() {
 				return nil
 			}
 
+			// OS release information
+
+			OSInfo, err := helpers.GetOSInfo()
+			if err != nil {
+				if debug {
+					fmt.Fprintf(os.Stderr, "OSInfo: warning: os-release file could not be found\n(%v)\n", err) // only to be enforced when BTF needs to be downloaded, later on
+					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", helpers.OS_KERNEL_RELEASE, OSInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE))
+				}
+			} else if debug {
+				for k, v := range OSInfo.GetOSReleaseAllFieldValues() {
+					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", k, v)
+				}
+			}
+
 			// enable debug mode if debug flag is passed
 			if c.Bool("debug") {
 				err := flags.EnableDebugMode()

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -50,20 +50,6 @@ func main() {
 				return nil
 			}
 
-			// OS release information
-
-			OSInfo, err := helpers.GetOSInfo()
-			if err != nil {
-				if debug {
-					fmt.Fprintf(os.Stderr, "OSInfo: warning: os-release file could not be found\n(%v)\n", err) // only to be enforced when BTF needs to be downloaded, later on
-					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", helpers.OS_KERNEL_RELEASE, OSInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE))
-				}
-			} else if debug {
-				for k, v := range OSInfo.GetOSReleaseAllFieldValues() {
-					fmt.Fprintf(os.Stdout, "OSInfo: %v: %v\n", k, v)
-				}
-			}
-
 			// enable debug mode if debug flag is passed
 			if c.Bool("debug") {
 				err := flags.EnableDebugMode()

--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -211,7 +211,7 @@ func GetParamType(paramType string) ArgType {
 		return credT
 	case "umode_t":
 		return u16T
-	case "unsigned long[]":
+	case "unsigned long[]", "HookedFunctionData[]":
 		return uint64ArrT
 	default:
 		// Default to pointer (printed as hex) for unsupported types

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -112,10 +112,6 @@ func (s SlimCred) GetSizeBytes() uint32 {
 }
 
 type HookedSymbolData struct {
-	SyscallName string
+	SymbolName  string
 	ModuleOwner string
-}
-type SymbolData struct {
-	SymbolName    string
-	SymbolAddress string
 }

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -111,7 +111,7 @@ func (s SlimCred) GetSizeBytes() uint32 {
 	return 80
 }
 
-type HookedSyscallData struct {
+type HookedSymbolData struct {
 	SyscallName string
 	ModuleOwner string
 }

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -409,6 +409,12 @@ struct path {
 
 typedef unsigned int fmode_t;
 
+struct dir_context{};
+struct file_operations {
+	int (*iterate_shared) (struct file *, struct dir_context *);
+};
+
+
 struct file {
 	struct path f_path;
 	struct inode *f_inode;
@@ -582,6 +588,7 @@ struct inode {
 	long unsigned int i_ino;
 	struct timespec64 i_ctime;
 	loff_t i_size;
+	struct file_operations *i_fop;
 };
 
 struct super_block {

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -412,8 +412,8 @@ typedef unsigned int fmode_t;
 struct dir_context{};
 struct file_operations {
 	int (*iterate_shared) (struct file *, struct dir_context *);
+	int (*iterate) (struct file *, struct dir_context *);
 };
-
 
 struct file {
 	struct path f_path;

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -86,6 +86,7 @@ const (
 	DirtyPipeSpliceEventID
 	DebugfsCreateFile
 	PrintSyscallTableEventID
+	FetchProcFopsEventID
 	MaxCommonEventID
 )
 
@@ -96,6 +97,7 @@ const (
 	ContainerRemoveEventID
 	ExistingContainerEventID
 	DetectHookedSyscallsEventID
+	DetectHookedProcFopsEventID
 	MaxUserSpaceEventID
 )
 
@@ -6238,6 +6240,29 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "const char*", Name: "runtime"},
 			{Type: "const char*", Name: "container_id"},
 			{Type: "unsigned long", Name: "ctime"},
+		},
+	},
+	FetchProcFopsEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "fetch_proc_fops",
+		Probes: []probe{
+			{event: "security_file_permission", attach: kprobe, fn: "trace_security_file_permission"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "unsigned long[]", Name: "fops_address"},
+		},
+	},
+	DetectHookedProcFopsEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "detect_hooked_proc_fops",
+		Probes:  []probe{},
+		Dependencies: dependencies{
+			events: []eventDependency{{FetchProcFopsEventID}},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "HookedFunctionData[]", Name: "hooked_fops_pointers"},
 		},
 	},
 	NetPacket: {

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -86,7 +86,7 @@ const (
 	DirtyPipeSpliceEventID
 	DebugfsCreateFile
 	PrintSyscallTableEventID
-	FetchProcFopsEventID
+	DetectHookedProcFopsEventID
 	MaxCommonEventID
 )
 
@@ -97,7 +97,6 @@ const (
 	ContainerRemoveEventID
 	ExistingContainerEventID
 	DetectHookedSyscallsEventID
-	DetectHookedProcFopsEventID
 	MaxUserSpaceEventID
 )
 
@@ -6242,23 +6241,13 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "unsigned long", Name: "ctime"},
 		},
 	},
-	FetchProcFopsEventID: {
-		ID32Bit: sys32undefined,
-		Name:    "fetch_proc_fops",
-		Probes: []probe{
-			{event: "security_file_permission", attach: kprobe, fn: "trace_security_file_permission"},
-		},
-		Sets: []string{},
-		Params: []trace.ArgMeta{
-			{Type: "unsigned long[]", Name: "fops_address"},
-		},
-	},
 	DetectHookedProcFopsEventID: {
 		ID32Bit: sys32undefined,
 		Name:    "detect_hooked_proc_fops",
-		Probes:  []probe{},
+		Probes: []probe{
+			{event: "security_file_permission", attach: kprobe, fn: "trace_security_file_permission"},
+		},
 		Dependencies: dependencies{
-			events:   []eventDependency{{FetchProcFopsEventID}},
 			ksymbols: []string{"_stext", "_etext"},
 		},
 		Sets: []string{},

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -28,7 +28,7 @@ type eventDependency struct {
 
 type dependencies struct {
 	events   []eventDependency // Events required to be loaded and/or submitted for the event to happen
-	ksymbols []string
+	ksymbols []string          // kernel symbols required to the bpf programs
 }
 
 // EventDefinition is a struct describing an event configuration
@@ -6258,7 +6258,8 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "detect_hooked_proc_fops",
 		Probes:  []probe{},
 		Dependencies: dependencies{
-			events: []eventDependency{{FetchProcFopsEventID}},
+			events:   []eventDependency{{FetchProcFopsEventID}},
+			ksymbols: []string{"_stext", "_etext"},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -29,10 +29,18 @@ func (t *Tracee) initEventDerivationMap() error {
 		PrintSyscallTableEventID: {
 			DetectHookedSyscallsEventID: deriveDetectHookedSyscall(t),
 		},
+		FetchProcFopsEventID: {
+			DetectHookedProcFopsEventID: deriveDetectHookedProcFops(t),
+		},
 	}
 
 	return nil
 }
+
+const (
+	StructFopsPointer int = iota + 1
+	IterateShared
+)
 
 // deriveEvent takes a trace.Event and checks if it can derive additional events from it
 // as defined by tracee's eventDerivations map.
@@ -182,4 +190,52 @@ func parseSymbol(address uint64, table *helpers.KernelSymbolTable) *helpers.Kern
 	hookingFunction.Owner = strings.TrimPrefix(hookingFunction.Owner, "[")
 	hookingFunction.Owner = strings.TrimSuffix(hookingFunction.Owner, "]")
 	return hookingFunction
+}
+
+func deriveDetectHookedProcFops(t *Tracee) deriveFn{
+	return func(event trace.Event) (trace.Event, bool, error) {
+		fopsAddresses, err := getEventArgUlongArrVal(&event, "fops_address")
+		if err != nil {
+			return trace.Event{}, false, err
+		}
+		hookedFops := make([]bufferdecoder.HookedFunctionData, 0, 0)
+		for idx, addr := range fopsAddresses {
+			inTextSeg, err := t.kernelSymbols.TextSegmentContains(addr)
+			if err != nil {
+				return trace.Event{}, false, fmt.Errorf("error checking kernel address: %v", err)
+			}
+			if !inTextSeg {
+				hookingFunction, err := t.kernelSymbols.GetSymbolByAddr(addr)
+				if hookingFunction.Owner == "system" && err == nil {
+					continue
+				}
+				if err != nil {
+					hookingFunction.Owner = "hidden"
+				} else {
+					hookingFunction.Owner = strings.TrimPrefix(hookingFunction.Owner, "[")
+					hookingFunction.Owner = strings.TrimSuffix(hookingFunction.Owner, "]")
+				}
+				functionName := "unknown"
+				switch idx + 1 {
+				case StructFopsPointer:
+					functionName = "struct file_operations pointer"
+				case IterateShared:
+					functionName = "iterate_shared"
+				}
+				hookedFops = append(hookedFops, bufferdecoder.HookedFunctionData{functionName, hookingFunction.Owner})
+			}
+		}
+		de := event
+		de.EventID = int(DetectHookedProcFopsEventID)
+		de.EventName = "detect_hooked_proc_fops"
+		de.ReturnValue = 0
+		de.Args = []trace.Argument{
+			{ArgMeta: def.Params[0], Value: hookedFops},
+		}
+		de.ArgsNum = 1
+
+		return de, true, nil
+	}
+
+
 }

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -327,7 +327,6 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 				go t.netExit(pcapContext)
 			}
 		}
-
 		hId, err := getEventArgUint32Val(event, "hierarchy_id")
 		if err != nil {
 			return fmt.Errorf("error parsing cgroup_mkdir args: %w", err)


### PR DESCRIPTION
Hi 
This PR solves #1560 .

It is adding two new events.
1. `fetch_proc_fops` that print the user the addresses of the members of /proc file_opertions
2.  `detect_hooked_proc_fops` user-driven event that checks the memory region of the function address and alerts if it is out the range

Note:
The events now are just checking the addresses of the struct itself and the `iterate_shared` function because AFAIK this the function and this struct are commonly hooked by malware