### PR TITLE
refactor: clean up tracee-rules/main.go

### DIFF
--- a/cmd/tracee-rules/main_test.go
+++ b/cmd/tracee-rules/main_test.go
@@ -44,7 +44,7 @@ func Test_listSigs(t *testing.T) {
 	}
 
 	buf := bytes.Buffer{}
-	assert.NoError(t, listSigs(&buf, inputSigs))
+	listSigs(&buf, inputSigs)
 	assert.Equal(t, `ID         NAME                                VERSION DESCRIPTION
 FOO-1      foo signature                       1.2.3   foo signature helps with foo
 BAR-1      bar signature                       4.5.6   bar signature helps with bar


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

This is a minor cleanup on `tracee-rules/main.go`:

- check for commands vs flags first
- fix errors returned for the flag `rego-runtime-target` because the var `target` is empty
- change `listSigs` signature, `error` return not used
- minor change for redability