### PR TITLE
add shared_object_loaded and memory protections lsm events

### DIFF
--- a/pkg/ebpf/argprinters.go
+++ b/pkg/ebpf/argprinters.go
@@ -60,7 +60,7 @@ func (t *Tracee) parseArgs(event *trace.Event) error {
 				}
 			}
 		}
-	case MmapEventID, MprotectEventID, PkeyMprotectEventID:
+	case MmapEventID, MprotectEventID, PkeyMprotectEventID, SecurityMmapFileEventID, SecurityFileMprotectEventID:
 		if protArg := getEventArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -274,6 +274,7 @@ struct signal_struct {
 
 struct vm_area_struct {
 	long unsigned int vm_flags;
+	struct file * vm_file;
 };
 
 typedef unsigned int __kernel_gid32_t;

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -12,8 +12,8 @@ import (
 
 // deriveFn is a function prototype for a function that receives an event as
 // argument and may produce a new event if relevant.
-// It returns the a derived or empty event, depending on succesful derivation,
-// a bool indicating if an event was derived, and an error if one occured.
+// It returns a derived or empty event, depending on successful derivation,
+// a bool indicating if an event was derived, and an error if one occurred.
 type deriveFn func(trace.Event) (trace.Event, bool, error)
 
 // Initialize the eventDerivations map.
@@ -90,7 +90,7 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 /*
 * Derivation functions:
 * Most derivation functions take tracee as a closure argument to track it's runtime state
-* Tracee builds it's derivation map from these functions and injects itself as an argument to the closures
+* Tracee builds its derivation map from these functions and injects itself as an argument to the closures
 * The derivation map is then built with the returned deriveFn functions, which is used in deriveEvents
  */
 


### PR DESCRIPTION
The shared_object_loaded event indicates a shared object was loaded to a process.

It relies on `security_mmap_file` kprobe.
The event is only generated if the calling syscall to `security_mmap_file` is `mmap` and if the requested protection has `EXEC`.

The other events are a memory protection lsm events that are meant to provide a debugging interface for research purposes. 