### PR TITLE
containers: mount cpuset on cgroupsv1

### DIFF
--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -34,6 +34,8 @@ capabilities:
 * `CAP_SETPCAP` (if given - used to reduce bounding set capabilities)
 * `CAP_SYSLOG` (to access kernel symbols through /proc/kallsyms)
 * On some environments (e.g. Ubuntu) `CAP_IPC_LOCK` might be required as well.
+* On cgroup v1 environments, `CAP_SYS_ADMIN` is recommended if running from a container in 
+order to allow tracee to mount the cpuset cgroup controller.
 
 > Alternatively, run as `root` or with the `--privileged` flag of Docker.
 

--- a/pkg/containers/utils.go
+++ b/pkg/containers/utils.go
@@ -1,0 +1,119 @@
+package containers
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// runsOnContainerV1 tests if process is running on a container in cgroupsv1
+// it tests by checking for existance of a release_agent file in cpuset
+// from https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt:
+//
+// - release_agent: ...	 (this file exists in the top cgroup only)
+//
+// WARNING: IF THIS WASN'T CLEAR THIS IS ONLY VALID FOR CGROUPSV1 MACHINES
+func runsOnContainerV1() (bool, error) {
+	const releseAgentPath = "/sys/fs/cgroup/cpuset/release_agent"
+	_, err := os.Stat(releseAgentPath)
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// mountsCpuset mounts cpuset cgroup controller to the container's current working directory
+// this is done in order to detect host cgroup data when running tracee from a container in cgroupsv1
+// since the function uses the mount syscall, it requires CAP_SYS_ADMIN
+func mountCpuset(mountPath string) error {
+	mp, _ := isMountpoint(mountPath, cgroupV1FsType)
+
+	if mp {
+		// already mounted
+		return nil
+	}
+
+	// equivalent to mount -t cgroup -o cpuset cgroup mountPath
+	// we ignore EBUSY because it means we already mounted the cpuset
+	if err := syscall.Mount("cgroup", mountPath, "cgroup", 0, "cpuset"); err != nil && !errors.Is(err, syscall.EBUSY) {
+		return fmt.Errorf("failed to mount %s", err)
+	}
+	return nil
+}
+
+// getCgroupV1HierarchyId returns the hierarchyId of cgroupsv1
+func getCgroupV1HierarchyId() (int, error) {
+	const cgroupsFile = "/proc/cgroups"
+	file, err := os.Open(cgroupsFile)
+	if err != nil {
+		return -1, fmt.Errorf("could not open cgroups file %s: %w", cgroupsFile, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for i := 1; scanner.Scan(); i++ {
+		sline := strings.Fields(scanner.Text())
+		if len(sline) < 2 || sline[0] != cgroupV1Controller {
+			continue
+		}
+		intID, err := strconv.Atoi(sline[1])
+		if err != nil || intID < 0 {
+			return -1, fmt.Errorf("error parsing %s: %w", cgroupsFile, err)
+		}
+		return intID, nil
+	}
+	return -1, fmt.Errorf("couldn't determine cgroup v1 hierarchy id")
+}
+
+// isMountpoint searches if path is a mountpoint for fstype
+func isMountpoint(path string, fstype string) (bool, error) {
+	mountsFile := "/proc/mounts"
+	file, err := os.Open(mountsFile)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for i := 1; scanner.Scan(); i++ {
+		sline := strings.Split(scanner.Text(), " ")
+		mountpoint := sline[1]
+		currFstype := sline[2]
+
+		if fstype == currFstype && mountpoint == path {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// findMountpoint finds the last mountpoint for the given fstype
+func findMountpoint(fstype string) (string, error) {
+	mountsFile := "/proc/mounts"
+	file, err := os.Open(mountsFile)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	mp := ""
+	scanner := bufio.NewScanner(file)
+	for i := 1; scanner.Scan(); i++ {
+		sline := strings.Split(scanner.Text(), " ")
+		mountpoint := sline[1]
+		currFstype := sline[2]
+
+		if fstype == currFstype {
+			mp = mountpoint
+		}
+	}
+	return mp, nil
+}


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Mon Jul 4 15:29:33 2022 +0000

    containers: mount cpuset on cgroupsv1
    
    When cgroupsV1 is used, the cgroup controller is located at the host
    /sys/fs/cgroup/cpuset. However, this fs is duplicated to the container's
    filesystem and used instead of it when running tracee-ebpf
    from a container. As a result, a different root cgroupId is given,
    and existing cgroups are not detected for population on startup.
    
    This fix makes tracee create a local mountpoint for the host's cpuset
    if it detects usage of cgroupsV1.
```

Fixes: #1900
Fixes: #1338

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

You can test with either of these ways:
1. Add the log described in #1900, build tracee to a container and run. The log should be empty of the repeated cgroup 1 checks.
2. I. Start a redis container `docker run -d --rm redis`
    II. Run tracee as a container with `trace -t event=existing_container` and confirm you get a result 

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
