### PR TITLE
Signature Filter Metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,3 +103,5 @@ require (
 )
 
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0
+
+replace github.com/aquasecurity/tracee/types => github.com/NDStrahilevitz/tracee/types v0.0.0-20220914094121-cb19d081cd77

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/Microsoft/hcsshim v0.9.4 h1:mnUj0ivWy6UzbB1uLFqKR6F+ZyiDc7j4iGgHTpO+5
 github.com/Microsoft/hcsshim v0.9.4/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
+github.com/NDStrahilevitz/tracee/types v0.0.0-20220914094121-cb19d081cd77 h1:Cr7bamFZUk74PQswF0s94j0JKsM42BgkhLx0l4neYAY=
+github.com/NDStrahilevitz/tracee/types v0.0.0-20220914094121-cb19d081cd77/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -124,8 +126,6 @@ github.com/aquasecurity/libbpfgo v0.4.4-libbpf-1.0.1 h1:cjdRq/YhQ5ZVU0jm6H3VXVcH
 github.com/aquasecurity/libbpfgo v0.4.4-libbpf-1.0.1/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.4 h1:a8RnY90e0O9Du8MIEJfHOsLb/AiLP6McKndIUfrSdZM=
 github.com/aquasecurity/libbpfgo/helpers v0.4.4/go.mod h1:H72+/tC8b1bqeylP1n7c+AfC18ksK9/7Z16ECafVRhM=
-github.com/aquasecurity/tracee/types v0.0.0-20220804074749-e785ea989919 h1:1tvaIwXjjSciTa1JNqw3W4iofSONLX/GORWL8ee5Ocw=
-github.com/aquasecurity/tracee/types v0.0.0-20220804074749-e785ea989919/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/rules/benchmark/signature/golang/anti_debugging.go
+++ b/pkg/rules/benchmark/signature/golang/anti_debugging.go
@@ -43,6 +43,10 @@ func (sig *antiDebugging) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 	}, nil
 }
 
+func (sig *antiDebugging) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (sig *antiDebugging) OnEvent(event protocol.Event) error {
 	ee, ok := event.Payload.(trace.Event)
 

--- a/pkg/rules/benchmark/signature/golang/code_injection.go
+++ b/pkg/rules/benchmark/signature/golang/code_injection.go
@@ -53,6 +53,10 @@ func (sig *codeInjection) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 	}, nil
 }
 
+func (sig *codeInjection) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	// event example:
 	// { "eventName": "ptrace", "args": [{"name": "request", "value": "PTRACE_POKETEXT" }]}

--- a/pkg/rules/benchmark/signature/golang/noop.go
+++ b/pkg/rules/benchmark/signature/golang/noop.go
@@ -21,6 +21,10 @@ func (n *noop) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{}, nil
 }
 
