### PR TITLE
tracee-ebpf: flatten event probe dependencies

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -23,8 +23,7 @@ type probe struct {
 }
 
 type eventDependency struct {
-	eventID      int32
-	shouldSubmit bool
+	eventID int32
 }
 
 type dependencies struct {
@@ -5869,15 +5868,15 @@ var EventsDefinitions = map[int32]EventDefinition{
 	MagicWriteEventID: {
 		ID32Bit: sys32undefined,
 		Name:    "magic_write",
-		Probes:  []probe{},
-		Sets:    []string{},
-		Dependencies: dependencies{
-			events: []eventDependency{
-				{eventID: VfsWriteEventID},
-				{eventID: VfsWritevEventID},
-				{eventID: __KernelWriteEventID},
-			},
+		Probes: []probe{
+			{event: "vfs_write", attach: kprobe, fn: "trace_vfs_write"},
+			{event: "vfs_write", attach: kretprobe, fn: "trace_ret_vfs_write"},
+			{event: "vfs_writev", attach: kprobe, fn: "trace_vfs_writev"},
+			{event: "vfs_writev", attach: kretprobe, fn: "trace_ret_vfs_writev"},
+			{event: "__kernel_write", attach: kprobe, fn: "trace_kernel_write"},
+			{event: "__kernel_write", attach: kretprobe, fn: "trace_ret_kernel_write"},
 		},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "bytes", Name: "bytes"},
@@ -6139,10 +6138,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "socket_dup",
 		Probes:  []probe{},
-		Dependencies: dependencies{
-			events: []eventDependency{{eventID: DupEventID}, {eventID: Dup2EventID}, {eventID: Dup3EventID}},
-		},
-		Sets: []string{},
+		Sets:    []string{},
 		Params: []trace.ArgMeta{
 			{Type: "int", Name: "oldfd"},
 			{Type: "int", Name: "newfd"},
@@ -6202,7 +6198,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "container_create",
 		Probes:  []probe{},
 		Dependencies: dependencies{
-			events: []eventDependency{{eventID: CgroupMkdirEventID, shouldSubmit: true}},
+			events: []eventDependency{{eventID: CgroupMkdirEventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6216,7 +6212,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "container_remove",
 		Probes:  []probe{},
 		Dependencies: dependencies{
-			events: []eventDependency{{eventID: CgroupRmdirEventID, shouldSubmit: true}},
+			events: []eventDependency{{eventID: CgroupRmdirEventID}},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Currently, in order to define which probes are required for an event to
function correctly, we either define the probes explicitly or use an
event dependency, which will load and attach the required probes.
This other method of defining the probes implicitly should be used only
when the event is a real dependency, and not just as a mechanism to load
and attach the other event's bpf program.

This commit explicitly defines which probes are required for an event to
function correctly, and always submit an event to userspace when it is
defined as a dependency of another event. In addition, it sets tracee to
always load all the bpf programs that exists on the BPF object file.
This is required to break the coupling between an event and the probes
used by it. It will also be required to support dynamically changing
events during runtime as described in [1]. Another future PR might not
load all the BPF probes if it will detect that not all the required BPF
dependencies are met (e.g. LSM-BPF is not supported by the running
kernel).

## Type of change

- [x] New feature (non-breaking change adding functionality).

## How Has This Been Tested?

Manually

Reproduce the test by running (run whatever to trigger these events, and validate they work as expected):

- ./tracee-ebpf -t e=vfs_write,magic_write
- ./tracee-ebpf -t e=socket_dup

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
