### PR TITLE
types: match EventHeaders to SignatureEventSelector

### DIFF
--- a/types/protocol/protocol.go
+++ b/types/protocol/protocol.go
@@ -3,12 +3,21 @@ package protocol
 
 //EventHeaders are headers attached to the Event struct, used to send metadata about the payload
 type EventHeaders struct {
-	// ContentType indicates the content of the Event payload.
-	ContentType string
-	// Origin indicates whether Event originates from host or container.
-	Origin string
+	// Selector is a propriotary header used for filtering event subscriptions in the engin
+	Selector Selector
+
 	// Custom additional custom headers, nil most of the time
 	custom map[string]string
+}
+
+// Selector is a propriotary header used for filtering event subscriptions in the engine
+type Selector struct {
+	// Name indicates the name of the Event payload
+	Name string
+	// Origin indicates where the event was generated (host, container, pod), this may be empty depending on Source
+	Origin string
+	// Source indicates the producer of the Event (example: tracee, CNDR, K8SAuditLog...)
+	Source string
 }
 
 //Event is a generic event that the Engine can process
@@ -17,14 +26,12 @@ type Event struct {
 	Payload interface{}
 }
 
-func (e *Event) ContentType() string {
-	return e.Headers.ContentType
+// Get Event's Selector
+func (e *Event) Selector() Selector {
+	return e.Headers.Selector
 }
 
-func (e *Event) Origin() string {
-	return e.Headers.Origin
-}
-
+// Get a custom header that was set through SetHeader
 func (e *Event) Header(header string) string {
 	if e.Headers.custom != nil {
 		return e.Headers.custom[header]
@@ -32,6 +39,7 @@ func (e *Event) Header(header string) string {
 	return ""
 }
 
+// Set a custom header
 func (e *Event) SetHeader(header string, value string) {
 	if e.Headers.custom == nil {
 		e.Headers.custom = make(map[string]string)

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -34,6 +34,7 @@ type Event struct {
 	Args                []Argument `json:"args"` //Arguments are ordered according their appearance in the original event
 }
 
+// EventOrigin is where a trace.Event occured, it can either be from the host machine or from a container
 type EventOrigin string
 
 const (
@@ -41,6 +42,7 @@ const (
 	HostOrigin      EventOrigin = "host"
 )
 
+// Derive the EventOrigin of a trace.Event
 func (e Event) Origin() EventOrigin {
 	if e.ContainerID != "" || e.ProcessID != e.HostProcessID {
 		return ContainerOrigin
@@ -50,18 +52,18 @@ func (e Event) Origin() EventOrigin {
 }
 
 const (
-	EventSource      = "tracee"
-	EventContentType = "tracee/event"
+	EventSource = "tracee"
 )
 
+// Converts a trace.Event into a protocol.Event that the rules engine can consume
 func (e Event) ToProtocol() protocol.Event {
-	origin := EventSource + "/" + string(e.Origin())
-	contentType := EventContentType + "-" + e.EventName
-
 	return protocol.Event{
 		Headers: protocol.EventHeaders{
-			ContentType: contentType,
-			Origin:      origin,
+			Selector: protocol.Selector{
+				Name:   e.EventName,
+				Origin: string(e.Origin()),
+				Source: "tracee",
+			},
 		},
 		Payload: e,
 	}

--- a/types/trace/trace_test.go
+++ b/types/trace/trace_test.go
@@ -167,8 +167,11 @@ func TestEvent_ToProtocol(t *testing.T) {
 			},
 			expected: protocol.Event{
 				Headers: protocol.EventHeaders{
-					ContentType: "tracee/event-execve",
-					Origin:      "tracee/host",
+					Selector: protocol.Selector{
+						Origin: string(HostOrigin),
+						Source: "tracee",
+						Name:   "execve",
+					},
 				},
 				Payload: Event{
 					EventName:     "execve",
@@ -185,8 +188,11 @@ func TestEvent_ToProtocol(t *testing.T) {
 			},
 			expected: protocol.Event{
 				Headers: protocol.EventHeaders{
-					ContentType: "tracee/event-execve",
-					Origin:      "tracee/container",
+					Selector: protocol.Selector{
+						Origin: string(ContainerOrigin),
+						Source: "tracee",
+						Name:   "execve",
+					},
 				},
 				Payload: Event{
 					EventName:     "execve",
@@ -202,8 +208,11 @@ func TestEvent_ToProtocol(t *testing.T) {
 			},
 			expected: protocol.Event{
 				Headers: protocol.EventHeaders{
-					ContentType: "tracee/event-open",
-					Origin:      "tracee/container",
+					Selector: protocol.Selector{
+						Origin: string(ContainerOrigin),
+						Source: "tracee",
+						Name:   "open",
+					},
 				},
 				Payload: Event{
 					EventName:   "open",


### PR DESCRIPTION
This is in preparation for PR 3 in #1644.

Matches the default headers of `protocol.Event` to the selector fields defined in `detect.SignatureEventSelector`.