+func (n *noop) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (n *noop) Init(cb detect.SignatureHandler) error {
 	n.cb = cb
 	return nil

--- a/pkg/rules/celsig/config.go
+++ b/pkg/rules/celsig/config.go
@@ -44,6 +44,9 @@ type SignatureConfig struct {
 	// to evaluate them.
 	EventSelectors []detect.SignatureEventSelector `yaml:"eventSelectors"`
 
+	// Filters to define which events the signatures need from the source
+	Filters []detect.Filter `yaml:"filters"`
+
 	// Expression is a CEL expression that is used to evaluate events.
 	// To indicate a possible threat the Expression must evaluate to `true`,
 	// otherwise event is considered innocent.

--- a/pkg/rules/celsig/signature.go
+++ b/pkg/rules/celsig/signature.go
@@ -13,6 +13,7 @@ import (
 type signature struct {
 	metadata       detect.SignatureMetadata
 	selectedEvents []detect.SignatureEventSelector
+	filter         []detect.Filter
 	program        cel.Program
 	cb             detect.SignatureHandler
 }
@@ -38,6 +39,7 @@ func NewSignature(config SignatureConfig) (detect.Signature, error) {
 		program:        program,
 		selectedEvents: config.EventSelectors,
 		metadata:       config.Metadata,
+		filter:         config.Filters,
 	}, nil
 }
 
@@ -47,6 +49,10 @@ func (s *signature) GetMetadata() (detect.SignatureMetadata, error) {
 
 func (s *signature) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return s.selectedEvents, nil
+}
+
+func (s *signature) GetFilters() ([]detect.Filter, error) {
+	return s.filter, nil
 }
 
 func (s *signature) Init(cb detect.SignatureHandler) error {

--- a/pkg/rules/engine/engine_test.go
+++ b/pkg/rules/engine/engine_test.go
@@ -18,6 +18,7 @@ import (
 type regoFakeSignature struct {
 	getMetadata       func() (detect.SignatureMetadata, error)
 	getSelectedEvents func() ([]detect.SignatureEventSelector, error)
+	getFilter         func() ([]detect.Filter, error)
 	init              func(detect.SignatureHandler) error
 	onEvent           func(protocol.Event) error
 	onSignal          func(signal detect.Signal) error
@@ -40,6 +41,14 @@ func (fs regoFakeSignature) GetSelectedEvents() ([]detect.SignatureEventSelector
 	}
 
 	return []detect.SignatureEventSelector{}, nil
+}
+
+func (fs regoFakeSignature) GetFilters() ([]detect.Filter, error) {
+	if fs.getFilter != nil {
+		return fs.getFilter()
+	}
+
+	return []detect.Filter{}, nil
 }
 
 func (fs regoFakeSignature) Init(cb detect.SignatureHandler) error {
@@ -67,6 +76,7 @@ func (fs *regoFakeSignature) Close() {}
 type fakeSignature struct {
 	getMetadata       func() (detect.SignatureMetadata, error)
 	getSelectedEvents func() ([]detect.SignatureEventSelector, error)
+	getFilter         func() ([]detect.Filter, error)
 	init              func(detect.SignatureHandler) error
 	onEvent           func(protocol.Event) error
 	onSignal          func(signal detect.Signal) error
@@ -89,6 +99,14 @@ func (fs fakeSignature) GetSelectedEvents() ([]detect.SignatureEventSelector, er
 	}
 
 	return []detect.SignatureEventSelector{}, nil
+}
+
+func (fs fakeSignature) GetFilters() ([]detect.Filter, error) {
+	if fs.getFilter != nil {
+		return fs.getFilter()
+	}
+
+	return []detect.Filter{}, nil
 }
 
 func (fs fakeSignature) Init(cb detect.SignatureHandler) error {

--- a/pkg/rules/regosig/aio.go
+++ b/pkg/rules/regosig/aio.go
@@ -25,6 +25,7 @@ const (
 	moduleMain             = "main.rego"
 	queryMetadataAll       = "data.main.__rego_metadoc_all__"
 	querySelectedEventsAll = "data.main.tracee_selected_events_all"
+	queryFiltersAll        = "data.main.tracee_filters_all"
 	queryMatchAll          = "data.main.tracee_match_all"
 )
 
@@ -186,6 +187,10 @@ func (a *aio) GetMetadata() (detect.SignatureMetadata, error) {
 
 func (a *aio) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return a.selectedEvents, nil
+}
+
+func (a *aio) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
 }
 
 func (a *aio) OnEvent(event protocol.Event) error {

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	args "github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -40,6 +41,12 @@ func (sig *AntiDebuggingPtraceme) GetMetadata() (detect.SignatureMetadata, error
 func (sig *AntiDebuggingPtraceme) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{
 		{Source: "tracee", Name: "ptrace", Origin: "*"},
+	}, nil
+}
+
+func (sig *AntiDebuggingPtraceme) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("ptrace.args.request", args.PTRACE_TRACEME.Value()),
 	}, nil
 }
 

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -43,6 +43,12 @@ func (sig *AslrInspection) GetSelectedEvents() ([]detect.SignatureEventSelector,
 	}, nil
 }
 
+func (sig *AslrInspection) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_file_open.args.pathname", sig.aslrPath),
+	}, nil
+}
+
 func (sig *AslrInspection) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -44,6 +44,12 @@ func (sig *CgroupNotifyOnReleaseModification) GetSelectedEvents() ([]detect.Sign
 	}, nil
 }
 
+func (sig *CgroupNotifyOnReleaseModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.SuffixFilter("security_file_open.args.pathname", sig.notifyFileName),
+	}, nil
+}
+
 func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -45,6 +45,13 @@ func (sig *CgroupReleaseAgentModification) GetSelectedEvents() ([]detect.Signatu
 	}, nil
 }
 
+func (sig *CgroupReleaseAgentModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.SuffixFilter("security_file_open.args.pathname", sig.releaseAgentName),
+		detect.SuffixFilter("security_inode_rename.args.new_path", sig.releaseAgentName),
+	}, nil
+}
+
 func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -44,6 +44,12 @@ func (sig *CorePatternModification) GetSelectedEvents() ([]detect.SignatureEvent
 	}, nil
 }
 
+func (sig *CorePatternModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.SuffixFilter("security_file_open.args.pathname", sig.corePattern),
+	}, nil
+}
+
 func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -48,6 +48,13 @@ func (sig *DefaultLoaderModification) GetSelectedEvents() ([]detect.SignatureEve
 	}, nil
 }
 
+func (sig *DefaultLoaderModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.PrefixFilter("security_file_open.args.pathname", "/lib/usr/", "/lib/"),
+		detect.PrefixFilter("security_inode_rename.args.new_path", "/lib/usr/", "/lib/"),
+	}, nil
+}
+
 func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/disk_mount.go
+++ b/signatures/golang/disk_mount.go
@@ -44,6 +44,14 @@ func (sig *DiskMount) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 	}, nil
 }
 
+func (sig *DiskMount) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_sb_mount.context.tid", 1).Not(),
+		detect.PrefixFilter("security_sb_mount.context.processName", "runc:").Not(),
+		detect.PrefixFilter("security_sb_mount.args.dev_name", sig.devDir),
+	}, nil
+}
+
 func (sig *DiskMount) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -45,6 +45,13 @@ func (sig *DockerAbuse) GetSelectedEvents() ([]detect.SignatureEventSelector, er
 	}, nil
 }
 
+func (sig *DockerAbuse) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.ContainsFilter("security_socket_connect.args.remote_addr", sig.dockerSock), //maps parse as strings to "map[key1:value1 key2:value2 ...]"
+		detect.SuffixFilter("security_file_open.args.pathname", sig.dockerSock),
+	}, nil
+}
+
 func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/dropped_executable.go
+++ b/signatures/golang/dropped_executable.go
@@ -41,6 +41,13 @@ func (sig *DroppedExecutable) GetSelectedEvents() ([]detect.SignatureEventSelect
 	}, nil
 }
 
+func (sig *DroppedExecutable) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		helpers.MemoryPathFilter("magic_write.args.pathname").Not(),
+		helpers.IsElfFilter("magic_write.args.bytes"),
+	}, nil
+}
+
 func (sig *DroppedExecutable) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -39,6 +40,12 @@ func (sig *DynamicCodeLoading) GetMetadata() (detect.SignatureMetadata, error) {
 func (sig *DynamicCodeLoading) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{
 		{Source: "tracee", Name: "mem_prot_alert", Origin: "*"},
+	}, nil
+}
+
+func (sig *DynamicCodeLoading) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("mem_prot_alert.args.alert", int(trace.ProtAlertMprotectWXToX)),
 	}, nil
 }
 

--- a/signatures/golang/fileless_execution.go
+++ b/signatures/golang/fileless_execution.go
@@ -41,6 +41,10 @@ func (sig *FilelessExecution) GetSelectedEvents() ([]detect.SignatureEventSelect
 	}, nil
 }
 
+func (sig *FilelessExecution) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (sig *FilelessExecution) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/hidden_file_created.go
+++ b/signatures/golang/hidden_file_created.go
@@ -44,6 +44,13 @@ func (sig *HiddenFileCreated) GetSelectedEvents() ([]detect.SignatureEventSelect
 	}, nil
 }
 
+func (sig *HiddenFileCreated) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("magic_write.args.pathname", sig.hiddenPathPattern),
+		helpers.IsElfFilter("magic_write.args.bytes"),
+	}, nil
+}
+
 func (sig *HiddenFileCreated) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/illegitimate_shell.go
