### PR TITLE
Move pprof to server

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -211,6 +211,10 @@ func main() {
 					httpServer.EnableHealthzEndpoint()
 				}
 
+				if c.Bool(server.PProfEndpointFlag) {
+					httpServer.EnablePProfEndpoint()
+				}
+
 				go httpServer.Start()
 			}
 
@@ -334,6 +338,11 @@ func main() {
 			&cli.BoolFlag{
 				Name:  server.HealthzEndpointFlag,
 				Usage: "enable healthz endpoint",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  server.PProfEndpointFlag,
+				Usage: "enables pprof endpoints",
 				Value: false,
 			},
 			&cli.StringFlag{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"os"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -12,6 +13,7 @@ import (
 const (
 	MetricsEndpointFlag = "metrics"
 	HealthzEndpointFlag = "healthz"
+	PProfEndpointFlag   = "pprof"
 	ListenEndpointFlag  = "listen-addr"
 )
 
@@ -54,6 +56,18 @@ func (s *Server) Start() {
 	}
 }
 
+func (s *Server) EnablePProfEndpoint() {
+	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+	s.mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	s.mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+	s.mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	s.mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	s.mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
 func ShouldStart(c *cli.Context) bool {
-	return c.Bool(MetricsEndpointFlag) || c.Bool(HealthzEndpointFlag)
+	return c.Bool(MetricsEndpointFlag) || c.Bool(HealthzEndpointFlag) || c.Bool(PProfEndpointFlag)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -14,6 +14,7 @@ func TestServer(t *testing.T) {
 
 	httpServer.EnableMetricsEndpoint()
 	httpServer.EnableHealthzEndpoint()
+	httpServer.EnablePProfEndpoint()
 
 	server := httptest.NewServer(httpServer.mux)
 	defer server.Close()
@@ -25,6 +26,7 @@ func TestServer(t *testing.T) {
 	}{
 		{name: "TestHealthzEndpoint", endpoint: "/healthz", status: 200},
 		{name: "TestMetricsEndpoint", endpoint: "/metrics", status: 200},
+		{name: "TestPProfEndpoint", endpoint: "/debug/pprof", status: 200},
 		{name: "TestIndexEndpoint", endpoint: "", status: 404},
 	}
 


### PR DESCRIPTION
Moves pprof to server (DRY) and add it to tracee-ebpf.

Fixes: #2137