### PR TITLE
Fix typo in README file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,7 +104,7 @@ Hostname: ubuntu-impish
 
 In some cases, you might want to **leverage Tracee's eBPF event collection
 capabilities** directly, without involving the **detection engine**. This might
-be useful for debugging, troubleshooting, analysising, researching OR
+be useful for debugging, troubleshooting, analysing, researching OR
 education.
 
 Execute docker container with the word `trace` as an initial argument, and


### PR DESCRIPTION
Analysising -> Analysing

## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [X] Git log contains summary of the change.
- [X] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit 6f5f9f244c01cac85ed9520fc021f7b2ea35e9d0 (HEAD -> patch-1)
Author: Margarita Manterola <margamanterola@gmail.com>
Date:   Wed Sep 28 18:03:24 2022 -0300

    README: Fix typo
    
    Analysising -> Analysing

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [X] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

I haven't tested this as it's fixing a typo in the Readme file.

## Final Checklist:

"Bug Fix" (Maybe? It's a typo fix)

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [X] Subject starts with "subsystem|file: description".
- [X] Do not end the subject line with a period.
- [X] Limit the subject line to 50 characters.
- [X] Separate subject from body with a blank line.
- [X] Use the imperative mood in the subject line.
- [X] Wrap the body at 72 characters.
- [X] Use the body to explain what and why instead of how.
