### PR TITLE
arm64: fix compilation error by removing undefined cast

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -68,7 +68,7 @@ Copyright (C) Aqua Security inc.
 #if defined(bpf_target_x86)
 #define PT_REGS_PARM6(ctx)  ((ctx)->r9)
 #elif defined(bpf_target_arm64)
-#define PT_REGS_PARM6(x) (((PT_REGS_ARM64 *)(x))->regs[5])
+#define PT_REGS_PARM6(x) ((x)->regs[5])
 #endif
 
 #define MAX_PERCPU_BUFSIZE              (1 << 15) // set by the kernel as an upper bound


### PR DESCRIPTION
@grantseltzer this fix could land in this release as it is the only thing blocking tracee-ebpf to work in arm64 currently.

In order to have tracee-ebpf AND tracee-rules working (at least the events needed by existing signatures), I have opened https://github.com/aquasecurity/tracee/issues/1588.

@AnaisUrlichs I believe that with this one you may start playing with tracee-ebpf and tracee-rules in arm64 VMs.