### PR TITLE
add device create event

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -86,6 +86,7 @@ const (
 	DirtyPipeSpliceEventID
 	DebugfsCreateFile
 	PrintSyscallTableEventID
+	DeviceCreateEventID
 	MaxCommonEventID
 )
 
@@ -6323,6 +6324,18 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "HookedSyscallData[]", Name: "hooked_syscalls"},
+		},
+	},
+	DeviceCreateEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "device_create",
+		Probes: []probe{
+			{event: "device_create", attach: kprobe, fn: "trace_device_create"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "const char*", Name: "name"},
+			{Type: "const char*", Name: "parent_name"},
 		},
 	},
 }


### PR DESCRIPTION
## Description

Hi this PR is part of #1613, it adds an event to trace the call to device_create kernel function which is used to create a device and register it to the sysfs 

Fixes: #1613

## Type of change

Please pick one and delete the others:

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I ran the test with the event and with this kernel module:
[](https://github.com/dwmkerr/linux-kernel-module/tree/main/babel)

This is the output I got:
`09:00:24:504937  0      insmod           56152   56152   0                device_create        name: babel, parent_name: 
`

**Note: that parent name is empty because that was the given argument in the module 

**Manual Test Setup**:

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [ ] Separate subject from body with a blank line.
- [ ] Limit the subject line to 50 characters.
- [ ] Capitalize the subject line.
- [ ] Do not end the subject line with a period.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
