### PR TITLE
enrich: fix enrichment queue locks

### DIFF
--- a/pkg/ebpf/events_enrich.go
+++ b/pkg/ebpf/events_enrich.go
@@ -10,6 +10,11 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
+const (
+	enrichResultQueueSize = 1000
+	enrichmentQueueSize   = 10000
+)
+
 func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.Event) (chan *trace.Event, chan error) {
 	type enrichResult struct {
 		cgroupId uint64
@@ -19,9 +24,11 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 
 	queues := make(map[uint64]chan *trace.Event) // cgroupId and queues
 	queuesMutex := sync.RWMutex{}
-	attempted := make(map[uint64]*sync.Mutex) // cgroupId and enrichment attempt expressed as transaction lock
-	attemptedMutex := sync.RWMutex{}          // big lock for attempted map
-	enriches := make(chan enrichResult, 10)   // small buffer to reduce chance for blocking
+	attempted := make(map[uint64]*sync.Mutex)                  // cgroupId and enrichment attempt expressed as transaction lock
+	attemptedMutex := sync.RWMutex{}                           // big lock for attempted map
+	enriches := make(chan enrichResult, enrichResultQueueSize) // small buffer to reduce chance for blocking
+	//queues that are no longer used. we don't want to close on receiving side so it will mark queues as stale and sender can close
+	staleQueues := make(map[uint64]chan *trace.Event)
 	out := make(chan *trace.Event, 10000)
 	errc := make(chan error, 1)
 	done := make(chan struct{}, 1)
@@ -69,7 +76,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 					queuesMutex.RUnlock()
 					if !exists {
 						queuesMutex.Lock()
-						queues[cgroupId] = make(chan *trace.Event, 2500)
+						queues[cgroupId] = make(chan *trace.Event, enrichmentQueueSize)
 						queuesMutex.Unlock()
 
 						go func() {
@@ -78,9 +85,32 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 						}()
 					}
 					queuesMutex.RLock()
-					queue := queues[cgroupId]
+					queue, ok := queues[cgroupId]
 					queuesMutex.RUnlock()
-					queue <- event
+					if ok {
+						//if queue still exists send as usual
+						queue <- event
+					} else {
+						//if not, get the enriched data and handle the stale queue
+						info := t.containers.GetCgroupInfo(cgroupId)
+						queuesMutex.RLock()
+						queue = staleQueues[cgroupId]
+						queuesMutex.RUnlock()
+
+						//probably empty but just to make sure
+						for evt := range queue {
+							enrichEvent(evt, info.Container)
+							out <- evt
+						}
+
+						enrichEvent(event, info.Container)
+
+						close(queue)
+						queuesMutex.Lock()
+						delete(staleQueues, cgroupId)
+						queuesMutex.Unlock()
+						out <- event
+					}
 				}
 			}
 		}
@@ -117,20 +147,10 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 					}
 				}
 			} else {
-				containerImage := enrich.result.Image
-				containerName := enrich.result.Name
-				podName := enrich.result.Pod.Name
-				podNamespace := enrich.result.Pod.Namespace
-				podUid := enrich.result.Pod.UID
-
 				//go through the queue and inject the enrichment data that was missing during decoding
 				for evt := range queue {
 					if evt.ContainerID != "" {
-						evt.ContainerImage = containerImage
-						evt.ContainerName = containerName
-						evt.PodName = podName
-						evt.PodNamespace = podNamespace
-						evt.PodUID = podUid
+						enrichEvent(evt, enrich.result)
 					}
 					select {
 					case out <- evt:
@@ -149,12 +169,21 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 
 			//after enrichment was done and all events were processed we can close and delete the channel from the map
 			//subsequent events will be enriched during decoding
-			close(queue)
+
 			queuesMutex.Lock()
 			delete(queues, cgroupId)
+			staleQueues[cgroupId] = queue
 			queuesMutex.Unlock()
 		}
 	}()
 
 	return out, errc
+}
+
+func enrichEvent(evt *trace.Event, enrichData runtime.ContainerMetadata) {
+	evt.ContainerImage = enrichData.Image
+	evt.ContainerName = enrichData.Name
+	evt.PodName = enrichData.Pod.Name
+	evt.PodNamespace = enrichData.Pod.Namespace
+	evt.PodUID = enrichData.Pod.UID
 }


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

This PR solves two potential mutex locks that can occur in the enrichment pipeline. It also increases the queue sizes as a backup buffer.

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Tue Jun 28 09:26:54 2022 +0000

    enrich: read queue only once at enrich start
    
    This commit includes two fixes:
    1. In the enrichment receiving part of this pipeline stage,
    the relevant queue is read with a mutex acquire at multiple points.
    To avoid unnecessary points of failure with that I've moved this
    queue acquisition to the top of the loop.
    2. In the enrich sending routine, the enrich is sent to a queue while
    a lock is acquired. If the queue is full the send will be stuck and
    the lock will not be unlocked. The queue is now read before sending the
    enrichment so the lock will always be available.
  
    This commit also increases the size of the enrichment queue buffers from
    1000 to 2500.
```

It also solves an edge case where an event could be sent to a closed enrichment queue:
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Thu Jun 30 14:38:09 2022 +0000

    enrich: fix send on closed channel
    
    On some edge cases an event could be semnt to an enrich queue which
    was closed.
    Now, a map of stale queues exists to hold these queues so the sending
    routine can close them.
```

Fixes: #1873

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

This has been tested according to the procedure described in #1873. With this fix, the pipeline may get stuck for a while since the queues may be full, but no lock will occur, so removing the stress test will cause the pipeline to drain, unlike the noticed effect in #1873. 

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
