### PR TITLE
readme: bring the documentation session back

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,13 @@ Watch a quick video demo of Tracee:
 
 Check out the [Tracee video hub](https://info.aquasec.com/ebpf-runtime-security) for more videos.
 
+## Documentation
+
+The full documentation of Tracee is available at
+[https://aquasecurity.github.io/tracee/dev](https://aquasecurity.github.io/tracee/dev).
+You can use the version selector on top to view documentation for a specific
+version of Tracee.
+
 ## Quickstart
 
 Before you proceed, make sure you follow the [minimum requirements for running Tracee](./docs/install/prerequisites.md).


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Previous `Readme.md` file change removed the documentation session because it was just a literal copy of `docs/index.md`. I'm bringing it back after @yanivagman requested saying there are users that couldn't find documentation and asked us about it.

## Type of change

- [x] Bug fix (non-breaking change fixing an issue).
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Checking markdown translation in my repo.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
