### PR TITLE
entrypoint: restore trace subcommand for docker image

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -101,6 +101,12 @@ if [ ! -x ${TRACEE_RULES_EXE} ]; then
     exit 1
 fi
 
+# docker 1st argument might be "trace" only (so tracee-ebpf is executed)
+if [ "${1}" == "trace" ]; then
+    TRACEE_EBPF_ONLY=1
+    shift
+fi
+
 for arg in ${@}; do
     case ${arg} in
     "--help")

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,8 +88,10 @@ Hostname: ubuntu-impish
 
 In some cases, you might want to leverage Tracee's eBPF event collection
 capabilities directly, without involving the detection engine. This might be
-useful for debugging/troubleshooting/analysis/research/education. In this case,
-you can run tracee exporting `TRACEE_EBPF_ONLY=1` environment variable.
+useful for debugging/troubleshooting/analysis/research/education.
+
+Just execute docker with `trace` argument first, and tracee-ebpf will be
+executed, instead of the full tracee detection engine.
 
 ```shell
 docker run \
@@ -97,8 +99,8 @@ docker run \
   --pid=host --cgroupns=host --privileged \
   -v /etc/os-release:/etc/os-release-host:ro \
   -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
-  -e TRACEE_EBPF_ONLY=1 \
-  aquasec/tracee:{{ git.tag[1:] }}
+  aquasec/tracee:latest \
+  trace
 ```
 
 !!! note
@@ -114,8 +116,8 @@ aquasecurity/tracee repository:
 
 ---
 
-Tracee is an [Aqua Security] open source project.  
-Learn about our open source work and portfolio [Here].  
+Tracee is an [Aqua Security] open source project.
+Learn about our open source work and portfolio [Here].
 Join the community, and talk to us about any matter in [GitHub Discussion] or [Slack].
 
 [Tracee-eBPF]: https://github.com/aquasecurity/tracee/tree/{{ git.tag }}/cmd/tracee-ebpf


### PR DESCRIPTION
Fixes: #1658

## Description

This change re-creates the "trace" subcommand to our tracee:latest (future) docker image. Users may be able to execute `docker run tracee trace`, like they used to do before v0.7.

Fixes: #1658 

## Type of change

Please pick one and delete the others:

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This change doesn't have a unit test but we're able to test if it is effective by not having failures in the PR workflow (on container building) and then generating the container locally and trying out multiple execution types:

```
$ make -f builder/Makefile.tracee-container build-tracee
```

It does not break current behavior:

```
$ docker run --rm --pid=host --privileged -v /etc/os-release:/etc/os-release-host:ro -v /sys/kernel/security:/sys/kernel/security:ro -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host --rm -it tracee:latest
INFO: probing tracee-ebpf capabilities...
INFO: starting tracee-ebpf...
INFO: starting tracee-rules...
Loaded 14 signature(s): [TRC-1 TRC-13 TRC-2 TRC-14 TRC-3 TRC-11 TRC-9 TRC-4 TRC-5 TRC-12 TRC-8 TRC-6 TRC-10 TRC-7]
Serving metrics endpoint at :4466
```

And it brings back the old behavior:

```
$ docker run --rm --pid=host --privileged -v /etc/os-release:/etc/os-release-host:ro -v /sys/kernel/security:/sys/kernel/security:ro -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host --rm -it tracee:latest trace --debug | head -50 2>&1
INFO: probing tracee-ebpf capabilities...
OSInfo: VERSION_CODENAME: impish
OSInfo: ID: ubuntu
OSInfo: ID_LIKE: debian
OSInfo: KERNEL_RELEASE: 5.13.0-25-generic
OSInfo: ARCH: x86_64
OSInfo: PRETTY_NAME: "Ubuntu 21.10"
OSInfo: VERSION_ID: "21.10"
OSInfo: VERSION: "21.10 (Impish Indri)"
OSInfo: Security Lockdown is 'none'
KConfig: warning: could not check enabled kconfig features
(could not read /boot/config-5.13.0-25-generic: stat /boot/config-5.13.0-25-generic: no such file or directory)
KConfig: warning: assuming kconfig values, might have unexpected behavior
BTF: bpfenv = false, btfenv = false, vmlinux = true
BPF: using embedded BPF object
unpacked CO:RE bpf object file into memory
KConfig: warning: assuming kconfig values, might have unexpected behavior
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
13:00:13:556311  0      preload          2415288 2415288 0                security_file_open   pathname: /usr/lib/x86_64-linux-gnu/libgrpc++.so.1.30.2, flags: O_RDONLY|O_NOCTTY|O_LARGEFILE|O_NOATIME, dev: 271581185, inode: 2752635, ctime: 1625088163018585837
```

**Manual Test Setup**:

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line. <- this should be removed
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
