### PR TITLE
Makefile: add DEBUG flag to enable symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,15 @@ VERSION ?= $(if $(RELEASE_TAG),$(RELEASE_TAG),$(LAST_GIT_TAG))
 # environment
 #
 
+DEBUG ?= 0
 UNAME_M := $(shell uname -m)
 UNAME_R := $(shell uname -r)
+
+ifeq ($(DEBUG),1)
+	GO_DEBUG_FLAG =
+else
+	GO_DEBUG_FLAG = -w
+endif
 
 ifeq ($(UNAME_M),x86_64)
    ARCH = x86_64
@@ -177,6 +184,9 @@ env:
 	@echo "GO_ARCH                  $(GO_ARCH)"
 	@echo "GO_TAGS_EBPF             $(GO_TAGS_EBPF)"
 	@echo "GO_TAGS_RULES            $(GO_TAGS_RULES)"
+	@echo ---------------------------------------
+	@echo "DEBUG                    $(DEBUG)"
+	@echo "GO_DEBUG_FLAG            $(GO_DEBUG_FLAG)"
 	@echo ---------------------------------------
 	@echo "CUSTOM_CGO_CFLAGS        $(CUSTOM_CGO_CFLAGS)"
 	@echo "CUSTOM_CGO_LDFLAGS       $(CUSTOM_CGO_LDFLAGS)"
@@ -246,6 +256,7 @@ help:
 	@echo ""
 	@echo "    $$ STATIC=1 make ...                 # build static binaries"
 	@echo "    $$ BTFHUB=1 STATIC=1 make ...        # build static binaries, embed BTF"
+	@echo "    $$ DEBUG=1 make ...                  # build binaries with debug symbols"
 	@echo ""
 
 #
@@ -465,7 +476,7 @@ $(OUTPUT_DIR)/tracee-ebpf: \
 	$(MAKE) btfhub
 	$(GO_ENV_EBPF) $(CMD_GO) build \
 		-tags $(GO_TAGS_EBPF) \
-		-ldflags="-w \
+		-ldflags="$(GO_DEBUG_FLAG) \
 			-extldflags \"$(CGO_EXT_LDFLAGS_EBPF)\" \
 			-X main.version=\"$(VERSION)\" \
 			" \
@@ -535,7 +546,7 @@ $(OUTPUT_DIR)/tracee-rules: \
 #
 	$(GO_ENV_RULES) $(CMD_GO) build \
 		-tags $(GO_TAGS_RULES) \
-		-ldflags="-w \
+		-ldflags="$(GO_DEBUG_FLAG) \
 			-extldflags \"$(CGO_EXT_LDFLAGS_RULES)\" \
 			" \
 		-v -o $@ \
@@ -629,7 +640,7 @@ test-integration: \
 	$(GO_ENV_EBPF) \
 	$(CMD_GO) test \
 		-tags $(GO_TAGS_EBPF) \
-		-ldflags="-w \
+		-ldflags="$(GO_DEBUG_FLAG) \
 			-extldflags \"$(CGO_EXT_LDFLAGS_EBPF)\" \
 			-X main.version=\"$(VERSION)\" \
 			" \

--- a/docs/building/building.md
+++ b/docs/building/building.md
@@ -71,6 +71,7 @@
     
         $ STATIC=1 make ...                 # build static binaries
         $ BTFHUB=1 STATIC=1 make ...        # build static binaries, embed BTF
+        $ DEBUG=1 make ...                  # build binaries with debug symbols
     ```
 
 4. Build **all** targets at once (but bpf-nocore)
@@ -134,3 +135,18 @@
         >2021/12/13 13:27:21 error opening plugin /tracee/dist/rules/builtin.so:
         >plugin.Open("/tracee/dist/rules/builtin.so"): Dynamic loading not supported
         >```
+
+7. Build a **debuggable binary** with DWARF generation by setting `DEBUG=1`
+
+    ```text
+    $ DEBUG=1 make
+    ...
+    GOOS=linux CC=clang GOARCH=amd64 CGO_CFLAGS="-I/home/gg/code/tracee/dist/libbpf" CGO_LDFLAGS="-lelf  -lz  /home/gg/code/tracee/dist/libbpf/libbpf.a" go build \
+	-tags core,ebpf \
+	-ldflags=" \
+		-extldflags \"\" \
+		-X main.version=\"v0.8.0-107-g121efeb\" \
+		" \
+	-v -o dist/tracee-ebpf \
+	./cmd/tracee-ebpf
+    ```


### PR DESCRIPTION
`-ldflags= -w` turns off DWARF debugging information, so removing it one can have a debuggable binary. 

Usage: `DEBUG=1 make ...`

It sets GO_DEBUG_FLAG accordingly.

Docs updated.

## Initial Checklist

- [x] Git log contains summary of the change.

## Description (git log)

commit 121efeb3428e24ed0c7f676e62c9491669d19502 (HEAD -> debug, origin/debug)
Author: Geyslan Gregório <geyslan@gmail.com>
Date:   Tue Sep 13 14:28:46 2022 -0300
```
    Makefile: add DEBUG flag to enable symbols
    
    "-ldflags= -w" turns off DWARF debugging information, so removing it one
    can have a debuggable binary.
    
    Usage: DEBUG=1 make ...
    
    It sets GO_DEBUG_FLAG accordingly.
    
    Docs updated.
```

## Type of change

- [x] New feature (non-breaking change adding functionality).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
