### PR TITLE
rules: allow generic protocol.Events in rego signatures

### DIFF
--- a/pkg/rules/regosig/traceerego.go
+++ b/pkg/rules/regosig/traceerego.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
-	"github.com/aquasecurity/tracee/types/trace"
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 )
@@ -159,14 +158,7 @@ func (sig *RegoSignature) getSelectedEvents(pkgName string) ([]detect.SignatureE
 // if bool is "returned", a true evaluation will generate a Finding with no data
 // if document is "returned", any non-empty evaluation will generate a Finding with the document as the Finding's "Data"
 func (sig *RegoSignature) OnEvent(event protocol.Event) error {
-	var input rego.EvalOption
-	eventObj, ok := event.Payload.(trace.Event)
-
-	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
-	}
-
-	input = rego.EvalInput(eventObj)
+	input := rego.EvalInput(event.Payload)
 	results, err := sig.matchPQ.Eval(context.TODO(), input)
 	if err != nil {
 		return fmt.Errorf("evaluating rego: %w", err)


### PR DESCRIPTION
## Changes

1. Removes the validation for trace.Event casting
2. In case of an irrelevant payload to a rego signature, no error will be returned, the document will simply not match
3. Adds relevant tests for invalid event payloads, where the finding is nil
