### PR TITLE
[REFACTOR] Cgroup Interface (cgroupv1 and cgroupv2 initialization)

### DIFF
--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -14,21 +14,360 @@ import (
 	"github.com/aquasecurity/tracee/pkg/mount"
 )
 
-const CgroupV1Controller = "cpuset"
-const CgroupV1FsType = "cgroup"
-const CgroupV2FsType = "cgroup2"
+// Constants
 
-const CgroupCpusetReleaseAgent = "/sys/fs/cgroup/cpuset/release_agent"
+const (
+	CgroupV1FsType          = "cgroup"
+	CgroupV2FsType          = "cgroup2"
+	CgroupDefaultController = "cpuset"
+	CgroupControllersFile   = "/sys/fs/cgroup/cgroup.controllers"
+	procCgroups             = "/proc/cgroups"
+	sysFsCgroup             = "/sys/fs/cgroup"
+)
+
+// Versions
+
+type CgroupVersion int
+
+func (v CgroupVersion) String() string {
+	switch v {
+	case CgroupVersion1:
+		return CgroupV1FsType
+	case CgroupVersion2:
+		return CgroupV2FsType
+	}
+
+	return ""
+}
+
+const (
+	CgroupVersion1 CgroupVersion = iota
+	CgroupVersion2
+)
+
+//
+// Cgroups
+//
+
+type Cgroups struct {
+	cgroupv1 Cgroup
+	cgroupv2 Cgroup
+	cgroup   *Cgroup // pointer to default cgroup version
+	hid      int     // default cgroup controller hiearchy ID
+}
+
+func NewCgroups() (*Cgroups, error) {
+	var err error
+	var cgrp *Cgroup
+	var cgroupv1, cgroupv2 Cgroup
+
+	// discover the default cgroup being used
+	defaultVersion, err := GetCgroupDefaultVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	// only start cgroupv1 if it is the OS default (orelse it isn't needed)
+	if defaultVersion == CgroupVersion1 {
+		cgroupv1, err = NewCgroup(CgroupVersion1)
+		if err != nil {
+			if _, ok := err.(*VersionNotSupported); !ok {
+				return nil, err
+			}
+		}
+	}
+
+	// start cgroupv2 (if supported)
+	cgroupv2, err = NewCgroup(CgroupVersion2)
+	if err != nil {
+		if _, ok := err.(*VersionNotSupported); !ok {
+			return nil, err
+		}
+	}
+
+	// at least one (or both) has to be supported
+	if cgroupv1 == nil && cgroupv2 == nil {
+		return nil, NoCgroupSupport()
+
+	}
+
+	hid := 0
+
+	// adjust pointer to the default cgroup version
+	switch defaultVersion {
+	case CgroupVersion1:
+		if cgroupv1 == nil {
+			return nil, CouldNotFindOrMountDefaultCgroup(CgroupVersion1)
+		}
+		cgrp = &cgroupv1
+
+		// discover default cgroup controller hierarchy id for cgroupv1
+		hid, err = GetCgroupControllerHierarchy(CgroupDefaultController)
+		if err != nil {
+			return nil, err
+		}
+
+	case CgroupVersion2:
+		if cgroupv2 == nil {
+			return nil, CouldNotFindOrMountDefaultCgroup(CgroupVersion2)
+		}
+		cgrp = &cgroupv2
+	}
+
+	cs := &Cgroups{
+		cgroupv1: cgroupv1,
+		cgroupv2: cgroupv2,
+		cgroup:   cgrp,
+		hid:      hid,
+	}
+
+	return cs, nil
+}
+
+func (cs *Cgroups) Destroy() error {
+	if cs.cgroupv1 != nil {
+		err := cs.cgroupv1.destroy()
+		if err != nil {
+			return err
+		}
+	}
+	if cs.cgroupv2 != nil {
+		return cs.cgroupv2.destroy()
+	}
+
+	return nil
+}
+
+func (cs *Cgroups) GetDefaultCgroupHierarchyID() int {
+	return cs.hid
+}
+
+func (cs *Cgroups) GetDefaultCgroup() Cgroup {
+	return *cs.cgroup
+}
+
+//
+// Cgroup
+//
+
+type Cgroup interface {
+	init() error
+	destroy() error
+	GetMountPoint() string
+	getDefaultHierarchyID() int
+}
+
+func NewCgroup(ver CgroupVersion) (Cgroup, error) {
+	var c Cgroup
+
+	switch ver {
+	case CgroupVersion1:
+		c = &CgroupV1{}
+	case CgroupVersion2:
+		c = &CgroupV2{}
+	}
+
+	return c, c.init()
+}
+
+// cgroupv1
+
+type CgroupV1 struct {
+	mounted    *mount.MountOnce
+	mountpoint string
+	hid        int
+}
+
+func (c *CgroupV1) init() error {
+
+	// 0. check if cgroup type is supported
+	supported, err := mount.IsFileSystemSupported(CgroupVersion1.String())
+	if err != nil {
+		return err
+	}
+	if !supported {
+		return &VersionNotSupported{}
+	}
+
+	// 1. mount cgroup (if needed)
+	c.mounted, err = mount.NewMountOnce(
+		CgroupV1FsType,
+		CgroupV1FsType,
+		CgroupDefaultController,
+		sysFsCgroup, // where to check for already mounted cgroupfs
+	)
+	if err != nil {
+		return err
+	}
+
+	// 2. discover where cgroup is mounted
+	c.mountpoint = c.mounted.GetMountpoint()
+
+	return nil
+}
+
+func (c *CgroupV1) destroy() error {
+	return c.mounted.Umount()
+}
+
+func (c *CgroupV1) GetMountPoint() string {
+	return c.mountpoint
+}
+
+func (c *CgroupV1) getDefaultHierarchyID() int {
+	return c.hid
+}
+
+// cgroupv2
+
+type CgroupV2 struct {
+	mounted    *mount.MountOnce
+	mountpoint string
+	hid        int
+}
+
+func (c *CgroupV2) init() error {
+	// 0. check if cgroup type is supported
+	supported, err := mount.IsFileSystemSupported(CgroupVersion2.String())
+	if err != nil {
+		return err
+	}
+	if !supported {
+		return &VersionNotSupported{}
+	}
+
+	// 1. mount cgroup (if needed)
+	c.mounted, err = mount.NewMountOnce(
+		CgroupV2FsType,
+		CgroupV2FsType,
+		"",          // cgroupv2 has no default controller
+		sysFsCgroup, // where to check for already mounted cgroupfs
+	)
+	if err != nil {
+		return err
+	}
+
+	// 2. discover where cgroup is mounted
+	c.mountpoint = c.mounted.GetMountpoint()
+
+	return nil
+}
+
+func (c *CgroupV2) destroy() error {
+	return c.mounted.Umount()
+}
+
+func (c *CgroupV2) GetMountPoint() string {
+	return c.mountpoint
+}
+
+func (c *CgroupV2) getDefaultHierarchyID() int {
+	return c.hid
+}
+
+//
+// General
+//
+
+func GetCgroupDefaultVersion() (CgroupVersion, error) {
+	// 1st Method: already mounted cgroupv1 filesystem
+
+	if ok, _ := IsCgroupV2MountedAndDefault(); ok {
+		return CgroupVersion2, nil
+	}
+
+	//
+	// 2nd Method: From cgroup man page:
+	// ...
+	// 2. The unique ID of the cgroup hierarchy on which this
+	//    controller is mounted. If multiple cgroups v1
+	//    controllers are bound to the same hierarchy, then each
+	//    will show the same hierarchy ID in this field.  The
+	//    value in this field will be 0 if:
+	//
+	//    a) the controller is not mounted on a cgroups v1
+	//       hierarchy;
+	//    b) the controller is bound to the cgroups v2 single
+	//       unified hierarchy; or
+	//    c) the controller is disabled (see below).
+	// ...
+
+	var value int
+
+	file, err := os.Open(procCgroups)
+	if err != nil {
+		return -1, CouldNotOpenFile(procCgroups, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.Fields(scanner.Text())
+		if line[0] != CgroupDefaultController {
+			continue
+		}
+		value, err = strconv.Atoi(line[1])
+		if err != nil || value < 0 {
+			return -1, ErrorParsingFile(procCgroups, err)
+		}
+	}
+
+	if value == 0 { // == (a), (b) or (c)
+		return CgroupVersion2, nil
+	}
+
+	return CgroupVersion1, nil
+}
+
+// IsCgroupV2MountedAndDefault tests if cgroup2 is mounted and is the default
+// cgroup version being used by the running environment. It does so by checking
+// the existance of a "cgroup.controllers" file in default cgroupfs mountpoint.
+func IsCgroupV2MountedAndDefault() (bool, error) {
+	_, err := os.Stat(CgroupControllersFile)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, CouldNotOpenFile(CgroupControllersFile, err)
+	}
+
+	return true, nil
+}
+
+// Returns a cgroup controller hierarchy value
+func GetCgroupControllerHierarchy(subsys string) (int, error) {
+	var value int
+
+	file, err := os.Open(procCgroups)
+	if err != nil {
+		return -1, CouldNotOpenFile(procCgroups, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.Fields(scanner.Text())
+		if len(line) < 2 || line[0] != subsys {
+			continue
+		}
+		value, err = strconv.Atoi(line[1])
+		if err != nil || value < 0 {
+			return -1, ErrorParsingFile(procCgroups, err)
+		}
+	}
+
+	return value, nil
+}
 
 // RunsOnContainerV1 tests if process is running on a container in cgroupsv1 it
 // tests by checking for existance of a release_agent file in cpuset from
 // https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt:
 //
-// - release_agent: ...	 (this file exists in the top cgroup only)
+// - release_agent: ...         (this file exists in the top cgroup only)
 //
 // WARNING: IF THIS WASN'T CLEAR THIS IS ONLY VALID FOR CGROUPSV1 MACHINES
 func RunsOnContainerV1() (bool, error) {
-	_, err := os.Stat(CgroupCpusetReleaseAgent)
+	_, err := os.Stat(CgroupReleaseAgent)
 	if os.IsNotExist(err) {
 		return true, nil
 	}
@@ -50,7 +389,7 @@ func GetCgroupV1HierarchyId() (int, error) {
 	scanner := bufio.NewScanner(file)
 	for i := 1; scanner.Scan(); i++ {
 		sline := strings.Fields(scanner.Text())
-		if len(sline) < 2 || sline[0] != CgroupV1Controller {
+		if len(sline) < 2 || sline[0] != CgroupDefaultController {
 			continue
 		}
 		intID, err := strconv.Atoi(sline[1])

--- a/pkg/cgroup/errors.go
+++ b/pkg/cgroup/errors.go
@@ -1,0 +1,26 @@
+package cgroup
+
+import "fmt"
+
+type VersionNotSupported struct{}
+
+func (c *VersionNotSupported) Error() string {
+	return "unsupported cgroup version"
+}
+
+func NoCgroupSupport() error {
+	return fmt.Errorf("could not find cgroup support")
+}
+
+func CouldNotFindOrMountDefaultCgroup(ver CgroupVersion) error {
+	return fmt.Errorf("could not find/mount default %v support", ver.String())
+}
+
+func ErrorParsingFile(file string, err error) error {
+	return fmt.Errorf("error parsing %s: %w", file, err)
+}
+
+func CouldNotOpenFile(file string, err error) error {
+	return fmt.Errorf("could not open %s: %w", file, err)
+
+}

--- a/pkg/mount/errors.go
+++ b/pkg/mount/errors.go
@@ -1,0 +1,11 @@
+package mount
+
+import "fmt"
+
+func UnmountedDirNotEmpty(dir string) error {
+	return fmt.Errorf("unmounted directory %v isn't empty", dir)
+}
+
+func CouldNotOpenFile(path string, err error) error {
+	return fmt.Errorf("could not open %s: %w", path, err)
+}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -3,13 +3,181 @@ package mount
 import (
 	"bufio"
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
+
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/utils"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
+
+// Constants
+
+const (
+	procMounts      = "/proc/mounts"
+	procFilesystems = "/proc/filesystems"
+	tmpPathPrefix   = "tracee"
+)
+
+//
+// MountOnce
+//
+
+// MountOnce will make sure a given source and filesystem type are mounted just
+// once: it will check if given source and fs type are already mounted and, if
+// not, it will mount it (in a temporary directory) and manage it (umounting at
+// its destruction). If already mounted, the filesystem is left untouched at
+// object's destruction.
+type MountOnce struct {
+	source  string
+	target  string
+	fsType  string
+	data    string
+	managed bool
+	mounted bool
+}
+
+func NewMountOnce(source, fstype, data, where string) (*MountOnce, error) {
+	m := &MountOnce{
+		source: source, // device and/or pseudo-filesystem to mount
+		fsType: fstype, // fs type
+		data:   data,   // extra data
+	}
+
+	// already mounted filesystems will be like mounted ones, but unmanaged
+	alreadyMounted, err := m.isMountedByOS(where)
+	if err != nil {
+		return nil, err
+	}
+	if !alreadyMounted {
+		err = m.Mount()
+		if err != nil {
+			return nil, err
+		}
+		m.managed = true // managed by this object
+	}
+
+	m.mounted = true
+
+	return m, nil
+}
+
+func (m *MountOnce) Mount() error {
+	path, err := os.MkdirTemp(os.TempDir(), tmpPathPrefix) // create temp dir
+	if err != nil {
+		return err
+	}
+	mp, err := filepath.Abs(path) // pick mountpoint path
+	if err != nil {
+		return err
+	}
+
+	m.target = mp
+
+	// mount the filesystem to the target dir
+	err = capabilities.GetInstance().Requested( // ring2
+		func() error {
+			return syscall.Mount(m.fsType, m.target, m.fsType, 0, m.data)
+		},
+		cap.SYS_ADMIN,
+	)
+	if err != nil {
+		// remove created target directory on errors
+		empty, _ := utils.IsDirEmpty(m.target)
+		if empty {
+			os.RemoveAll(m.target) // best effort for cleanup
+		}
+	}
+
+	return err
+}
+
+func (m *MountOnce) Umount() error {
+	if m.managed && m.mounted {
+		// umount the filesystem from the target dir
+		err := capabilities.GetInstance().Requested( // ring2
+			func() error {
+				return syscall.Unmount(m.target, 0)
+			},
+			cap.SYS_ADMIN,
+		)
+		if err != nil {
+			return err
+		}
+
+		m.mounted = false
+		m.managed = false
+
+		// check if target dir is empty before removing it
+		empty, err := utils.IsDirEmpty(m.target)
+		if err != nil {
+			return err
+		}
+		if !empty {
+			return UnmountedDirNotEmpty(m.target)
+		}
+
+		// remove target dir (cleanup)
+		return os.RemoveAll(m.target)
+	}
+
+	return nil
+}
+
+func (m *MountOnce) IsMounted() bool {
+	return m.mounted
+}
+
+func (m *MountOnce) GetMountpoint() string {
+	return m.target
+}
+
+// private
+
+func (m *MountOnce) isMountedByOS(where string) (bool, error) {
+	mp, err := SearchMountpoint(m.fsType, m.data)
+	if err != nil || mp == "" {
+		return false, err
+	}
+	if where != "" && !strings.Contains(mp, where) {
+		return false, nil
+	}
+
+	m.target = mp // replace given target dir with existing mountpoint
+	m.mounted = true
+	m.managed = false // proforma
+
+	return true, nil
+}
+
+//
+// General
+//
+
+// IsFileSystemSupported checks if given fs is supported by the running kernel
+func IsFileSystemSupported(fsType string) (bool, error) {
+	file, err := os.Open(procFilesystems)
+	if err != nil {
+		return false, CouldNotOpenFile(procFilesystems, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.Fields(scanner.Text())
+		last := line[len(line)-1]
+		if last == fsType {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
 
 // IsMountpoint searches if path is a mountpoint for fstype
 func IsMountpoint(path string, fstype string) (bool, error) {
-	mountsFile := "/proc/mounts"
-	file, err := os.Open(mountsFile)
+	file, err := os.Open(procMounts)
 	if err != nil {
 		return false, err
 	}
@@ -17,9 +185,9 @@ func IsMountpoint(path string, fstype string) (bool, error) {
 
 	scanner := bufio.NewScanner(file)
 	for i := 1; scanner.Scan(); i++ {
-		sline := strings.Split(scanner.Text(), " ")
-		mountpoint := sline[1]
-		currFstype := sline[2]
+		line := strings.Split(scanner.Text(), " ")
+		mountpoint := line[1]
+		currFstype := line[2]
 
 		if fstype == currFstype && mountpoint == path {
 			return true, nil
@@ -29,27 +197,26 @@ func IsMountpoint(path string, fstype string) (bool, error) {
 	return false, nil
 }
 
-// SearchMountpoint finds the last mountpoint for the given fstype which
-// includes the search string if the search string is empty the function will
-// return the last found path
+// SearchMountpoint returns the last mountpoint for a given filesystem type
+// containing a searchable string.
 func SearchMountpoint(fstype string, search string) (string, error) {
-	mountsFile := "/proc/mounts"
-	file, err := os.Open(mountsFile)
+	mp := ""
+
+	file, err := os.Open(procMounts)
 	if err != nil {
 		return "", err
 	}
 	defer file.Close()
 
-	mp := ""
 	scanner := bufio.NewScanner(file)
-	for i := 1; scanner.Scan(); i++ {
-		sline := strings.Split(scanner.Text(), " ")
-		mountpoint := sline[1]
-		currFstype := sline[2]
-
+	for scanner.Scan() {
+		line := strings.Split(scanner.Text(), " ")
+		mountpoint := line[1]
+		currFstype := line[2]
 		if fstype == currFstype && strings.Contains(mountpoint, search) {
 			mp = mountpoint
 		}
 	}
+
 	return mp, nil
 }

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -175,28 +175,6 @@ func IsFileSystemSupported(fsType string) (bool, error) {
 	return false, nil
 }
 
-// IsMountpoint searches if path is a mountpoint for fstype
-func IsMountpoint(path string, fstype string) (bool, error) {
-	file, err := os.Open(procMounts)
-	if err != nil {
-		return false, err
-	}
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for i := 1; scanner.Scan(); i++ {
-		line := strings.Split(scanner.Text(), " ")
-		mountpoint := line[1]
-		currFstype := line[2]
-
-		if fstype == currFstype && mountpoint == path {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
 // SearchMountpoint returns the last mountpoint for a given filesystem type
 // containing a searchable string.
 func SearchMountpoint(fstype string, search string) (string, error) {

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -115,3 +115,19 @@ func CopyRegularFileByRelativePath(srcName string, dstDir *os.File, dstName stri
 	}
 	return nil
 }
+
+// IsDirEmpty returns true if directory contains no files
+func IsDirEmpty(pathname string) (bool, error) {
+	dir, err := os.Open(pathname)
+	if err != nil {
+		return false, err
+	}
+	defer dir.Close()
+
+	_, err = dir.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+
+	return false, err
+}

--- a/tests/kerneltest.sh
+++ b/tests/kerneltest.sh
@@ -184,16 +184,19 @@ for TEST in $TESTS; do
     rm -f $SCRIPT_TMP_DIR/build-$$
     rm -f $SCRIPT_TMP_DIR/ebpf-$$
 
-    # make sure we exit both to start them again
+    rules_pid=$(pidof tracee-rules)
+    tracee_pid=$(pidof tracee-ebpf)
 
-    kill -19 $(pidof tracee-rules)
-    kill -19 $(pidof tracee-ebpf)
-
-    kill -9 $(pidof tracee-rules)
-    kill -9 $(pidof tracee-ebpf)
+    # cleanup tracee with SIGINT
+    kill -2 $rules_pid
+    kill -2 $tracee_pid
 
     # give a little break for OS noise to reduce
     sleep 5
+
+    # make sure tracee is exited with SIGKILL
+    kill -9 $rules_pid > /dev/null 2>&1
+    kill -9 $tracee_pid > /dev/null 2>&1
 done
 
 info


### PR DESCRIPTION
## Description (git log)

This is a refactor triggered by comment https://github.com/aquasecurity/tracee/pull/2200#discussion_r990781388. Tracee needs to always initialize cgroupv1 and/or groupv2 when needed. Cgroupv2 is always needed for cgroup ebpf programs.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

```
sudo ./dist/tracee-ebpf --install-path /tmp/tracee --cache cache-type=mem --cache mem-cache-size=512 --output format:json --output option:parse-arguments --output option:detect-syscall --containers --trace container --trace comm=bash --trace follow --capabilities bypass=false | jq -c
```

Note: Set bypass to false so capabilities are applied:

```
# cat /proc/$(pidof tracee-ebpf)/status | grep Cap
CapInh: 0000000000000000
CapPrm: 000001ffffffffff
CapEff: 0000000000000000
CapBnd: 0000000000000000
CapAmb: 0000000000000000
```
