### PR TITLE
fix: delete syscall data on socket dup

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2577,7 +2577,7 @@ int sys_dup_exit_tail(void *ctx)
 
     if (sys->ret < 0) {
         // dup failed
-        return 0;
+        goto out;
     }
 
     if (sys->id == SYS_DUP) {
@@ -2592,9 +2592,9 @@ int sys_dup_exit_tail(void *ctx)
         send_socket_dup(&data, sys->args.args[0], sys->args.args[1]);
     }
 
+out:
     // delete syscall data before return
     bpf_map_delete_elem(&syscall_data_map, &data.context.host_tid);
-
     return 0;
 }
 


### PR DESCRIPTION
if dup failed, we returned without deleting syscall data from map.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

fix not deleting syscall data on all cases in socket_dup

Fixes: #1717 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue).
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

tested locally

Reproduce the test by running:

- command 01: ./dist/tracee-ebpf -t e=socket_dup

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
