### PR TITLE
Lowering the thresold to drop CAP_SYS_ADMIN

### DIFF
--- a/cmd/tracee-ebpf/capabilities.go
+++ b/cmd/tracee-ebpf/capabilities.go
@@ -133,11 +133,11 @@ func getCapabilitiesRequiredByEBPF(OSInfo KernelVersionInfo, debug bool) ([]cap.
 	const BpfCapabilitiesMinKernelVersion = "5.8"
 	if OSInfo.CompareOSBaseKernelRelease(BpfCapabilitiesMinKernelVersion) < 0 {
 		// if kernelParanoidValue is too high, CAP_SYS_ADMIN is required
-		if kernelParanoidValue > 3 {
+		if kernelParanoidValue > 2 {
 			if debug {
-				fmt.Println("Paranoid: Value in /proc/sys/kernel/perf_event_paranoid is > 3")
+				fmt.Println("Paranoid: Value in /proc/sys/kernel/perf_event_paranoid is > 2")
 				fmt.Println("Paranoid: Tracee needs CAP_SYS_ADMIN instead of CAP_BPF + CAP_PERFMON")
-				fmt.Println("Paranoid: To change that behavior set perf_event_paranoid to 3 or less.")
+				fmt.Println("Paranoid: To change that behavior set perf_event_paranoid to 2 or less.")
 			}
 			return privilegedCaps, nil
 		} else {

--- a/docs/installing/prerequisites.md
+++ b/docs/installing/prerequisites.md
@@ -28,7 +28,7 @@ capabilities:
 
 * Manage eBPF maps limits (`CAP_SYS_RESOURCE`)
 * Load and Attach eBPF programs:
-    1. `CAP_BPF`+`CAP_PERFMON` for recent kernels (>=5.8) where the kernel perf paranoid value in `/proc/sys/kernel/perf_event_paranoid` is equal to 3 or less
+    1. `CAP_BPF`+`CAP_PERFMON` for recent kernels (>=5.8) where the kernel perf paranoid value in `/proc/sys/kernel/perf_event_paranoid` is equal to 2 or less
     2. or `CAP_SYS_ADMIN` otherwise
 * `CAP_SYS_PTRACE` (to collect information about processes upon startup)
 * `CAP_NET_ADMIN` (to use tc for packets capture)


### PR DESCRIPTION
As the kernel documentation doesn't document any value above 2 for `/proc/sys/kernel/perf_event_paranoid`,
distributions are allowed to interpret any value above 2 as they want. To ensure that Tracee runs in a maximum
number of environment, Tracee should only drop CAP_SYS_ADMIN when perf_event_paranoid is lesser or equal to 2,
in order to avoid any distribution-dependent behavior.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Fixes: #2077 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
