### PR TITLE
event: set_task_comm

### DIFF
--- a/pkg/ebpf/argprinters.go
+++ b/pkg/ebpf/argprinters.go
@@ -34,7 +34,7 @@ func (t *Tracee) parseArgs(event *trace.Event) error {
 				alertArg.Value = trace.MemProtAlert(alert).String()
 			}
 		}
-	case SysEnterEventID, SysExitEventID, CapCapableEventID, CommitCredsEventID, SecurityFileOpenEventID:
+	case SysEnterEventID, SysExitEventID, CapCapableEventID, CommitCredsEventID, SecurityFileOpenEventID, TaskRenameEventID:
 		if syscallArg := getEventArg(event, "syscall"); syscallArg != nil {
 			if id, isInt32 := syscallArg.Value.(int32); isInt32 {
 				if event, isKnown := EventsDefinitions[id]; isKnown {

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -95,6 +95,7 @@ const (
 	LoadElfPhdrsEventID
 	HookedProcFopsEventID
 	PrintNetSeqOpsEventID
+	TaskRenameEventID
 	MaxCommonEventID
 )
 
@@ -5767,6 +5768,19 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Params: []trace.ArgMeta{
 			{Type: "string", Name: "struct_name"},
 			{Type: "[]helpers.KernelSymbol", Name: "hooked_seq_ops"},
+		},
+	},
+	TaskRenameEventID: {
+		ID32Bit: sys32undefined,
+		Name:    "task_rename",
+		Probes: []probeDependency{
+			{handle: probes.TaskRename, required: true},
+		},
+		Sets: []string{"proc"},
+		Params: []trace.ArgMeta{
+			{Type: "const char*", Name: "old_name"},
+			{Type: "const char*", Name: "new_name"},
+			{Type: "int", Name: "syscall"},
 		},
 	},
 }

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -81,6 +81,7 @@ func Init(module *bpf.Module) (Probes, error) {
 			DoInitModuleRet:            {event: "do_init_module", probeType: kretprobe, fn: "trace_ret_do_init_module"},
 			LoadElfPhdrs:               {event: "load_elf_phdrs", probeType: kprobe, fn: "trace_load_elf_phdrs"},
 			Filldir64:                  {event: "filldir64", probeType: kprobe, fn: "trace_filldir64"},
+			TaskRename:                 {event: "task:task_rename", probeType: rawTracepoint, fn: "tracepoint__task__task_rename"},
 		},
 		module: module,
 	}, nil
@@ -225,4 +226,5 @@ const (
 	LoadElfPhdrs
 	Filldir64
 	SecurityFilePermission
+	TaskRename
 )


### PR DESCRIPTION
create new event indicating process name change

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

using `__set_task_comm` kprobe to indicate event of process name change

Fixes: #1810

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tests being included in this PR:

- [ ] Test File A
- [ ] Test File B

Reproduce the test by running:

- command 01
- command 02

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
