### PR TITLE
[MAINT] kerneltest: fix test name variable

### DIFF
--- a/tests/kerneltest.sh
+++ b/tests/kerneltest.sh
@@ -167,9 +167,8 @@ for TEST in $TESTS; do
 
     ## cleanup at EXIT
 
-    success=1
     found=0
-    cat $SCRIPT_TMP_DIR/build-$$ | grep "Signature ID: $test_name" -B2 | head -3 | grep -q "\*\*\* Detection" && found=1
+    cat $SCRIPT_TMP_DIR/build-$$ | grep "Signature ID: $TEST" -B2 | head -3 | grep -q "\*\*\* Detection" && found=1
     info
     if [[ $found -eq 1 ]]
     then


### PR DESCRIPTION
This is a quick fix as the tests might be facing false positives without it.