### PR TITLE
signatures: fix runc false-positive on TRC-11

### DIFF
--- a/signatures/rego/disk_mount.rego
+++ b/signatures/rego/disk_mount.rego
@@ -30,5 +30,13 @@ tracee_match = res {
 	devname := helpers.get_tracee_argument("dev_name")
 	startswith(devname, "/dev/")
 
+	# exclude runc
+	not runc_process with input as input
+
 	res := {"mounted device": devname}
+}
+
+runc_process {
+	startswith(input.processName, "runc:")
+	input.threadId == 1
 }

--- a/signatures/rego/disk_mount_test.rego
+++ b/signatures/rego/disk_mount_test.rego
@@ -2,6 +2,8 @@ package tracee.TRC_11
 
 test_match_1 {
 	tracee_match with input as {
+		"processName": "mal",
+		"threadId": 8,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
 		"args": [{
@@ -14,6 +16,8 @@ test_match_1 {
 
 test_match_2 {
 	tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 8,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
 		"args": [{
@@ -24,14 +28,30 @@ test_match_2 {
 	}
 }
 
-test_match_wrong_request {
+test_match_wrong_device {
 	not tracee_match with input as {
+		"processName": "proc",
+		"threadId": 8,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
 		"args": [{
 			"name": "dev_name",
 			"type": "const char*",
 			"value": "/disk",
+		}],
+	}
+}
+
+test_match_wrong_proc {
+	not tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 1,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"args": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
 		}],
 	}
 }


### PR DESCRIPTION
don't trigger signature TRC-11 if the process is runc

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

check if `processName` starts with `runc:` and if `threadId == 1` - if so, don't trigger the signature because it is expected behavior for `runc` process to mount devices upon container startup.

Fixes: #1611

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

tested locally.

Reproduce the test by running:

- command 01 (on 1st shell): `./dist/tracee-ebpf -t e=security_sb_mount -o format:gob | ./dist/tracee-rules --input-tracee file:stdin --input-tracee format:gob`
- command 02 (on 2nd shell): `docker run --rm -it ubuntu:latest`

shouldn't trigger TRC-11 signature after this PR.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
