### PR TITLE
adding detection for sequence operations hooks

### DIFF
--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -111,7 +111,7 @@ func (s SlimCred) GetSizeBytes() uint32 {
 	return 80
 }
 
-type HookedSyscallData struct {
+type HookedFunctionData struct {
 	SyscallName string
 	ModuleOwner string
 }

--- a/pkg/ebpf/argprinters.go
+++ b/pkg/ebpf/argprinters.go
@@ -179,6 +179,16 @@ func (t *Tracee) parseArgs(event *trace.Event) error {
 				ParseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
+	case FetchNetSeqOpsEventID:
+		if netSeqOpsArg := getEventArg(event, "net_seq_ops"); netSeqOpsArg != nil {
+			if netSeqOps, isUint64Arr := netSeqOpsArg.Value.([]uint64); isUint64Arr {
+				hexArr := make([]string, 5)
+				for idx, val := range netSeqOps {
+					hexArr[idx] = fmt.Sprintf("0x%x", val)
+				}
+				netSeqOpsArg.Value = hexArr
+			}
+		}
 	}
 
 	return nil

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -804,6 +804,15 @@ struct kprobe {
 	kprobe_post_handler_t post_handler;
 };
 
+struct seq_file{};
+
+struct seq_operations {
+	void * (*start) (struct seq_file *m, loff_t *pos);
+	void (*stop) (struct seq_file *m, void *v);
+	void * (*next) (struct seq_file *m, void *v, loff_t *pos);
+	int (*show) (struct seq_file *m, void *v);
+};
+
 #include <struct_flavors.h>
 
 #pragma clang attribute pop

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -86,6 +86,7 @@ const (
 	DirtyPipeSpliceEventID
 	DebugfsCreateFile
 	PrintSyscallTableEventID
+	FetchNetSeqOpsEventID
 	MaxCommonEventID
 )
 
@@ -96,6 +97,7 @@ const (
 	ContainerRemoveEventID
 	ExistingContainerEventID
 	DetectHookedSyscallsEventID
+	HiddenSocketsEventID
 	MaxUserSpaceEventID
 )
 
@@ -6323,6 +6325,15 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "HookedSyscallData[]", Name: "hooked_syscalls"},
+		},
+	},
+	FetchNetSeqOpsEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "fetch_net_seq_ops",
+		Probes:  []probe{{event: "security_file_ioctl", attach: kprobe, fn: "trace_security_file_ioctl"}},
+		Sets:    []string{},
+		Params: []trace.ArgMeta{
+			{Type: "unsigned long[]", Name: "net_seq_ops"},
 		},
 	},
 }

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -6330,10 +6330,34 @@ var EventsDefinitions = map[int32]EventDefinition{
 	FetchNetSeqOpsEventID: {
 		ID32Bit: sys32undefined,
 		Name:    "fetch_net_seq_ops",
-		Probes:  []probe{{event: "security_file_ioctl", attach: kprobe, fn: "trace_security_file_ioctl"}},
-		Sets:    []string{},
+		Probes: []probe{
+			{event: "security_file_ioctl", attach: kprobe, fn: "trace_tracee_fetch_net_seq_ops"},
+		},
+		Dependencies: dependencies{
+			ksymbols: []string{
+				"tcp4_seq_ops",
+				"tcp6_seq_ops",
+				"udp_seq_ops",
+				"udp6_seq_ops",
+				"raw_seq_ops",
+				"raw6_seq_ops"},
+		},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "unsigned long[]", Name: "net_seq_ops"},
+		},
+	},
+	HiddenSocketsEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "hidden_sockets",
+		Probes:  []probe{},
+		Dependencies: dependencies{
+			events: []eventDependency{{FetchNetSeqOpsEventID}},
+		},
+
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "[]helpers.KernelSymbol", Name: "hooked_seq_ops"},
 		},
 	},
 }


### PR DESCRIPTION
Hi 
This PR solves #1582 , by adding two events. 

The first event fetch addresses of the network interfaces sequence operations functions, and the second one is higher-level event that used to analyze if those function address are hooked 