### PR TITLE
Makefile: add "-fPIC" to libbpf compilation flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ $(OUTPUT_DIR)/tracee.bpf: \
 # libbpf
 #
 
-LIBBPF_CFLAGS =
+LIBBPF_CFLAGS = "-fPIC"
 LIBBPF_LDLAGS =
 LIBBPF_SRC = ./3rdparty/libbpf/src
 


### PR DESCRIPTION
@rafaeldtinoco 

This is in preparation for container enrichment, the issue arised when importing `containerd`'s runtime SDK, compilation would fail due to relocations, as I understand it most go modules are compiled with position independence by default but clang doesn't do so, and so conflicts sometimes happens with libbpf.

This flag should solve those issues.