### PR TITLE
docs: add manual trigger to dev docs

### DIFF
--- a/.github/workflows/mkdocs-dev.yaml
+++ b/.github/workflows/mkdocs-dev.yaml
@@ -1,5 +1,6 @@
 name: Deploy the dev documentation
 on:
+  workflow_dispatch: {}
   push:
     paths:
       - 'docs/**'


### PR DESCRIPTION
This adds a button to release dev documentation

Signed-off-by: grantseltzer <grantseltzer@gmail.com>

## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit d69dee9e73c067526b095f45724f489672abbfd8 (HEAD -> manual-dev-doc, pfork/manual-dev-doc)
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Thu Jul 14 13:37:51 2022 -0400

    docs: add manual trigger to dev docs
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>
