### PR TITLE
network events: expose new http events

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -817,6 +817,16 @@ struct ipv6hdr {
 struct tcphdr {
     __be16 source;
     __be16 dest;
+    __u16 res1 : 4;
+    __u16 doff : 4;
+    __u16 fin : 1;
+    __u16 syn : 1;
+    __u16 rst : 1;
+    __u16 psh : 1;
+    __u16 ack : 1;
+    __u16 urg : 1;
+    __u16 ece : 1;
+    __u16 cwr : 1;
 };
 
 struct udphdr {

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -122,6 +122,8 @@ const (
 	NetPacket int32 = iota + 4000
 	DnsRequest
 	DnsResponse
+	HttpRequest
+	HttpResponse
 	MaxNetEventID
 )
 
@@ -5737,6 +5739,37 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "[]trace.HookedSymbolData", Name: "hooked_fops_pointers"},
+		},
+	},
+	HttpRequest: {
+		ID32Bit:      sys32undefined,
+		Name:         "http_request",
+		Probes:       []probe{},
+		Dependencies: dependencies{},
+		Sets:         []string{"network_events"},
+		Params: []trace.ArgMeta{
+			{Type: "trace.PktMeta", Name: "metadata"},
+			{Type: "string", Name: "method"},
+			{Type: "string", Name: "protocol"},
+			{Type: "string", Name: "host"},
+			{Type: "string", Name: "uri_path"},
+			{Type: "http.Header", Name: "headers"},
+			{Type: "int64", Name: "content_length"},
+		},
+	},
+	HttpResponse: {
+		ID32Bit:      sys32undefined,
+		Name:         "http_response",
+		Probes:       []probe{},
+		Dependencies: dependencies{},
+		Sets:         []string{"network_events"},
+		Params: []trace.ArgMeta{
+			{Type: "trace.PktMeta", Name: "metadata"},
+			{Type: "string", Name: "status"},
+			{Type: "int", Name: "status_code"},
+			{Type: "string", Name: "protocol"},
+			{Type: "http.Header", Name: "headers"},
+			{Type: "int64", Name: "content_length"},
 		},
 	},
 }

--- a/pkg/ebpf/events_derived.go
+++ b/pkg/ebpf/events_derived.go
@@ -35,6 +35,12 @@ func (t *Tracee) initEventDerivationMap() error {
 		DnsResponse: {
 			NetPacket: deriveNetPacket(),
 		},
+		HttpRequest: {
+			NetPacket: deriveNetPacket(),
+		},
+		HttpResponse: {
+			NetPacket: deriveNetPacket(),
+		},
 	}
 
 	return nil

--- a/pkg/ebpf/net_proto.go
+++ b/pkg/ebpf/net_proto.go
@@ -39,8 +39,10 @@ func CreateNetEvent(eventMeta bufferdecoder.NetEventMetadata, ctx procinfo.Proce
 // callProtocolHandler calls protocol handler
 func callProtocolHandler(eventId int32, decoder *bufferdecoder.EbpfDecoder, evt *trace.Event, ifaceName string, packetLen uint32) error {
 	protocolHandlers := map[int32][]protocolHandler{
-		DnsRequest:  {dnsQueryProtocolHandler},
-		DnsResponse: {dnsReplyProtocolHandler},
+		DnsRequest:   {dnsQueryProtocolHandler},
+		DnsResponse:  {dnsReplyProtocolHandler},
+		HttpRequest:  {httpRequestProtocolHandler},
+		HttpResponse: {httpResponseProtocolHandler},
 	}
 
 	// call the generic netPacketHandler


### PR DESCRIPTION
parse http data from packets labeled as http, and output the event.
support two http events - http_request and http_response.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

example of events:
http_request
`13:37:56:509721  1000   curl             5844    5844    0                http_request         metadata: {192.168.1.201 142.250.184.110 45186 80 6}, method: GET, protocol: HTTP/1.1, host: google.com, uri_path: /, headers: map[Accept:[*/*] User-Agent:[curl/7.68.0]], content_length: 0`

http_response
`13:37:56:689060  1000   curl             5844    5844    0                http_response        metadata: {142.250.184.110 192.168.1.201 80 45186 6}, status: 301 Moved Permanently, status_code: 301, protocol: HTTP/1.1, headers: map[Cache-Control:[public, max-age=2592000] Content-Length:[219] Content-Type:[text/html; charset=UTF-8] Date:[Sun, 15 May 2022 10:37:56 GMT] Expires:[Tue, 14 Jun 2022 10:37:56 GMT] Location:[http://www.google.com/] Server:[gws] X-Frame-Options:[SAMEORIGIN] X-Xss-Protection:[0]], content_length: 219`

Fixes: #1385

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

events were tested locally.
tests included: 
all the network events - net_packet, dns_request, dns_response, http_request, http_response ;
some network events - net_packet, http_request, http_response ;  dns_request, dns_response, http_request, http_response ;  http_request, http_response ;  http_request ; http_response ;
with capture net
without capture net

Reproduce the test by running:

- command 01: `./dist/tracee-ebpf -t e=net_packet,dns_request,dns_response,http_request,http_response -t net=enp0s3 --capture net=enp0s3 --capture pcap:per-process`
- command 02: `./dist/tracee-ebpf -t e=net_packet,dns_request,dns_response,http_request,http_response -t net=enp0s3`
- command 03: `./dist/tracee-ebpf -t e=net_packethttp_request,http_response -t net=enp0s3`
- command 04: `./dist/tracee-ebpf -t e=http_response -t net=enp0s3`

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
