### PR TITLE
refactor: move debug setting to flags package

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/debug.go
+++ b/cmd/tracee-ebpf/internal/flags/debug.go
@@ -1,0 +1,28 @@
+package flags
+
+var (
+	debug bool
+)
+
+func init() {
+	debug = false
+}
+
+// returns if the internal debug variable has been enabled
+func DebugModeEnabled() bool {
+	return debug
+}
+
+// enable debug mode
+func EnableDebugMode() error {
+	debug = true
+
+	return nil
+}
+
+// disable debug mode
+func DisableDebugMode() error {
+	debug = false
+
+	return nil
+}

--- a/cmd/tracee-ebpf/internal/flags/debug_test.go
+++ b/cmd/tracee-ebpf/internal/flags/debug_test.go
@@ -1,0 +1,25 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/tracee/cmd/tracee-ebpf/internal/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebug_Initial(t *testing.T) {
+	assert.Equal(t, false, flags.DebugModeEnabled())
+}
+
+func TestDebug_EnableDebug(t *testing.T) {
+	err := flags.EnableDebugMode()
+	require.NoError(t, err)
+	assert.Equal(t, true, flags.DebugModeEnabled())
+}
+
+func TestDebug_DisableDebug(t *testing.T) {
+	err := flags.DisableDebugMode()
+	require.NoError(t, err)
+	assert.Equal(t, false, flags.DebugModeEnabled())
+}

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -58,7 +58,7 @@ func main() {
 				}
 			}
 
-			// for the rest of execution, use this debug mdoe value
+			// for the rest of execution, use this debug mode value
 			debug := flags.DebugModeEnabled()
 
 			cfg := tracee.Config{


### PR DESCRIPTION
## Changes

The debug settings is now defined in the `flags` package.
The PR also uses Tracee's internal debug setting instead of the previous global var where it was needed.

## Why?

This was done so flags can access the debug status without passing it as an arg.
