### PR TITLE
add support for "loff_t" event argument type

### DIFF
--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -185,7 +185,7 @@ func GetParamType(paramType string) ArgType {
 		return ulongT
 	case "bool":
 		return boolT
-	case "off_t":
+	case "off_t", "loff_t":
 		return offT
 	case "mode_t":
 		return modeT

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -49,14 +49,6 @@ func TestReadArgFromBuff(t *testing.T) {
 			expectedArg: uint64(18446744073709551615),
 		},
 		{
-			name: "offT",
-			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
-			},
-			params:      []trace.ArgMeta{{Type: "off_t", Name: "offT0"}},
-			expectedArg: uint64(18446744073709551615),
-		},
-		{
 			name: "modeT",
 			input: []byte{0,
 				0xB6, 0x11, 0x0, 0x0, //0x000011B6 == 010666 == S_IFIFO|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH
@@ -78,6 +70,14 @@ func TestReadArgFromBuff(t *testing.T) {
 				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
 			},
 			params:      []trace.ArgMeta{{Type: "off_t", Name: "offT0"}},
+			expectedArg: uint64(18446744073709551615),
+		},
+		{
+			name: "loffT",
+			input: []byte{0,
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+			},
+			params:      []trace.ArgMeta{{Type: "loff_t", Name: "loffT0"}},
 			expectedArg: uint64(18446744073709551615),
 		},
 		{ // This is expected to fail. TODO: change pointer parsed type to uint64


### PR DESCRIPTION
## Description

Add support for `loff_t` in the `eventsreader.go` file.

Fixes: #1674 

## Type of change

- New feature (non-breaking change which adds functionality)

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
