### PR TITLE
Call pkg-config --libs to get dynamic package libs flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ CMD_OPA ?= opa # https://github.com/open-policy-agent/opa/releases/download/v0.3
 LIB_ELF ?= libelf
 LIB_ZLIB ?= zlib
 
+define pkg_config
+	$(CMD_PKGCONFIG) --libs $(1)
+endef
+
 .checklib_%: \
 	| .check_$(CMD_PKGCONFIG)
 #
@@ -442,7 +446,7 @@ ifeq ($(STATIC), 1)
 endif
 
 CUSTOM_CGO_CFLAGS = "-I$(abspath $(OUTPUT_DIR)/libbpf)"
-CUSTOM_CGO_LDFLAGS = "-lelf -lz $(abspath $(OUTPUT_DIR)/libbpf/libbpf.a)"
+CUSTOM_CGO_LDFLAGS = "$(shell $(call pkg_config, $(LIB_ELF))) $(shell $(call pkg_config, $(LIB_ZLIB))) $(abspath $(OUTPUT_DIR)/libbpf/libbpf.a)"
 
 GO_ENV_EBPF =
 GO_ENV_EBPF += GOOS=linux


### PR DESCRIPTION
Resolves #1542

Although checking the availability of a package in `checklib` rules,
the `pkg-config --libs` command should be used instead of hardcoded
`-lelf -lz` flags to support edge cases (for example,
when the libraries aren't located in the default directories).

cc @rafaeldtinoco 