+++ b/signatures/golang/illegitimate_shell.go
@@ -46,6 +46,13 @@ func (sig *IllegitimateShell) GetSelectedEvents() ([]detect.SignatureEventSelect
 	}, nil
 }
 
+func (sig *IllegitimateShell) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_bprm_check.context.processName", sig.webServersProcessNames),
+		detect.SuffixFilter("security_bprm_check.context.pathname", sig.shellNames...),
+	}, nil
+}
+
 func (sig *IllegitimateShell) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -49,6 +49,12 @@ func (sig *K8SServiceAccountToken) GetSelectedEvents() ([]detect.SignatureEventS
 	}, nil
 }
 
+func (sig *K8SServiceAccountToken) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.ContainsFilter("security_file_open.args.pathname", "secrets/kubernetes.io/serviceaccount"),
+	}, nil
+}
+
 func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/kernel_module_loading.go
+++ b/signatures/golang/kernel_module_loading.go
@@ -42,6 +42,10 @@ func (sig *KernelModuleLoading) GetSelectedEvents() ([]detect.SignatureEventSele
 	}, nil
 }
 
+func (sig *KernelModuleLoading) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/kubernetes_api_connection.go
+++ b/signatures/golang/kubernetes_api_connection.go
@@ -43,6 +43,12 @@ func (sig *K8sApiConnection) GetSelectedEvents() ([]detect.SignatureEventSelecto
 	}, nil
 }
 
+func (sig *K8sApiConnection) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.ContainsFilter("security_socket_connect.args.remote_addr", "sa_family:AF_INET", "sa_family:AF_INET6"), //maps parse as strings to "map[key1:value1 key2:value2 ...]"
+	}, nil
+}
+
 func (sig *K8sApiConnection) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -47,6 +47,13 @@ func (sig *KubernetesCertificateTheftAttempt) GetSelectedEvents() ([]detect.Sign
 	}, nil
 }
 
+func (sig *KubernetesCertificateTheftAttempt) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.PrefixFilter("security_file_open.args.pathname", sig.k8sCertificatesDir),
+		detect.PrefixFilter("security_inode_rename.args.old_path", sig.k8sCertificatesDir),
+	}, nil
+}
+
 func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -48,6 +48,13 @@ func (sig *LdPreload) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 	}, nil
 }
 
+func (sig *LdPreload) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.SuffixFilter("security_file_open.args.pathname", sig.preloadPath),
+		detect.SuffixFilter("security_inode_rename.args.new_path", sig.preloadPath),
+	}, nil
+}
+
 func (sig *LdPreload) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/proc_fops_hooking.go
+++ b/signatures/golang/proc_fops_hooking.go
@@ -41,6 +41,12 @@ func (sig *ProcFopsHooking) GetSelectedEvents() ([]detect.SignatureEventSelector
 	}, nil
 }
 
+func (sig *ProcFopsHooking) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.NotEqualFilter("hooked_proc_fops.args.hooked_fops_pointers", "[]"),
+	}, nil
+}
+
 func (sig *ProcFopsHooking) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -44,6 +44,12 @@ func (sig *ProcKcoreRead) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 	}, nil
 }
 
+func (sig *ProcKcoreRead) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.SuffixFilter("security_file_open.args.pathname", sig.kcorePath),
+	}, nil
+}
+
 func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -47,6 +47,12 @@ func (sig *ProcMemAccess) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 	}, nil
 }
 
+func (sig *ProcMemAccess) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.PrefixFilter("security_file_open.args.pathname", "/proc/"),
+	}, nil
+}
+
 func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -47,6 +47,12 @@ func (sig *ProcMemCodeInjection) GetSelectedEvents() ([]detect.SignatureEventSel
 	}, nil
 }
 
+func (sig *ProcMemCodeInjection) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.PrefixFilter("security_file_open.args.pathname", "/proc/"),
+	}, nil
+}
+
 func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/process_vm_write_code_injection.go
+++ b/signatures/golang/process_vm_write_code_injection.go
@@ -42,6 +42,10 @@ func (sig *ProcessVmWriteCodeInjection) GetSelectedEvents() ([]detect.SignatureE
 	}, nil
 }
 
