### PR TITLE
Refactor event derivation mechanism

### DIFF
--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -6,87 +6,113 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
-type deriveFn func(EventDefinition) error
+// deriveFn is a function prototype for a function that receives an event as
+// argument and may produce a new event if relevant.
+// It returns the a derived or empty event, depending on succesful derivation,
+// a bool indicating if an event was derived, and an error if one occured.
+type deriveFn func(trace.Event) (trace.Event, bool, error)
 
-func (t *Tracee) deriveEvent(event trace.Event) []trace.Event {
-	var deriveFns map[int32]deriveFn
-	var derivatives []trace.Event
-
-	eventID := int32(event.EventID)
-	switch eventID {
-	case CgroupMkdirEventID:
-		containerCreateFn := func(def EventDefinition) error {
-			cgroupId, err := getEventArgUint64Val(&event, "cgroup_id")
-			if err != nil {
-				return err
-			}
-
-			if info := t.containers.GetCgroupInfo(cgroupId); info.ContainerId != "" {
-				de := event
-				de.EventID = int(ContainerCreateEventID)
-				de.EventName = "container_create"
-				de.ReturnValue = 0
-				de.StackAddresses = make([]uint64, 1)
-				de.Args = []trace.Argument{
-					{ArgMeta: def.Params[0], Value: info.Runtime},
-					{ArgMeta: def.Params[1], Value: info.ContainerId},
-					{ArgMeta: def.Params[2], Value: info.Ctime.UnixNano()},
-				}
-				de.ArgsNum = 3
-
-				derivatives = append(derivatives, de)
-			}
-
-			return nil
-		}
-		deriveFns = map[int32]deriveFn{
-			ContainerCreateEventID: containerCreateFn,
-		}
-	case CgroupRmdirEventID:
-		containerRemoveFn := func(def EventDefinition) error {
-			cgroupId, err := getEventArgUint64Val(&event, "cgroup_id")
-			if err != nil {
-				return err
-			}
-
-			if info := t.containers.GetCgroupInfo(cgroupId); info.ContainerId != "" {
-				de := event
-				de.EventID = int(ContainerRemoveEventID)
-				de.EventName = "container_remove"
-				de.ReturnValue = 0
-				de.StackAddresses = make([]uint64, 1)
-				de.Args = []trace.Argument{
-					{ArgMeta: def.Params[0], Value: info.Runtime},
-					{ArgMeta: def.Params[1], Value: info.ContainerId},
-				}
-				de.ArgsNum = 2
-
-				derivatives = append(derivatives, de)
-			}
-
-			return nil
-		}
-		deriveFns = map[int32]deriveFn{
-			ContainerRemoveEventID: containerRemoveFn,
-		}
+// Initialize the eventDerivations map.
+// Here we declare for each Event (represented through it's ID)
+// to which other Events it can be derived and the corresponding function to derive into that Event.
+func (t *Tracee) initEventDerivationMap() error {
+	t.eventDerivations = map[int32]map[int32]deriveFn{
+		CgroupMkdirEventID: {
+			ContainerCreateEventID: deriveContainerCreate(t),
+		},
+		CgroupRmdirEventID: {
+			ContainerRemoveEventID: deriveContainerRemoved(t),
+		},
 	}
 
+	return nil
+}
+
+// deriveEvent takes a trace.Event and checks if it can derive additional events from it
+// as defined by tracee's eventDerivations map.
+// The map is initialized in the above function
+func (t *Tracee) deriveEvent(event trace.Event) []trace.Event {
+	derivatives := []trace.Event{}
+	deriveFns := t.eventDerivations[int32(event.EventID)]
 	for id, deriveFn := range deriveFns {
 		// Don't derive events which were not requested by the user
 		if !t.eventsToTrace[id] {
 			continue
 		}
 
-		def, ok := EventsDefinitions[id]
-		if !ok {
-			t.handleError(fmt.Errorf("failed to get configuration of event %d", id))
-			continue
-		}
-
-		if err := deriveFn(def); err != nil {
+		derivative, derived, err := deriveFn(event)
+		if err != nil {
 			t.handleError(fmt.Errorf("failed to derive event %d: %v", id, err))
+		} else if derived {
+			derivatives = append(derivatives, derivative)
 		}
 	}
 
 	return derivatives
+}
+
+/*
+* Derivation functions:
+* Most derivation functions take tracee as a closure argument to track it's runtime state
+* Tracee builds it's derivation map from these functions and injects itself as an argument to the closures
+* The derivation map is then built with the returned deriveFn functions, which is used in deriveEvents
+ */
+
+//Receives a tracee object as a closure argument to track it's containers
+//If it receives a cgroup_mkdir event, it can derive a container_create event from it
+func deriveContainerCreate(t *Tracee) deriveFn {
+	return func(event trace.Event) (trace.Event, bool, error) {
+		cgroupId, err := getEventArgUint64Val(&event, "cgroup_id")
+		if err != nil {
+			return trace.Event{}, false, err
+		}
+
+		def := EventsDefinitions[ContainerCreateEventID]
+		if info := t.containers.GetCgroupInfo(cgroupId); info.ContainerId != "" {
+			de := event
+			de.EventID = int(ContainerCreateEventID)
+			de.EventName = def.Name
+			de.ReturnValue = 0
+			de.StackAddresses = make([]uint64, 1)
+			de.Args = []trace.Argument{
+				{ArgMeta: def.Params[0], Value: info.Runtime},
+				{ArgMeta: def.Params[1], Value: info.ContainerId},
+				{ArgMeta: def.Params[2], Value: info.Ctime.UnixNano()},
+			}
+			de.ArgsNum = len(de.Args)
+
+			return de, true, nil
+		}
+
+		return trace.Event{}, false, nil
+	}
+}
+
+//Receives a tracee object as a closure argument to track it's containers
+//If it receives a cgroup_rmdir event, it can derive a container_remove event from it
+func deriveContainerRemoved(t *Tracee) deriveFn {
+	return func(event trace.Event) (trace.Event, bool, error) {
+		cgroupId, err := getEventArgUint64Val(&event, "cgroup_id")
+		if err != nil {
+			return trace.Event{}, false, err
+		}
+
+		def := EventsDefinitions[ContainerRemoveEventID]
+		if info := t.containers.GetCgroupInfo(cgroupId); info.ContainerId != "" {
+			de := event
+			de.EventID = int(ContainerRemoveEventID)
+			de.EventName = def.Name
+			de.ReturnValue = 0
+			de.StackAddresses = make([]uint64, 1)
+			de.Args = []trace.Argument{
+				{ArgMeta: def.Params[0], Value: info.Runtime},
+				{ArgMeta: def.Params[1], Value: info.ContainerId},
+			}
+			de.ArgsNum = len(de.Args)
+
+			return de, true, nil
+		}
+
+		return trace.Event{}, false, nil
+	}
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"io"
 	"net"
 	"os"
@@ -24,6 +23,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/pkg/containers"
 	"github.com/aquasecurity/tracee/pkg/ebpf/initialization"
+	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"github.com/aquasecurity/tracee/pkg/events/sorting"
 	"github.com/aquasecurity/tracee/pkg/metrics"
 	"github.com/aquasecurity/tracee/pkg/procinfo"
@@ -179,6 +179,7 @@ type Tracee struct {
 	containers        *containers.Containers
 	procInfo          *procinfo.ProcInfo
 	eventsSorter      *sorting.EventsChronologicalSorter
+	eventDerivations  map[int32]map[int32]deriveFn
 }
 
 func (t *Tracee) Stats() *metrics.Stats {
@@ -260,6 +261,12 @@ func New(cfg Config) (*Tracee, error) {
 		if event.EssentialEvent && !t.eventsToTrace[id] {
 			t.eventsToTrace[id] = false
 		}
+	}
+
+	// Initialize event derivation map
+	err = t.initEventDerivationMap()
+	if err != nil {
+		return nil, fmt.Errorf("error intitalizing event derivation map: %w", err)
 	}
 
 	c, err := containers.InitContainers()


### PR DESCRIPTION
This PR refactors the `deriveEvent` function and mechanism so that it is:

1. More declarative in syntax
2. Takes less cpu time (reduced by 3.91% of overall time in code path)

# The changes

The `Tracee` object now initializes a map on startup of type `map[int32]map[int32]deriveFn`, this represents a map of a derived EventID to its possible derivations and their corresponding deriving functions.

Then `deriveEvents` can simply check if the current event has any derivations to be done and get the map of all it's derivative functions, instead of calculating that map on each `deriveEvents` call which causes unnecessary GC work due to the map and function variable assignments.

This improves CPU usage in runtime and allows a more declarative approach to defining event derivatives through the map initialization function (`initEventDerivationMap` in `events_derived.go`)

# Performance analysis

In terms of benchmarking I did not see any regression in throughput.
I have generated pprofs of before and after to check if the bottleneck was removed, the graph output shows this:

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/22661609/160284355-82abf924-b884-4db2-9eef-441632adc675.png">

As can be seen we have reduced time in mallocgc through a reduction from `deriveEvents`. As expected we have gained some time back in `mapaccess` however it's easily seen that the difference in time is negative (a gain in cpu time).
I have not seen any new bottleneck arising from this, and I have attached the pprofs so this can be confirmed by others.

pprofs: 
1. [before](https://github.com/aquasecurity/tracee/files/8357725/070.pb.gz)
2. [after](https://github.com/aquasecurity/tracee/files/8357728/refactor.pb.gz)

A diff pprof can be generated as such:
`go tool pprof -http=":4441" -diff_base 070.pb.gz refactor.pb.gz`

