### PR TITLE
add syscall detection signature

### DIFF
--- a/cmd/tracee-ebpf/printer.go
+++ b/cmd/tracee-ebpf/printer.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/pkg/metrics"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -236,6 +237,7 @@ func (p *gobEventPrinter) Init() error {
 	gob.Register(trace.SlimCred{})
 	gob.Register(make(map[string]string))
 	gob.Register(trace.PktMeta{})
+	gob.Register([]bufferdecoder.HookedSyscallData{})
 	return nil
 }
 

--- a/cmd/tracee-ebpf/printer.go
+++ b/cmd/tracee-ebpf/printer.go
@@ -10,7 +10,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/pkg/metrics"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -237,7 +236,7 @@ func (p *gobEventPrinter) Init() error {
 	gob.Register(trace.SlimCred{})
 	gob.Register(make(map[string]string))
 	gob.Register(trace.PktMeta{})
-	gob.Register([]bufferdecoder.HookedSyscallData{})
+	gob.Register([]trace.HookedSyscallData{})
 	return nil
 }
 

--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -49,6 +50,7 @@ func setupTraceeGobInputSource(opts *traceeInputOptions) (chan protocol.Event, e
 	gob.Register(trace.SlimCred{})
 	gob.Register(make(map[string]string))
 	gob.Register(trace.PktMeta{})
+	gob.Register([]bufferdecoder.HookedSyscallData{})
 	res := make(chan protocol.Event)
 	go func() {
 		for {

--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -50,7 +49,7 @@ func setupTraceeGobInputSource(opts *traceeInputOptions) (chan protocol.Event, e
 	gob.Register(trace.SlimCred{})
 	gob.Register(make(map[string]string))
 	gob.Register(trace.PktMeta{})
-	gob.Register([]bufferdecoder.HookedSyscallData{})
+	gob.Register([]protocol.HookedSyscallData{})
 	res := make(chan protocol.Event)
 	go func() {
 		for {

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -111,10 +111,6 @@ func (s SlimCred) GetSizeBytes() uint32 {
 	return 80
 }
 
-type HookedSyscallData struct {
-	SyscallName string
-	ModuleOwner string
-}
 type SymbolData struct {
 	SymbolName    string
 	SymbolAddress string

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/libbpfgo/helpers"
-	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -145,8 +144,8 @@ func deriveDetectHookedSyscall(t *Tracee) deriveFn {
 	}
 }
 
-func analyzeHookedAddresses(addresses []uint64, OsConfig *helpers.OSInfo, kernelSymbols *helpers.KernelSymbolTable) ([]bufferdecoder.HookedSyscallData, error) {
-	hookedSyscallData := make([]bufferdecoder.HookedSyscallData, 0, 0)
+func analyzeHookedAddresses(addresses []uint64, OsConfig *helpers.OSInfo, kernelSymbols *helpers.KernelSymbolTable) ([]trace.HookedSyscallData, error) {
+	hookedSyscallData := make([]trace.HookedSyscallData, 0, 0)
 	for idx, syscallsAdress := range addresses {
 		InTextSegment, err := kernelSymbols.TextSegmentContains(syscallsAdress)
 		if err != nil {
@@ -166,7 +165,7 @@ func analyzeHookedAddresses(addresses []uint64, OsConfig *helpers.OSInfo, kernel
 			} else {
 				hookedSyscallName = fmt.Sprint(syscallNumber)
 			}
-			hookedSyscallData = append(hookedSyscallData, bufferdecoder.HookedSyscallData{hookedSyscallName, hookingFunction.Owner})
+			hookedSyscallData = append(hookedSyscallData, trace.HookedSyscallData{hookedSyscallName, hookingFunction.Owner})
 
 		}
 	}

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -135,10 +135,10 @@ func deriveDetectHookedSyscall(t *Tracee) deriveFn {
 		}
 		de := event
 		de.EventID = int(DetectHookedSyscallsEventID)
-		de.EventName = "hooked_syscalls"
+		de.EventName = "detect_hooked_syscalls"
 		de.ReturnValue = 0
 		de.Args = []trace.Argument{
-			{ArgMeta: trace.ArgMeta{Name: "hooked_syscalls", Type: "hookedSyscallData[]"}, Value: hookedSyscallData},
+			{ArgMeta: trace.ArgMeta{Name: "hooked_syscalls", Type: "[]bufferdecoder.HookedSyscallData"}, Value: hookedSyscallData},
 		}
 		de.ArgsNum = 1
 		return de, true, nil

--- a/signatures/rego/syscall_table_hooking.rego
+++ b/signatures/rego/syscall_table_hooking.rego
@@ -1,0 +1,35 @@
+package tracee.TRC_15
+
+import data.tracee.helpers
+
+__rego_metadoc__ := {
+    "id": "TRC-15",
+    "version": "0.1.0",
+    "name": "Hooking system calls by override the system call table entires",
+    "description": "Usage of kernel module to hooks system calls",
+    "tags": ["linux"],
+    "properties": {
+        "Severity": 5,
+        "MITRE ATT&CK": "Persistence: Hooking system calls entires in the system-call table",
+    }
+}
+
+eventSelectors := [
+    {
+        "source": "tracee",
+        "name": "detect_hooked_syscalls"
+    },
+]
+
+tracee_selected_events[eventSelector] {
+	eventSelector := eventSelectors[_]
+}
+
+tracee_match = res {
+    input.eventName == "detect_hooked_syscalls"
+    hooked_syscalls_arr := helpers.get_tracee_argument("hooked_syscalls")
+    c := count(hooked_syscalls_arr)
+    c > 0
+    res :={"hooked syscall": hooked_syscalls_arr}
+
+}

--- a/signatures/rego/syscall_table_hooking_test.rego
+++ b/signatures/rego/syscall_table_hooking_test.rego
@@ -1,0 +1,40 @@
+package tracee.TRC_15
+
+test_match_diamorphine_rootkit_output {
+    tracee_match with input as {
+        "eventName": "detect_hooked_syscalls",
+        "argsNum": 1,
+        "args": [
+            {
+                "name": "hooked_syscalls",
+                "value": [{"SyscallName":"kill","ModuleOwner":"diamorphine"},{"SyscallName":"getdents","ModuleOwner":"diamorphine"},{"SyscallName":"getdents64","ModuleOwner":"diamorphine"}]
+            }
+        ]
+    }
+}
+
+test_match_custom_output {
+    tracee_match with input as {
+        "eventName": "detect_hooked_syscalls",
+        "argsNum": 1,
+        "args": [
+            {
+                "name": "hooked_syscalls",
+                "value": [{"SyscallName":"open","ModuleOwner":"diamorphine"},{"SyscallName":"read","ModuleOwner":"diamorphine"}]
+            }
+        ]
+    }
+}
+
+test_match_empty_array {
+    not tracee_match with input as {
+        "eventName": "detect_hooked_syscalls",
+        "argsNum": 1,
+        "args": [
+            {
+                "name": "hooked_syscalls",
+                "value": []
+            }
+        ]
+    }
+}

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -203,3 +203,8 @@ func (alert MemProtAlert) String() string {
 		return "Unknown alert"
 	}
 }
+
+type HookedSyscallData struct {
+	SyscallName string
+	ModuleOwner string
+}


### PR DESCRIPTION
## Description

Hi this PR adds to tracee-rules a signeture for detecting hooking of system calls in the system call table.

I added it as an extra to the `detect_hooked_syscalls` event in tracee-ebpf
The changes i added is the signature and also a little mistake (n the derived event of `detect_hooked_syscalls`, the mistake is that the name of the event we print wasn't like in the events definition map (in the map it was `detect_hooked_syscalls` and in the drived-event it was `hooked_syscalls`)

Fixes: #1672 


Please pick one and delete the others:

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I add to the signature test file and test manually the `detect_hooked_syscalls` event


## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [ ] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [ ] Capitalize the subject line.
- [ ] Do not end the subject line with a period.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
