### PR TITLE
events: add bpf_attach event

### DIFF
--- a/pkg/ebpf/c/missing_definitions.h
+++ b/pkg/ebpf/c/missing_definitions.h
@@ -62,6 +62,45 @@
 #define _AC(X, Y)  __AC(X, Y)
 #define _UL(x)     (_AC(x, UL))
 
+// ioctl
+#define _IOC_NRBITS   8
+#define _IOC_TYPEBITS 8
+
+#ifndef _IOC_SIZEBITS
+    #define _IOC_SIZEBITS 14
+#endif
+
+#define _IOC_NRSHIFT   0
+#define _IOC_TYPESHIFT (_IOC_NRSHIFT + _IOC_NRBITS)
+#define _IOC_SIZESHIFT (_IOC_TYPESHIFT + _IOC_TYPEBITS)
+#define _IOC_DIRSHIFT  (_IOC_SIZESHIFT + _IOC_SIZEBITS)
+
+#ifndef _IOC_WRITE
+    #define _IOC_WRITE 1U
+#endif
+
+#define _IOC(dir, type, nr, size)                                                                  \
+    (((dir) << _IOC_DIRSHIFT) | ((type) << _IOC_TYPESHIFT) | ((nr) << _IOC_NRSHIFT) |              \
+     ((size) << _IOC_SIZESHIFT))
+
+#define _IOC_TYPECHECK(t)      (sizeof(t))
+#define _IOW(type, nr, size)   _IOC(_IOC_WRITE, (type), (nr), (_IOC_TYPECHECK(size)))
+#define PERF_EVENT_IOC_SET_BPF _IOW('$', 8, __u32)
+
+#define BPF_FUNC_probe_write_user 36
+
+enum perf_type_id
+{
+    PERF_TYPE_HARDWARE = 0,
+    PERF_TYPE_SOFTWARE = 1,
+    PERF_TYPE_TRACEPOINT = 2,
+    PERF_TYPE_HW_CACHE = 3,
+    PERF_TYPE_RAW = 4,
+    PERF_TYPE_BREAKPOINT = 5,
+
+    PERF_TYPE_MAX, /* non-ABI */
+};
+
 /*=============================== ARCH SPECIFIC ===========================*/
 #if defined(__TARGET_ARCH_x86)
 