+func (sig *ProcessVmWriteCodeInjection) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (sig *ProcessVmWriteCodeInjection) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	args "github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -40,6 +41,12 @@ func (sig *PtraceCodeInjection) GetMetadata() (detect.SignatureMetadata, error) 
 func (sig *PtraceCodeInjection) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{
 		{Source: "tracee", Name: "ptrace", Origin: "*"},
+	}, nil
+}
+
+func (sig *PtraceCodeInjection) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("ptrace.args.request", args.PTRACE_POKETEXT.Value()),
 	}, nil
 }
 

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -51,6 +51,15 @@ func (sig *RcdModification) GetSelectedEvents() ([]detect.SignatureEventSelector
 	}, nil
 }
 
+func (sig *RcdModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_file_open.args.pathname", sig.rcdFiles),
+		detect.EqualFilter("security_inode_rename.args.new_path", sig.rcdFiles),
+		detect.PrefixFilter("security_file_open.args.pathname", sig.rcdDirs...),
+		detect.PrefixFilter("security_inode_rename.args.new_path", sig.rcdDirs...),
+	}, nil
+}
+
 func (sig *RcdModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -43,6 +43,12 @@ func (sig *SchedDebugRecon) GetSelectedEvents() ([]detect.SignatureEventSelector
 	}, nil
 }
 
+func (sig *SchedDebugRecon) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_file_open.args.pathname", sig.schedDebugPaths),
+	}, nil
+}
+
 func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -51,6 +51,15 @@ func (sig *ScheduledTaskModification) GetSelectedEvents() ([]detect.SignatureEve
 	}, nil
 }
 
+func (sig *ScheduledTaskModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_file_open.args.pathname", sig.cronFiles),
+		detect.EqualFilter("security_inode_rename.args.new_path", sig.cronFiles),
+		detect.PrefixFilter("security_file_open.args.pathname", sig.cronDirs...),
+		detect.PrefixFilter("security_inode_rename.args.new_path", sig.cronDirs...),
+	}, nil
+}
+
 func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/stdio_over_socket.go
+++ b/signatures/golang/stdio_over_socket.go
@@ -44,9 +44,15 @@ func (sig *StdioOverSocket) GetSelectedEvents() ([]detect.SignatureEventSelector
 	}, nil
 }
 
-func (sig *StdioOverSocket) OnEvent(event protocol.Event) error {
+func (sig *StdioOverSocket) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.ContainsFilter("security_socket_connect.args.remote_addr", "sa_family:AF_INET", "sa_family:AF_INET6"), //maps parse as strings to "map[key1:value1 key2:value2 ...]"
+	}, nil
+}
 
+func (sig *StdioOverSocket) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
+
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -47,6 +47,15 @@ func (sig *SudoersModification) GetSelectedEvents() ([]detect.SignatureEventSele
 	}, nil
 }
 
+func (sig *SudoersModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_file_open.args.pathname", sig.sudoersFiles),
+		detect.EqualFilter("security_inode_rename.args.new_path", sig.sudoersFiles),
+		detect.PrefixFilter("security_file_open.args.pathname", sig.sudoersDirs...),
+		detect.PrefixFilter("security_inode_rename.args.new_path", sig.sudoersDirs...),
+	}, nil
+}
+
 func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/syscall_table_hooking.go
+++ b/signatures/golang/syscall_table_hooking.go
@@ -41,6 +41,10 @@ func (sig *SyscallTableHooking) GetSelectedEvents() ([]detect.SignatureEventSele
 	}, nil
 }
 
+func (sig *SyscallTableHooking) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{}, nil
+}
+
 func (sig *SyscallTableHooking) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -43,6 +43,12 @@ func (sig *SystemRequestKeyConfigModification) GetSelectedEvents() ([]detect.Sig
 	}, nil
 }
 
