### PR TITLE
Remove net debug

### DIFF
--- a/pkg/bufferdecoder/net_decoder.go
+++ b/pkg/bufferdecoder/net_decoder.go
@@ -20,7 +20,7 @@ func (NetEventMetadata) GetSizeBytes() uint32 {
 	return 32
 }
 
-//DecodeNetEventMetadata parsing the NetEventMetadata struct from byte array
+// DecodeNetEventMetadata parsing the NetEventMetadata struct from byte array
 func (decoder *EbpfDecoder) DecodeNetEventMetadata(eventMetaData *NetEventMetadata) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(eventMetaData.GetSizeBytes()) {
@@ -44,7 +44,7 @@ func (NetCaptureData) GetSizeBytes() uint32 {
 	return 8
 }
 
-//DecodeNetCaptureData parsing the NetCaptureData struct from byte array
+// DecodeNetCaptureData parsing the NetCaptureData struct from byte array
 func (decoder *EbpfDecoder) DecodeNetCaptureData(netCaptureData *NetCaptureData) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(netCaptureData.GetSizeBytes()) {
@@ -70,7 +70,7 @@ func (NetPacketEvent) GetSizeBytes() uint32 {
 	return 40
 }
 
-//DecodeNetPacketEvent parsing the NetPacketEvent struct from byte array
+// DecodeNetPacketEvent parsing the NetPacketEvent struct from byte array
 func (decoder *EbpfDecoder) DecodeNetPacketEvent(netPacketEvent *NetPacketEvent) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(netPacketEvent.GetSizeBytes()) {
@@ -83,42 +83,6 @@ func (decoder *EbpfDecoder) DecodeNetPacketEvent(netPacketEvent *NetPacketEvent)
 	netPacketEvent.Protocol = decoder.buffer[offset+36]
 
 	decoder.cursor += int(netPacketEvent.GetSizeBytes())
-	return nil
-}
-
-type NetDebugEvent struct {
-	LocalIP     [16]byte
-	RemoteIP    [16]byte
-	LocalPort   uint16
-	RemotePort  uint16
-	Protocol    uint8
-	_           [3]byte //padding
-	TcpOldState uint32
-	TcpNewState uint32
-	_           [4]byte //padding
-	SockPtr     uint64
-}
-
-func (NetDebugEvent) GetSizeBytes() uint32 {
-	return 60
-}
-
-//DecodeNetDebugEvent parsing the NetDebugEvent struct from byte array
-func (decoder *EbpfDecoder) DecodeNetDebugEvent(netDebugEvent *NetDebugEvent) error {
-	offset := decoder.cursor
-	if len(decoder.buffer[offset:]) < int(netDebugEvent.GetSizeBytes()) {
-		return fmt.Errorf("can't read NetDebugEvent from buffer: buffer too short")
-	}
-	copy(netDebugEvent.LocalIP[:], decoder.buffer[offset:offset+16])
-	copy(netDebugEvent.RemoteIP[:], decoder.buffer[offset+16:offset+32])
-	netDebugEvent.LocalPort = binary.LittleEndian.Uint16(decoder.buffer[offset+32 : offset+34])
-	netDebugEvent.RemotePort = binary.LittleEndian.Uint16(decoder.buffer[offset+34 : offset+36])
-	netDebugEvent.Protocol = decoder.buffer[offset+36]
-	netDebugEvent.TcpOldState = binary.LittleEndian.Uint32(decoder.buffer[offset+40 : offset+44])
-	netDebugEvent.TcpNewState = binary.LittleEndian.Uint32(decoder.buffer[offset+44 : offset+48])
-	netDebugEvent.SockPtr = binary.LittleEndian.Uint64(decoder.buffer[offset+52 : offset+60])
-
-	decoder.cursor += int(netDebugEvent.GetSizeBytes())
 	return nil
 }
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -66,6 +66,11 @@
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
 
+char LICENSE[] SEC("license") = "GPL";
+#ifndef CORE
+int KERNEL_VERSION SEC("version") = LINUX_VERSION_CODE;
+#endif
+
 #if defined(bpf_target_x86)
     #define PT_REGS_PARM6(ctx) ((ctx)->r9)
 #elif defined(bpf_target_arm64)
@@ -6329,8 +6334,3 @@ int tc_ingress(struct __sk_buff *skb)
 {
     return tc_probe(skb, true);
 }
-
-char LICENSE[] SEC("license") = "GPL";
-#ifndef CORE
-int KERNEL_VERSION SEC("version") = LINUX_VERSION_CODE;
-#endif

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -518,7 +518,6 @@ const (
 	optCaptureFiles
 	optExtractDynCode
 	optStackAddresses
-	optDebugNet
 	optCaptureModules
 	optCgroupV1
 	optProcessInfo
@@ -572,9 +571,6 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	}
 	if t.config.Capture.Mem {
 		cOptVal = cOptVal | optExtractDynCode
-	}
-	if t.config.Debug {
-		cOptVal = cOptVal | optDebugNet
 	}
 	if t.containers.IsCgroupV1() {
 		cOptVal = cOptVal | optCgroupV1

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -157,14 +157,6 @@ const (
 	SymbolsLoaded
 	SecurityInodeRename
 	MaxCommonID
-	DebugNetSecurityBind
-	DebugNetUdpSendmsg
-	DebugNetUdpDisconnect
-	DebugNetUdpDestroySock
-	DebugNetUdpV6DestroySock
-	DebugNetInetSockSetState
-	DebugNetTcpConnect
-	MaxDebugID
 )
 
 // Events originated from user-space


### PR DESCRIPTION
## Initial Checklist

- [x] If part of an EPIC, PR git log contains EPIC number.

## Description (git log)

    net_events: remove current net debugging mechanism

    Preparation for moving away from the TC eBPF program types for ingress
    and egress. The current net_debug is also interefering in the normal
    debug output. A similar (or not) debugging approach will be made if/when
    needed.

Related: #2152

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

General CI/CD tests.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
