### PR TITLE
release: prepare for 0.8.2 by reverting libbpfgo bump

### DIFF
--- a/cmd/tracee-ebpf/capabilities.go
+++ b/cmd/tracee-ebpf/capabilities.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/cmd/tracee-ebpf/flags"
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
@@ -20,7 +19,7 @@ type KernelVersionInfo interface {
 	// CompareOSBaseKernelRelease compare given kernel version to current one.
 	// The return value is -1, 0 or 1 if given version is less,
 	// equal or bigger, respectively, than running one.
-	CompareOSBaseKernelRelease(string) (helpers.KernelVersionComparison, error)
+	CompareOSBaseKernelRelease(string) int
 }
 
 // ensureInitCapabilities makes sure program initialize with required capabilities only.
@@ -153,14 +152,8 @@ func getCapabilitiesRequiredByEBPF(OSInfo KernelVersionInfo, debug bool) ([]cap.
 		}
 		return privilegedCaps, nil
 	}
-
 	const BpfCapabilitiesMinKernelVersion = "5.8"
-	kernel58CompareToRunningKernel, err := OSInfo.CompareOSBaseKernelRelease(BpfCapabilitiesMinKernelVersion)
-	if err != nil {
-		return privilegedCaps, fmt.Errorf("could not determine kernel version requirements: %w", err)
-	}
-
-	if kernel58CompareToRunningKernel == helpers.KernelVersionNewer {
+	if OSInfo.CompareOSBaseKernelRelease(BpfCapabilitiesMinKernelVersion) < 0 {
 		// if kernelParanoidValue is too high, CAP_SYS_ADMIN is required
 		if kernelParanoidValue > 2 {
 			if debug {

--- a/cmd/tracee-ebpf/capabilities_test.go
+++ b/cmd/tracee-ebpf/capabilities_test.go
@@ -15,7 +15,7 @@ type mockOSInfo struct {
 	version string
 }
 
-func (mOSInfo mockOSInfo) CompareOSBaseKernelRelease(version string) (helpers.KernelVersionComparison, error) {
+func (mOSInfo mockOSInfo) CompareOSBaseKernelRelease(version string) int {
 	return helpers.CompareKernelRelease(mOSInfo.version, version)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20220904034814-b5b0a6e72d7a
+	github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0
 	github.com/aquasecurity/tracee/types v0.0.0-20220804074749-e785ea989919
 	github.com/containerd/containerd v1.6.6
 	github.com/docker/docker v20.10.17+incompatible

--- a/go.sum
+++ b/go.sum
@@ -123,12 +123,6 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed h1:u
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0 h1:NQEf484vQOshZwZOLTE7kzo62TvYrM906gUjlVg4D2k=
 github.com/aquasecurity/libbpfgo v0.3.0-libbpf-0.8.0/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0 h1:WHKqRRCVhEI5CG/2gqKhTZ494QeriVe/cuQrpkHzTAk=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20220902131537-0f690863dbe1 h1:ca4d5yudfitX4Y6j9a+h5vizEkCQy1RVuR2aYDa8x6Q=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20220902131537-0f690863dbe1/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20220904034814-b5b0a6e72d7a h1:GLg+i7roFosEKSMMMeYBTvEqOuYXkSEOvw7ou47Td4w=
-github.com/aquasecurity/libbpfgo v0.4.0-libbpf-1.0.0.0.20220904034814-b5b0a6e72d7a/go.mod h1:qu0TVGRvtNMFkuKLscJkY1FwmageNBLqeImAFslqPPc=
 github.com/aquasecurity/tracee/types v0.0.0-20220804074749-e785ea989919 h1:1tvaIwXjjSciTa1JNqw3W4iofSONLX/GORWL8ee5Ocw=
 github.com/aquasecurity/tracee/types v0.0.0-20220804074749-e785ea989919/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -425,7 +425,7 @@ func (p *tcProbe) attachTc(module *bpf.Module, netIface *net.Interface) error {
 		return fmt.Errorf("could not find tc program %s", p.programName)
 	}
 
-	tcOpts := bpf.TcOpts{ProgFd: int(prog.FileDescriptor())}
+	tcOpts := bpf.TcOpts{ProgFd: int(prog.GetFd())}
 
 	err = hook.Attach(&tcOpts)
 	if err != nil {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -488,7 +488,7 @@ func (t *Tracee) initTailCall(mapName string, mapIdx uint32, progName string) er
 	if err != nil {
 		return fmt.Errorf("could not get BPF program %s: %v", progName, err)
 	}
-	fd := bpfProg.FileDescriptor()
+	fd := bpfProg.GetFd()
 	if fd < 0 {
 		return fmt.Errorf("could not get BPF program FD for %s: %v", progName, err)
 	}


### PR DESCRIPTION
After some e2e tests gone wrong, and broader discussion, a rollback to
previous libbpfgo version was decided to keep v0.8.2 stable. This commit
reverts recent changes:

- Revert "libbpf: upgrade to v1.0.0"
    This reverts commit 911d01b70e5cd362472c283c2ab8184d1d3ec734.
- Revert "libbpfgo: update to latest (1.0.0+)"
    This reverts commit eb1fe11db143e98bd1c3b8bcaed6056ff4c17589.
- Revert "parse_args: fix {get,set}sockopt new parse option"
    This reverts commit fdacd945953feb6b97f1bcba3a6c52889cc3cdf3.
- Revert "capabilities: fix usage of kernel version interface"
    This reverts commit 9001dbc8dd9b04ae36ff4ebbdd18329f9b315d45.
- Revert "deprecation: adjust deprecation warnings"
    This reverts commit afa634764995681aad33d2c3cfb78e6a04fd41a6.
