### PR TITLE
added debugfs_create_file event

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3262,13 +3262,13 @@ int BPF_KPROBE(trace_debugfs_create_file)
     if (!should_trace((&data.context)))
         return 0;
 
-    char * name = (char *)PT_REGS_PARM1(ctx);
+    char *name = (char *)PT_REGS_PARM1(ctx);
     mode_t mode = (unsigned short)PT_REGS_PARM2(ctx);
     struct dentry *dentry = (struct dentry *)PT_REGS_PARM3(ctx);
     void *dentry_path = get_dentry_path_str(dentry);
     unsigned long proc_ops_addr = (unsigned long) PT_REGS_PARM5(ctx);
 
-    save_str_to_buf(&data,name, 0);
+    save_str_to_buf(&data, name, 0);
     save_str_to_buf(&data, dentry_path, 1);
     save_to_submit_buf(&data, &mode, sizeof(mode_t), 2);
     save_to_submit_buf(&data, (void *)&proc_ops_addr, sizeof(u64), 3);

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -84,6 +84,7 @@ const (
 	KprobeAttachEventID
 	CallUsermodeHelperEventID
 	DirtyPipeSpliceEventID
+	DebugfsCreateFile
 	MaxCommonEventID
 )
 
@@ -6283,6 +6284,20 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "const char*const*", Name: "argv"},
 			{Type: "const char*const*", Name: "envp"},
 			{Type: "int", Name: "wait"},
+		},
+	},
+	DebugfsCreateFile: {
+		ID32Bit: sys32undefined,
+		Name:    "debugfs_create_file",
+		Probes: []probe{
+			{event: "debugfs_create_file", attach: kprobe, fn: "trace_debugfs_create_file"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "const char*", Name: "file_name"},
+			{Type: "const char*", Name: "path"},
+			{Type: "mode_t", Name: "mode"},
+			{Type: "u64", Name: "proc_ops_addr"},
 		},
 	},
 }


### PR DESCRIPTION
Hi 

This PR is the second PR (2nd out of 3) that will solve #1613 .
It adds to Tracee a kprobe event that traces calls to 'debugfs_create_file' which is a kernel function that is used to create a file under the debug filesystem (under /sys/fs/debug).

BTW this is the main page of the function:
[https://www.kernel.org/doc/htmldocs/filesystems/API-debugfs-create-file.html](https://www.kernel.org/doc/htmldocs/filesystems/API-debugfs-create-file.html
)

The event's arguments will be the file name, its path, mode, and the file operations pointer in the memory 