### PR TITLE
set network related options for traced net events instead of just cap…

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -281,7 +281,7 @@ func New(cfg Config) (*Tracee, error) {
 		t.events[MprotectEventID] = eventConfig{}
 		t.events[MemProtAlertEventID] = eventConfig{}
 	}
-	if t.config.Capture.NetIfaces != nil || cfg.Debug {
+	if t.config.Capture.NetIfaces != nil || t.config.Filter.NetFilter.InterfacesToTrace != nil || cfg.Debug {
 		t.events[SecuritySocketBindEventID] = eventConfig{}
 	}
 
@@ -501,7 +501,7 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	if t.containers.IsCgroupV1() {
 		cOptVal = cOptVal | optCgroupV1
 	}
-	if t.config.Capture.NetIfaces != nil || t.config.Debug {
+	if t.config.Capture.NetIfaces != nil || t.config.Filter.NetFilter.InterfacesToTrace != nil || t.config.Debug {
 		cOptVal = cOptVal | optProcessInfo
 		t.config.ProcessInfo = true
 	}


### PR DESCRIPTION
…ture net

## Description

Up until now the process tree was only used for the net events - network events from the kernel to the `netChannel` come only with `hostTid`, so in order to have the full process context, we retrieve it from the process tree (with `hostTid` as key).

The configuration to maintain process tree (`optProcessInfo`) was only set if user asked to capture net.

Once the `net_packet` event was introduced, user can also ask to trace net, and so we need to set the configuration to maintain process tree for trace net, which is what this PR is doing.

Also, for the same reason, setting security_socket_bind as essential event (it is not related to this bug, but it should be set in the same manner).

Fixes: #1688

## Type of change

Please pick one and delete the others:

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

ran 
`./dist/tracee-ebpf -t e=net_packet -t net=enp0s3`

and got the expected results - process context not empty.

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [ ] Separate subject from body with a blank line.
- [ ] Limit the subject line to 50 characters.
- [ ] Capitalize the subject line.
- [ ] Do not end the subject line with a period.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
