### PR TITLE
pkg/ebpf: change authentication symbol for kallsyms

### DIFF
--- a/pkg/ebpf/initialization/ksymbols.go
+++ b/pkg/ebpf/initialization/ksymbols.go
@@ -35,9 +35,9 @@ func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helper
 
 // ValidateKsymbolsTable check if the addresses in the table are valid by checking a specific symbol address.
 // The reason for the addresses to be invalid is if the capabilities required to read the kallsyms file are not given.
-// The chosen symbol used here is "current_task" because it is used by all supported kernel versions and shouldn't be 0.
+// The chosen symbol used here is "security_file_open" because it is a must-have symbol for tracee to run.
 func ValidateKsymbolsTable(ksyms *helpers.KernelSymbolTable) bool {
-	if sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "current_task"); err != nil || sym.Address == 0 {
+	if sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "security_file_open"); err != nil || sym.Address == 0 {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

When reading `/proc/kallsyms` file, a symbol address is checked to
identify if the file was read correctly.
The "current_task" symbol is not available on ARM, so it had to be
changed to a symbol supported on all architectures.

Fixes: #2034

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
