### PR TITLE
cmd/tracee-ebpf: add capabilities dropping bypasses

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -77,7 +77,9 @@ run_tracee_rules() {
         --cache cache-type=mem \
         --cache mem-cache-size=512 \
         --containers=${CONTAINERS_ENRICHMENT:="0"}\
-        --allow-high-capabilities=${ALLOW_HIGH_CAPABILITIES:="0"}\
+        --caps allow-failed-drop=${ALLOW_HIGH_CAPABILITIES:="0"}\
+        --caps cancel-drop=${CANCEL_CAPS_DROP:="0"}\
+        ${CAPS_TO_PRESERVE:+--caps} ${CAPS_TO_PRESERVE:+ add=$CAPS_TO_PRESERVE}\
         --trace event=${events} \
         --output=out-file:${TRACEE_PIPE} &
     tracee_ebpf_pid=$!

--- a/cmd/tracee-ebpf/flags/capabilities.go
+++ b/cmd/tracee-ebpf/flags/capabilities.go
@@ -1,0 +1,120 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+)
+
+const (
+	CapsMainFlag        = "caps"
+	AllowFailedDropFlag = "allow-failed-drop"
+	CancelDropFlag      = "cancel-drop"
+	AddReqCapsFlag      = "add"
+)
+
+func CapabilitiesHelp() string {
+	mainHelp := fmt.Sprintf(`Manage the capabilities and capabilities-related operations of tracee-ebpf
+Normally, tracee will drop all capabilities not required to its operations.
+
+Possible options:
+  %-51s allow tracee-ebpf to run with high capabilities, in case that capabilities dropping fails
+  %-51s cancel capabilities drop, so tracee will run with all given capabilities (unless missing required capabilities)
+  %-51s add required capabilities, so tracee won't drop them`,
+		AllowFailedDropFlag,
+		CancelDropFlag,
+		fmt.Sprintf("%s=<list_of_caps>", AddReqCapsFlag))
+
+	exampleUses := map[string]string{
+		"--%[1]s %[2]s":                          "Try capabilities drop, but continue run if failed",
+		"--%[1]s %[3]s":                          "Don't do capabilities drop",
+		"--%[1]s %[4]s=cap_syslog":               "Drop all required capabilities except for required and CAP_SYSLOG",
+		"--%[1]s %[4]s!=cap_sys_ptrace":          "Drop all capabilities except CAP_SYS_PTRACE, unless required",
+		"--%[1]s %[2]s --%[1]s %[4]s=cap_syslog": "Try drop all capabilities except for required and CAP_SYSLOG, but continue run if failed",
+	}
+
+	var exampleUsesString string
+	for cmd, exp := range exampleUses {
+		cmd = fmt.Sprintf(cmd, CapsMainFlag, AllowFailedDropFlag, CancelDropFlag, AddReqCapsFlag)
+		exampleUsesString += fmt.Sprintf("  %-65s | %s\n", cmd, exp)
+	}
+
+	return fmt.Sprintf("%s\n\nExample uses:\n%s", mainHelp, exampleUsesString)
+}
+
+type CapsConfig struct {
+	AllowHighCaps  bool
+	CancelCapsDrop bool
+	CapsToPreserve []cap.Value
+}
+
+func PrepareCapsConfig(capsCfgArray []string) (CapsConfig, error) {
+	var cfg CapsConfig
+	for _, opt := range capsCfgArray {
+		optName := opt
+		var operatorAndValues string
+		operatorIndex := strings.IndexAny(opt, "=!<>")
+		if operatorIndex > 0 {
+			optName = opt[0:operatorIndex]
+			operatorAndValues = opt[operatorIndex:]
+		}
+
+		switch optName {
+		case AllowFailedDropFlag:
+			cfg.AllowHighCaps = true
+		case CancelDropFlag:
+			cfg.CancelCapsDrop = true
+		case AddReqCapsFlag:
+			addedCapsFilter := filters.StringFilter{}
+			err := addedCapsFilter.Parse(operatorAndValues)
+			if err != nil {
+				return cfg, err
+			}
+			if addedCapsFilter.FilterOut() {
+				capsFilteredOut, err := capsStringSliceToValues(addedCapsFilter.NotEqual)
+				if err != nil {
+					return cfg, err
+				}
+				rcaps := capabilities.GetAllCapabilities()
+				for _, c := range capsFilteredOut {
+					rcaps = removeCapFromSlice(rcaps, c)
+				}
+				cfg.CapsToPreserve = rcaps
+			} else {
+				cfg.CapsToPreserve, err = capsStringSliceToValues(addedCapsFilter.Equal)
+				if err != nil {
+					return cfg, err
+				}
+			}
+		default:
+			return cfg, fmt.Errorf("illegal flag '--%s %s'. Run '--%[1]s help' for more info", CapsMainFlag, optName)
+		}
+	}
+	return cfg, nil
+}
+
+func capsStringSliceToValues(slice []string) ([]cap.Value, error) {
+	var caps []cap.Value
+	if len(slice) > 0 {
+		for _, cName := range slice {
+			c, err := cap.FromName(strings.ToLower(cName))
+			if err != nil {
+				return nil, fmt.Errorf("invalid capability name - %s", cName)
+			}
+			caps = append(caps, c)
+		}
+	}
+	return caps, nil
+}
+
+func removeCapFromSlice(slice []cap.Value, rcap cap.Value) []cap.Value {
+	for i, c := range slice {
+		if c == rcap {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}

--- a/cmd/tracee-ebpf/flags/capabilities_test.go
+++ b/cmd/tracee-ebpf/flags/capabilities_test.go
@@ -1,0 +1,88 @@
+package flags_test
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/tracee/cmd/tracee-ebpf/flags"
+	"github.com/stretchr/testify/assert"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+)
+
+func TestPrepareCapsConfig(t *testing.T) {
+	testCases := []struct {
+		Name           string
+		Input          []string
+		ExpectedResult flags.CapsConfig
+		ExpectedError  bool
+	}{
+		{
+			Name:           "No flags",
+			Input:          []string{},
+			ExpectedResult: flags.CapsConfig{},
+			ExpectedError:  false,
+		},
+		{
+			Name:  "Only allow failed drop",
+			Input: []string{flags.AllowFailedDropFlag},
+			ExpectedResult: flags.CapsConfig{
+				AllowHighCaps: true,
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:  "Only cancel drop",
+			Input: []string{flags.CancelDropFlag},
+			ExpectedResult: flags.CapsConfig{
+				CancelCapsDrop: true,
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:  "Only add caps",
+			Input: []string{flags.AddReqCapsFlag + "=cap_syslog"},
+			ExpectedResult: flags.CapsConfig{
+				CapsToPreserve: []cap.Value{
+					cap.SYSLOG,
+				},
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:  "All flags",
+			Input: []string{flags.AllowFailedDropFlag, flags.CancelDropFlag, flags.AddReqCapsFlag + "=cap_syslog"},
+			ExpectedResult: flags.CapsConfig{
+				AllowHighCaps:  true,
+				CancelCapsDrop: true,
+				CapsToPreserve: []cap.Value{
+					cap.SYSLOG,
+				},
+			},
+			ExpectedError: false,
+		},
+		{
+			Name:           "Illegal flag",
+			Input:          []string{"illegal-flag"},
+			ExpectedResult: flags.CapsConfig{},
+			ExpectedError:  true,
+		},
+		{
+			Name:           "Illegal added cap",
+			Input:          []string{flags.AddReqCapsFlag + "=illegal_cap"},
+			ExpectedResult: flags.CapsConfig{},
+			ExpectedError:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			cfg, err := flags.PrepareCapsConfig(testCase.Input)
+			if testCase.ExpectedError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, testCase.ExpectedResult.AllowHighCaps, cfg.AllowHighCaps)
+				assert.Equal(t, testCase.ExpectedResult.CancelCapsDrop, cfg.CancelCapsDrop)
+				assert.ElementsMatch(t, testCase.ExpectedResult.CapsToPreserve, cfg.CapsToPreserve)
+			}
+		})
+	}
+}

--- a/docs/deep-dive/dropping-capabilities.md
+++ b/docs/deep-dive/dropping-capabilities.md
@@ -1,11 +1,13 @@
 # Special: Dropping Capabilities
 
+**tracee-ebpf** and **tracee-rules** both try to reduce capabilities upon
+startup.
+
+## Dropping Errors
+
 !!! Attention
     This session is important if you're facing errors while **tracee-ebpf** is
-    trying to drop its capabilities.
-
-**tracee-ebpf** and **tracee-rules** both try to reduce capabilities upon
-startup.  
+    trying to drop its capabilities or any other permissions errors.
 
 Some environments **won't allow capabilities dropping** because of permission
 issues (for example - **AWS Lambdas**).
@@ -18,6 +20,24 @@ error, to **guarantee that tracee isn't running with excess capabilities
 without the user agreement**.
 
 To **allow tracee to run with high capabilities** and prevent errors, the
-`--allow-high-capabilities` flag can be used. For docker users, to allow
+`--allow-high-capabilities` flag can be used in tracee-rules, or
+`--caps allow-failed-drop` in tracee-ebpf. For docker users, to allow
 **tracee-ebpf** high capabilities the environment variable
 `ALLOW_HIGH_CAPABILITIES=1` should be used.
+
+## Missing Capabilities Errors
+
+New features and refactoring might result missing capabilities for **tracee-ebpf**.
+This may cause a wide variety of errors.
+
+Our team tries to solve bugs as quickly as possible, but it might
+still take some time to solve some bugs. Moreover, after a bug is fixed
+it might take some time until a new version of Tracee is released.
+
+To fix specific missing capabilities errors locally, users can add capabilities
+using the `--caps add` flag to tracee-ebpf. For docker users, the environment variable
+`CAPS_TO_PRESERVE=<list_of_capabilities>` should be used.
+
+In addition, the `--caps cancel-drop` flag can be used to cancel capability
+dropping of tracee-ebpf. For docker users, the environment variable
+`CANCEL_CAPS_DROP=1` should be used. **We advise to not use this option unless required**.

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -46,7 +46,7 @@ func DropUnrequired(reqCaps []cap.Value) error {
 
 func dropUnrequired(selfCaps set, reqCaps []cap.Value) error {
 	// Dropping the bounding set is a best effort, so we ignore any error resulted from doing it.
-	cap.DropBound(getAllCapabilities()...)
+	cap.DropBound(GetAllCapabilities()...)
 	err := selfCaps.Clear()
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func dropUnrequired(selfCaps set, reqCaps []cap.Value) error {
 	return nil
 }
 
-func getAllCapabilities() []cap.Value {
+func GetAllCapabilities() []cap.Value {
 	var allCaps []cap.Value
 	for capVal := cap.CHOWN; capVal < cap.MaxBits(); capVal++ {
 		allCaps = append(allCaps, capVal)


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Add options to bypass capabilities dropping partly or entirely
in tracee-ebpf.
This will help to solve locally capabilities issues for developers or
users which face capabilities bug.

Fixes: #1996

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
