### PR TITLE
pkg/ebpf: fix bug in support for arg types

### DIFF
--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -18,7 +18,6 @@ type ArgType uint8
 
 const (
 	noneT ArgType = iota
-	u8T
 	intT
 	uintT
 	longT
@@ -36,6 +35,7 @@ const (
 	credT
 	intArr2T
 	uint64ArrT
+	u8T
 )
 
 // These types don't match the ones defined in the ebpf code since they are not being used by syscalls arguments.

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -157,6 +157,7 @@ enum argument_type_e
     CRED_T,
     INT_ARR_2_T,
     UINT64_ARR_T,
+    U8_T,
     TYPE_MAX = 255UL
 };
 
@@ -2442,6 +2443,12 @@ static __always_inline int save_args_to_submit_buf(event_data_t *data, u64 types
                 break;
             case POINTER_T:
                 size = sizeof(void *);
+                break;
+            case U8_T:
+                size = sizeof(u8);
+                break;
+            case U16_T:
+                size = sizeof(u16);
                 break;
             case STR_T:
                 rc = save_str_to_buf(data, (void *) args->args[i], index);


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

In `tracee.bpf.c` we use arg types to determine syscall arguments. Recent feature changed arguments types enum values, causing bug in argument parsing of syscalls.
This commit fix this issue and add unsupported basic types should be supported in parsing.

Fixes: #2227

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
