### PR TITLE
dns events: support dns events over tcp

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5378,16 +5378,10 @@ static __always_inline void set_net_event_id(net_packet_t *pkt)
         DNS = 53,
     };
 
-    switch (pkt->protocol) {
-        case IPPROTO_UDP:
-            if (pkt->dst_port == DNS)
-                pkt->event_id = DNS_REQUEST;
-            if (pkt->src_port == DNS)
-                pkt->event_id = DNS_RESPONSE;
-            break;
-        default:
-            pkt->event_id = NET_PACKET;
-    }
+    if (pkt->dst_port == DNS)
+        pkt->event_id = DNS_REQUEST;
+    if (pkt->src_port == DNS)
+        pkt->event_id = DNS_RESPONSE;
 }
 
 // some network events might need payload (even without capture)


### PR DESCRIPTION
output dns events which are on top of tcp, not just udp.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

supporing DNS events over TCP

Fixes: #1806

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tests being included in this PR:

- [ ] Test File A
- [ ] Test File B

Reproduce the test by running:

- command 01
- command 02

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
