### PR TITLE
pkg/events: fix capture pcap feature w/out net events

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5501,6 +5501,7 @@ var Definitions = eventDefinitions{
 				{Handle: probes.ICMPv6Send, Required: true},
 				{Handle: probes.Pingv4Sendmsg, Required: true},
 				{Handle: probes.Pingv6Sendmsg, Required: true},
+				{Handle: probes.SecuritySocketBind, Required: true},
 			},
 			Dependencies: dependencies{
 				Capabilities: []cap.Value{cap.NET_ADMIN},
@@ -5758,7 +5759,7 @@ var Definitions = eventDefinitions{
 			Name:     "capture_pcap",
 			Internal: true,
 			Dependencies: dependencies{
-				Events:       []eventDependency{{EventID: SecuritySocketBind}},
+				Events:       []eventDependency{{EventID: NetPacket}},
 				Capabilities: []cap.Value{cap.NET_ADMIN},
 			},
 		},


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
pkg/events: fix capture pcap feature w/out net events

Fixes: #1923

Before this commit, capturing network packets into pcap file needed
not only the '-capture net=<interface>' cmdline argument, but also
selecting '-trace event=net_packet -trace net=<interface>'.

By making the capture meta-event "CapturePcap" to depend on "net_packet"
event, and making sure "net_packet" event depends on all network probes
that manipulate "network_map" eBPF map, we have the desired behavior.

* A good way to test this behavior:

   $ sudo ./dist/tracee-ebpf \
        -o format:json \
        -o option:parse-arguments \
        -o option:detect-syscall \
        -trace comm=ping \
        -capture net=lo

1) and execute on the host:

   $ ping 127.0.0.1

   and observe pcap file:

   $ tcpdump -n -r /tmp/tracee/out/host/capture.pcap

   15:48:33.109392 IP 127.0.0.1 > 127.0.0.1: ICMP echo request, id 74, seq 1, length 64
   15:48:33.109440 IP 127.0.0.1 > 127.0.0.1: ICMP echo reply, id 74, seq 1, length 64
   15:48:34.138680 IP 127.0.0.1 > 127.0.0.1: ICMP echo request, id 74, seq 2, length 64
   15:48:34.138725 IP 127.0.0.1 > 127.0.0.1: ICMP echo reply, id 74, seq 2, length 64

* OR, mix capture and tracing options w/ different interfaces:

   $ sudo ./dist/tracee-ebpf \
        -o format:json \
        -o option:parse-arguments \
        -o option:detect-syscall \
        -trace comm=ping \
        -trace event=net_packet \
        -trace net=docker0 \
        -capture net=lo

1) If user executes on the host:

   $ ping 1.1.1.1

   it won't be captured into pcap file (since it won't go through lo).

2) Now, if user executes on the host:

   $ ping 127.0.0.1

   this will be captured into the pcap file (lo interface captured).

3) If user executes in a container:

   $ ping 127.0.0.1

   this won't be captured into pcap file (lo refers to the host only for
   now).

4) Now, if user executes:

   $ ping 1.1.1.1

   this won't be captured into pcap file (but it will be traced because
   command is tracing docker0 interface).
```

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

The git log message describes how to test as well.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
