### PR TITLE
chore(docs): preview mkdocs on macOS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,9 @@ Vagrant.configure("2") do |config|
   # config.vm.box = "ubuntu/hirsute64"   # Ubuntu 21.04 Hirsute Hippo (CO-RE)
   config.vm.box = "ubuntu/impish64"      # Ubuntu 21.10 Impish Indri (CO-RE)
 
+  # Forward MkDocs dev server to preview documentation on the host at http://localhost:8000/tracee
+  config.vm.network :forwarded_port, guest: 8000, host: 8000
+
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
     vb.memory = "2048"


### PR DESCRIPTION
Running make -f builder/Makefile.mkdocs on macOS doesn't really work.
With this patch to Vagrantfile we can run MkDocs server in Vagrant
guest machine and forward it to macOS host on http://localhost:8000.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>