--- a/pkg/ebpf/c/missing_noncore_definitions.h
+++ b/pkg/ebpf/c/missing_noncore_definitions.h
@@ -1,0 +1,178 @@
+
+// cannot include trace/trace_probe.h
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0))
+typedef void (*fetch_func_t)(struct pt_regs *, void *, void *);
+typedef int (*print_type_func_t)(struct trace_seq *, const char *, void *, void *);
+
+enum
+{
+    FETCH_MTD_reg = 0,
+    FETCH_MTD_stack,
+    FETCH_MTD_retval,
+    FETCH_MTD_comm,
+    FETCH_MTD_memory,
+    FETCH_MTD_symbol,
+    FETCH_MTD_deref,
+    FETCH_MTD_bitfield,
+    FETCH_MTD_file_offset,
+    FETCH_MTD_END,
+};
+
+struct fetch_type {
+    const char *name;        /* Name of type */
+    size_t size;             /* Byte size of type */
+    int is_signed;           /* Signed flag */
+    print_type_func_t print; /* Print functions */
+    const char *fmt;         /* Fromat string */
+    const char *fmttype;     /* Name in format file */
+    /* Fetch functions */
+    fetch_func_t fetch[FETCH_MTD_END];
+};
+
+struct fetch_param {
+    fetch_func_t fn;
+    void *data;
+};
+
+struct probe_arg {
+    struct fetch_param fetch;
+    struct fetch_param fetch_size;
+    unsigned int offset;           /* Offset from argument entry */
+    const char *name;              /* Name of this argument */
+    const char *comm;              /* Command of this argument */
+    const struct fetch_type *type; /* Type of this argument */
+};
+
+struct trace_probe {
+    unsigned int flags; /* For TP_FLAG_* */
+    struct trace_event_class class;
+    struct trace_event_call call;
+    struct list_head files;
+    ssize_t size; /* trace entry size */
+    unsigned int nr_args;
+    struct probe_arg args[];
+};
+
+#else
+
+    #include <linux/seq_buf.h>
+    #include <linux/trace_seq.h>
+
+typedef int (*print_type_func_t)(struct trace_seq *, void *, void *);
+
+enum fetch_op
+{
+    FETCH_OP_NOP = 0,
+    // Stage 1 (load) ops
+    FETCH_OP_REG,    /* Register : .param = offset */
+    FETCH_OP_STACK,  /* Stack : .param = index */
+    FETCH_OP_STACKP, /* Stack pointer */
+    FETCH_OP_RETVAL, /* Return value */
+    FETCH_OP_IMM,    /* Immediate : .immediate */
+    FETCH_OP_COMM,   /* Current comm */
+    FETCH_OP_ARG,    /* Function argument : .param */
+    FETCH_OP_FOFFS,  /* File offset: .immediate */
+    FETCH_OP_DATA,   /* Allocated data: .data */
+    // Stage 2 (dereference) op
+    FETCH_OP_DEREF,  /* Dereference: .offset */
+    FETCH_OP_UDEREF, /* User-space Dereference: .offset */
+    // Stage 3 (store) ops
+    FETCH_OP_ST_RAW,     /* Raw: .size */
+    FETCH_OP_ST_MEM,     /* Mem: .offset, .size */
+    FETCH_OP_ST_UMEM,    /* Mem: .offset, .size */
+    FETCH_OP_ST_STRING,  /* String: .offset, .size */
+    FETCH_OP_ST_USTRING, /* User String: .offset, .size */
+    // Stage 4 (modify) op
+    FETCH_OP_MOD_BF, /* Bitfield: .basesize, .lshift, .rshift */
+    // Stage 5 (loop) op
+    FETCH_OP_LP_ARRAY, /* Array: .param = loop count */
+    FETCH_OP_END,
+    FETCH_NOP_SYMBOL, /* Unresolved Symbol holder */
+};
+
+struct fetch_insn {
+    enum fetch_op op;
+    union {
+        unsigned int param;
+        struct {
+            unsigned int size;
+            int offset;
+        };
+        struct {
+            unsigned char basesize;
+            unsigned char lshift;
+            unsigned char rshift;
+        };
+        unsigned long immediate;
+        void *data;
+    };
+};
+
+struct fetch_type {
+    const char *name;        /* Name of type */
+    size_t size;             /* Byte size of type */
+    int is_signed;           /* Signed flag */
+    print_type_func_t print; /* Print functions */
+    const char *fmt;         /* Fromat string */
+    const char *fmttype;     /* Name in format file */
+};
+
+struct probe_arg {
+    struct fetch_insn *code;
+    bool dynamic;                  /* Dynamic array (string) is used */
+    unsigned int offset;           /* Offset from argument entry */
+    unsigned int count;            /* Array count */
+    const char *name;              /* Name of this argument */
+    const char *comm;              /* Command of this argument */
+    char *fmt;                     /* Format string if needed */
+    const struct fetch_type *type; /* Type of this argument */
+};
+
+struct trace_probe_event {
+    unsigned int flags; /* For TP_FLAG_* */
+    struct trace_event_class class;
+    struct trace_event_call call;
+    struct list_head files;
+    struct list_head probes;
+};
+
+struct trace_probe {
+    struct list_head list;
+    struct trace_probe_event *event;
+    ssize_t size; /* trace entry size */
+    unsigned int nr_args;
+    struct probe_arg args[];
+};
+
+#endif
+
+// cannot include trace/trace_kprobe.c
+
+struct trace_kprobe {
+    struct list_head list;
+    struct kretprobe rp; /* Use rp.kp for kprobe use */
+    unsigned long __percpu *nhit;
+    const char *symbol; /* symbol name */
+    struct trace_probe tp;
+};
+
+// cannot include trace/trace_uprobe.c
+
+struct trace_uprobe_filter {
+    rwlock_t rwlock;
+    int nr_systemwide;
+    struct list_head perf_events;
+};
+
+struct trace_uprobe {
+    struct list_head list;
+    struct trace_uprobe_filter filter;
+    struct uprobe_consumer consumer;
+    struct path path;
+    struct inode *inode;
+    char *filename;
+    unsigned long offset;
+    unsigned long nhit;
+    struct trace_probe tp;
+};

