### PR TITLE
tracee-ebpf: handle event configuration

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -23,7 +23,8 @@ type probe struct {
 }
 
 type eventDependency struct {
-	eventID int32
+	eventID      int32
+	shouldSubmit bool
 }
 
 type dependencies struct {
@@ -33,13 +34,12 @@ type dependencies struct {
 
 // EventDefinition is a struct describing an event configuration
 type EventDefinition struct {
-	ID32Bit        int32
-	Name           string
-	Probes         []probe
-	Dependencies   dependencies
-	EssentialEvent bool
-	Sets           []string
-	Params         []trace.ArgMeta
+	ID32Bit      int32
+	Name         string
+	Probes       []probe
+	Dependencies dependencies
+	Sets         []string
+	Params       []trace.ArgMeta
 }
 
 // Common events (used by all architectures)
@@ -5685,8 +5685,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "raw_syscalls:sys_enter", attach: rawTracepoint, fn: "tracepoint__raw_syscalls__sys_enter"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "int", Name: "syscall"},
 		},
@@ -5697,8 +5696,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "raw_syscalls:sys_exit", attach: rawTracepoint, fn: "tracepoint__raw_syscalls__sys_exit"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "int", Name: "syscall"},
 		},
@@ -5709,8 +5707,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "sched:sched_process_fork", attach: rawTracepoint, fn: "tracepoint__sched__sched_process_fork"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "int", Name: "parent_tid"},
 			{Type: "int", Name: "parent_ns_tid"},
@@ -5729,8 +5726,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "sched:sched_process_exec", attach: rawTracepoint, fn: "tracepoint__sched__sched_process_exec"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{"default", "proc"},
+		Sets: []string{"default", "proc"},
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "cmdpath"},
 			{Type: "const char*", Name: "pathname"},
@@ -5749,8 +5745,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "sched:sched_process_exit", attach: rawTracepoint, fn: "tracepoint__sched__sched_process_exit"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{"default", "proc", "proc_life"},
+		Sets: []string{"default", "proc", "proc_life"},
 		Params: []trace.ArgMeta{
 			{Type: "long", Name: "exit_code"},
 			// The field value represents that all threads exited at the event time.
@@ -5907,8 +5902,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "cgroup:cgroup_mkdir", attach: rawTracepoint, fn: "tracepoint__cgroup__cgroup_mkdir"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "u64", Name: "cgroup_id"},
 			{Type: "const char*", Name: "cgroup_path"},
@@ -5921,8 +5915,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "cgroup:cgroup_rmdir", attach: rawTracepoint, fn: "tracepoint__cgroup__cgroup_rmdir"},
 		},
-		EssentialEvent: true,
-		Sets:           []string{},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "u64", Name: "cgroup_id"},
 			{Type: "const char*", Name: "cgroup_path"},
@@ -6145,7 +6138,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "socket_dup",
 		Probes:  []probe{},
 		Dependencies: dependencies{
-			events: []eventDependency{{DupEventID}, {Dup2EventID}, {Dup3EventID}},
+			events: []eventDependency{{eventID: DupEventID}, {eventID: Dup2EventID}, {eventID: Dup3EventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6207,7 +6200,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "container_create",
 		Probes:  []probe{},
 		Dependencies: dependencies{
-			events: []eventDependency{{CgroupMkdirEventID}},
+			events: []eventDependency{{eventID: CgroupMkdirEventID, shouldSubmit: true}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6221,7 +6214,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "container_remove",
 		Probes:  []probe{},
 		Dependencies: dependencies{
-			events: []eventDependency{{CgroupRmdirEventID}},
+			events: []eventDependency{{eventID: CgroupRmdirEventID, shouldSubmit: true}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -42,7 +42,7 @@ func (t *Tracee) deriveEvent(event trace.Event) []trace.Event {
 	deriveFns := t.eventDerivations[int32(event.EventID)]
 	for id, deriveFn := range deriveFns {
 		// Don't derive events which were not requested by the user
-		if !t.eventsToTrace[id] {
+		if !t.events[id].emit {
 			continue
 		}
 

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -218,7 +218,7 @@ func (t *Tracee) processEvents(ctx gocontext.Context, in <-chan *trace.Event) <-
 			derivatives := t.deriveEvent(*event)
 
 			// Only emit events requested by the user
-			if t.eventsToTrace[int32(event.EventID)] {
+			if t.events[int32(event.EventID)].emit {
 				if t.config.Output.ParseArguments {
 					err = t.parseArgs(event)
 					if err != nil {

--- a/pkg/ebpf/net_events.go
+++ b/pkg/ebpf/net_events.go
@@ -244,7 +244,7 @@ func (t *Tracee) processNetEvents(ctx gocontext.Context) {
 				ifaceName := t.netInfo.ifaces[int(netCaptureData.ConfigIfaceIndex)].Name
 				ifaceIdx, err := t.getTracedIfaceIdx(ifaceName)
 				if err == nil && ifaceIdx >= 0 {
-					if t.eventsToTrace[netEventMetadata.NetEventId] {
+					if t.events[netEventMetadata.NetEventId].emit {
 						evt, err := netPacketProtocolHandler(netDecoder, netEventMetadata, networkThread, "net_packet")
 						if err != nil {
 							t.handleError(err)


### PR DESCRIPTION
It is required to differentiate between different events configurations.
When an event is chosen, its bpf programs need to be loaded.
Some bpf programs might be used by different events, so it is required to know which events should be submitted to userspace, and which shouldn't.
In addition, not every event that is submitted to userspace needs to be emited to the user. For example, when a derived event such as container_create is chosen, the cgroup_mkdir event should be submitted to userspace, however, if the user didn't choose the cgroup_mkdir event, it shuoldn't be emitted as part of the output.

This PR dynamically creates the required configuration for each event according to the chosen events and their dependencies.