### PR TITLE
release: add manual trigger to workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: release
 on:
+  workflow_dispatch: {}
   push:
     tags:
       - "v*"


### PR DESCRIPTION
The github actions runner isn't picking up the git tag for some reason 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>

## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.

## Description (git log)

commit d0a2b005cc219ce57cbc04520e8efdbad7a648f3 (HEAD -> manual-release-trigger, pfork/manual-release-trigger)
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Thu Jul 14 11:38:56 2022 -0400

    release: add manual trigger to workflow
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>