--- a/pkg/ebpf/c/struct_flavors.h
+++ b/pkg/ebpf/c/struct_flavors.h
@@ -69,6 +69,10 @@ struct task_struct___older_v50 {
     struct pid_link pids[PIDTYPE_MAX];
 };
 
+struct trace_probe___v53 {
+    struct trace_event_call call;
+};
+
 #pragma clang attribute pop
 
 #endif

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -889,6 +889,168 @@ struct sighand_struct {
     struct k_sigaction action[_NSIG];
 };
 
+enum bpf_cmd
+{
+    BPF_MAP_CREATE,
+    BPF_MAP_LOOKUP_ELEM,
+    BPF_MAP_UPDATE_ELEM,
+    BPF_MAP_DELETE_ELEM,
+    BPF_MAP_GET_NEXT_KEY,
+    BPF_PROG_LOAD,
+    BPF_OBJ_PIN,
+    BPF_OBJ_GET,
+    BPF_PROG_ATTACH,
+    BPF_PROG_DETACH,
+    BPF_PROG_TEST_RUN,
+    BPF_PROG_RUN = BPF_PROG_TEST_RUN,
+    BPF_PROG_GET_NEXT_ID,
+    BPF_MAP_GET_NEXT_ID,
+    BPF_PROG_GET_FD_BY_ID,
+    BPF_MAP_GET_FD_BY_ID,
+    BPF_OBJ_GET_INFO_BY_FD,
+    BPF_PROG_QUERY,
+    BPF_RAW_TRACEPOINT_OPEN,
+    BPF_BTF_LOAD,
+    BPF_BTF_GET_FD_BY_ID,
+    BPF_TASK_FD_QUERY,
+    BPF_MAP_LOOKUP_AND_DELETE_ELEM,
+    BPF_MAP_FREEZE,
+    BPF_BTF_GET_NEXT_ID,
+    BPF_MAP_LOOKUP_BATCH,
+    BPF_MAP_LOOKUP_AND_DELETE_BATCH,
+    BPF_MAP_UPDATE_BATCH,
+    BPF_MAP_DELETE_BATCH,
+    BPF_LINK_CREATE,
+    BPF_LINK_UPDATE,
+    BPF_LINK_GET_FD_BY_ID,
+    BPF_LINK_GET_NEXT_ID,
+    BPF_ENABLE_STATS,
+    BPF_ITER_CREATE,
+    BPF_LINK_DETACH,
+    BPF_PROG_BIND_MAP,
+};
+
+union bpf_attr {
+    struct {
+        __u32 prog_fd;
+        union {
+            __u32 target_fd;
+        };
+    } link_create;
+};
+
+enum bpf_prog_type
+{
+    BPF_PROG_TYPE_UNSPEC,
+    BPF_PROG_TYPE_SOCKET_FILTER,
+    BPF_PROG_TYPE_KPROBE,
+    BPF_PROG_TYPE_SCHED_CLS,
+    BPF_PROG_TYPE_SCHED_ACT,
+    BPF_PROG_TYPE_TRACEPOINT,
+    BPF_PROG_TYPE_XDP,
+    BPF_PROG_TYPE_PERF_EVENT,
+    BPF_PROG_TYPE_CGROUP_SKB,
+    BPF_PROG_TYPE_CGROUP_SOCK,
+    BPF_PROG_TYPE_LWT_IN,
+    BPF_PROG_TYPE_LWT_OUT,
+    BPF_PROG_TYPE_LWT_XMIT,
+    BPF_PROG_TYPE_SOCK_OPS,
+    BPF_PROG_TYPE_SK_SKB,
+    BPF_PROG_TYPE_CGROUP_DEVICE,
+    BPF_PROG_TYPE_SK_MSG,
+    BPF_PROG_TYPE_RAW_TRACEPOINT,
+    BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
+    BPF_PROG_TYPE_LWT_SEG6LOCAL,
+    BPF_PROG_TYPE_LIRC_MODE2,
+    BPF_PROG_TYPE_SK_REUSEPORT,
+    BPF_PROG_TYPE_FLOW_DISSECTOR,
+    BPF_PROG_TYPE_CGROUP_SYSCTL,
+    BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE,
+    BPF_PROG_TYPE_CGROUP_SOCKOPT,
+    BPF_PROG_TYPE_TRACING,
+    BPF_PROG_TYPE_STRUCT_OPS,
+    BPF_PROG_TYPE_EXT,
+    BPF_PROG_TYPE_LSM,
+    BPF_PROG_TYPE_SK_LOOKUP,
+    BPF_PROG_TYPE_SYSCALL, /* a program that can execute syscalls */
+};
+
+#define BPF_OBJ_NAME_LEN 16U
+
+struct bpf_prog_aux {
+    u32 id;
+    char name[BPF_OBJ_NAME_LEN];
+};
+
+struct bpf_prog {
+    enum bpf_prog_type type;
+    struct bpf_prog_aux *aux;
+};
+
+struct tracepoint {
+    const char *name;
+};
+
+struct trace_event_class {
+    const char *system;
+};
+
+struct trace_event_call {
+    struct trace_event_class *class;
+    union {
+        char *name;
+        struct tracepoint *tp;
+    };
+    void *module; // only from 5.15
+    int flags;
+};
+
+struct trace_probe {
+    struct list_head list;
+};
+
+struct trace_probe_event {
+    struct trace_event_call call;
+    struct list_head probes;
+};
+
+struct uprobe_consumer {
+    int (*ret_handler)(struct uprobe_consumer *self, unsigned long func, struct pt_regs *regs);
+};
+
+struct trace_uprobe {
+    struct uprobe_consumer consumer;
+    char *filename;
+    unsigned long offset;
+    struct trace_probe tp;
+};
+
+struct kretprobe {
+    struct kprobe kp;
+    kretprobe_handler_t handler;
+};
+
+struct trace_kprobe {
+    struct kretprobe rp;
+    const char *symbol;
+    struct trace_probe tp;
+};
+
+struct perf_event {
+    struct trace_event_call *tp_event;
+};
+
+struct bpf_verifier_env {
+    struct bpf_prog *prog;
+};
+
+struct bpf_insn {
+    __s32 imm;
+};
+
+const int TRACE_EVENT_FL_TRACEPOINT_BIT = 4;
+const int TRACE_EVENT_FL_TRACEPOINT = (1 << TRACE_EVENT_FL_TRACEPOINT_BIT);
+
 #include <struct_flavors.h>
 
 #pragma clang attribute pop

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -129,6 +129,10 @@ func Init(module *bpf.Module, netEnabled bool) (Probes, error) {
 		PrintNetSeqOps:             &uProbe{eventName: "print_net_seq_ops", binaryPath: binaryPath, symbolName: "github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).triggerSeqOpsIntegrityCheckCall", programName: "uprobe_seq_ops_trigger"},
 		SecurityInodeRename:        &traceProbe{eventName: "security_inode_rename", probeType: kprobe, programName: "trace_security_inode_rename"},
 		DoSigaction:                &traceProbe{eventName: "do_sigaction", probeType: kprobe, programName: "trace_do_sigaction"},
+		SecurityBpfProg:            &traceProbe{eventName: "security_bpf_prog", probeType: kprobe, programName: "trace_security_bpf_prog"},
+		SecurityFileIoctl:          &traceProbe{eventName: "security_file_ioctl", probeType: kprobe, programName: "trace_security_file_ioctl"},
+		CheckHelperCall:            &traceProbe{eventName: "check_helper_call", probeType: kprobe, programName: "trace_check_helper_call"},
+		CheckMapFuncCompatibility:  &traceProbe{eventName: "check_map_func_compatibility", probeType: kprobe, programName: "trace_check_map_func_compatibility"},
 	}
 
 	// disable autoload for network related eBPF programs in network is disabled
