### PR TITLE
bugfix: pkg/events: fix setsockopt doc mismatch

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -774,7 +774,6 @@ var Definitions = eventDefinitions{
 		Setsockopt: {
 			ID32Bit: sys32setsockopt,
 			Name:    "setsockopt",
-			DocPath: "lsm_hooks/security_socket_setsockopt.md",
 			Syscall: true,
 			Sets:    []string{"syscalls", "net", "net_sock"},
 			Params: []trace.ArgMeta{
@@ -5227,6 +5226,7 @@ var Definitions = eventDefinitions{
 		SecuritySocketSetsockopt: {
 			ID32Bit: sys32undefined,
 			Name:    "security_socket_setsockopt",
+			DocPath: "lsm_hooks/security_socket_setsockopt.md",
 			Probes: []probeDependency{
 				{Handle: probes.SecuritySocketSetsockopt, Required: true},
 			},


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Fix wrong doc path of the events `setsockopt` and `security_socket_setsockopt`.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
