### PR TITLE
Adding call_usermode_helper event

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -82,6 +82,7 @@ const (
 	__KernelWriteEventID
 	ProcCreateEventID
 	KprobeAttachEventID
+	CallUsermodeHelperEventID
 	MaxCommonEventID
 )
 
@@ -6246,6 +6247,20 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "char*", Name: "symbol_name"},
 			{Type: "u64", Name: "pre_handler_addr"},
 			{Type: "u64", Name: "post_handler_addr"},
+		},
+	},
+	CallUsermodeHelperEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "call_usermodehelper",
+		Probes: []probe{
+			{event: "call_usermodehelper", attach: kprobe, fn: "trace_call_usermodehelper"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "const char*", Name: "pathname"},
+			{Type: "const char*const*", Name: "argv"},
+			{Type: "const char*const*", Name: "envp"},
+			{Type: "int", Name: "wait"},
 		},
 	},
 }


### PR DESCRIPTION
Hello 

This PR solves #1565 by adding kprobe to `call_usermode_helper()`.

`call_usermode_helper` is a function that is commonly used by kernel rootkits to interact with the user space from the kernel.

Here is the function man page:
[https://www.kernel.org/doc/htmldocs/kernel-api/API-call-usermodehelper.html](https://www.kernel.org/doc/htmldocs/kernel-api/API-call-usermodehelper.html
)

And This is an example of using this function to get container escape:
[https://xcellerator.github.io/posts/docker_escape/](https://xcellerator.github.io/posts/docker_escape/ )