### PR TITLE
introduce dns events

### DIFF
--- a/pkg/bufferdecoder/net_decoder.go
+++ b/pkg/bufferdecoder/net_decoder.go
@@ -34,6 +34,15 @@ func (decoder *EbpfDecoder) DecodeNetEventMetadata(eventMetaData *NetEventMetada
 	return nil
 }
 
+func (decoder *EbpfDecoder) DecodePacketBytes(packetBytes []byte, packetstartOffset uint32, packetLength uint32) error {
+	if int(packetstartOffset+packetLength) > len(decoder.buffer) {
+		print(packetstartOffset+packetLength, " len is ", decoder.buffer)
+		return fmt.Errorf("offset to the payload to big")
+	}
+	_ = copy(packetBytes[:], decoder.buffer[packetstartOffset:packetstartOffset+packetLength])
+	return nil
+}
+
 type NetCaptureData struct {
 	PacketLength     uint32 `json:"pkt_len"`
 	ConfigIfaceIndex uint32 `json:"if_index"`

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4838,7 +4838,7 @@ static __always_inline bool skb_revalidate_data(struct __sk_buff *skb, uint8_t *
     return true;
 }
 
-void parse_net_protocols(net_packet_t *pkt){
+void set_net_event_id(net_packet_t *pkt){
     if (pkt->protocol == IPPROTO_UDP && pkt->dst_port == 53){
         pkt->event_id = DNS_REQUEST;
     }
@@ -5010,7 +5010,7 @@ static __always_inline int tc_probe(struct __sk_buff *skb, bool ingress) {
         pkt_size = sizeof(pkt);
         pkt.src_port = __bpf_ntohs(pkt.src_port);
         pkt.dst_port = __bpf_ntohs(pkt.dst_port);
-        parse_net_protocols(&pkt);
+        set_net_event_id(&pkt);
     }
 
     if (iface_conf & CAPTURE_IFACE || should_send_payload(&pkt)){

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4839,15 +4839,16 @@ static __always_inline bool skb_revalidate_data(struct __sk_buff *skb, uint8_t *
 }
 
 void set_net_event_id(net_packet_t *pkt){
-    if (pkt->protocol == IPPROTO_UDP && pkt->dst_port == 53){
+    const int dns_port = 53;
+    if (pkt->protocol == IPPROTO_UDP && pkt->dst_port == dns_port){
         pkt->event_id = DNS_REQUEST;
     }
-    if (pkt->protocol == IPPROTO_UDP && pkt->src_port == 53){
+    if (pkt->protocol == IPPROTO_UDP && pkt->src_port == dns_port){
         pkt->event_id = DNS_RESPONSE;
     }
 }
 
-bool should_send_payload(net_packet_t *pkt){
+bool should_submit_payload(net_packet_t *pkt){
     if (pkt->event_id == DNS_REQUEST || pkt->event_id == DNS_RESPONSE)
         return true;
     return false;
@@ -5013,7 +5014,7 @@ static __always_inline int tc_probe(struct __sk_buff *skb, bool ingress) {
         set_net_event_id(&pkt);
     }
 
-    if (iface_conf & CAPTURE_IFACE || should_send_payload(&pkt)){
+    if (iface_conf & CAPTURE_IFACE || should_submit_payload(&pkt)){
         flags |= (u64)skb->len << 32;
     }
     bpf_perf_event_output(skb, &net_events, flags, &pkt, pkt_size);

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -103,6 +103,8 @@ const Unique32BitSyscallsStartID = 3000
 
 const (
 	NetPacket int32 = iota + 4000
+	DnsRequest
+	DnsResponse
 	MaxNetEventID
 )
 
@@ -6241,12 +6243,35 @@ var EventsDefinitions = map[int32]EventDefinition{
 		},
 	},
 	NetPacket: {
-		ID32Bit: sys32undefined,
-		Name:    "net_packet",
-		Probes:  []probe{},
-		Sets:    []string{},
+		ID32Bit:      sys32undefined,
+		Name:         "net_packet",
+		Probes:       []probe{},
+		Dependencies: dependencies{},
+		Sets:         []string{"network_events"},
 		Params: []trace.ArgMeta{
-			{Type: "external.PktMeta", Name: "metadata"},
+			{Type: "trace.PktMeta", Name: "metadata"},
+		},
+	},
+	DnsRequest: {
+		ID32Bit:      sys32undefined,
+		Name:         "dns_request",
+		Probes:       []probe{},
+		Dependencies: dependencies{},
+		Sets:         []string{"network_events"},
+		Params: []trace.ArgMeta{
+			{Type: "trace.PktMeta", Name: "metadata"},
+			{Type: "[]bufferdecoder.DnsQueryData", Name: "dns_questions"},
+		},
+	},
+	DnsResponse: {
+		ID32Bit:      sys32undefined,
+		Name:         "dns_response",
+		Probes:       []probe{},
+		Dependencies: dependencies{},
+		Sets:         []string{"network_events"},
+		Params: []trace.ArgMeta{
+			{Type: "trace.PktMeta", Name: "metadata"},
+			{Type: "[]bufferdecoder.DnsResponseData", Name: "dns_response"},
 		},
 	},
 	ProcCreateEventID: {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -95,7 +95,7 @@ func (tc Config) Validate() error {
 		if _, ok := EventsDefinitions[e]; !ok {
 			return fmt.Errorf("invalid event to trace: %d", e)
 		}
-		if e == NetPacket {
+		if isNetEvent(e) {
 			if len(tc.Filter.NetFilter.InterfacesToTrace) == 0 {
 				return fmt.Errorf("missing interface for net event: %s, please add -t net=<iface>", EventsDefinitions[e].Name)
 			}
@@ -1025,7 +1025,7 @@ func (t *Tracee) initBPF() error {
 		return err
 	}
 
-	if t.eventsToTrace[NetPacket] && len(t.config.Filter.NetFilter.InterfacesToTrace) == 0 {
+	if t.netEventChoosen() && len(t.config.Filter.NetFilter.InterfacesToTrace) == 0 {
 		return fmt.Errorf("couldn't trace %s event, missing interface", EventsDefinitions[NetPacket].Name)
 	}
 	for _, iface := range t.netInfo.ifaces {
@@ -1292,6 +1292,14 @@ func findInList(element string, list *[]string) (int, error) {
 		}
 	}
 	return 0, fmt.Errorf("element: %s dosent found\n", element)
+}
+func (t *Tracee) netEventChoosen() bool {
+	for i := NetPacket; i < MaxNetEventID; i++ {
+		if t.eventsToTrace[i] {
+			return true
+		}
+	}
+	return false
 }
 
 const IoctlFetchSyscalls int = 65 // randomly picked number for ioctl cmd

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1025,7 +1025,7 @@ func (t *Tracee) initBPF() error {
 		return err
 	}
 
-	if t.netEventChoosen() && len(t.config.Filter.NetFilter.InterfacesToTrace) == 0 {
+	if t.shouldTraceNetEvents() && len(t.config.Filter.NetFilter.InterfacesToTrace) == 0 {
 		return fmt.Errorf("couldn't trace %s event, missing interface", EventsDefinitions[NetPacket].Name)
 	}
 	for _, iface := range t.netInfo.ifaces {
@@ -1293,7 +1293,7 @@ func findInList(element string, list *[]string) (int, error) {
 	}
 	return 0, fmt.Errorf("element: %s dosent found\n", element)
 }
-func (t *Tracee) netEventChoosen() bool {
+func (t *Tracee) shouldTraceNetEvents() bool {
 	for i := NetPacket; i < MaxNetEventID; i++ {
 		if t.eventsToTrace[i] {
 			return true


### PR DESCRIPTION
Hi 
This PR solves #1384.

Its adds 2 new events that are part of the net events.
Also, it adds the set of the net events to the `events_definitions `map and changes the function that handles the net events to be able to handle more than one event (until today we had only one net event which is `NetPacket`).


How it works:
In the `tc_probe` function at the bpf code, I check if the packet is has a src/dst port of DNS (53) and if it's UDP.
Then it sends it with event_id of `DnsRequest` or `DnsResponse`.
in the `net_event.go` I added a function that will handle the processing of all the network events.
It basically has a switch-case with the event_id of the packet and the net events types, in case it found the event, it calls its `event_handler_function`.

Here's an example for output for trying loacte the ip of www.ubuntu.com:
`itamar@ubuntu:~/golang_env$ sudo ./dist/tracee-ebpf -t  event=dns_request,dns_response -t net=ens33 -o json
`
libbpf: Kernel error message: Exclusivity flag on, cannot modify

"timestamp":1649334493999995757,"processorId":0,"processId":759,"threadId":759,"parentProcessId":759,"hostProcessId":759,"hostThreadId":759,"hostParentProcessId":1,"userId":101,"mountNamespace":4026532596,"pidNamespace":4026531836,"processName":"systemd-resolve\u0000","hostName":"","containerId":"","eventId":"4001","eventName":"dns_request","argsNum":2,"returnValue":0,"stackAddresses":null,"args":[{"name":"metadata","type":"trace.PktMeta","value":{"src_ip":"192.168.16.134","dst_ip":"192.168.16.2","src_port":35807,"dst_port":53,"protocol":17}},{"name":"dns_questions","type":"[]bufferdecoder.DnsQueryData","value":[{"query":"www.ubuntu.com","queryType":"A","queryClass":"IN"}]}]}

{"timestamp":1649334494085087526,"processorId":0,"processId":759,"threadId":759,"parentProcessId":759,"hostProcessId":759,"hostThreadId":759,"hostParentProcessId":1,"userId":101,"mountNamespace":4026532596,"pidNamespace":4026531836,"processName":"systemd-resolve\u0000","hostName":"","containerId":"","eventId":"4002","eventName":"dns_response","argsNum":2,"returnValue":0,"stackAddresses":null,"args":[{"name":"metadata","type":"trace.PktMeta","value":{"src_ip":"192.168.16.2","dst_ip":"192.168.16.134","src_port":53,"dst_port":35807,"protocol":17}},{"name":"dns_response","type":"[]bufferdecoder.DnsResponseData","value":[{"query_data":{"query":"www.ubuntu.com","queryType":"A","queryClass":"IN"},"dns_answer":[{"answer_type":"A","ttl":5,"answer":"185.125.190.20"},{"answer_type":"A","ttl":5,"answer":"185.125.190.21"},{"answer_type":"A","ttl":5,"answer":"185.125.190.29"}]}]}]}

{"timestamp":1649334494088166734,"processorId":0,"processId":759,"threadId":759,"parentProcessId":759,"hostProcessId":759,"hostThreadId":759,"hostParentProcessId":1,"userId":101,"mountNamespace":4026532596,"pidNamespace":4026531836,"processName":"systemd-resolve\u0000","hostName":"","containerId":"","eventId":"4001","eventName":"dns_request","argsNum":2,"returnValue":0,"stackAddresses":null,"args":[{"name":"metadata","type":"trace.PktMeta","value":{"src_ip":"192.168.16.134","dst_ip":"192.168.16.2","src_port":51095,"dst_port":53,"protocol":17}},{"name":"dns_questions","type":"[]bufferdecoder.DnsQueryData","value":[{"query":"www.ubuntu.com","queryType":"AAAA","queryClass":"IN"}]}]}

{"timestamp":1649334494169898401,"processorId":0,"processId":759,"threadId":759,"parentProcessId":759,"hostProcessId":759,"hostThreadId":759,"hostParentProcessId":1,"userId":101,"mountNamespace":4026532596,"pidNamespace":4026531836,"processName":"systemd-resolve\u0000","hostName":"","containerId":"","eventId":"4002","eventName":"dns_response","argsNum":2,"returnValue":0,"stackAddresses":null,"args":[{"name":"metadata","type":"trace.PktMeta","value":{"src_ip":"192.168.16.2","dst_ip":"192.168.16.134","src_port":53,"dst_port":51095,"protocol":17}},{"name":"dns_response","type":"[]bufferdecoder.DnsResponseData","value":[{"query_data":{"query":"www.ubuntu.com","queryType":"AAAA","queryClass":"IN"},"dns_answer":[{"answer_type":"AAAA","ttl":5,"answer":"2620:2d:4000:1::26"},{"answer_type":"AAAA","ttl":5,"answer":"2620:2d:4000:1::28"},{"answer_type":"AAAA","ttl":5,"answer":"2620:2d:4000:1::27"}]}]}]}



