### PR TITLE
printer: make sure output and errfile are always truncated

### DIFF
--- a/cmd/tracee-ebpf/flags/output.go
+++ b/cmd/tracee-ebpf/flags/output.go
@@ -110,17 +110,14 @@ func PrepareOutput(outputSlice []string) (tracee.OutputConfig, printer.Config, e
 	} else {
 		printcfg.OutPath = outPath
 		fileInfo, err := os.Stat(outPath)
-		if err == nil {
-			if fileInfo.IsDir() {
-				return outcfg, printcfg, fmt.Errorf("cannot use a path of existing directory %s", outPath)
-			}
-		} else {
-			dir := filepath.Dir(outPath)
-			os.MkdirAll(dir, 0755)
-			printcfg.OutFile, err = os.Create(outPath)
-			if err != nil {
-				return outcfg, printcfg, fmt.Errorf("failed to create output path: %v", err)
-			}
+		if err == nil && fileInfo.IsDir() {
+			return outcfg, printcfg, fmt.Errorf("cannot use a path of existing directory %s", outPath)
+		}
+		dir := filepath.Dir(outPath)
+		os.MkdirAll(dir, 0755)
+		printcfg.OutFile, err = os.Create(outPath)
+		if err != nil {
+			return outcfg, printcfg, fmt.Errorf("failed to create output path: %v", err)
 		}
 	}
 
@@ -129,17 +126,14 @@ func PrepareOutput(outputSlice []string) (tracee.OutputConfig, printer.Config, e
 	} else {
 		printcfg.ErrPath = errPath
 		fileInfo, err := os.Stat(errPath)
-		if err == nil {
-			if fileInfo.IsDir() {
-				return outcfg, printcfg, fmt.Errorf("cannot use a path of existing directory %s", errPath)
-			}
-		} else {
-			dir := filepath.Dir(errPath)
-			os.MkdirAll(dir, 0755)
-			printcfg.ErrFile, err = os.Create(errPath)
-			if err != nil {
-				return outcfg, printcfg, fmt.Errorf("failed to create output path: %v", err)
-			}
+		if err == nil && fileInfo.IsDir() {
+			return outcfg, printcfg, fmt.Errorf("cannot use a path of existing directory %s", errPath)
+		}
+		dir := filepath.Dir(errPath)
+		os.MkdirAll(dir, 0755)
+		printcfg.ErrFile, err = os.Create(errPath)
+		if err != nil {
+			return outcfg, printcfg, fmt.Errorf("failed to create output path: %v", err)
 		}
 	}
 

--- a/cmd/tracee-ebpf/internal/printer/printer.go
+++ b/cmd/tracee-ebpf/internal/printer/printer.go
@@ -42,6 +42,14 @@ type Config struct {
 func New(config Config) (EventPrinter, error) {
 	var res EventPrinter
 	kind := config.Kind
+
+	if config.OutFile == nil {
+		return res, fmt.Errorf("out file is not set")
+	}
+	if config.ErrFile == nil {
+		return res, fmt.Errorf("err file is not set")
+	}
+
 	switch {
 	case kind == "ignore":
 		res = &ignoreEventPrinter{

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -218,19 +218,6 @@ func main() {
 
 			}
 
-			if printerConfig.OutFile == nil {
-				printerConfig.OutFile, err = os.OpenFile(printerConfig.OutPath, os.O_WRONLY, 0755)
-				if err != nil {
-					return err
-				}
-			}
-			if printerConfig.ErrFile == nil {
-				printerConfig.ErrFile, err = os.OpenFile(printerConfig.ErrPath, os.O_WRONLY, 0755)
-				if err != nil {
-					return err
-				}
-			}
-
 			printer, err := printer.New(printerConfig)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description (git log)

Output and error files should be always truncated.

It is imperative that either the output file is truncated OR that the cursor positioning (to EOF) is done before any write to the file happens. If not, then we might have situations such as:

$ cat ebpf_events.json | wc -l
58010
$ cat ebpf_events.json | wc -l
58010
$ cat ebpf_events.json | wc -l
58011
$ cat ebpf_events.json | wc -l
58002
$ cat ebpf_events.json | wc -l
57989
$ cat ebpf_events.json | wc -l
57978

when the output file is truncated while being written to.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).