### PR TITLE
btfhub: fix compilation for when BTFHUB is enabled

### DIFF
--- a/3rdparty/btfhub.sh
+++ b/3rdparty/btfhub.sh
@@ -45,7 +45,7 @@ branch_clean() {
     cd ${1} || die "could not change dirs"
 
     # small sanity check
-    [ ! -f ./README.md ] && die "$(basename $(pwd)) not a repo dir"
+    [ ! -d ./.git ] && die "$(basename $(pwd)) not a repo dir"
 
     git fetch -a || die "could not fetch ${1}"  # make sure its updated
     git clean -fdX                              # clean leftovers

--- a/Makefile
+++ b/Makefile
@@ -462,17 +462,16 @@ TRACEE_EBPF_SRC = $(shell find $(TRACEE_EBPF_SRC_DIRS) -type f -name '*.go' ! -n
 tracee-ebpf: $(OUTPUT_DIR)/tracee-ebpf
 
 $(OUTPUT_DIR)/tracee-ebpf: \
-	.checkver_$(CMD_GO) \
-	.checklib_$(LIB_ELF) \
-	.checklib_$(LIB_ZLIB) \
 	$(OUTPUT_DIR)/tracee.bpf.core.o \
 	$(TRACEE_EBPF_SRC) \
-	./embedded-ebpf.go
+	./embedded-ebpf.go \
+	| .checkver_$(CMD_GO) \
+	.checklib_$(LIB_ELF) \
+	.checklib_$(LIB_ZLIB) \
+	btfhub
 #
 	$(MAKE) $(OUTPUT_DIR)/btfhub
-ifeq ($(BTFHUB), 1)
 	$(MAKE) btfhub
-endif
 	$(GO_ENV_EBPF) $(CMD_GO) build \
 		-tags $(GO_TAGS_EBPF) \
 		-ldflags="-w \


### PR DESCRIPTION
## Description

"Smoke Test CO-RE" has issues when executing btfhub.sh during build
time:

  HEAD is now at 83e0916 Documentation fix (#32)
  Branch 'main-200' set up to track remote branch 'main' from 'origin'.
  Switched to a new branch 'main-200'
  Deleted branch main (was 83e0916).
  btfhub-archive not a repo dir
  make[1]: *** [Makefile:503: btfhub] Error 1
  go: downloading github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0

That happens because of a bad existing sanity check. The "tracee-ebpf"
Makefile target should also place btfhub target as a dependency so the
files are always included in the resulting tracee-ebpf binary.

## Type of change

Please pick one and delete the others:

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

$ BTFHUB=1 make tracee-ebpf

The error has been observed from:

https://github.com/aquasecurity/tracee/runs/6178874152?check_suite_focus=true

```
HEAD is now at 83e0916 Documentation fix (#32)
Branch 'main-200' set up to track remote branch 'main' from 'origin'.
Switched to a new branch 'main-200'
Deleted branch main (was 83e0916).
btfhub-archive not a repo dir
make[1]: *** [Makefile:503: btfhub] Error 1
go: downloading github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0
```

**Manual Test Setup**:

## Final Checklist:

- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published already.

## Git Log Checklist:

My commits logs have:

- [x] Separate subject from body with a blank line.
- [x] Limit the subject line to 50 characters.
- [x] Capitalize the subject line.
- [x] Do not end the subject line with a period.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
