### PR TITLE
retain context of triggering event to the triggered event

### DIFF
--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -371,8 +371,8 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			if err != nil {
 				return err
 			}
-			t.triggerSyscallsIntegrityCheck()
-			t.triggerSeqOpsIntegrityCheck()
+			t.triggerSyscallsIntegrityCheck(*event)
+			t.triggerSeqOpsIntegrityCheck(*event)
 		}
 
 	case events.HookedProcFops:

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -978,8 +978,8 @@ func (t *Tracee) getProcessCtx(hostTid uint32) (procinfo.ProcessCtx, error) {
 // Run starts the trace. it will run until ctx is cancelled
 func (t *Tracee) Run(ctx gocontext.Context) error {
 	t.invokeInitEvents()
-	t.triggerSyscallsIntegrityCheck()
-	t.triggerSeqOpsIntegrityCheck()
+	t.triggerSyscallsIntegrityCheck(trace.Event{})
+	t.triggerSeqOpsIntegrityCheck(trace.Event{})
 	t.eventsPerfMap.Start()
 	t.fileWrPerfMap.Start()
 	t.netPerfMap.Start()
@@ -1110,22 +1110,23 @@ func (t *Tracee) getCapturedIfaceIdx(ifaceName string) (int, bool) {
 }
 
 // TODO: move to triggerEvents package
-func (t *Tracee) triggerSyscallsIntegrityCheck() {
+func (t *Tracee) triggerSyscallsIntegrityCheck(event trace.Event) {
 	_, ok := t.events[events.HookedSyscalls]
 	if !ok {
 		return
 	}
-	t.triggerSyscallsIntegrityCheckCall()
+	contextMapID := derive.StoreEventContext(event)
+	t.triggerSyscallsIntegrityCheckCall(contextMapID)
 }
 
 // triggerSyscallsIntegrityCheck is used by a Uprobe to trigger an eBPF program that prints the syscall table
 // TODO: move to triggerEvents package
 //go:noinline
-func (t *Tracee) triggerSyscallsIntegrityCheckCall() {
+func (t *Tracee) triggerSyscallsIntegrityCheckCall(contextMapID uint64) {
 }
 
 // TODO: move to triggerEvents package
-func (t *Tracee) triggerSeqOpsIntegrityCheck() {
+func (t *Tracee) triggerSeqOpsIntegrityCheck(event trace.Event) {
 	_, ok := t.events[events.HookedSeqOps]
 	if !ok {
 		return
@@ -1138,13 +1139,14 @@ func (t *Tracee) triggerSeqOpsIntegrityCheck() {
 		}
 		seqOpsPointers[i] = seqOpsStruct.Address
 	}
-	t.triggerSeqOpsIntegrityCheckCall(seqOpsPointers)
+	contextMapID := derive.StoreEventContext(event)
+	t.triggerSeqOpsIntegrityCheckCall(contextMapID, seqOpsPointers)
 }
 
 // triggerSeqOpsIntegrityCheck is used by a Uprobe to trigger an eBPF program that prints the seq ops pointers
 // TODO: move to triggerEvents package
 //go:noinline
-func (t *Tracee) triggerSeqOpsIntegrityCheckCall(seqOpsStruct [len(derive.NetSeqOps)]uint64) error {
+func (t *Tracee) triggerSeqOpsIntegrityCheckCall(contextMapID uint64, seqOpsStruct [len(derive.NetSeqOps)]uint64) error {
 	return nil
 }
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1115,14 +1115,14 @@ func (t *Tracee) triggerSyscallsIntegrityCheck(event trace.Event) {
 	if !ok {
 		return
 	}
-	contextMapID := derive.StoreEventContext(event)
-	t.triggerSyscallsIntegrityCheckCall(contextMapID)
+	eventHandle := derive.StoreEventContext(event)
+	t.triggerSyscallsIntegrityCheckCall(eventHandle)
 }
 
 // triggerSyscallsIntegrityCheck is used by a Uprobe to trigger an eBPF program that prints the syscall table
 // TODO: move to triggerEvents package
 //go:noinline
-func (t *Tracee) triggerSyscallsIntegrityCheckCall(contextMapID uint64) {
+func (t *Tracee) triggerSyscallsIntegrityCheckCall(eventHandle uint64) {
 }
 
 // TODO: move to triggerEvents package
@@ -1139,14 +1139,14 @@ func (t *Tracee) triggerSeqOpsIntegrityCheck(event trace.Event) {
 		}
 		seqOpsPointers[i] = seqOpsStruct.Address
 	}
-	contextMapID := derive.StoreEventContext(event)
-	t.triggerSeqOpsIntegrityCheckCall(contextMapID, seqOpsPointers)
+	eventHandle := derive.StoreEventContext(event)
+	t.triggerSeqOpsIntegrityCheckCall(eventHandle, seqOpsPointers)
 }
 
 // triggerSeqOpsIntegrityCheck is used by a Uprobe to trigger an eBPF program that prints the seq ops pointers
 // TODO: move to triggerEvents package
 //go:noinline
-func (t *Tracee) triggerSeqOpsIntegrityCheckCall(contextMapID uint64, seqOpsStruct [len(derive.NetSeqOps)]uint64) error {
+func (t *Tracee) triggerSeqOpsIntegrityCheckCall(eventHandle uint64, seqOpsStruct [len(derive.NetSeqOps)]uint64) error {
 	return nil
 }
 

--- a/pkg/events/derive/container_create.go
+++ b/pkg/events/derive/container_create.go
@@ -10,7 +10,7 @@ import (
 // ContainerCreate receives a containers as a closure argument to track it's containers.
 // If it receives a cgroup_mkdir event, it can derive a container_create event from it.
 func ContainerCreate(containers *containers.Containers) events.DeriveFunction {
-	return singleEventDeriveFunc(events.ContainerCreate, deriveContainerCreateArgs(containers))
+	return singleEventDeriveFunc(events.ContainerCreate, deriveContainerCreateArgs(containers), withOriginalContext)
 }
 
 func deriveContainerCreateArgs(containers *containers.Containers) func(event trace.Event) ([]interface{}, error) {

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -10,7 +10,7 @@ import (
 // ContainerRemove receives a containers.Containers object as a closure argument to track it's containers.
 // If it receives a cgroup_rmdir event, it can derive a container_remove event from it.
 func ContainerRemove(containers *containers.Containers) events.DeriveFunction {
-	return singleEventDeriveFunc(events.ContainerRemove, deriveContainerRemoveArgs(containers))
+	return singleEventDeriveFunc(events.ContainerRemove, deriveContainerRemoveArgs(containers), withOriginalContext)
 }
 
 func deriveContainerRemoveArgs(containers *containers.Containers) deriveArgsFunction {

--- a/pkg/events/derive/derive.go
+++ b/pkg/events/derive/derive.go
@@ -76,6 +76,8 @@ func makeEventSkeleton(eventID events.ID) eventSkeleton {
 	}
 }
 
+// withOriginalContext is used to create the derived event with the event skeleton provided
+// compared to withInvokingContext which is used to create the derived event with the triggering event context
 func withOriginalContext(event *trace.Event) (trace.Event, error) {
 	return *event, nil
 }

--- a/pkg/events/derive/derive_test.go
+++ b/pkg/events/derive/derive_test.go
@@ -83,7 +83,7 @@ func TestSingleEventDeriveFunc(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			deriveFunc := singleEventDeriveFunc(testEventID, testCase.ArgsDeriveFunc)
+			deriveFunc := singleEventDeriveFunc(testEventID, testCase.ArgsDeriveFunc, withOriginalContext)
 			derivedEvents, errs := deriveFunc(baseEvent)
 			assert.Len(t, derivedEvents, testCase.DerivedEventsAmount)
 			if testCase.ExpectedError != "" {

--- a/pkg/events/derive/detect_hooked_syscall.go
+++ b/pkg/events/derive/detect_hooked_syscall.go
@@ -10,7 +10,7 @@ import (
 )
 
 func DetectHookedSyscall(kernelSymbols *helpers.KernelSymbolTable) events.DeriveFunction {
-	return singleEventDeriveFunc(events.HookedSyscalls, deriveDetectHookedSyscallArgs(kernelSymbols))
+	return singleEventDeriveFunc(events.HookedSyscalls, deriveDetectHookedSyscallArgs(kernelSymbols), withInvokingContext)
 }
 
 func deriveDetectHookedSyscallArgs(kernelSymbols *helpers.KernelSymbolTable) deriveArgsFunction {

--- a/pkg/events/derive/hooked_seq_ops.go
+++ b/pkg/events/derive/hooked_seq_ops.go
@@ -27,7 +27,7 @@ var NetSeqOpsFuncs = [4]string{
 }
 
 func HookedSeqOps(kernelSymbols *helpers.KernelSymbolTable) events.DeriveFunction {
-	return singleEventDeriveFunc(events.HookedSeqOps, deriveHookedSeqOpsArgs(kernelSymbols))
+	return singleEventDeriveFunc(events.HookedSeqOps, deriveHookedSeqOpsArgs(kernelSymbols), withInvokingContext)
 
 }
 

--- a/pkg/events/derive/net_packet.go
+++ b/pkg/events/derive/net_packet.go
@@ -8,7 +8,7 @@ import (
 
 // NetPacket derives net_packet from net events with 'metadata' arg
 func NetPacket() events.DeriveFunction {
-	return singleEventDeriveFunc(events.NetPacket, deriveNetPacketArgs())
+	return singleEventDeriveFunc(events.NetPacket, deriveNetPacketArgs(), withOriginalContext)
 }
 
 func deriveNetPacketArgs() deriveArgsFunction {

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -11,7 +11,7 @@ import (
 
 func SymbolsLoaded(soLoader sharedobjs.DynamicSymbolsLoader, watchedSymbols []string, whitelistedLibsPrefixes []string) events.DeriveFunction {
 	gen := initSymbolsLoadedEventGenerator(soLoader, watchedSymbols, whitelistedLibsPrefixes)
-	return singleEventDeriveFunc(events.SymbolsLoaded, gen.deriveArgs)
+	return singleEventDeriveFunc(events.SymbolsLoaded, gen.deriveArgs, withOriginalContext)
 }
 
 // Most specific paths should be at the top, to prevent bugs with iterations over the list

--- a/pkg/events/derive/trigger.go
+++ b/pkg/events/derive/trigger.go
@@ -1,0 +1,55 @@
+package derive
+
+import (
+	"fmt"
+	"github.com/aquasecurity/tracee/pkg/counter"
+	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/types/trace"
+	"sync"
+)
+
+// Context is a struct used to store the triggering events' context
+type context struct {
+	Map     map[uint64]trace.Event
+	Mutex   sync.RWMutex
+	Counter counter.Counter
+}
+
+var invokedContext = context{make(map[uint64]trace.Event), sync.RWMutex{}, counter.Counter(1)}
+
+func StoreEventContext(event trace.Event) uint64 {
+	// Initial event - no need to save
+	if event.Timestamp == 0 {
+		return 0
+	}
+	contextMapID := uint64(invokedContext.Counter.Read())
+	invokedContext.Counter.Increment(1)
+	invokedContext.Mutex.Lock()
+	invokedContext.Map[contextMapID] = event
+	invokedContext.Mutex.Unlock()
+	return contextMapID
+}
+
+func GetEventContext(contextID uint64) (trace.Event, error) {
+	invokedContext.Mutex.RLock()
+	contextEvent, ok := invokedContext.Map[contextID]
+	invokedContext.Mutex.RUnlock()
+	if !ok {
+		return trace.Event{}, fmt.Errorf("caller_context_id arg not in context map")
+	}
+	// Remove from map to avoid memory leak
+	delete(invokedContext.Map, contextID)
+	return contextEvent, nil
+}
+
+func withInvokingContext(event *trace.Event) (trace.Event, error) {
+	contextID, err := parse.ArgUint64Val(event, "caller_context_id")
+	if err != nil {
+		return trace.Event{}, fmt.Errorf("error parsing caller_context_id arg: %v", err)
+	}
+	if contextID > 0 {
+		return GetEventContext(contextID)
+	} else {
+		return *event, nil
+	}
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5622,6 +5622,7 @@ var Definitions = eventDefinitions{
 			Sets: []string{},
 			Params: []trace.ArgMeta{
 				{Type: "unsigned long[]", Name: "syscalls_addresses"},
+				{Type: "unsigned long", Name: "caller_context_id"},
 			},
 		},
 		HookedSyscalls: {
@@ -5877,6 +5878,7 @@ var Definitions = eventDefinitions{
 			Sets:     []string{},
 			Params: []trace.ArgMeta{
 				{Type: "unsigned long[]", Name: "net_seq_ops"},
+				{Type: "unsigned long", Name: "caller_context_id"},
 			},
 		},
 		HookedSeqOps: {


### PR DESCRIPTION
Retains the event context of the triggering event
(e.g. hooked_syscall gets the context of the insmod that preceded it)

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.


Fixes: #2019

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

- `tracee-ebpf -t e=hooked_syscalls`
- load a kernel module with `insmod`
- the `hooked_syscall` event should have `insmod` as it's process name

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.