### PR TITLE
btfhub: add oracle 7 (5.4 kernels) support

### DIFF
--- a/3rdparty/btfhub.sh
+++ b/3rdparty/btfhub.sh
@@ -83,21 +83,24 @@ cd ${BTFHUB_DIR}
 # - centos7 & v4.15 kernels: unsupported eBPF features
 # - fedora 29 & 30 (from 5.3 and on) and newer: already have BTF embedded
 # - amzn2: older than 4.19
+# - ol7: older than 5.4
 #
 
 rsync -avz \
-    ${BTFHUB_ARCH_DIR}/                 \
-    --exclude=.git*                     \
-    --exclude=README.md                 \
-    --exclude="centos/7*"               \
-    --exclude="fedora/29/*/5.3*"        \
-    --exclude="fedora/30/*/5.6*"        \
-    --exclude="fedora/31*"              \
-    --exclude="fedora/32*"              \
-    --exclude="fedora/33*"              \
-    --exclude="fedora/34*"              \
-    --exclude="4.15*"                   \
-    --exclude="amzn*"			\
+    ${BTFHUB_ARCH_DIR}/                   \
+    --exclude=.git*                       \
+    --exclude=README.md                   \
+    --exclude="centos/7*"                 \
+    --exclude="fedora/29/*/5.3*"          \
+    --exclude="fedora/30/*/5.6*"          \
+    --exclude="fedora/31*"                \
+    --exclude="fedora/32*"                \
+    --exclude="fedora/33*"                \
+    --exclude="fedora/34*"                \
+    --exclude="4.15*"                     \
+    --exclude="amzn*"                     \
+    --exclude="oracle-linux/ol7/*/4.14*"  \
+    --exclude="oracle-linux/ol7/*/3.10*"  \
     ./archive/
 
 # cleanup unneeded architectures


### PR DESCRIPTION

## Initial Checklist

- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.

## Description (git log)

BTFHUB got oracle-linux 7 BTF files for many kernels. Include the 5.4 kernels BTF files into tracee (more recent 5.4 kernels are already being released with BTF support, so this is to add support to legacy OL7 kernels, just like other cases).

## Type of change

- [x] New feature (non-breaking change, adding functionality).

## How Has This Been Tested?

Reproduce the test by running:

```
$ BTFHUB=1 STATIC=1 make all
```
