### PR TITLE
ebpf: optimize SysEnter and SysExit probes

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -4874,6 +4874,11 @@ var Definitions = eventDefinitions{
 			Probes: []probeDependency{
 				{Handle: probes.SysEnter, Required: true},
 			},
+			Dependencies: dependencies{
+				TailCalls: []TailCall{
+					{MapName: "sys_enter_submit_tail", MapIdx: 0, ProgName: "sys_enter_submit"},
+				},
+			},
 			Sets: []string{},
 			Params: []trace.ArgMeta{
 				{Type: "int", Name: "syscall"},
@@ -4884,6 +4889,11 @@ var Definitions = eventDefinitions{
 			Name:    "sys_exit",
 			Probes: []probeDependency{
 				{Handle: probes.SysExit, Required: true},
+			},
+			Dependencies: dependencies{
+				TailCalls: []TailCall{
+					{MapName: "sys_exit_submit_tail", MapIdx: 0, ProgName: "sys_exit_submit"},
+				},
 			},
 			Sets: []string{},
 			Params: []trace.ArgMeta{


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Sun Aug 28 13:31:21 2022 +0000

    tracee.bpf.c: optimize sys_enter and sys_exit
    
    Optimize these hot path probes by moving the logic of event init and
    submit to run conditionally in a tail call.
    Only the following logic will run if no event submission is needed:
    1. Storing task's current syscall
    2. Storing syscalls arguments in task
```

Fixes: #issue_number

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Currently tested with this script (credits to @rafaeldtinoco):
```
#!/bin/bash
# sysctl -w kernel.bpf_stats_enabled=1
bpftool prog show > /tmp/progshow.$$
checkfile() {
    prognum=$(echo $line | cut -d' ' -f1)
    progname=$(echo $line | cut -d' ' -f2)
    runtime=$(cat /tmp/progshow.$$ | grep ^$prognum | awk '{print $9}')
    amount=$(cat /tmp/progshow.$$ | grep ^$prognum | awk '{print $11}')
    if [[ $runtime -eq 0 ]]; then runtime=1; fi
    if [[ $amount -eq 0 ]]; then amount=1; fi
    average=$((runtime/amount))
    echo "PROGRAM: $progname (runtime: $runtime ns, amount: $amount times, average: $average ns)"
}
# kprobes
bpftool perf | grep kprobe | awk '{print $6" "$9}' | \
while read line; do
    checkfile
done
# traces
bpftool perf | grep trace | awk '{print $6" "$8}' | \
while read line; do
    checkfile
done
rm -f /tmp/progshow.$$
```

1. Run `tracee-ebpf -o none`
2. Let it run for about 30 seconds
3. Run the above script, observe the average of sys_enter and sys_exit (should be around ~1000ns and ~3000ns respectively)
4. Rerun tracee-ebpf with `tracee-ebpf -o none -t e=task_rename,container_create,security_file_open` (this will cause skipping of the event logic)
5. Let it run for 30 seconds
6. Run the above script - average for sys_enter and sys_exit should now be lower.

In addition: no events should break their previous behavior, this can be verified as such:
1. Run `tracee-ebpf -o option:detect-syscall -t e=task_rename`
2. Syscall arguments should be parsed successfully

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
