### PR TITLE
Add internal event feature

### DIFF
--- a/cmd/tracee-ebpf/internal/flags/flags-filter.go
+++ b/cmd/tracee-ebpf/internal/flags/flags-filter.go
@@ -145,7 +145,9 @@ func PrepareFilter(filters []string) (tracee.Filter, error) {
 
 	eventsNameToID := make(map[string]int32, len(tracee.EventsDefinitions))
 	for id, event := range tracee.EventsDefinitions {
-		eventsNameToID[event.Name] = id
+		if !event.Internal {
+			eventsNameToID[event.Name] = id
+		}
 	}
 
 	for _, f := range filters {

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -537,7 +537,7 @@ func printEventGroup(b *strings.Builder, firstEventID, lastEventID int) {
 	for i := firstEventID; i < lastEventID; i++ {
 		index := int32(i)
 		event, ok := tracee.EventsDefinitions[index]
-		if !ok {
+		if !ok || event.Internal {
 			continue
 		}
 		if event.Sets != nil {

--- a/cmd/tracee-ebpf/main_test.go
+++ b/cmd/tracee-ebpf/main_test.go
@@ -210,6 +210,12 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError:  errors.New("invalid event to trace: bl*ah"),
 		},
 		{
+			testName:       "internal event selection",
+			filters:        []string{"event=print_syscall_table"},
+			expectedFilter: tracee.Filter{},
+			expectedError:  errors.New("invalid event to trace: print_syscall_table"),
+		},
+		{
 			testName:       "invalid not wildcard",
 			filters:        []string{"event!=bl*ah"},
 			expectedFilter: tracee.Filter{},

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -36,6 +36,7 @@ type dependencies struct {
 type EventDefinition struct {
 	ID32Bit      int32
 	Name         string
+	Internal     bool
 	Probes       []probe
 	Dependencies dependencies
 	Sets         []string
@@ -6296,8 +6297,9 @@ var EventsDefinitions = map[int32]EventDefinition{
 		},
 	},
 	PrintSyscallTableEventID: {
-		ID32Bit: sys32undefined,
-		Name:    "print_syscall_table",
+		ID32Bit:  sys32undefined,
+		Name:     "print_syscall_table",
+		Internal: true,
 		Probes: []probe{
 			{event: "security_file_ioctl", attach: kprobe, fn: "trace_tracee_trigger_event"},
 		},


### PR DESCRIPTION
## Description

for some events we need the ability to pass information to the user mode.
this results in internal events being exported to the user.
this commit marks those events as internal and makes them unfiltered
and doesn't print them to the user in the --list message.

This is a feature that will improve #1583 and #1561 .

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] trying to select `print_syscall_table` as an event filter does not work
- [x] printing the available events with `--list` does not include `print_syscall_table`

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.

