### PR TITLE
add register_chrdev event

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -203,7 +203,8 @@ Copyright (C) Aqua Security inc.
 #define DEBUGFS_CREATE_FILE             1039
 #define PRINT_SYSCALL_TABLE             1040
 #define DEBUGFS_CREATE_DIR              1041
-#define MAX_EVENT_ID                    1042
+#define REGISTER_CHRDEV                 1042
+#define MAX_EVENT_ID                    1043
 
 #define NET_PACKET                      4000
 
@@ -4748,6 +4749,45 @@ int BPF_KPROBE(trace_security_inode_mknod)
     return events_perf_submit(&data, SECURITY_INODE_MKNOD, 0);
 }
 
+SEC("kprobe/__register_chrdev")
+TRACE_ENT_FUNC(__register_chrdev, REGISTER_CHRDEV);
+
+SEC("kretprobe/__register_chrdev")
+int BPF_KPROBE(trace_ret__register_chrdev)
+{
+    args_t saved_args;
+    if (load_args(&saved_args, REGISTER_CHRDEV) != 0) {
+        // missed entry or not traced
+        return 0;
+    }
+    del_args(REGISTER_CHRDEV);
+
+    event_data_t data = {};
+    if (!init_event_data(&data, ctx))
+        return 0;
+
+    if (!should_trace(&data.context))
+        return 0;
+
+    unsigned int major_number = (unsigned int)saved_args.args[0];
+    unsigned int returned_major = PT_REGS_RC(ctx);
+
+    // sets the returned major to the requested one in case of a successful registration
+    if (major_number > 0 && returned_major == 0) {
+        returned_major = major_number;
+    }
+
+    char* char_device_name = (char*)saved_args.args[3];
+    struct file_operations *char_device_fops = (struct file_operations *)saved_args.args[4];
+
+    save_to_submit_buf(&data, &major_number, sizeof(unsigned int), 0);
+    save_to_submit_buf(&data, &returned_major, sizeof(unsigned int), 1);
+    save_str_to_buf(&data, char_device_name, 2);
+    save_to_submit_buf(&data, &char_device_fops, sizeof(void *), 3);
+
+    return events_perf_submit(&data, REGISTER_CHRDEV, 0);
+}
+
 SEC("kprobe/do_splice")
 TRACE_ENT_FUNC(do_splice, DIRTY_PIPE_SPLICE);
 
@@ -4759,6 +4799,7 @@ int BPF_KPROBE(trace_ret_do_splice)
         // missed entry or not traced
         return 0;
     }
+    del_args(DIRTY_PIPE_SPLICE);
 
     event_data_t data = {};
     if (!init_event_data(&data, ctx))

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -88,6 +88,7 @@ const (
 	DebugfsCreateFileEventID
 	PrintSyscallTableEventID
 	DebugfsCreateDirEventID
+	RegisterChrdevEventID
 	MaxCommonEventID
 )
 
@@ -6331,6 +6332,21 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "name"},
 			{Type: "const char*", Name: "path"},
+		},
+	},
+	RegisterChrdevEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "register_chrdev",
+		Probes: []probe{
+			{event: "__register_chrdev", attach: kprobe, fn: "trace___register_chrdev"},
+			{event: "__register_chrdev", attach: kretprobe, fn: "trace_ret__register_chrdev"},
+		},
+		Sets: []string{},
+		Params: []trace.ArgMeta{
+			{Type: "unsigned int", Name: "requested_major_number"},
+			{Type: "unsigned int", Name: "granted_major_number"},
+			{Type: "const char*", Name: "char_device_name"},
+			{Type: "struct file_operations *", Name: "char_device_fops"},
 		},
 	},
 }


### PR DESCRIPTION
## Description

Adds `register_chrdev` event indicating a character device was overridden.
Char devices are usually used to create a communication between the user space and the kernel.

Fixes: replaces #1661 to solve #1613 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Overriding device triggers the event

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
