### PR TITLE
Bugfix: cmd: enable running with high capabilities by flag

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -77,6 +77,7 @@ run_tracee_rules() {
         --cache cache-type=mem \
         --cache mem-cache-size=512 \
         --containers=${CONTAINERS_ENRICHMENT:="0"}\
+        --allow-high-capabilities=${ALLOW_HIGH_CAPABILITIES:="0"}\
         --trace event=${events} \
         --output=out-file:${TRACEE_PIPE} &
     tracee_ebpf_pid=$!
@@ -84,7 +85,11 @@ run_tracee_rules() {
     # start tracee-rules
 
     echo "INFO: starting tracee-rules..."
-    $TRACEE_RULES_EXE --metrics --input-tracee=file:${TRACEE_PIPE} --input-tracee=format:gob $@
+    $TRACEE_RULES_EXE\
+        --metrics --input-tracee=file:${TRACEE_PIPE}\
+        --input-tracee=format:gob\
+        --allow-high-capabilities=${ALLOW_HIGH_CAPABILITIES:="0"}\
+        $@
     TRACEE_RET=$?
 }
 

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -34,6 +34,10 @@ var enrich bool
 
 var version string
 
+const (
+	allowHighCapabilitiesFlag = "allow-high-capabilities"
+)
+
 func main() {
 	app := &cli.App{
 		Name:    "Tracee",
@@ -149,7 +153,7 @@ func main() {
 			cfg.Output = &output
 
 			// environment capabilities
-			err = ensureCapabilities(OSInfo, &cfg)
+			err = ensureCapabilities(OSInfo, &cfg, c.Bool(allowHighCapabilitiesFlag))
 			if err != nil {
 				return err
 			}
@@ -368,6 +372,12 @@ func main() {
 				Name:        "containers",
 				Usage:       "enable container info enrichment to events. this feature is experimental and may cause unexpected behavior in the pipeline",
 				Destination: &enrich,
+			},
+			&cli.BoolFlag{
+				Name:    allowHighCapabilitiesFlag,
+				Aliases: []string{"ahc"},
+				Usage:   "allow tracee-ebpf to run with high capabilities, in case that capabilities dropping fails",
+				Value:   false,
 			},
 		},
 	}

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	signatureBufferFlag = "sig-buffer"
-	metricsFlag         = "metrics"
-	metricsAddrFlag     = "metrics-addr"
+	signatureBufferFlag       = "sig-buffer"
+	metricsFlag               = "metrics"
+	metricsAddrFlag           = "metrics-addr"
+	allowHighCapabilitiesFlag = "allow-high-capabilities"
 )
 
 func main() {
@@ -35,7 +36,12 @@ func main() {
 		Action: func(c *cli.Context) error {
 			err := dropCapabilities()
 			if err != nil {
-				return err
+				if !c.Bool(allowHighCapabilitiesFlag) {
+					return fmt.Errorf("%w - to avoid this error use the --%s flag", err, allowHighCapabilitiesFlag)
+				} else {
+					fmt.Fprintf(os.Stdout, "Capabilities dropping failed - %v\n", err)
+					fmt.Fprintf(os.Stdout, "Continue with high capabilities according to the configuration\n")
+				}
 			}
 
 			if c.NumFlags() == 0 {
@@ -221,6 +227,12 @@ func main() {
 				Name:  metricsAddrFlag,
 				Usage: "listening address of the metrics endpoint server",
 				Value: ":4466",
+			},
+			&cli.BoolFlag{
+				Name:    allowHighCapabilitiesFlag,
+				Aliases: []string{"ahc"},
+				Usage:   "allow tracee-rules to run with high capabilities, in case that capabilities dropping fails",
+				Value:   false,
 			},
 		},
 	}

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -39,3 +39,13 @@ capabilities:
 
 [libbpf CO-RE documentation]: https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere
 [BTFHUB]: https://github.com/aquasecurity/btfhub-archive
+
+# Corner Cases
+
+## Drop Capabilities Error
+
+Tracee-ebpf and tracee-rules both try to reduce capabilities upon startup.
+Some environments won't allow capabilities dropping because of permission issues (for example - AWS Lambdas). It might be a result of seccomp filter for example, restricting syscalls access. 
+Failure in capabilities dropping will result tracee's exit with a matching error, to guarantee that tracee isn't running with excess capabilities without the user agreement.
+To allow tracee to run with high capabilities and prevent crushing, the `--allow-high-capabilities` flag can be used.
+For docker users, to allow tracee-ebpf high capabilities the environment variable `ALLOW_HIGH_CAPABILITIES=1` should be used.


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Enable tracee-ebpf and tracee-rules to keep running with high
capabilities if dropping capabilities failed, if configured to do so
by the user.
This will allow tracee to run in environment that don't allow
capabilities dropping.

Fixes: #1874 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
