### PR TITLE
engine: Accept partial non tracee source selectors

### DIFF
--- a/pkg/rules/engine/engine.go
+++ b/pkg/rules/engine/engine.go
@@ -155,18 +155,28 @@ func (engine *Engine) consumeSources(done <-chan bool) {
 					Name:   event.Headers.Selector.Name,
 					Source: event.Headers.Selector.Source,
 				}
+				source := signatureSelector.Source
 				engine.stats.Events.Increment()
 
+				//Check the selector for every case and partial case
+
+				//Match full selector
 				for _, s := range engine.signaturesIndex[signatureSelector] {
 					engine.dispatchEvent(s, event)
 				}
-				for _, s := range engine.signaturesIndex[detect.SignatureEventSelector{Source: "tracee", Name: signatureSelector.Name, Origin: ALL_EVENT_ORIGINS}] {
+
+				//Match partial selector, select for all origins
+				for _, s := range engine.signaturesIndex[detect.SignatureEventSelector{Source: source, Name: signatureSelector.Name, Origin: ALL_EVENT_ORIGINS}] {
 					engine.dispatchEvent(s, event)
 				}
-				for _, s := range engine.signaturesIndex[detect.SignatureEventSelector{Source: "tracee", Name: ALL_EVENT_TYPES, Origin: signatureSelector.Origin}] {
+
+				//Match partial selector, select for event names
+				for _, s := range engine.signaturesIndex[detect.SignatureEventSelector{Source: source, Name: ALL_EVENT_TYPES, Origin: signatureSelector.Origin}] {
 					engine.dispatchEvent(s, event)
 				}
-				for _, s := range engine.signaturesIndex[detect.SignatureEventSelector{Source: "tracee", Name: ALL_EVENT_TYPES, Origin: ALL_EVENT_ORIGINS}] {
+
+				//Match partial selector, select for all origins and event names
+				for _, s := range engine.signaturesIndex[detect.SignatureEventSelector{Source: source, Name: ALL_EVENT_TYPES, Origin: ALL_EVENT_ORIGINS}] {
 					engine.dispatchEvent(s, event)
 				}
 				engine.signaturesMutex.RUnlock()

--- a/pkg/rules/engine/engine_test.go
+++ b/pkg/rules/engine/engine_test.go
@@ -399,6 +399,30 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			expectedNumEvents: 1,
 			expectedEvent:     "a great payload",
 		},
+		{
+			name: "happy path - signature with partial selector and non tracee source",
+			inputEvent: protocol.Event{
+				Headers: protocol.EventHeaders{
+					Selector: protocol.Selector{
+						Name:   "foobar",
+						Source: "system",
+					},
+				},
+				Payload: "a great payload",
+			},
+			inputSignature: regoFakeSignature{
+				getSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
+					return []detect.SignatureEventSelector{
+						{
+							Name:   "foobar",
+							Source: "system",
+						},
+					}, nil
+				},
+			},
+			expectedNumEvents: 1,
+			expectedEvent:     "a great payload",
+		},
 	}
 
 	emptyEvent := protocol.Event{}


### PR DESCRIPTION
## Description

Fix an issue where events with a partial `Selector` headers without a `Source` field of value `"tracee"` would be unaccounted for in event dispatching.
Adds comments to explain event selection process.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This shouldn't be a breaking change, unit tests were locally run to validate and a test path with a partial selector was added to `TestEngine_ConsumeSources`.

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
