### PR TITLE
pkg/events: fix socket option parse args edge cases

### DIFF
--- a/pkg/events/parse_args_test.go
+++ b/pkg/events/parse_args_test.go
@@ -1,0 +1,188 @@
+package events
+
+import (
+	"github.com/aquasecurity/libbpfgo/helpers"
+	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestParseArgs(t *testing.T) {
+	t.Run("Parse setsockopt value", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			args         []trace.Argument
+			expectedArgs []trace.Argument
+		}{
+			{
+				name: "normal flow",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "int",
+						},
+						Value: int32(helpers.SO_LOCK_FILTER.Value()),
+					},
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "level",
+							Type: "int",
+						},
+						Value: int32(helpers.SOL_IP.Value()),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "string",
+						},
+						Value: helpers.SO_LOCK_FILTER.String(),
+					},
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "level",
+							Type: "string",
+						},
+						Value: helpers.SOL_IP.String(),
+					},
+				},
+			},
+			{
+				name: "SO_ATTACH_FILTER optname",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "int",
+						},
+						Value: int32(helpers.SO_ATTACH_OR_GET_FILTER.Value()),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "string",
+						},
+						Value: "SO_ATTACH_FILTER",
+					},
+				},
+			},
+			{
+				name: "normal optname",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "int",
+						},
+						Value: int32(helpers.SO_LOCK_FILTER.Value()),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "string",
+						},
+						Value: helpers.SO_LOCK_FILTER.String(),
+					},
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			event := trace.Event{
+				EventID: int(Setsockopt),
+				Args:    testCase.args,
+			}
+			err := ParseArgs(&event)
+			require.NoError(t, err)
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(&event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		}
+	})
+
+	t.Run("Parse getsockopt value", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			args         []trace.Argument
+			expectedArgs []trace.Argument
+		}{
+			{
+				name: "normal optname",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "int",
+						},
+						Value: int32(helpers.SO_LOCK_FILTER.Value()),
+					},
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "level",
+							Type: "int",
+						},
+						Value: int32(helpers.SOL_IP.Value()),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "string",
+						},
+						Value: helpers.SO_LOCK_FILTER.String(),
+					},
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "level",
+							Type: "string",
+						},
+						Value: helpers.SOL_IP.String(),
+					},
+				},
+			},
+			{
+				name: "SO_GET_FILTER optname",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "int",
+						},
+						Value: int32(helpers.SO_ATTACH_OR_GET_FILTER.Value()),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "optname",
+							Type: "string",
+						},
+						Value: "SO_GET_FILTER",
+					},
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			event := &trace.Event{
+				EventID: int(Getsockopt),
+				Args:    testCase.args,
+			}
+			err := ParseArgs(event)
+			require.NoError(t, err)
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

libbpfgo currently parse the socket option argument in some cases to include "or" in the middle between to consts names. The reason is that the kernel has 2 consts with the same name. According to the context we know which constant is relevant. This PR fix the parsed option name to be the one we expect it to be.

Fixes: #2156

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
