### PR TITLE
capabilities: mount cpuset in tmpfs when in a container

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -116,7 +116,12 @@ func (c *Containers) initCgroupV1() error {
 	}
 
 	if inContainer {
-		os.Mkdir("./cpuset", 0644)
+		err = os.Mkdir("./cpuset", 0644)
+		if err != nil && !os.IsExist(err) {
+			fmt.Fprintf(os.Stderr, "failed to create cpuset directory %s\n", err)
+			return nil
+		}
+
 		mountPath, err := filepath.Abs("./cpuset")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to get absolute path of cputset mountpoint %s\n", mountPath)

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -116,13 +116,13 @@ func (c *Containers) initCgroupV1() error {
 	}
 
 	if inContainer {
-		err = os.Mkdir("./cpuset", 0644)
-		if err != nil && !os.IsExist(err) {
+		path, err := os.MkdirTemp("/tmp", "tracee-cpuset")
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to create cpuset directory %s\n", err)
 			return nil
 		}
 
-		mountPath, err := filepath.Abs("./cpuset")
+		mountPath, err := filepath.Abs(path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to get absolute path of cputset mountpoint %s\n", mountPath)
 			return nil


### PR DESCRIPTION
This fixes the logic of creating the cgroup mount when in a container using cgroupv1. It adds an error check and creates the mount in tmpfs instead of the src directory. 

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.

## Description (git log)

commit 04af9297f788782231e58cc831148f4f275a30e1 (HEAD -> breakup-capabilities-check-and-drop, pfork/breakup-capabilities-check-and-drop)
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Wed Jul 13 18:17:08 2022 -0400

    containers: move cpuset cgroup mount to tmpfs
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>

commit d10100f36c7c0a64f762d7f5619d87436d5ecb45
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Wed Jul 13 10:33:55 2022 -0400

    Add error check to cpuset mkdir call
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>

Fixes  #1945 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).

## How Has This Been Tested?

#1945 contains reproduction instructions