+func (sig *SystemRequestKeyConfigModification) GetFilters() ([]detect.Filter, error) {
+	return []detect.Filter{
+		detect.EqualFilter("security_file_open.args.pathname", sig.sysrqPaths),
+	}, nil
+}
+
 func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) error {
 
 	eventObj, ok := event.Payload.(trace.Event)

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -3,6 +3,8 @@ package helpers
 import (
 	"fmt"
 	"strings"
+
+	"github.com/aquasecurity/tracee/types/detect"
 )
 
 // IsFileWrite returns whether the passed file permissions string contains
@@ -35,6 +37,10 @@ func IsMemoryPath(pathname string) bool {
 	return false
 }
 
+func MemoryPathFilter(field string) detect.Filter {
+	return detect.PrefixFilter(field, "memfd:", "/run/shm/", "/dev/shm/")
+}
+
 // IsElf checks if the file starts with an ELF magic.
 func IsElf(bytesArray []byte) bool {
 	if len(bytesArray) >= 4 {
@@ -44,6 +50,10 @@ func IsElf(bytesArray []byte) bool {
 	}
 
 	return false
+}
+
+func IsElfFilter(field string) detect.Filter {
+	return detect.PrefixFilter(field, "[127 69 76 70")
 }
 
 func GetFamilyFromRawAddr(addr map[string]string) (string, error) {

--- a/signatures/rego/anti_debugging_ptraceme.rego
+++ b/signatures/rego/anti_debugging_ptraceme.rego
@@ -1,5 +1,7 @@
 package tracee.TRC_2
 
+import data.tracee.helpers
+
 __rego_metadoc__ := {
 	"id": "TRC-2",
 	"version": "0.1.0",
@@ -18,6 +20,14 @@ tracee_selected_events[eventSelector] {
 		"name": "ptrace",
 	}
 }
+
+signature_filters := [
+	{
+		"field": "ptrace.args.request",
+		"operator": helpers.filter_equal,
+		"value": ["PTRACE_TRACEME"]
+	}
+]
 
 tracee_match {
 	input.eventName == "ptrace"

--- a/signatures/rego/cgroup_release_agent_modification.rego
+++ b/signatures/rego/cgroup_release_agent_modification.rego
@@ -23,6 +23,14 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_file_open.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["*/release_agent"]
+	}
+]
+
 tracee_match = res {
 	input.eventName == "security_file_open"
 	flags = helpers.get_tracee_argument("flags")

--- a/signatures/rego/code_injection.rego
+++ b/signatures/rego/code_injection.rego
@@ -33,6 +33,24 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "ptrace.args.request",
+		"operator": helpers.filter_equal,
+		"value": ["PTRACE_POKETEXT"]
+	},
+	{
+		"field": "security_file_open.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["/proc/*"]
+	},
+	{
+		"field": "security_file_open.args.flags",
+		"operator": helpers.filter_equal,
+		"value": ["*O_WRONLY*", "*o_wronly*", "*o_rdwr*", "*O_RDWR*"]
+	}
+]
+
 tracee_match {
 	input.eventName == "ptrace"
 	arg_value = helpers.get_tracee_argument("request")

--- a/signatures/rego/disk_mount.rego
+++ b/signatures/rego/disk_mount.rego
@@ -24,6 +24,24 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_sb_mount.args.dev_name",
+		"operator": helpers.filter_equal,
+		"value": ["/dev/*"]
+	},
+	{
+		"field": "security_sb_mount.context.processName",
+		"operator": helpers.filter_notequal,
+		"value": ["runc:*"]
+	},
+	{
+		"field": "security_sb_mount.context.threadId",
+		"operator": helpers.filter_notequal,
+		"value": [1]
+	}
+]
+
 tracee_match = res {
 	input.eventName == "security_sb_mount"
 

--- a/signatures/rego/dropped_executable.rego
+++ b/signatures/rego/dropped_executable.rego
@@ -24,6 +24,8 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := []
+
 tracee_match = res {
 	input.eventName == "magic_write"
 

--- a/signatures/rego/dynamic_code_loading.rego
+++ b/signatures/rego/dynamic_code_loading.rego
@@ -23,6 +23,14 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "mem_prot_alert.args.alert",
+		"operator": helpers.filter_equal,
+		"value": ["\"Protection changed from W+E to E!\""]
+	}
+]
+
 tracee_match {
 	input.eventName == "mem_prot_alert"
 	message := helpers.get_tracee_argument("alert")

--- a/signatures/rego/fileless_execution.rego
+++ b/signatures/rego/fileless_execution.rego
@@ -23,6 +23,14 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "sched_process_exec.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["memfd:*", "/dev/shm*", "/run/shm*"]
+	}
+]
+
 tracee_match {
 	input.eventName == "sched_process_exec"
 	pathname = helpers.get_tracee_argument("pathname")

--- a/signatures/rego/helpers.rego
+++ b/signatures/rego/helpers.rego
@@ -33,3 +33,10 @@ is_elf_file(string) {
 	sub_string := substring(decoded_string, 1, 3)
 	lower(sub_string) == "elf"
 }
+
+filter_equal = 0
+filter_notequal = 1
+filter_lesser = 2
+filter_lesseq = 3
+filter_greater = 4
+filter_greateq = 5

--- a/signatures/rego/illegitimate_shell.rego
+++ b/signatures/rego/illegitimate_shell.rego
@@ -24,6 +24,19 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_bprm_check.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["*/ash", "*/bash", "*/csh", "*/ksh", "*/sh", "*/tcsh", "*/zsh", "*/dash"]
+	},
+	{
+		"field": "security_bprm_check.context.processName",
+		"operator": helpers.filter_equal,
+		"value": ["nginx", "httpd", "httpd-foregroun", "lighttpd", "apache", "apache2"]
+	}
+]
+
 tracee_match {
 	input.eventName == "security_bprm_check"
 

--- a/signatures/rego/k8s_service_account_token.rego.disabled
+++ b/signatures/rego/k8s_service_account_token.rego.disabled
@@ -24,6 +24,24 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_file_open.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["*secrets/kubernetes.io/serviceaccount*", "*token"]
+	},
+	{
+		"field": "security_file_open.context.processName",
+		"operator": helpers.filter_notequal,
+		"value": ["flanneld", "kube-proxy", "etcd", "kube-apiserver", "coredns", "kube-controller", "kubectl"]
+	},
+	{
+		"field": "security_file_open.args.flags",
+		"operator": helpers.filter_equal,
+		"value": ["*O_RDONLY*", "*o_rdonly*", "*o_rdwr*", "*O_RDWR*"]
+	}
+] 
+
 tracee_match {
 	input.eventName == "security_file_open"
 

--- a/signatures/rego/kernel_module_loading.rego
+++ b/signatures/rego/kernel_module_loading.rego
@@ -29,6 +29,14 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_kernel_read_file.args.type",
+		"operator": helpers.filter_equal,
+		"value": ["kernel-module"]
+	},
+]
+
 tracee_match {
 	input.eventName == "init_module"
 }

