### PR TITLE
pkg/events/derive: silence symbols loaded errors

### DIFF
--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -39,7 +39,6 @@ type symbolsLoadedEventGenerator struct {
 	pathPrefixWhitelist []string
 	librariesWhitelist  []string
 	isDebug             bool
-	returnedErrors      map[string]bool
 }
 
 func initSymbolsLoadedEventGenerator(
@@ -65,7 +64,6 @@ func initSymbolsLoadedEventGenerator(
 		pathPrefixWhitelist: prefixes,
 		librariesWhitelist:  libraries,
 		isDebug:             isDebug,
-		returnedErrors:      make(map[string]bool),
 	}
 }
 
@@ -81,11 +79,8 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(event trace.Event)
 
 	soSyms, err := symbsLoadedGen.soLoader.GetExportedSymbols(loadingObjectInfo)
 	if err != nil {
-		_, ok := symbsLoadedGen.returnedErrors[err.Error()]
-		if !ok {
-			symbsLoadedGen.returnedErrors[err.Error()] = true
-			return nil, err
-		}
+		// TODO: Create a warning upon this error when logger is available
+
 		// This error happens frequently in some environments, so we need to silence it to reduce spam.
 		if symbsLoadedGen.isDebug {
 			return nil, err

--- a/pkg/events/derive/symbols_loaded_test.go
+++ b/pkg/events/derive/symbols_loaded_test.go
@@ -203,13 +203,8 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 			mockLoader := initLoaderMock(true)
 			gen := initSymbolsLoadedEventGenerator(mockLoader, nil, nil, false)
 
-			// First error should be always returned
-			eventArgs, err := gen.deriveArgs(generateSOLoadedEvent(pid, sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"}))
-			assert.Error(t, err)
-			assert.Nil(t, eventArgs)
-
 			// Error should be suppressed
-			eventArgs, err = gen.deriveArgs(generateSOLoadedEvent(pid, sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"}))
+			eventArgs, err := gen.deriveArgs(generateSOLoadedEvent(pid, sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"}))
 			assert.NoError(t, err)
 			assert.Nil(t, eventArgs)
 		})


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

The errors received from the symbols loaded are expected to happen.
Thus, until we have a logger which enables us to declare this as a
warning, we need to silence the error so it won't be counted as an
error.

Fixes: #2036

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
