### PR TITLE
[FIX] containers: add enrichment logic for unknown runtime

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -244,10 +244,6 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 		return metadata, fmt.Errorf("no containerId")
 	}
 
-	if runtime == cruntime.Unknown {
-		return metadata, fmt.Errorf("unknown runtime")
-	}
-
 	//There might be a performance overhead with the cancel
 	//But, I think it will be negligable since this code path shouldn't be reached too frequently
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
If an enrichment request is received with an unknown runtime
the enrichment service will try to enrich from all known registered
runtimes before failing.

This is done in order to fix repeated "unknown runtime" errors and failed
enrichments in kubernetes environments such as microk8s and k3s.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Jun 8 10:47:02 2022 +0000

    containers: add enrichment logic for unknown runtime
    
    If an enrichment request is received with an unknown runtime
    the enrichment service will try to enrich from all known registered
    runtimes before failing.
    
    This is done in order to fix repeated "unknown runtime" errors and failed
    enrichments in kubernetes environments such as microk8s and k3s.
```

Fixes: #1786
Fixes: #1789

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Code refactor (code improvement and/or code removal)

## How Has This Been Tested?

Tested manually through deploying an image on a microk8s cluster.
Make sure to mount the appropriate runtime sockets (As done for example in #1786 OP).
This was tested with TRACEE_EBPF_ONLY=1 and `--trace event=container_create --output json`

Reproduce the test by running:

- microk8s kubectl apply -f deploy/kubernetes/tracee-postee/tracee.yaml
- microk8s kubectl get pods (get your tracee's pod name)
- microk8s run redis --image=redis
- microk8s logs <pod_name>

A pause container and redis container `container_create` events should be outputted with enrichment data in their args.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
