### PR TITLE
bugfix: support dirty_pipe_splice in unexploited kernels

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -441,6 +441,14 @@ struct public_key_signature {
     const void *data;
 };
 
+enum zone_type{
+    ZONE_DMA,
+};
+
+struct alloc_context {
+    enum zone_type high_zoneidx;
+};
+
 struct socket {
 	struct sock *sk;
 };


### PR DESCRIPTION
Event implementation uses a symbol which was introduced only in kernel version 5.8.
Fixed the bug using it and a bug of using the `get_symbol_addr` helper (global values are not supported in older kernels),
Also prevent event analyzing if splice failed, just to reduce overhead and wrong analyze of kernel's data.

This PR has a problem that old Manajro kernels don't have the `do_splice` symbol for some reason in `kallsyms` file, which make the event unloadable in these versions. Ubuntu 4.18 was fine though. I don't see a way to bypass it so it will be suffice for now.

fix #1659 
fix #1691