### PR TITLE
Revert "fix leak"

### DIFF
--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -145,7 +145,6 @@ func parseTraceeInputFile(option *traceeInputOptions, fileOpt string) error {
 	if err != nil {
 		return fmt.Errorf("invalid file: %s", fileOpt)
 	}
-	defer f.Close()
 	option.inputFile = f
 	return nil
 }


### PR DESCRIPTION
Reverts aquasecurity/tracee#1875.

It wasn't a leak it was tracee's event pipe so closing it caused e2e tests to fail.