### PR TITLE
engine: use the matching headers for signature selection

### DIFF
--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -95,8 +95,11 @@ HostName: foobar.local
 			name: "sad path with unknown event",
 			inputEvent: protocol.Event{
 				Headers: protocol.EventHeaders{
-					ContentType: "application/wrong",
-					Origin:      "/untrusted",
+					Selector: protocol.Selector{
+						Name:   "unrecognized_event",
+						Source: "nottrracee",
+						Origin: "somewhere",
+					},
 				},
 				Payload: "something wrong",
 			},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0
-	github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94
+	github.com/aquasecurity/tracee/types v0.0.0-20220412160215-ccc81e5e59cd
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/mitchellh/go-ps v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:C
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0 h1:BpW7qxkveYXx8TCtvYWIvmliPqaTCz/IYs1i+Gyj0MQ=
 github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
-github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94 h1:8dNst7rq3V688n0CyVGy0aNV179s5jGfi6i+C8fCeh4=
-github.com/aquasecurity/tracee/types v0.0.0-20220228102148-dffb469aed94/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
+github.com/aquasecurity/tracee/types v0.0.0-20220412160215-ccc81e5e59cd h1:eZ0KdM1drinNluLlfyMGKLBWaeECnuFDNrWgClli/tM=
+github.com/aquasecurity/tracee/types v0.0.0-20220412160215-ccc81e5e59cd/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/rules/regosig/traceerego_test.go
+++ b/pkg/rules/regosig/traceerego_test.go
@@ -354,8 +354,11 @@ func OnEventSpec(t *testing.T, target string, partial bool) {
 
 		notTraceeEvt := protocol.Event{
 			Headers: protocol.EventHeaders{
-				ContentType: "tracee.notevent.lol",
-				Origin:      "nottracee/*",
+				Selector: protocol.Selector{
+					Name:   "unrecognized_event",
+					Source: "nottrracee",
+					Origin: "somewhere",
+				},
 			},
 			Payload: "just some stuff",
 		}


### PR DESCRIPTION
As described in #1644 

This implements the header changes in #1645 

With this PR the engine signature selection will be decoupled from tracee-ebpf's events, and will be able to process any `protocol.Event` which existing signatures can support.

This will be in draft until #1645 is merged.