### PR TITLE
pkg/ebpf: created dirty_pipe_splice event

### DIFF
--- a/pkg/ebpf/argprinters.go
+++ b/pkg/ebpf/argprinters.go
@@ -172,6 +172,13 @@ func (t *Tracee) parseArgs(event *trace.Event) error {
 				ParseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
+	case DirtyPipeSpliceEventID:
+		if modeArg := getEventArg(event, "in_file_type"); modeArg != nil {
+			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
+				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
+				ParseOrEmptyString(modeArg, inodeModeArgument, err)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/ebpf/c/missing_definitions.h
+++ b/pkg/ebpf/c/missing_definitions.h
@@ -193,4 +193,6 @@ static inline struct inet_sock *inet_sk(const struct sock *sk)
 	return (struct inet_sock *)sk;
 }
 
+#define PIPE_BUF_FLAG_CAN_MERGE	0x10	/* can merge buffers */
+
 #endif

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -417,6 +417,29 @@ struct file {
 	void *private_data;
 };
 
+struct pipe_inode_info {
+    struct pipe_buffer *bufs;
+    int head;
+    int ring_size;
+    unsigned int curbuf;
+};
+
+struct pipe_inode_info___v54 {
+    struct pipe_buffer *bufs;
+    unsigned int nrbufs, curbuf, buffers;
+};
+
+struct pipe_buffer {
+    struct page *page;
+    unsigned int offset;
+    unsigned int len;
+    unsigned int flags;
+};
+
+struct public_key_signature {
+    const void *data;
+};
+
 struct socket {
 	struct sock *sk;
 };
@@ -558,6 +581,7 @@ struct inode {
 	struct super_block *i_sb;
 	long unsigned int i_ino;
 	struct timespec64 i_ctime;
+	loff_t i_size;
 };
 
 struct super_block {

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -80,6 +80,7 @@ const (
 	SocketDupEventID
 	HiddenInodesEventID
 	__KernelWriteEventID
+	DirtyPipeSpliceEventID
 	MaxCommonEventID
 )
 
@@ -6172,6 +6173,27 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "unsigned long", Name: "inode"},
 			{Type: "size_t", Name: "count"},
 			{Type: "off_t", Name: "pos"},
+		},
+	},
+	DirtyPipeSpliceEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "dirty_pipe_splice",
+		Probes: []probe{
+			{event: "do_splice", attach: kprobe, fn: "trace_do_splice"},
+			{event: "do_splice", attach: kretprobe, fn: "trace_ret_do_splice"},
+		},
+		Sets: []string{},
+		Dependencies: dependencies{
+			ksymbols: []string{"pipefifo_fops"},
+		},
+		Params: []trace.ArgMeta{
+			{Type: "unsigned long", Name: "inode_in"},
+			{Type: "umode_t", Name: "in_file_type"},
+			{Type: "const char*", Name: "in_file_path"},
+			{Type: "loff_t", Name: "exposed_data_start_offset"},
+			{Type: "size_t", Name: "exposed_data_len"},
+			{Type: "unsigned long", Name: "inode_out"},
+			{Type: "unsigned int", Name: "out_pipe_last_buffer_flags"},
 		},
 	},
 	ContainerCreateEventID: {


### PR DESCRIPTION
Created an event to catch splice to a pipe which results that the last `pipe_buffer` struct has the `PIPE_BUF_CAN_MERGE` flag on. 
This will enable to catch vulnerable pipes used.
To have visibility of using the vulnerable pipe, an event that catches `pipe_write` function to a vulnerable pipe is needed.

Partly solves #1558 