--- a/signatures/rego/kubernetes_certificate_theft_attempt.rego
+++ b/signatures/rego/kubernetes_certificate_theft_attempt.rego
@@ -24,6 +24,24 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_file_open.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["/etc/kubernetes/pki/*"]
+	},
+	{
+		"field": "security_file_open.context.processName",
+		"operator": helpers.filter_notequal,
+		"value": ["kube-apiserver", "kubelet", "kube-controller", "etcd"]
+	},
+	{
+		"field": "security_file_open.args.flags",
+		"operator": helpers.filter_equal,
+		"value": ["*O_RDONLY*", "*o_rdonly*", "*o_rdwr*", "*O_RDWR*"]
+	}
+]
+
 tracee_match {
 	input.eventName == "security_file_open"
 

--- a/signatures/rego/ld_preload.rego
+++ b/signatures/rego/ld_preload.rego
@@ -29,6 +29,24 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		"field": "security_file_open.args.pathname",
+		"operator": helpers.filter_equal,
+		"value": ["/etc/ld.so.preload"]
+	},
+	{
+		"field": "security_file_open.args.flags",
+		"operator": helpers.filter_equal,
+		"value": ["*O_WRONLY*", "*o_wronly*", "*o_rdwr*", "*O_RDWR*"]
+	},
+	{
+		"field": "execve.args.envp",
+		"operator": helpers.filter_equal,
+		"value": ["*LD_PRELOAD*", "*LD_LIBRARY_PATH*"]
+	}
+]
+
 tracee_match {
 	input.eventName == "execve"
 	envp = helpers.get_tracee_argument("envp")

--- a/signatures/rego/proc_fops_hooking.rego
+++ b/signatures/rego/proc_fops_hooking.rego
@@ -19,6 +19,15 @@ eventSelectors := [{
 	"name": "hooked_proc_fops",
 }]
 
+signature_filters := [
+	{
+		#test for hooked_fops_pointers != [] so non empty
+		"field": "hooked_proc_fops.args.hooked_fops_pointers",
+		"operator": helpers.filter_notequal,
+		"value": ["[]"]
+	},
+]
+
 tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }

