### PR TITLE
k8s deployment: increase needed limits because of caching

### DIFF
--- a/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
+++ b/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
@@ -30,13 +30,19 @@ spec:
         - name: etc-os-release
           mountPath: /etc/os-release-host
           readOnly: true
-        resources:
-          limits:
-            cpu: 500m
-            memory: 300Mi
-          requests:
-            cpu: 350m
-            memory: 50Mi
+        # NOTE: Resource consumption will vary between different use cases and
+        # workload characteristics. User should monitor tracee for resource
+        # consumption before enabling resource limits. Capping tracee
+        # resources may cause loss of events and miss detections. Golang
+        # signatures outperforms REGO signatures, use less HW resources,
+        # and are preferred if that is an option.
+        # resources:
+        #   limits:
+        #     cpu: "1"
+        #     memory: 1Gi # tracee has a 512MB in-memory events cache enabled by default
+        #   requests:
+        #     cpu: "1"
+        #     memory: 1Gi
       tolerations:
         - effect: NoSchedule
           operator: Exists

--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -36,13 +36,20 @@ spec:
         - name: etc-os-release
           mountPath: /etc/os-release-host
           readOnly: true
-        resources:
-          limits:
-            cpu: 500m
-            memory: 300Mi
-          requests:
-            cpu: 350m
-            memory: 50Mi
+        # NOTE: Resource consumption will vary between different use cases and
+        # workload characteristics. User should monitor tracee for resource
+        # consumption before enabling resource limits. Capping tracee
+        # resources may cause loss of events and miss detections. Golang
+        # signatures outperforms REGO signatures, use less HW resources,
+        # and are preferred if that is an option.
+        # resources:
+        # resources:
+        #   limits:
+        #     cpu: "1"
+        #     memory: 1Gi # tracee has a 512MB in-memory events cache enabled by default
+        #   requests:
+        #     cpu: "1"
+        #     memory: 1Gi
       tolerations:
         - effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

When caching was added to entrypoint the limits were not increased from
the deployment recipes, making tracee to fail with OOM in real
environments.

The default memory consumption shall be in between 768M and 1GB of ram
by default. That might be changed in a near future when performance
increases and less caching is needed.

Fixes: #1798

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

By the same user who reported the issue (while talking to me in Slack).

![image](https://user-images.githubusercontent.com/7395852/171997278-c91a9df6-3730-457d-b87f-a520712b7433.png)

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
