### PR TITLE
containers: add Close function for cleanup

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -324,7 +324,7 @@ func New(cfg Config) (*Tracee, error) {
 		}
 	}
 
-	c, err := containers.InitContainers(t.config.Sockets, t.config.Debug)
+	c, err := containers.New(t.config.Sockets, t.config.Debug)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing containers: %w", err)
 	}
@@ -997,13 +997,22 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 
 // Close cleans up created resources
 func (t *Tracee) Close() {
-
 	if t.probes != nil {
-		t.probes.DetachAll()
+		err := t.probes.DetachAll()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to detach probes when closing tracee: %s", err)
+		}
 	}
 
 	if t.bpfModule != nil {
 		t.bpfModule.Close()
+	}
+
+	if t.containers != nil {
+		err := t.containers.Close()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to clean containers module when closing tracee: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Mon Jul 18 12:05:06 2022 +0000

    containers: add Close function for cleanup
    
    Currently Close() performs cleanup logic for the cpuset mounting done
    on cgroupv1 environments.
```

Fixes: #1945

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Test is done to ensure the cpuset mounting logic still works as expected on cgroupv1 environments.

1. Build tracee as container on a cgroupv1 environment.
2. Run some arbitrary container, for the sake of this example:
     `docker run --rm redis`
3. Run tracee as such:
```
docker run \
  --name tracee --rm \
  --pid=host --cgroupns=host --privileged \
  -v /etc/os-release:/etc/os-release-host:ro \
  -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host \
  -e ALLOW_HIGH_CAPABILITIES=0 \
  tracee trace -t event=existing_container
```

Expected output: an `existing_container` event for redis


## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
