### PR TITLE
Enrich container events review fixes

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -44,7 +44,7 @@ type CgroupInfo struct {
 
 // InitContainers initializes a Containers object and returns a pointer to it.
 // User should further call "Populate" and iterate with Containers data.
-func InitContainers(sockets cruntime.Sockets) (*Containers, error) {
+func InitContainers(sockets cruntime.Sockets, debug bool) (*Containers, error) {
 	cgroupV1 := false
 	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); os.IsNotExist(err) {
 		cgroupV1 = true
@@ -57,16 +57,16 @@ func InitContainers(sockets cruntime.Sockets) (*Containers, error) {
 
 	//attempt to register for all supported runtimes
 	err := runtimeService.Register(cruntime.Containerd, cruntime.ContainerdEnricher)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to register enricher: %v\n", err)
+	if err != nil && debug {
+		fmt.Fprintf(os.Stderr, "Enricher: %v\n", err)
 	}
 	err = runtimeService.Register(cruntime.Crio, cruntime.CrioEnricher)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to register enricher: %v\n", err)
+	if err != nil && debug {
+		fmt.Fprintf(os.Stderr, "Enricher: %v\n", err)
 	}
 	err = runtimeService.Register(cruntime.Docker, cruntime.DockerEnricher)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to register enricher: %v\n", err)
+	if err != nil && debug {
+		fmt.Fprintf(os.Stderr, "Enricher: %v\n", err)
 	}
 
 	return &Containers{

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -314,7 +314,7 @@ func New(cfg Config) (*Tracee, error) {
 		return nil, fmt.Errorf("error intitalizing event derivation map: %w", err)
 	}
 
-	c, err := containers.InitContainers(t.config.Sockets)
+	c, err := containers.InitContainers(t.config.Sockets, t.config.Debug)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing containers: %w", err)
 	}


### PR DESCRIPTION
@NDStrahilevitz is out for the next days and we needed the enricher merged before the next release. I have spoken with him about this fixes needs before he was out and I'm addressing issues observed in https://github.com/aquasecurity/tracee/pull/1572.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit 109f5249
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 17 02:20:12 2022

    events_enrich: make sure queue flushing is ordered

    Events enricher needs to make sure event is not sent to the out channel
    before emptying the cache, for the same cgroupId, entirely. This commit
    creates a "per cgroupId cache flush" transaction, guaranteed by a mutex.

    Fixes: https://github.com/aquasecurity/tracee/pull/1572#discussion_r874024076

commit cc150850
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Mon May 16 22:43:39 2022

    enricher: service register errors are debug info

    Instead of always displaying error messages to stderr when not able to
    register an enrichment service, make it an informative message through
    debug if it is enabled.

    Fixes: https://github.com/aquasecurity/tracee/pull/1572#issuecomment-1128079602

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

I have tested this by adding "-race" option to Makefile and running the following command:

```
sudo ./dist/tracee-ebpf -o format:json -o option:parse-arguments -o option:detect-syscall -trace container -trace comm=bash -trace follow --crs docker:/var/run/docker.sock | jq
```

I have also done test described at: https://github.com/aquasecurity/tracee/pull/1572#issuecomment-1128421147

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
