### PR TITLE
pkg/ebpf: add inode mode to sched_process_exec args

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2877,6 +2877,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
     u64 ctime = get_ctime_nanosec_from_file(file);
+    umode_t inode_mode = get_inode_mode_from_file(file);
 
     // bprm->mm is null at this point (set by begin_new_exec()), and task->mm is already initialized
     struct mm_struct *mm = get_mm_from_task(task);
@@ -2917,11 +2918,12 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
         save_to_submit_buf(&data, &invoked_from_kernel, sizeof(int), 6);
         save_to_submit_buf(&data, &ctime, sizeof(u64), 7);
         save_to_submit_buf(&data, &stdin_type, sizeof(unsigned short), 8);
-        save_str_to_buf(&data, (void *) interp, 9);
+        save_to_submit_buf(&data, &inode_mode, sizeof(umode_t), 9);
+        save_str_to_buf(&data, (void *) interp, 10);
         if (elf_interpreter != NULL) {
-            save_str_to_buf(&data, &elf_interpreter->pathname, 10);
-            save_to_submit_buf(&data, &elf_interpreter->device, sizeof(dev_t), 11);
-            save_to_submit_buf(&data, &elf_interpreter->inode, sizeof(unsigned long), 12);
+            save_str_to_buf(&data, &elf_interpreter->pathname, 11);
+            save_to_submit_buf(&data, &elf_interpreter->device, sizeof(dev_t), 12);
+            save_to_submit_buf(&data, &elf_interpreter->inode, sizeof(unsigned long), 13);
         }
 
         events_perf_submit(&data, SCHED_PROCESS_EXEC, 0);

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -4927,6 +4927,7 @@ var Definitions = eventDefinitions{
 				{Type: "int", Name: "invoked_from_kernel"},
 				{Type: "unsigned long", Name: "ctime"},
 				{Type: "umode_t", Name: "stdin_type"},
+				{Type: "umode_t", Name: "inode_mode"},
 				{Type: "const char*", Name: "interp"},
 				{Type: "const char*", Name: "interpreter_pathname"},
 				{Type: "dev_t", Name: "interpreter_dev"},


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

The inode mode (aka i_mode member of the inode) contains information
regarding the file's privileges and type.
Thus, it is interesting from security point of view to know its value
for executed files.

Fixes: #1888

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
