### PR TITLE
add proc_create event

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3154,10 +3154,11 @@ int BPF_KPROBE(trace_proc_create)
 
     char * name = (char *)PT_REGS_PARM1(ctx);
     unsigned long proc_ops_addr = (unsigned long) PT_REGS_PARM4(ctx);
+    
     save_str_to_buf(&data, name, 0);
     save_to_submit_buf(&data, (void *)&proc_ops_addr, sizeof(u64), 1);
+    
     return events_perf_submit(&data, PROC_CREATE, 0);
-
 }
 
 SEC("kprobe/security_socket_listen")

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -80,6 +80,7 @@ const (
 	SocketDupEventID
 	HiddenInodesEventID
 	__KernelWriteEventID
+	ProcCreateEventID
 	MaxCommonEventID
 )
 
@@ -6219,6 +6220,18 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets:    []string{},
 		Params: []trace.ArgMeta{
 			{Type: "external.PktMeta", Name: "metadata"},
+		},
+	},
+	ProcCreateEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "proc_create",
+		Probes: []probe{
+			{event: "proc_create", attach: kprobe, fn: "trace_proc_create"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "char*", Name: "name"},
+			{Type: "u64", Name: "proc_ops_addr"},
 		},
 	},
 }


### PR DESCRIPTION
Hi 

Sometimes malware try to create a secret backdoor to communicate with the user-space, which could be done by creating a file under /proc with a special file operation that handles that the malware tasks.

This PR on of 2 that will solve #1613 which is the about this problem around the entire the Linux kernel (not just under /proc).


Its added an event that trace calls of `proc_create` that communally used by malwares to deploy files under /proc in order to create a commination between the kernel space to the user space.