### PR TITLE
docs: fix `symbols_loaded` event doc

### DIFF
--- a/docs/events/security_alerts/symbols_loaded.md
+++ b/docs/events/security_alerts/symbols_loaded.md
@@ -24,8 +24,8 @@ starts with the prefix will be whitelisted.
 The use is only with the `!=` operator, and wildcards aren't supported.
 
 ## Arguments
-* `library_path`:`const char*`[K] - the path of the file written.
-* `symbols`:`const char*const*`[U,TOCTOU] - the first 20 bytes of the file.
+* `library_path`:`const char*`[K] - the path of the shared object file loaded.
+* `symbols`:`const char*const*`[U,TOCTOU] - the watched symbols exported by the shared object.
 
 ## Dependency Events
 ### shared_object_loaded
@@ -38,6 +38,7 @@ Used by tracee to maintain mount NS cache, used in this event to get to processe
 ## Example Use Case
 To catch SO which tries to override the `fopen` function of `libc`, we can use the event in
 the following way:
+
 `./dist/tracee-ebpf -t e=symbols_load -t symbols_load.symbols=fopen symbols_load.library_path!=libc`
 
 ## Issues


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Fix wrong description of the event arguments in the event documentation

Fixes: #2052

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
