### PR TITLE
Remove interactive tty flags from docker run when building, RELEASING.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,4 +17,5 @@ jobs:
           docker login docker.io --username ${{ secrets.DOCKERHUB_USER }} --password-stdin <<<'${{ secrets.DOCKERHUB_TOKEN }}'
       - name: release
         run: |
-          make -f builder/Makefile.release SNAPSHOT_VERSION=$(git describe --tags --abbrev=0) PUSH_DOCKER_REPO=aquasec/tracee snapshot publish
+          make -f builder/Makefile.release SNAPSHOT_VERSION=$(git describe --tags --abbrev=0) PUSH_DOCKER_REPO=aquasec/tracee snapshot
+          make -f builder/Makefile.release SNAPSHOT_VERSION=$(git describe --tags --abbrev=0) PUSH_DOCKER_REPO=aquasec/tracee publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,6 +17,9 @@
 1. Prepare release by creating the PR with the following changes
    1. Update the libbpfgo module
    1. Update the types module
+   1. Update the container image tag in the following files:
+      1. `deploy/kubernetes/tracee-falcosidekick/falcosidekick.yaml`
+      1. `deploy/kubernetes/tracee-postee/tracee.yaml`
 1. Run tests and checks
    1. Check that there are no verifier issues when choosing all events in tracee-ebpf (using `--trace e=*`)
    1. Check both CO-RE and non CO-RE builds

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,46 @@
+# Releasing
+
+1. Checkout your fork and make sure it's up-to-date with the `upstream`
+   ```console
+   $ git remote -v
+   origin     git@github.com:<your account>/tracee.git (fetch)
+   origin     git@github.com:<your account>/tracee.git (push)
+   upstream   git@github.com:aquasecurity/tracee.git (fetch)
+   upstream   git@github.com:aquasecurity/tracee.git (push)
+   ```
+   ```
+   git pull -r
+   git fetch upstream
+   git merge upstream/main
+   git push
+   ```
+1. Prepare release by creating the PR with the following changes
+   1. Update the libbpfgo module
+   1. Update the types module
+1. Run tests and checks
+   1. Check that there are no verifier issues when choosing all events in tracee-ebpf (using `--trace e=*`)
+   1. Check both CO-RE and non CO-RE builds
+   1. Run all unit, integration, and e2e tests
+   1. Sanity checks for different special features
+      1. capture artifacts (files, memory, net, etc...)
+      1. table/json/gob printers output
+      1. tracee-ebpf with various filters
+   1. Check that docker images build correctly
+1. Run the above tests/checks for three different kernel versions include old kernels (4.18/4.19) and new ones (5.10+)
+1. Review and merge the PR (make sure all tests are passing)
+1. Update your fork again
+   ```
+   git pull -r
+   git fetch upstream
+   git merge upstream/main
+   git push
+   ```
+1. Create an annotated git tag and push it to the `upstream`. This will trigger the [`.github/workflows/release.yaml`] workflow
+   ```
+   git tag -v0.8.1 -m 'Release v0.8.1'
+   git push upstream v0.8.1
+   ```
+1. Verify that the `release` workflow has built and published the following artifacts
+   1. Tracee binaries (tracee-ebpf, tracee-rules, rules) in the form of a tar archive `tracee.<VERSION>.tar.gz`
+   1. Source code zip and tar files
+   1. Docker images pushed to the aquasec/tracee repository (`docker.io/aquasec/tracee:<VERSION>` and `docker.io/aquasec/tracee:full-<VERSION>`)

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -13,6 +13,7 @@ release: snapshot publish
 .ONESHELL:
 SHELL = /bin/sh
 
+MAKE = make
 MAKEFLAGS += --no-print-directory
 
 #
@@ -157,7 +158,7 @@ snapshot: \
 	.check_$(CMD_GITHUB)
 #
 	# build binaries (tracee-ebpf (CO-RE + BTFHUB), tracee-rules, rules)
-	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare ARG="all"
+	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare
 	BTFHUB=1 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="all"
 	# create the tar ball and checksum files
 	$(CMD_TAR) --exclude="*.so" -czf $(OUT_ARCHIVE) $(RELEASE_FILES)

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -13,7 +13,6 @@ release: snapshot publish
 .ONESHELL:
 SHELL = /bin/sh
 
-MAKE = make
 MAKEFLAGS += --no-print-directory
 
 #

--- a/builder/Makefile.tracee-make
+++ b/builder/Makefile.tracee-make
@@ -12,7 +12,6 @@ all: help
 .ONESHELL:
 SHELL = /bin/sh
 
-MAKE = make
 MAKEFLAGS += --no-print-directory
 
 #

--- a/builder/Makefile.tracee-make
+++ b/builder/Makefile.tracee-make
@@ -12,6 +12,7 @@ all: help
 .ONESHELL:
 SHELL = /bin/sh
 
+MAKE = make
 MAKEFLAGS += --no-print-directory
 
 #
@@ -176,7 +177,7 @@ alpine-make: \
 ifneq ($(ARG),)
 	$(CMD_DOCKER) \
 		$(DOCKER_RUN_ARGS) \
-		-it $(ALPINE_MAKE_CONTNAME) \
+		$(ALPINE_MAKE_CONTNAME) \
 		$(MAKE) $(ARG)
 endif
 
@@ -188,7 +189,7 @@ ubuntu-make: \
 ifneq ($(ARG),)
 	$(CMD_DOCKER) \
 		$(DOCKER_RUN_ARGS) \
-		-it $(UBUNTU_MAKE_CONTNAME) \
+		$(UBUNTU_MAKE_CONTNAME) \
 		$(MAKE) $(ARG)
 endif
 


### PR DESCRIPTION
The new release workflow has a flaw where the tar file asset does not contain the tracee-ebpf and tracee-rules binaries. This appears to be because the actual build is done in a docker container but that container is invoked with the `-it` flag, causing the build to fail. This PR removes those flags.

See failing command here: 
https://github.com/aquasecurity/tracee/runs/5631481033?check_suite_focus=true#step:4:1277

This also adds a RELEASING markdown file consistent with other Aqua projects.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>