### PR TITLE
ebpf: add get_task_syscall_id helper

### DIFF
--- a/pkg/ebpf/c/missing_definitions.h
+++ b/pkg/ebpf/c/missing_definitions.h
@@ -60,6 +60,7 @@
 // include/uapi/linux/const.h
 #define __AC(X, Y) (X##Y)
 #define _AC(X, Y)  __AC(X, Y)
+#define _UL(x)     (_AC(x, UL))
 
 /*=============================== ARCH SPECIFIC ===========================*/
 #if defined(__TARGET_ARCH_x86)
@@ -83,11 +84,20 @@
     //  arch/arm64/include/asm/page-def.h
     //#define PAGE_SHIFT        CONFIG_ARM64_PAGE_SHIFT
     //  as a temporary workaround for failing builds, use the default value of PAGE_SHIFT
-    #define PAGE_SHIFT 12
-    #define PAGE_SIZE  (_AC(1, UL) << PAGE_SHIFT)
+    #define PAGE_SHIFT       12
+    #define PAGE_SIZE        (_AC(1, UL) << PAGE_SHIFT)
 
     // arch/arm64/include/asm/thread_info.h
-    #define _TIF_32BIT (1 << 22)
+    #define _TIF_32BIT       (1 << 22)
+
+    // arch/arm64/include/asm/memory.h
+    //#define MIN_THREAD_SHIFT	(14 + KASAN_THREAD_SHIFT)
+    #define MIN_THREAD_SHIFT 14 // default value if KASAN is disabled (which it should be usually)
+
+    // this can also be PAGE_SHIFT if (MIN_THREAD_SHIFT < PAGE_SHIFT) however here 14 > 12
+    // so we choose MIN_THREAD_SHIFT
+    #define THREAD_SHIFT     MIN_THREAD_SHIFT
+    #define THREAD_SIZE      (_UL(1) << THREAD_SHIFT)
 #endif
 /*=============================== ARCH SPECIFIC ===========================*/
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -270,6 +270,7 @@ struct task_struct {
     struct nsproxy *nsproxy;
     struct css_set *cgroups;
     struct signal_struct *signal;
+    void *stack;
 };
 
 typedef struct {


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] I have discussed this change with another maintainer.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Aug 31 12:49:38 2022 +0000

    ebpf: add get_task_syscall_id helper
    
    This is used in events supporting the detect-syscall option, in order to
    decouple them from the syscall_data_t struct tracking mechanism.
    This decoupling is required for these events to function in the future
    without calling sys_enter and sys_exit logic for every syscall.
    security_file_open is intentionally left as is, because it will have
    syscall tail call dependencies in the near future.
```

Fixes: #2133

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Test by running:
`./dist/tracee-ebpf -o option:detect-syscall -t e=task_rename`

Wait for an event output and confirm a valid syscall is printed.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
