### PR TITLE
fix: add containerId to derived container events

### DIFF
--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -72,6 +72,7 @@ func deriveContainerCreate(t *Tracee) deriveFn {
 			de := event
 			de.EventID = int(ContainerCreateEventID)
 			de.EventName = def.Name
+			de.ContainerID = info.ContainerId
 			de.ReturnValue = 0
 			de.StackAddresses = make([]uint64, 1)
 			de.Args = []trace.Argument{
@@ -102,6 +103,7 @@ func deriveContainerRemoved(t *Tracee) deriveFn {
 			de := event
 			de.EventID = int(ContainerRemoveEventID)
 			de.EventName = def.Name
+			de.ContainerID = info.ContainerId
 			de.ReturnValue = 0
 			de.StackAddresses = make([]uint64, 1)
 			de.Args = []trace.Argument{


### PR DESCRIPTION
This happens because the containerId is derived from the cgroup at the end of the pipeline.
However the process creating the container will be running from a different cgroup.