### PR TITLE
Bugfix: changed long and long long parsing to match real size

### DIFF
--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -35,6 +35,9 @@ const (
 	credT
 	intArr2T
 	uint64ArrT
+	longLongT
+	ulongLongT
+	loffT
 )
 
 // These types don't match the ones defined in the ebpf code since they are not being used by syscalls arguments.
@@ -65,19 +68,19 @@ func ReadArgFromBuff(ebpfMsgDecoder *EbpfDecoder, params []trace.ArgMeta) (trace
 		var data uint16
 		err = ebpfMsgDecoder.DecodeUint16(&data)
 		res = data
-	case intT:
+	case intT, longT:
 		var data int32
 		err = ebpfMsgDecoder.DecodeInt32(&data)
 		res = data
-	case uintT, devT, modeT:
+	case uintT, devT, modeT, ulongT, offT:
 		var data uint32
 		err = ebpfMsgDecoder.DecodeUint32(&data)
 		res = data
-	case longT:
+	case longLongT:
 		var data int64
 		err = ebpfMsgDecoder.DecodeInt64(&data)
 		res = data
-	case ulongT, offT, sizeT:
+	case ulongLongT, loffT, sizeT:
 		var data uint64
 		err = ebpfMsgDecoder.DecodeUint64(&data)
 		res = data
@@ -181,12 +184,18 @@ func GetParamType(paramType string) ArgType {
 		return uintT
 	case "long":
 		return longT
-	case "unsigned long", "u64":
+	case "unsigned long":
 		return ulongT
+	case "long long":
+		return longLongT
+	case "unsigned long long", "u64":
+		return ulongLongT
 	case "bool":
 		return boolT
 	case "off_t":
 		return offT
+	case "loff_t":
+		return loffT
 	case "mode_t":
 		return modeT
 	case "dev_t":
@@ -211,7 +220,7 @@ func GetParamType(paramType string) ArgType {
 		return credT
 	case "umode_t":
 		return u16T
-	case "unsigned long[]":
+	case "u64[]":
 		return uint64ArrT
 	default:
 		// Default to pointer (printed as hex) for unsupported types

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -35,25 +35,49 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "longT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //-1
+				0xFF, 0xFF, 0xFF, 0xFF, //-1
 			},
 			params:      []trace.ArgMeta{{Type: "long", Name: "long0"}},
-			expectedArg: int64(-1),
+			expectedArg: int32(-1),
 		},
 		{
 			name: "ulongT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+				0xFF, 0xFF, 0xFF, 0xFF, //4294967295
 			},
 			params:      []trace.ArgMeta{{Type: "unsigned long", Name: "ulong0"}},
+			expectedArg: uint32(4294967295),
+		},
+		{
+			name: "longLongT",
+			input: []byte{0,
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //-1
+			},
+			params:      []trace.ArgMeta{{Type: "long long", Name: "longLong0"}},
+			expectedArg: int64(-1),
+		},
+		{
+			name: "ulongLongT",
+			input: []byte{0,
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+			},
+			params:      []trace.ArgMeta{{Type: "unsigned long long", Name: "ulongLong0"}},
 			expectedArg: uint64(18446744073709551615),
 		},
 		{
 			name: "offT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+				0xFF, 0xFF, 0xFF, 0xFF, //4294967295
 			},
 			params:      []trace.ArgMeta{{Type: "off_t", Name: "offT0"}},
+			expectedArg: uint32(4294967295),
+		},
+		{
+			name: "loffT",
+			input: []byte{0,
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+			},
+			params:      []trace.ArgMeta{{Type: "loff_t", Name: "loffT0"}},
 			expectedArg: uint64(18446744073709551615),
 		},
 		{
@@ -71,14 +95,6 @@ func TestReadArgFromBuff(t *testing.T) {
 			},
 			params:      []trace.ArgMeta{{Type: "dev_t", Name: "devT0"}},
 			expectedArg: uint32(4294967295),
-		},
-		{
-			name: "offT",
-			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
-			},
-			params:      []trace.ArgMeta{{Type: "off_t", Name: "offT0"}},
-			expectedArg: uint64(18446744073709551615),
 		},
 		{ // This is expected to fail. TODO: change pointer parsed type to uint64
 			name: "pointerT",
@@ -158,7 +174,7 @@ func TestReadArgFromBuff(t *testing.T) {
 			input: []byte{1,
 				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
 			},
-			params:      []trace.ArgMeta{{Type: "const char*", Name: "str0"}, {Type: "off_t", Name: "offT1"}},
+			params:      []trace.ArgMeta{{Type: "const char*", Name: "str0"}, {Type: "loff_t", Name: "loffT1"}},
 			expectedArg: uint64(18446744073709551615),
 		},
 	}

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -5720,7 +5720,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "int", Name: "child_ns_tid"},
 			{Type: "int", Name: "child_pid"},
 			{Type: "int", Name: "child_ns_pid"},
-			{Type: "unsigned long", Name: "start_time"},
+			{Type: "u64", Name: "start_time"},
 		},
 	},
 	SchedProcessExecEventID: {
@@ -5739,7 +5739,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "dev_t", Name: "dev"},
 			{Type: "unsigned long", Name: "inode"},
 			{Type: "int", Name: "invoked_from_kernel"},
-			{Type: "unsigned long", Name: "ctime"},
+			{Type: "u64", Name: "ctime"},
 			{Type: "umode_t", Name: "stdin_type"},
 		},
 	},
@@ -5954,7 +5954,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "int", Name: "flags"},
 			{Type: "dev_t", Name: "dev"},
 			{Type: "unsigned long", Name: "inode"},
-			{Type: "unsigned long", Name: "ctime"},
+			{Type: "u64", Name: "ctime"},
 			{Type: "int", Name: "syscall"},
 		},
 	},
@@ -6081,7 +6081,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{Type: "dev_t", Name: "dev"},
 			{Type: "unsigned long", Name: "inode"},
 			{Type: "int", Name: "type"},
-			{Type: "unsigned long", Name: "ctime"},
+			{Type: "u64", Name: "ctime"},
 		},
 	},
 	SecurityPostReadFileEventID: {
@@ -6213,7 +6213,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "runtime"},
 			{Type: "const char*", Name: "container_id"},
-			{Type: "unsigned long", Name: "ctime"},
+			{Type: "u64", Name: "ctime"},
 		},
 	},
 	ContainerRemoveEventID: {
@@ -6237,7 +6237,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "runtime"},
 			{Type: "const char*", Name: "container_id"},
-			{Type: "unsigned long", Name: "ctime"},
+			{Type: "u64", Name: "ctime"},
 		},
 	},
 	NetPacket: {
@@ -6311,7 +6311,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Dependencies: dependencies{ksymbols: []string{"sys_call_table"}},
 		Sets:         []string{},
 		Params: []trace.ArgMeta{
-			{Type: "unsigned long[]", Name: "syscalls_addresses"},
+			{Type: "u64[]", Name: "syscalls_addresses"},
 		},
 	},
 	DetectHookedSyscallsEventID: {


### PR DESCRIPTION
## Description

Until now, when parsing the events arguments in the `eventsreader.go` file, we assumed that `long` is a 32bit integer and didn't support `long long` type.
In this PR I fix the wrong assumption and change the argument type of wrong defined events to match the expected size.

Fixes: #1671 

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have run the unit-tests on this.
I am not sure what this one might affect, so I would appreciate it if someone could go over it and make sure I didn't miss anything and that it didn't break anything (@grantseltzer / @yanivagman).

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
