### PR TITLE
add grafana dashboard for tracee metrics

### DIFF
--- a/deploy/grafana/README.md
+++ b/deploy/grafana/README.md
@@ -1,0 +1,3 @@
+# Using the Dashboard
+
+A tutorial for importing this dashboard (and general usage of Tracee with Prometheus and Grafana) can be found [here](https://github.com/aquasecurity/tracee/blob/grafana-dashboard/docs/tutorials/deploy-grafana-dashboard.md).

--- a/deploy/grafana/tracee.json
+++ b/deploy/grafana/tracee.json
@@ -1,0 +1,417 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 1,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 5,
+          "x": 0,
+          "y": 0
+        },
+        "id": 10,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "tracee_rules_detections_total",
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Detections",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 5,
+          "x": 5,
+          "y": 0
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "tracee_rules_signatures_total",
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "Signatures Loaded",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "description": "The rate of events processed and lost",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineInterpolation": "smooth",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 18,
+          "w": 13,
+          "x": 10,
+          "y": 0
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom"
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "rate(tracee_ebpf_events_total[10s])",
+            "interval": "",
+            "legendFormat": "events/sec",
+            "refId": "events/sec"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "rate(tracee_ebpf_lostevents_total[10s])",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "lost_events/sec",
+            "refId": "lost_events/sec"
+          }
+        ],
+        "title": "Events Throughput",
+        "type": "timeseries"
+      },
+      {
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 10,
+          "x": 0,
+          "y": 5
+        },
+        "id": 6,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "textMode": "auto"
+        },
+        "pluginVersion": "8.4.4",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "tracee_ebpf_events_total",
+            "interval": "",
+            "legendFormat": "",
+            "refId": "A"
+          }
+        ],
+        "title": "EBPF Events Produced",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              }
+            },
+            "mappings": []
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 10,
+          "x": 0,
+          "y": 10
+        },
+        "id": 8,
+        "options": {
+          "displayLabels": [
+            "value"
+          ],
+          "legend": {
+            "displayMode": "list",
+            "placement": "right"
+          },
+          "pieType": "pie",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "tracee_ebpf_lostevents_total",
+            "interval": "",
+            "legendFormat": "Buffer Lost Events",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "tracee_ebpf_network_lostevents_total",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Network Lost Events",
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "w5C9dFs7k"
+            },
+            "exemplar": true,
+            "expr": "tracee_ebpf_write_lostevents_total",
+            "hide": false,
+            "interval": "",
+            "legendFormat": "Write Lost Events",
+            "refId": "C"
+          }
+        ],
+        "title": "Lost Events",
+        "transparent": true,
+        "type": "piechart"
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 35,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Tracee Dashboard",
+    "uid": "6E_JKFy7z",
+    "version": 6,
+    "weekStart": ""
+  }

--- a/docs/tutorials/deploy-grafana-dashboard.md
+++ b/docs/tutorials/deploy-grafana-dashboard.md
@@ -1,0 +1,76 @@
+# Deploy Grafana Dashboard
+
+Grafana is a visualization tools for exported metrics and logs, most commomly used alongside prometheus.
+
+Since version 0.7.0, tracee exports useful runtime metrics to prometheus.
+These metrics exports are enabled by default in all docker images and can be enabled using the `--metrics` flag in both [tracee-ebpf](https://github.com/aquasecurity/tracee/tree/main/cmd/tracee-ebpf) and [tracee-rules](https://github.com/aquasecurity/tracee/tree/main/cmd/tracee-rules).
+
+By using grafana and the new metrics from tracee, we can deploy a simple dashboard which tracks your tracee's instance performance and outputs.
+
+# Prequisites
+
+The following tools must be available for use, they can all be installed either through docker or installed/built on your machine.
+
+- [Tracee](https://github.com/aquasecurity/tracee/)
+- [Prometheus](https://prometheus.io/download/)
+- [Grafana](https://grafana.com/docs/grafana/latest/getting-started/getting-started)
+
+# Run Tracee with Metrics Enabled
+
+Tracee can be most easily deployed with metrics enabled by default and port forwarded through the following commands:
+
+`docker run --name tracee --rm --pid=host --cgroupns=host --privileged -v /tmp/tracee:/tmp/tracee  -v /etc/os-release:/etc/os-release-host:ro  -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host -it -p 3366:3366 -p 4466:4466 aquasec/tracee:latest`
+
+Of course, the forwarded metrics ports can be changed, but you should note that some of the later instructions depend on these ports.
+
+If running Tracee locally through built binaries, the metrics address may be overriden with the `--metrics-addr` flag in both tracee-ebpf and tracee-rules.
+
+# Run Prometheus and Configure it to Scrape Tracee
+
+Install prometheus or pull it's docker image.
+Then create the following configuration file, call it `prometheus.yml` to scrape Tracee:
+```
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Tracee.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    #Scrape Tracee-Ebpf's and Tracee-Rules's default metrics hosts.
+    #If forwarding different ports make sure to change these addresses.
+    static_configs:
+      - targets: ['localhost:3366', 'localhost:4466']
+```
+
+We must then start prometheus with the following command:
+`prometheus --config.file=/path/to/prometheus.yml`
+Or alternatively with docker:
+`docker run -p 9090:9090 -v /path/to/config:/etc/prometheus prom/prometheus`
+
+Then, try to access prometheus through http://localhost:9090. If succesful, move to the next step, otherwise consult with prometheus documentation.
+
+# Run Grafana to display Tracee's Prometheus Metrics
+
+After succesfuly deploying Tracee and Prometheus we may now run Grafana to visualize it's metrics.
+
+Install grafana using their instructions and enter the now available grafana website (by default it's usually through http://localhost:3000).
+
+After entering the website, logging in with username and password `admin` (and changing your password if you wish), you should see the homepage:
+
+![image](https://user-images.githubusercontent.com/22661609/160572543-771d4a0e-d7d8-46d2-bf51-7c9f64487bf8.png)
+
+Add your data source by hovering the configuration tab (the gear icon), selecting "Data Sources" and pressing "Add Data Source" at the top left.
+Create a Prometheus Data Source and point it's URL to the relevant location (usually http://localhost:9090)
+
+You may now either create your own Dashboard or import our default dashboard.
+
+# Import Tracee's Default Dashboard
+
+First download our Grafana Dashboard's json [here](https://github.com/aquasecurity/tracee/tree/main/deploy/grafana/tracee.json).
+
+After adding the data source hover on the plus icon in the sidebar and select "Import". Press "Upload JSON File" at the top of the page and select the downloaded json from your file browser. Change the name and Dashboard UID if you wish and press "Import" to finish. 
+
+Finally you will be redirected to the dashboard 🥳


### PR DESCRIPTION
Adds a json for importing a tracee metrics dashboard (for both tracee-ebpf and tracee-rules).

An example of the dashboard:
![image](https://user-images.githubusercontent.com/22661609/160441500-c90a3bd2-e899-4469-b210-c279af24d777.png)

This provides a simple demonstration of the usage for the prometheus metrics feature.