### PR TITLE
pkg/ebpf: fix __kernel_write emit and tail bug

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4245,7 +4245,7 @@ static __always_inline int do_file_write_operation(struct pt_regs *ctx, u32 even
         return 0;
     }
 
-    if (!should_submit(VFS_WRITE) && !should_submit(VFS_WRITEV) && !should_submit(MAGIC_WRITE)) {
+    if (!should_submit(VFS_WRITE) && !should_submit(VFS_WRITEV) && !should_submit(__KERNEL_WRITE) && !should_submit(MAGIC_WRITE)) {
         bpf_tail_call(ctx, &prog_array, tail_call_id);
         return 0;
     }
@@ -4496,7 +4496,7 @@ int BPF_KPROBE(trace_ret_kernel_write)
 SEC("kretprobe/__kernel_write_tail")
 int BPF_KPROBE(trace_ret_kernel_write_tail)
 {
-    return do_file_write_operation_tail(ctx, TAIL_KERNEL_WRITE);
+    return do_file_write_operation_tail(ctx, __KERNEL_WRITE);
 }
 
 SEC("kprobe/security_mmap_addr")


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

__kernel_write event tail call passed ID was incorrect.
Also, the event was not emitted at all as result of not checking if
should submit the event.

Fixes: #1722 #1721 

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue).
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

1. Use the `acct` syscall to to enable processes accounting in the system to a file (which is implemented using `__kernel_write` function)
2. Run Tracee ebpf tracing the event
3. Run any command
4. See if tracee doesn't print anything

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
