### PR TITLE
containers: add missing detection for containerd

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -225,6 +225,9 @@ func getContainerIdFromCgroup(cgroupPath string) (string, string) {
 		case strings.HasPrefix(id, "cri-containerd-"):
 			runtime = "containerd"
 			id = strings.TrimPrefix(id, "cri-containerd-")
+		case strings.Contains(pc, ":cri-containerd:"):
+			runtime = "containerd"
+			id = pc[strings.LastIndex(pc, ":cri-containerd:")+len(":cri-containerd:"):]
 		case strings.HasPrefix(id, "libpod-"):
 			runtime = "podman"
 			id = strings.TrimPrefix(id, "libpod-")


### PR DESCRIPTION
This PR fixes the first case described in #1563

I've confirmed this works in a relevant local environment by tracing `cgroup_mkdir` and `container_create` events.