@@ -593,4 +597,8 @@ const (
 	PrintNetSeqOps
 	SecurityInodeRename
 	DoSigaction
+	SecurityBpfProg
+	SecurityFileIoctl
+	CheckHelperCall
+	CheckMapFuncCompatibility
 )

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -165,6 +165,7 @@ const (
 	TaskRename
 	SecurityInodeRename
 	DoSigaction
+	BpfAttach
 	MaxCommonID
 )
 
@@ -6002,6 +6003,26 @@ var Definitions = eventDefinitions{
 				{Type: "unsigned long", Name: "old_sa_mask"},
 				{Type: "u8", Name: "old_sa_handle_method"},
 				{Type: "void*", Name: "old_sa_handler"},
+			},
+		},
+		BpfAttach: {
+			ID32Bit: sys32undefined,
+			Name:    "bpf_attach",
+			Probes: []probeDependency{
+				{Handle: probes.SecurityFileIoctl, Required: true},
+				{Handle: probes.SecurityBpfProg, Required: true},
+				{Handle: probes.SecurityBPF, Required: true},
+				{Handle: probes.CheckHelperCall, Required: false},
+				{Handle: probes.CheckMapFuncCompatibility, Required: false},
+			},
+			Sets: []string{},
+			Params: []trace.ArgMeta{
+				{Type: "int", Name: "prog_type"},
+				{Type: "const char*", Name: "prog_name"},
+				{Type: "const char*", Name: "perf_symbol"},
+				{Type: "u64", Name: "perf_addr"},
+				{Type: "int", Name: "prog_write_user"},
+				{Type: "int", Name: "perf_type"},
 			},
 		},
 	},