--- a/signatures/rego/syscall_table_hooking.rego
+++ b/signatures/rego/syscall_table_hooking.rego
@@ -23,6 +23,15 @@ tracee_selected_events[eventSelector] {
 	eventSelector := eventSelectors[_]
 }
 
+signature_filters := [
+	{
+		#test for hooked_syscalls != [] so non empty
+		"field": "hooked_syscalls.args.hooked_syscalls",
+		"operator": helpers.filter_notequal,
+		"value": ["[]"]
+	},
+]
+
 tracee_match = res {
 	input.eventName == "hooked_syscalls"
 	hooked_syscalls_arr := helpers.get_tracee_argument("hooked_syscalls")


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

44cfa746e5cc88e8646035186b4bd8a6e31eef1c engine: add mediated filters method
f0b33000f091e76d0d2c3a585bdc9dd9badcc4f6 signatures: add filters to signatures
11086f905cc007156717183213e5503f91460617 types: add filter protocol for signatures

Commit 11086f905cc007156717183213e5503f91460617 will be added later as a separate perquisite PR.

Fixes: #1728
Fixes: #1729

Depends on #1842

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

New tests were added to engine_test.go for filter mediation.

In addition, filters were added to all existing signatures to generate the following mediated output:
```
filter: {Field:args.request Operator:0 Value:[PTRACE_TRACEME]}
filter: {Field:event Operator:0 Value:[execve security_socket_connect ptrace security_file_open magic_write sched_process_exec dup dup2 dup3 close security_bprm_check hooked_syscalls process_vm_writev mem_prot_alert init_module security_kernel_read_file security_sb_mount]}
filter: {Field:execve.args.envp Operator:0 Value:[*LD_PRELOAD* *LD_LIBRARY_PATH]}
filter: {Field:execve.container Operator:0 Value:[true]}
filter: {Field:hooked_syscalls.args.hooked_syscalls Operator:1 Value:[[]]}
filter: {Field:magic_write.container Operator:0 Value:[true]}
filter: {Field:ptrace.args.request Operator:0 Value:[PTRACE_POKETEXT]}
filter: {Field:sched_process_exec.args.pathname Operator:0 Value:[memfd:* /dev/shm* /run/shm*]}
filter: {Field:security_bprm_check.args.pathname Operator:0 Value:[*/ash */bash */csh */ksh */sh */tcsh */zsh */dash]}
filter: {Field:security_bprm_check.processName Operator:0 Value:[nginx httpd httpd-foregroun lighttpd apache apache2]}
filter: {Field:security_file_open.args.pathname Operator:0 Value:[*/release_agent /etc/kubernetes/pki/* *secrets/kubernetes.io/serviceaccount* *token /etc/ld.so.preload]}
filter: {Field:security_file_open.container Operator:0 Value:[true]}
filter: {Field:security_file_open.processName Operator:1 Value:[flanneld kube-proxy etcd kube-apiserver coredns kube-controller kubectl]}
filter: {Field:security_file_open.processName Operator:0 Value:[kube-apiserver kubelet kube-controller etcd]}
filter: {Field:security_kernel_read_file.args.type Operator:0 Value:[kernel-module]}
filter: {Field:security_sb_mount.args.dev_name Operator:0 Value:[/dev/*]}
filter: {Field:security_sb_mount.container Operator:0 Value:[true]}
filter: {Field:security_socket_connect.container Operator:0 Value:[true]}
```

This output will be used to test #1750

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes (#1842) have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
