### PR TITLE
pipeline: split process and sink stages

### DIFF
--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -133,7 +133,7 @@ func InitEventSorter() (*EventsChronologicalSorter, error) {
 
 func (sorter *EventsChronologicalSorter) StartPipeline(ctx gocontext.Context, in <-chan *trace.Event) (
 	chan *trace.Event, chan error) {
-	out := make(chan *trace.Event, 1000)
+	out := make(chan *trace.Event, 10000)
 	errc := make(chan error, 1)
 	go sorter.Start(in, out, ctx, errc)
 	return out, errc


### PR DESCRIPTION
## Description

This PR:
1. Removes the sinking and derivation of events from processEvents
2. Adds a new event sinking pipeline stage
3. Adds a new event derivation pipeline stage
4. Makes the out channel buffer uniform across the pipeline stages (10000)

Relevant to #1684

This was done in order to have an enrichment stage (see #1572) in the pipeline, after the process stage but before deriving and sinking.

## Type of change

- Refactor (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit tests were ran locally.

Manual testing:
In order to check that event derivation was working correctly I have done the following test:

1. Build tracee
2. Run it as such:`./dist/tracee-ebpf --trace event=cgroup_mkdir,container_create`
3. In parallel, start a container as such `docker run --rm redis`
4. A container_create event should be outputted

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [ ] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