### PR DESCRIPTION
this event indicates an ebpf program being attached to a perf event.
this event includes arguments describing the bpf program,
and arguments describing the perf event.

an example event:
`14:18:52:018729  0      bpftrace         30743   30743   0                bpf_attach           prog_type: BPF_PROG_TYPE_KPROBE, prog_name: do_nanosleep, perf_symbol: do_nanosleep, perf_addr: 0, prog_write_user: false, perf_type: kretprobe`

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

this event indicates an ebpf program being attached to a perf event.
this event includes arguments describing the bpf program,
and arguments describing the perf event.

Fixes: #2003 

more details about this PR:

bpf program can be attached to a perf event in the system in two methods.
in both this methods, the attach is between an already loaded bpf program to the already created perf event.
 - calling `ioctl` syscall with command `PERF_EVENT_IOC_SET_BPF`. 
 - calling `bpf` syscall with command `BPF_LINK_CREATE`. (only in newer kernel versions).

so for each method we extract the structs representing the bpf program and the perf event, and pass them on to the new `send_bpf_attach` function, which extracts all the arguments and outputs the event to userspace.

one of the arguments in this event is the `prog_write_user`. this argument indicates whether or not the bpf program uses the `bpf_probe_write_user` helper (to be used in signatures).
to fetch this information, we probe into the verfier function `check_helper_call`/`check_map_func_compatibility` (these functions are not always available - hence using both of them) which are called for each bpf helper called from a bpf program.

ideally, we would save this imformation in a map (`{host_tid, prog_id} -> true/false`), and then use it in a later phase in `send_bpf_attach`.

the problem is that in the verifier phase, the bpf program does not yet have an allocated `prog_id`.
to overcome this issue, we save the information in a temporary map (`host_tid -> true/false`), and we also probe into `security_bpf_prog`.
in `security_bpf_prog` the `prog_id` is already allocated, so we read from the temporary map, and save the information in the stable map (`{host_tid, prog_id} -> true/false`).

this approach works because `check_helper_call`/`check_map_func_compatibility` and `security_bpf_prog` are called in the context of the same syscall (`bpf` with command `BPF_PROG_LOAD`), so the temporary map with key of `host_tid` is enough. to access this value in `send_bpf_attach`, we must add the `prog_id` because it happens in the context of another syscall (mentioned above).

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

locally (with different kernel versions).

Reproduce the test by running:

- command 01: `./dist/tracee-ebpf -t e=bpf_attach -o option:parse-arguments`
- command 02: `sudo bpftrace -e 'kretprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }'`

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
