### PR TITLE
add debugfs_create_dir event

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -86,6 +86,7 @@ const (
 	DirtyPipeSpliceEventID
 	DebugfsCreateFile
 	PrintSyscallTableEventID
+	DebugfsCreateDir
 	MaxCommonEventID
 )
 
@@ -6323,6 +6324,18 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "HookedSyscallData[]", Name: "hooked_syscalls"},
+		},
+	},
+	DebugfsCreateDir: {
+		ID32Bit: sys32undefined,
+		Name:    "debugfs_create_dir",
+		Probes: []probe{
+			{event: "debugfs_create_dir", attach: kprobe, fn: "trace_debugfs_create_dir"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "const char*", Name: "name"},
+			{Type: "const char*", Name: "path"},
 		},
 	},
 }


### PR DESCRIPTION
Hi 

This PR is the third of 3 PR that solve #1613 .

It adds to Tracee a kprobe event that trace calls to `debugfs_create_dir`, which is a kernel function that is used by the kernel module to create directories under /sys/kernel/debug.

Here is the man page of the function from the kernel docs:
[https://www.kernel.org/doc/htmldocs/filesystems/API-debugfs-create-dir.html](https://www.kernel.org/doc/htmldocs/filesystems/API-debugfs-create-dir.html
)

The event will print the name of the dir and its path, here's s an example for output:
`04:33:27:509621  0      insmod           3426    3426    0                debugfs_create_dir   name: malware_poc, path: /sys/kernel/debug/
`