### PR TITLE
uprobe: fix uprobe trigger triggered from multiple tracee instances

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3689,6 +3689,7 @@ SEC("uprobe/trigger_syscall_event")
 int uprobe_syscall_trigger(struct pt_regs *ctx)
 {
     u64 caller_ctx_id = 0;
+    u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
 
     // clang-format off
     //
@@ -3718,6 +3719,10 @@ int uprobe_syscall_trigger(struct pt_regs *ctx)
 
     event_data_t data = {};
     if (!init_event_data(&data, ctx))
+        return 0;
+
+    // uprobe was triggered from other tracee instance
+    if (data.config->tracee_pid != trigger_pid)
         return 0;
 
     int key = 0;
@@ -3761,6 +3766,7 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
     u64 caller_ctx_id = 0;
     u64 *address_array = NULL;
     u64 struct_address;
+    u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
 
     // clang-format off
     //
@@ -3793,6 +3799,10 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
 
     event_data_t data = {};
     if (!init_event_data(&data, ctx))
+        return 0;
+
+    // uprobe was triggered from other tracee instance
+    if (data.config->tracee_pid != trigger_pid)
         return 0;
 
     u32 count_off = data.buf_off + 1;


### PR DESCRIPTION
Fixes the issue that multiple tracee instances are all invoking the uprobe trigger events for each instance.

Fixes: #2225

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [x] If part of an EPIC, PR git log contains EPIC number.
- [x] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit e5a6bf84285bd812f517cdd6fdfc1124a0835fee (HEAD -> fix_uprobe, origin/fix_uprobe)
Author: AsafEitani <eitaniasaf@gmail.com>
Date:   Wed Oct 12 18:28:32 2022 +0300

    uprobe: fix uprobe trigger triggered from multiple tracee instances
    
    Fixes the issue that multiple tracee instances are all invoking the uprobe
    trigger events for each instance.
    
    Fixes: #2225

Fixes: #2225

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

- running 2 instances of tracee-ebpf with `hooked_syscalls,hooked_seq_ops` events and loading a kernel module.

## Final Checklist:

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
