### PR TITLE
[MAINT] distro-tester: randomize and timeout tests

### DIFF
--- a/tests/distro-tester/03-run-qemu.sh
+++ b/tests/distro-tester/03-run-qemu.sh
@@ -31,6 +31,8 @@ error_syntax() {
 
 # check where the image is coming from (if inside container)
 
+image_name=$image
+
 if [[ -f ./kernels/$image.vmlinuz ]]; then
   vmlinuz=./kernels/$image.vmlinuz
   initrd=./kernels/$image.initrd
@@ -95,7 +97,7 @@ fi
 tempfile=$(mktemp)
 tempdir=$(mktemp -d)
 truncate -s 300M $tempfile
-mkfs.ext4 $tempfile
+mkfs.ext4 -Ltracee $tempfile
 
 mount $tempfile $tempdir
 rm -rf $tempdir/load+found
@@ -114,7 +116,7 @@ umount $tempdir
 rmdir $tempdir
 
 # kernel cmdline
-cmd_kernel=$cmd_kernel"root=/dev/sda "
+cmd_kernel=$cmd_kernel"root=LABEL=$image_name "
 cmd_kernel=$cmd_kernel"console=ttyS0 "
 cmd_kernel=$cmd_kernel"testname=$testname "
 cmd_kernel=$cmd_kernel"isnoncore=$isnoncore "
@@ -123,7 +125,9 @@ cmd_kernel=$cmd_kernel"apparmor=0 "
 cmd_kernel=$cmd_kernel"systemd.unified_cgroup_hierarchy=false "
 cmd_kernel=$cmd_kernel"net.ifnames=0"
 
-# qemu cmdline
+# run qemu with 20 minutes timeout (needed because of kernel soft/hard lockups)
+
+timeout --preserve-status --foreground --signal=9 20m \
 qemu-system-x86_64 \
   -name guest=$image \
   -machine accel=$kvmaccel \

--- a/tests/distro-tester/files/docker-entrypoint.sh
+++ b/tests/distro-tester/files/docker-entrypoint.sh
@@ -39,10 +39,14 @@ fi
 # create loop devices if running in LXD guest
 
 for seq in $(echo {150..170}); do
-  if [[ ! -f /dev/loop$seq ]]; then
-    mknod -m 660 /dev/loop$seq b 7 $seq
-  fi
+  mknod -m 660 /dev/loop$seq b 7 $seq > /dev/null 2>&1 || true
 done
+
+# sleep for random time not to start all jobs at once
+
+rand=$(( $RANDOM % 30 ))
+info "sleeping for $rand seconds"
+sleep $rand
 
 # run qemu
 

--- a/tests/distro-tester/files/qemu-entrypoint.sh
+++ b/tests/distro-tester/files/qemu-entrypoint.sh
@@ -24,7 +24,7 @@ beginhook() {
   mkdir -p /tracee
   dmesg --console-off
   trap cleanup EXIT
-  mount /dev/sdb /tracee
+  mount LABEL=tracee /tracee
 }
 
 ## main
@@ -47,6 +47,11 @@ info "SELECTED TEST: $testname"
 info "NON CO-RE: $isnoncore"
 info "CLANG: $(clang --version)"
 info "GO: $(go version)"
+
+# debug (if needed)
+
+# bash
+# exit
 
 info "pulling aquasec/tracee-tester:latest docker image"
 docker image pull aquasec/tracee-tester:latest


### PR DESCRIPTION
Maintenance PR.

## Description (git log)

- fix extract-images issue if initrd is not present
- randomize test initialization to save node's I/O
- timeout qemu execution to 20 minutes (because of lockups)
- mount disks by LABEL (solves stream9 boot problems)
