### PR TITLE
tracee: debug mode: only enable net probes if needed

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -970,7 +970,6 @@ func (t *Tracee) attachProbes() error {
 
 func (t *Tracee) initBPF() error {
 	var err error
-	isDebugSet := t.config.Debug
 	isCaptureNetSet := t.config.Capture.NetIfaces != nil
 	isFilterNetSet := len(t.config.Filter.NetFilter.Interfaces()) != 0
 
@@ -990,7 +989,7 @@ func (t *Tracee) initBPF() error {
 
 	// Initialize probes
 
-	netEnabled := isDebugSet || isCaptureNetSet || isFilterNetSet
+	netEnabled := isCaptureNetSet || isFilterNetSet
 
 	t.probes, err = probes.Init(t.bpfModule, netEnabled)
 	if err != nil {


### PR DESCRIPTION
## Description (git log)

Currently debug mode enables TC (and net related probes) automatically because net_debug was in place. Now, that net_debug has been removed, there is no need for that.

This also solves the permission problems when no net_event was given to debug (and it would fail without correct permissions for loading net probes).

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).
