### PR TITLE
fix hooked_seq_ops output bug

### DIFF
--- a/cmd/tracee-ebpf/internal/printer/printer.go
+++ b/cmd/tracee-ebpf/internal/printer/printer.go
@@ -247,6 +247,7 @@ func (p *gobEventPrinter) Init() error {
 	gob.Register(make(map[string]string))
 	gob.Register(trace.PktMeta{})
 	gob.Register([]trace.HookedSymbolData{})
+	gob.Register(map[string]trace.HookedSymbolData{})
 	gob.Register([]trace.DnsQueryData{})
 	gob.Register([]trace.DnsResponseData{})
 	return nil

--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -50,6 +50,7 @@ func setupTraceeGobInputSource(opts *traceeInputOptions) (chan protocol.Event, e
 	gob.Register(make(map[string]string))
 	gob.Register(trace.PktMeta{})
 	gob.Register([]trace.HookedSymbolData{})
+	gob.Register(map[string]trace.HookedSymbolData{})
 	gob.Register([]trace.DnsQueryData{})
 	gob.Register([]trace.DnsResponseData{})
 	res := make(chan protocol.Event)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5890,7 +5890,7 @@ var Definitions = eventDefinitions{
 			},
 			Sets: []string{},
 			Params: []trace.ArgMeta{
-				{Type: "[]helpers.KernelSymbol", Name: "hooked_seq_ops"},
+				{Type: "map[string]trace.HookedSymbolData", Name: "hooked_seq_ops"},
 			},
 		},
 		TaskRename: {


### PR DESCRIPTION
a bug was introduced in #2031 regarding the output of `map[string]HookedSymbolData`

fix: register gob map[string]HookedSymbolData and fix hooked_seq_ops argument type

## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Fixes: #issue_number

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
