### PR TITLE
feat: multi scopes (set) of filters

### DIFF
--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -268,7 +268,7 @@ func TestOutputTemplates(t *testing.T) {
 					"a":123,"b":"c","d":true,"f":{"123":"456","foo":"bar"}
 				},
 				"Context":{
-					"timestamp":1321321,"processorId":0,"processId":21312,"threadId":0,"threadStartTime":0,"parentProcessId":0,"hostProcessId":0,"hostThreadId":0,"hostParentProcessId":0,"userId":0,"mountNamespace":0,"pidNamespace":0,"processName":"","hostName":"","cgroupId":0,"containerId":"abbc123","containerImage":"", "containerName":"","podName":"","podNamespace":"","podUID":"","podSandbox":false,"eventId":"0","eventName":"execve","argsNum":0,"returnValue":0,"stackAddresses":null,"args":null,"contextFlags":{"containerStarted":true}
+					"timestamp":1321321,"processorId":0,"processId":21312,"threadId":0,"threadStartTime":0,"parentProcessId":0,"hostProcessId":0,"hostThreadId":0,"matchedScopes":0,"hostParentProcessId":0,"userId":0,"mountNamespace":0,"pidNamespace":0,"processName":"","hostName":"","cgroupId":0,"containerId":"abbc123","containerImage":"", "containerName":"","podName":"","podNamespace":"","podUID":"","podSandbox":false,"eventId":"0","eventName":"execve","argsNum":0,"returnValue":0,"stackAddresses":null,"args":null,"contextFlags":{"containerStarted":true}
 				},
 				"SigMetadata":{
 					"ID":"TRC-1","EventName": "stdio","Version":"0.1.0","Name":"Standard Input/Output Over Socket","Description":"Redirection of process's standard input/output to socket","Tags":["linux","container"],"Properties":{"MITRE ATT\u0026CK":"Persistence: Server Software Component","Severity":3}

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -255,14 +255,17 @@ func createEventsFromSignatures(startId events.ID, sigs []detect.Signature) {
 }
 
 func getEventNames(c *cli.Context) []string {
-	// TODO: --trace event= will become --events
 	traceArgs := c.StringSlice("trace")
+	events := make([]string, 0)
 	for _, optValue := range traceArgs {
-		if strings.HasPrefix(optValue, "event=") {
+		if strings.Contains(optValue, "event=") {
 			values := strings.Split(optValue, "=")
-			return strings.Split(values[1], ",")
+			if len(values[1]) == 0 {
+				continue
+			}
+			events = append(events, strings.Split(values[1], ",")...)
 		}
 	}
 
-	return []string{}
+	return events
 }

--- a/docs/docs/tracing/event-filtering.md
+++ b/docs/docs/tracing/event-filtering.md
@@ -47,15 +47,15 @@ expected.
      ```
 
     !!! Note
-        The "follow" operator will make tracee to follow all newly created
-        processes, that are being filtered for, childs.
+        The "follow" operator will make tracee follow all newly created
+        child processes of the parents being filtered.
 
 1. **Event Arguments** `(Operators: =, !=. Prefix/Suffix: *)`
 
      ```text
-     1) --trace event=openat --trace openat.pathname=/etc/shadow
-     2) --trace event=openat --trace openat.pathname=/tmp*
-     3) --trace event=openat --trace openat.pathname!=/tmp/1,/bin/ls
+     1) --trace event=openat --trace openat.args.pathname=/etc/shadow
+     2) --trace event=openat --trace openat.args.pathname=/tmp*
+     3) --trace event=openat --trace openat.args.pathname!=/tmp/1,/bin/ls
      ```
 
     !!! Note
@@ -65,8 +65,8 @@ expected.
 1. **Event Return Code** `(Operators: =, !=, <, >)`
 
     ```text
-    1) --trace event=openat --trace openat.pathname=/etc/shadow --trace "openat.retval>0"
-    2) --trace event=openat --trace openat.pathname=/etc/shadow --trace "openat.retval<0"
+    1) --trace event=openat --trace openat.args.pathname=/etc/shadow --trace "openat.retval>0"
+    2) --trace event=openat --trace openat.args.pathname=/etc/shadow --trace "openat.retval<0"
     ```
 
     !!! Tip
@@ -75,8 +75,8 @@ expected.
 1. **Event Context** `(Operators: vary by field)`
 
     ```text
-    1) --trace openat.context.container --trace openat.pathname=/etc/shadow
-    2) --trace event=openat --trace openat.context.container --trace openat.pathname=/etc/shadow
+    1) --trace openat.context.container --trace openat.args.pathname=/etc/shadow
+    2) --trace event=openat --trace openat.context.container --trace openat.args.pathname=/etc/shadow
     ```
 
     !!! Note
@@ -123,7 +123,7 @@ expected.
     2) --trace '!container' # events from the host only
     3) --trace container=new # containers created after tracee-ebf execution
     4) --trace container=3f93da58be3c --trace event=openat
-    5) --trace container=new --trace event=openat --trace openat.pathname="/etc/shadow"
+    5) --trace container=new --trace event=openat --trace openat.args.pathname="/etc/shadow"
     ```
 
     !!! Note
@@ -182,16 +182,6 @@ expected.
     2) --trace 'uid>0'
     3) --trace 'uid>0' --trace uid!=1000 # do not trace root and uid=1000
     ```
-
-1. **Network Interface**
-
-    ```text
-    1) -trace comm=nc,ping -trace event=net_packet -trace net=docker0
-    2) -trace event=dns_request,dns_response -trace net=docker0
-    ```
-
-    !!! Attention
-        Do not forget to provide the interface to be traced with "net=name"
 
 1. **UTS Namespace (hostnames)** `(Operators: =, !=)`
 

--- a/docs/docs/tracing/output-formats.md
+++ b/docs/docs/tracing/output-formats.md
@@ -51,8 +51,8 @@ Tracee supports different output formats for detected events:
         you can select fields, rename them, filter values, and many other things:
         > ```text
         > sudo ./dist/tracee-ebpf -o format:json -o option:parse-arguments
-        > -trace comm=ping -capture net=lo | jq -c '. | {eventId, hostName
-        > ,processName,hostProcessId,UserId}'
+        > -trace comm=ping | jq -c '. | {eventId, hostName, processName,
+        > hostProcessId,UserId}'
         > ```
 
 4. **GOB**

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1
-	github.com/aquasecurity/tracee/types v0.0.0-20230117125404-1384189de6c4
+	github.com/aquasecurity/tracee/types v0.0.0-20230120133341-690d04d56c0b
 	github.com/containerd/containerd v1.6.12
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1 h1:Et7WT8CEpaO03v7FIVk85GMR
 github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1 h1:pQQ/vb0z2dw3fFkvD4XDw6XGM82EjPfS93Cav77wjIo=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
-github.com/aquasecurity/tracee/types v0.0.0-20230117125404-1384189de6c4 h1:5F6Nrliipevgwki0/u4Wc/LFUnZ2qmm0x1TMqjfy6PU=
-github.com/aquasecurity/tracee/types v0.0.0-20230117125404-1384189de6c4/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
+github.com/aquasecurity/tracee/types v0.0.0-20230120133341-690d04d56c0b h1:EjqCuLmiAtX3r3SVxrQiPELe08H0my71fH+bsKHUE/k=
+github.com/aquasecurity/tracee/types v0.0.0-20230120133341-690d04d56c0b/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -21,32 +21,33 @@ const (
 // NOTE: Integers want to be aligned in memory, so if changing the format of this struct
 // keep the 1-byte 'Argnum' as the final parameter before the padding (if padding is needed).
 type Context struct {
-	Ts          uint64
-	StartTime   uint64
-	CgroupID    uint64
-	Pid         uint32
-	Tid         uint32
-	Ppid        uint32
-	HostPid     uint32
-	HostTid     uint32
-	HostPpid    uint32
-	Uid         uint32
-	MntID       uint32
-	PidID       uint32
-	Comm        [16]byte
-	UtsName     [16]byte
-	Flags       uint32
-	EventID     events.ID //int32
-	Pad2        [4]byte
-	Retval      int64
-	StackID     uint32
-	ProcessorId uint16
-	Argnum      uint8
-	_           [1]byte //padding
+	Ts            uint64
+	StartTime     uint64
+	CgroupID      uint64
+	Pid           uint32
+	Tid           uint32
+	Ppid          uint32
+	HostPid       uint32
+	HostTid       uint32
+	HostPpid      uint32
+	Uid           uint32
+	MntID         uint32
+	PidID         uint32
+	Comm          [16]byte
+	UtsName       [16]byte
+	Flags         uint32
+	EventID       events.ID //int32
+	_             [4]byte   // padding
+	MatchedScopes uint64
+	Retval        int64
+	StackID       uint32
+	ProcessorId   uint16
+	Argnum        uint8
+	_             [1]byte //padding
 }
 
 func (Context) GetSizeBytes() uint32 {
-	return 120
+	return 128
 }
 
 type ChunkMeta struct {

--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -92,16 +92,20 @@ To find out which scopes an event is related to, read the bitmask in one of thes
 - using '-o format:table-verbose', SCOPES collumn (in hexadecimal)
 
 Examples:
+
   -t 42:event=sched_process_exec -t 42:binary=/usr/bin/ls      | trace in scope 42 sched_process_exec event from /usr/bin/ls binary
-  -t 3:event=openat -t 3:comm=id -t 9:event=close -t 9:comm=ls | trace in scope 3 only openat event from id command
-                                                                 and
-                                                                 trace in scope 9 only close event from ls command
-  -t 6:event=openat -t 6:comm=id -t 7:event=close -t 7:comm=id | trace in scope 6 only openat event from id command
-                                                                 and
-                                                                 trace in scope 7 only close event from id command
-  -t 3:event=openat -t 3:comm=id -t 9:event=close              | trace in scope 3 only openat event from id command
-                                                                 and
-                                                                 trace in scope 9 only close event from all
+
+  -t 3:event=openat -t 3:comm=id -t 9:event=close -t 9:comm=ls - trace in scope 3 only openat event from id command
+                                                               | and
+                                                               - trace in scope 9 only close event from ls command
+
+  -t 6:event=openat -t 6:comm=id -t 7:event=close -t 7:comm=id - trace in scope 6 only openat event from id command
+                                                               | and
+                                                               _ trace in scope 7 only close event from id command
+
+  -t 3:event=openat -t 3:comm=id -t 9:event=close              - trace in scope 3 only openat event from id command
+                                                               | and
+                                                               - trace in scope 9 only close event from all
 
 Note: some of the above operators have special meanings in different shells.
 To 'escape' those operators, please use single quotes, e.g.: 'uid>0'

--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -8,6 +8,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func filterHelp() string {
@@ -421,8 +422,9 @@ func PrepareFilterScopes(filtersArr []string) (*tracee.FilterScopes, error) {
 			return nil, err
 		}
 
-		if err := filterScopes.Set(scopeIdx, filterScope); err != nil {
-			return nil, err
+		err = filterScopes.Set(scopeIdx, filterScope)
+		if err != nil {
+			logger.Warn("Setting scope", "error", err)
 		}
 	}
 
@@ -444,7 +446,10 @@ func PrepareFilterScopes(filtersArr []string) (*tracee.FilterScopes, error) {
 			return nil, err
 		}
 
-		filterScopes.Add(newScope)
+		err = filterScopes.Add(newScope)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return filterScopes, nil

--- a/pkg/cmd/flags/filter_test.go
+++ b/pkg/cmd/flags/filter_test.go
@@ -13,7 +13,7 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 		name        string
 		eventFilter cliFilter
 		setFilter   cliFilter
-		expected    []events.ID
+		expected    map[events.ID]string
 		expectedErr error
 	}{
 		{
@@ -21,18 +21,21 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 			eventFilter: cliFilter{
 				Equal: []string{"ptrace", "openat"},
 			},
-			expected: []events.ID{events.Ptrace, events.Openat},
+			expected: map[events.ID]string{
+				events.Ptrace: "ptrace",
+				events.Openat: "openat",
+			},
 		},
 		{
 			name: "happy path - sched_proc*",
 			eventFilter: cliFilter{
 				Equal: []string{"sched_proc*", "openat"},
 			},
-			expected: []events.ID{
-				events.SchedProcessExec,
-				events.SchedProcessExit,
-				events.SchedProcessFork,
-				events.Openat,
+			expected: map[events.ID]string{
+				events.SchedProcessExec: "sched_process_exec",
+				events.SchedProcessExit: "sched_process_exit",
+				events.SchedProcessFork: "sched_process_fork",
+				events.Openat:           "openat",
 			},
 		},
 		{
@@ -41,10 +44,10 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 				Equal:    []string{"sched_proc*", "openat"},
 				NotEqual: []string{"sched_process_exec"},
 			},
-			expected: []events.ID{
-				events.SchedProcessExit,
-				events.SchedProcessFork,
-				events.Openat,
+			expected: map[events.ID]string{
+				events.SchedProcessExit: "sched_process_exit",
+				events.SchedProcessFork: "sched_process_fork",
+				events.Openat:           "openat",
 			},
 		},
 		{
@@ -52,7 +55,11 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 			setFilter: cliFilter{
 				Equal: []string{"containers"},
 			},
-			expected: []events.ID{events.ContainerCreate, events.ContainerRemove, events.ExistingContainer},
+			expected: map[events.ID]string{
+				events.ContainerCreate:   "container_create",
+				events.ContainerRemove:   "container_remove",
+				events.ExistingContainer: "existing_container",
+			},
 		},
 		{
 			name: "sad path - event doesn't exist",
@@ -97,7 +104,7 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 				assert.Equal(t, err.Error(), tc.expectedErr.Error())
 			} else {
 				require.NoError(t, err)
-				assert.ElementsMatch(t, res, tc.expected)
+				assert.Equal(t, tc.expected, res)
 			}
 		})
 	}

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -18,12 +18,27 @@ import (
 )
 
 // This will only test failure cases since success cases are covered in the filter tests themselves
-func TestPrepareFilter(t *testing.T) {
+func TestPrepareFilterScope(t *testing.T) {
 	testCases := []struct {
 		testName      string
 		filters       []string
 		expectedError error
 	}{
+		{
+			testName:      "invalid scope id 1",
+			filters:       []string{":comm=bash"},
+			expectedError: filters.InvalidScope(":comm=bash"),
+		},
+		{
+			testName:      "invalid scope id 2",
+			filters:       []string{"0:comm=bash"},
+			expectedError: filters.InvalidScope("0:comm=bash"),
+		},
+		{
+			testName:      "invalid scope id 3",
+			filters:       []string{fmt.Sprintf("%d:comm=bash", tracee.MaxFilterScopes+1)},
+			expectedError: filters.InvalidScope(fmt.Sprintf("%d:comm=bash", tracee.MaxFilterScopes+1)),
+		},
 		{
 			testName:      "invalid argfilter 1",
 			filters:       []string{"open.args"},
@@ -40,17 +55,17 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError: flags.InvalidFilterOptionError("open.bla=5"),
 		},
 		{
-			testName:      "invalud context filter 1",
+			testName:      "invalid context filter 1",
 			filters:       []string{"open.context"},
 			expectedError: filters.InvalidExpression("open.context"),
 		},
 		{
-			testName:      "invalud context filter 2",
+			testName:      "invalid context filter 2",
 			filters:       []string{"bla.context.processName=ls"},
 			expectedError: filters.InvalidEventName("bla"),
 		},
 		{
-			testName:      "invalud context filter 3",
+			testName:      "invalid context filter 3",
 			filters:       []string{"openat.context.procName=ls"},
 			expectedError: filters.InvalidContextField("procName"),
 		},
@@ -125,6 +140,14 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError: filters.InvalidValue("-1\t"),
 		},
 		{
+			testName: "success - scope 1",
+			filters:  []string{"10:uid=4294967296"},
+		},
+		{
+			testName: "success - scope 2",
+			filters:  []string{"25:pid>50000"},
+		},
+		{
 			testName: "success - large uid filter",
 			filters:  []string{"uid=4294967296"},
 		},
@@ -153,6 +176,18 @@ func TestPrepareFilter(t *testing.T) {
 			filters:  []string{"comm=ls"},
 		},
 		{
+			testName: "success - binary=host:/usr/bin/ls",
+			filters:  []string{"binary=host:/usr/bin/ls"},
+		},
+		{
+			testName: "success - binary=/usr/bin/ls",
+			filters:  []string{"binary=/usr/bin/ls"},
+		},
+		{
+			testName: "success - scope 2:binary=host:/usr/bin/ls",
+			filters:  []string{"2:binary=host:/usr/bin/ls"},
+		},
+		{
 			testName: "success - uts!=deadbeaf",
 			filters:  []string{"uts!=deadbeaf"},
 		},
@@ -174,40 +209,81 @@ func TestPrepareFilter(t *testing.T) {
 			filters:  []string{"container"},
 		},
 		{
+			testName: "2:container",
+			filters:  []string{"2:container"},
+		},
+		{
 			testName: "container=new",
 			filters:  []string{"container=new"},
+		},
+		{
+			testName: "2:container=new",
+			filters:  []string{"2:container=new"},
 		},
 		{
 			testName: "pid=new",
 			filters:  []string{"pid=new"},
 		},
 		{
+			testName: "2:pid=new",
+			filters:  []string{"2:pid=new"},
+		},
+		{
 			testName: "container=abcd123",
 			filters:  []string{"container=abcd123"},
+		},
+		{
+			testName: "2:container=abcd123",
+			filters:  []string{"2:container=abcd123"},
 		},
 		{
 			testName: "argfilter",
 			filters:  []string{"openat.pathname=/bin/ls,/tmp/tracee", "openat.pathname!=/etc/passwd"},
 		},
 		{
+			testName: "argfilter scope",
+			filters:  []string{"2:openat.pathname=/bin/ls,/tmp/tracee", "2:openat.pathname!=/etc/passwd"},
+		},
+		{
 			testName: "retfilter",
 			filters:  []string{"openat.retval=2", "openat.retval>1"},
+		},
+		{
+			testName: "retfilter scope",
+			filters:  []string{"2:openat.retval=2", "2:openat.retval>1"},
 		},
 		{
 			testName: "wildcard filter",
 			filters:  []string{"event=open*"},
 		},
 		{
+			testName: "wildcard filter scope",
+			filters:  []string{"2:event=open*"},
+		},
+		{
 			testName: "wildcard not filter",
 			filters:  []string{"event!=*"},
+		},
+		{
+			testName: "wildcard not filter scope",
+			filters:  []string{"2:event!=*"},
 		},
 		{
 			testName: "multiple filters",
 			filters:  []string{"uid<1", "mntns=5", "pidns!=3", "pid!=10", "comm=ps", "uts!=abc"},
 		},
 		{
+			testName: "multiple filters scope",
+			filters:  []string{"2:uid<1", "2:mntns=5", "2:pidns!=3", "2:pid!=10", "2:comm=ps", "2:uts!=abc"},
+		},
+		{
 			testName:      "invalid value - extra operator",
 			filters:       []string{"uid==0"},
+			expectedError: filters.InvalidValue("=0"),
+		},
+		{
+			testName:      "invalid value scope - extra operator",
+			filters:       []string{"2:uid==0"},
 			expectedError: filters.InvalidValue("=0"),
 		},
 		{
@@ -216,13 +292,28 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError: filters.InvalidValue(">>>>>>>>>>>>>>>>>>>>>>>>>>>>0"),
 		},
 		{
+			testName:      "invalid value scope - extra operator",
+			filters:       []string{"2:uid>>>>>>>>>>>>>>>>>>>>>>>>>>>>>0"},
+			expectedError: filters.InvalidValue(">>>>>>>>>>>>>>>>>>>>>>>>>>>>0"),
+		},
+		{
 			testName:      "invalid value - string in numeric filter",
 			filters:       []string{"uid=a"},
 			expectedError: filters.InvalidValue("a"),
 		},
 		{
+			testName:      "invalid value scope - string in numeric filter",
+			filters:       []string{"2:uid=a"},
+			expectedError: filters.InvalidValue("a"),
+		},
+		{
 			testName:      "invalid pidns",
 			filters:       []string{"pidns=a"},
+			expectedError: filters.InvalidValue("a"),
+		},
+		{
+			testName:      "invalid pidns scope",
+			filters:       []string{"2:pidns=a"},
 			expectedError: filters.InvalidValue("a"),
 		},
 
@@ -231,12 +322,25 @@ func TestPrepareFilter(t *testing.T) {
 			filters:  []string{"pid>12"},
 		},
 		{
+			testName: "valid pid scope",
+			filters:  []string{"2:pid>12"},
+		},
+		{
 			testName: "adding retval filter then argfilter",
 			filters:  []string{"open.retval=5", "security_file_open.pathname=/etc/shadow"},
 		},
 		{
+			testName: "adding retval filter then argfilter scope",
+			filters:  []string{"2:open.retval=5", "2:security_file_open.pathname=/etc/shadow"},
+		},
+		{
 			testName:      "invalid wildcard",
 			filters:       []string{"event=blah*"},
+			expectedError: errors.New("invalid event to trace: blah"),
+		},
+		{
+			testName:      "invalid wildcard scope",
+			filters:       []string{"2:event=blah*"},
 			expectedError: errors.New("invalid event to trace: blah"),
 		},
 		{
@@ -245,8 +349,18 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError: errors.New("invalid event to trace: bl*ah"),
 		},
 		{
+			testName:      "invalid wildcard scope 2",
+			filters:       []string{"2:event=bl*ah"},
+			expectedError: errors.New("invalid event to trace: bl*ah"),
+		},
+		{
 			testName:      "internal event selection",
 			filters:       []string{"event=print_syscall_table"},
+			expectedError: errors.New("invalid event to trace: print_syscall_table"),
+		},
+		{
+			testName:      "internal event selection scope",
+			filters:       []string{"2:event=print_syscall_table"},
 			expectedError: errors.New("invalid event to trace: print_syscall_table"),
 		},
 		{
@@ -255,14 +369,24 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError: errors.New("invalid event to exclude: blah"),
 		},
 		{
+			testName:      "invalid not wildcard scope",
+			filters:       []string{"2:event!=blah*"},
+			expectedError: errors.New("invalid event to exclude: blah"),
+		},
+		{
 			testName:      "invalid not wildcard 2",
 			filters:       []string{"event!=bl*ah"},
+			expectedError: errors.New("invalid event to exclude: bl*ah"),
+		},
+		{
+			testName:      "invalid not wildcard scope 2",
+			filters:       []string{"2:event!=bl*ah"},
 			expectedError: errors.New("invalid event to exclude: bl*ah"),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			_, err := flags.PrepareFilter(tc.filters)
+			_, err := flags.PrepareFilterScopes(tc.filters)
 			if tc.expectedError != nil {
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedError.Error())

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -103,20 +103,102 @@ func (p tableEventPrinter) Preamble() {
 	if p.verbose {
 		switch p.containerMode {
 		case ContainerModeDisabled:
-			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12s %-12s %-6s %-16s %-7s %-7s %-7s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "MNT_NS", "PID_NS", "UID", "COMM", "PID", "TID", "PPID", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out,
+				"%-16s %-17s %-17s %-13s %-12s %-12s %-6s %-16s %-7s %-7s %-7s %-16s %-20s %s",
+				"TIME",
+				"SCOPES",
+				"UTS_NAME",
+				"CONTAINER_ID",
+				"MNT_NS",
+				"PID_NS",
+				"UID",
+				"COMM",
+				"PID",
+				"TID",
+				"PPID",
+				"RET",
+				"EVENT",
+				"ARGS",
+			)
 		case ContainerModeEnabled:
-			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "MNT_NS", "PID_NS", "UID", "COMM", "PID/host", "TID/host", "PPID/host", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out,
+				"%-16s %-17s %-17s %-13s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s",
+				"TIME",
+				"SCOPES",
+				"UTS_NAME",
+				"CONTAINER_ID",
+				"MNT_NS",
+				"PID_NS",
+				"UID",
+				"COMM",
+				"PID/host",
+				"TID/host",
+				"PPID/host",
+				"RET",
+				"EVENT",
+				"ARGS",
+			)
 		case ContainerModeEnriched:
-			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-16s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s", "TIME", "UTS_NAME", "CONTAINER_ID", "IMAGE", "MNT_NS", "PID_NS", "UID", "COMM", "PID/host", "TID/host", "PPID/host", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out,
+				"%-16s %-17s %-17s %-13s %-16s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s",
+				"TIME",
+				"SCOPES",
+				"UTS_NAME",
+				"CONTAINER_ID",
+				"IMAGE",
+				"MNT_NS",
+				"PID_NS",
+				"UID",
+				"COMM",
+				"PID/host",
+				"TID/host",
+				"PPID/host",
+				"RET",
+				"EVENT",
+				"ARGS",
+			)
 		}
 	} else {
 		switch p.containerMode {
 		case ContainerModeDisabled:
-			fmt.Fprintf(p.out, "%-16s %-6s %-16s %-7s %-7s %-16s %-20s %s", "TIME", "UID", "COMM", "PID", "TID", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out,
+				"%-16s %-6s %-16s %-7s %-7s %-16s %-20s %s",
+				"TIME",
+				"UID",
+				"COMM",
+				"PID",
+				"TID",
+				"RET",
+				"EVENT",
+				"ARGS",
+			)
 		case ContainerModeEnabled:
-			fmt.Fprintf(p.out, "%-16s %-13s %-6s %-16s %-15s %-15s %-16s %-20s %s", "TIME", "CONTAINER_ID", "UID", "COMM", "PID/host", "TID/host", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out,
+				"%-16s %-13s %-6s %-16s %-15s %-15s %-16s %-20s %s",
+				"TIME",
+				"CONTAINER_ID",
+				"UID",
+				"COMM",
+				"PID/host",
+				"TID/host",
+				"RET",
+				"EVENT",
+				"ARGS",
+			)
 		case ContainerModeEnriched:
-			fmt.Fprintf(p.out, "%-16s %-13s %-16s %-6s %-16s %-15s %-15s %-16s %-20s %s", "TIME", "CONTAINER_ID", "IMAGE", "UID", "COMM", "PID/host", "TID/host", "RET", "EVENT", "ARGS")
+			fmt.Fprintf(p.out,
+				"%-16s %-13s %-16s %-6s %-16s %-15s %-15s %-16s %-20s %s",
+				"TIME",
+				"CONTAINER_ID",
+				"IMAGE",
+				"UID",
+				"COMM",
+				"PID/host",
+				"TID/host",
+				"RET",
+				"EVENT",
+				"ARGS",
+			)
 		}
 	}
 	fmt.Fprintln(p.out)
@@ -146,20 +228,106 @@ func (p tableEventPrinter) Print(event trace.Event) {
 	if p.verbose {
 		switch p.containerMode {
 		case ContainerModeDisabled:
-			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12d %-12d %-6d %-16s %-7d %-7d %-7d %-16d %-20s ", timestamp, event.HostName, containerId, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.ThreadID, event.ParentProcessID, event.ReturnValue, eventName)
+			fmt.Fprintf(p.out,
+				"%-16s %016x  %-16s %-13s %-12d %-12d %-6d %-16s %-7d %-7d %-7d %-16d %-20s ",
+				timestamp,
+				event.MatchedScopes,
+				event.HostName,
+				containerId,
+				event.MountNS,
+				event.PIDNS,
+				event.UserID,
+				event.ProcessName,
+				event.ProcessID,
+				event.ThreadID,
+				event.ParentProcessID,
+				event.ReturnValue,
+				event.EventName,
+			)
 		case ContainerModeEnabled:
-			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, event.HostName, containerId, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ParentProcessID, event.HostParentProcessID, event.ReturnValue, eventName)
+			fmt.Fprintf(p.out,
+				"%-16s %016x  %-16s %-13s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				timestamp,
+				event.MatchedScopes,
+				event.HostName,
+				containerId,
+				event.MountNS,
+				event.PIDNS,
+				event.UserID,
+				event.ProcessName,
+				event.ProcessID,
+				event.HostProcessID,
+				event.ThreadID,
+				event.HostThreadID,
+				event.ParentProcessID,
+				event.HostParentProcessID,
+				event.ReturnValue,
+				event.EventName,
+			)
 		case ContainerModeEnriched:
-			fmt.Fprintf(p.out, "%-16s %-16s %-13s %-16s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, event.HostName, containerId, event.ContainerImage, event.MountNS, event.PIDNS, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ParentProcessID, event.HostParentProcessID, event.ReturnValue, eventName)
+			fmt.Fprintf(p.out,
+				"%-16s %016x  %-16s %-13s %-16s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				timestamp,
+				event.MatchedScopes,
+				event.HostName,
+				containerId,
+				event.ContainerImage,
+				event.MountNS,
+				event.PIDNS,
+				event.UserID,
+				event.ProcessName,
+				event.ProcessID,
+				event.HostProcessID,
+				event.ThreadID,
+				event.HostThreadID,
+				event.ParentProcessID,
+				event.HostParentProcessID,
+				event.ReturnValue,
+				event.EventName,
+			)
 		}
 	} else {
 		switch p.containerMode {
 		case ContainerModeDisabled:
-			fmt.Fprintf(p.out, "%-16s %-6d %-16s %-7d %-7d %-16d %-20s ", timestamp, event.UserID, event.ProcessName, event.ProcessID, event.ThreadID, event.ReturnValue, eventName)
+			fmt.Fprintf(p.out,
+				"%-16s %-6d %-16s %-7d %-7d %-16d %-20s ",
+				timestamp,
+				event.UserID,
+				event.ProcessName,
+				event.ProcessID,
+				event.ThreadID,
+				event.ReturnValue,
+				eventName,
+			)
 		case ContainerModeEnabled:
-			fmt.Fprintf(p.out, "%-16s %-13s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, containerId, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ReturnValue, eventName)
+			fmt.Fprintf(p.out,
+				"%-16s %-13s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				timestamp,
+				containerId,
+				event.UserID,
+				event.ProcessName,
+				event.ProcessID,
+				event.HostProcessID,
+				event.ThreadID,
+				event.HostThreadID,
+				event.ReturnValue,
+				eventName,
+			)
 		case ContainerModeEnriched:
-			fmt.Fprintf(p.out, "%-16s %-13s %-16s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ", timestamp, containerId, containerImage, event.UserID, event.ProcessName, event.ProcessID, event.HostProcessID, event.ThreadID, event.HostThreadID, event.ReturnValue, eventName)
+			fmt.Fprintf(p.out,
+				"%-16s %-13s %-16s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				timestamp,
+				containerId,
+				containerImage,
+				event.UserID,
+				event.ProcessName,
+				event.ProcessID,
+				event.HostProcessID,
+				event.ThreadID,
+				event.HostThreadID,
+				event.ReturnValue,
+				eventName,
+			)
 		}
 	}
 	for i, arg := range event.Args {

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -150,17 +150,19 @@ func getPad(padChar string, padLength int) (pad string) {
 
 func GetContainerMode(cfg tracee.Config) printer.ContainerMode {
 	containerMode := printer.ContainerModeDisabled
-	isCfgContainerEnabled := (cfg.Filter.ContFilter.Enabled() && cfg.Filter.ContFilter.Value()) ||
-		(cfg.Filter.NewContFilter.Enabled() && cfg.Filter.NewContFilter.Value()) ||
-		cfg.Filter.ContIDFilter.Enabled()
 
-	if isCfgContainerEnabled {
-		// enable printer container print mode if container filters are set
-		containerMode = printer.ContainerModeEnabled
-		if cfg.ContainersEnrich {
-			// further enable container enrich print mode if container enrichment is enabled
-			containerMode = printer.ContainerModeEnriched
+	for filterScope := range cfg.FilterScopes.Map() {
+		if filterScope.ContainerFilterEnabled() {
+			// enable printer container print mode if container filters are set
+			containerMode = printer.ContainerModeEnabled
+			if cfg.ContainersEnrich {
+				// further enable container enrich print mode if container enrichment is enabled
+				containerMode = printer.ContainerModeEnriched
+			}
+
+			break
 		}
 	}
+
 	return containerMode
 }

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -92,11 +92,13 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Filtering (trace) command line flags
 
-	filter, err := flags.PrepareFilter(c.StringSlice("trace"))
+	filterScopes, err := flags.PrepareFilterScopes(c.StringSlice("trace"))
 	if err != nil {
 		return runner, err
 	}
-	cfg.Filter = &filter
+	cfg.FilterScopes = filterScopes
+
+	// Container information printer flag
 
 	printerConfig.ContainerMode = cmd.GetContainerMode(cfg)
 	cfg.Output = &output.OutputConfig

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4727,6 +4727,8 @@ int tracepoint__cgroup__cgroup_mkdir(struct bpf_raw_tracepoint_args *ctx)
     if (!init_program_data(&p, ctx))
         return 0;
 
+    p.event->context.matched_scopes = 0xFFFFFFFFFFFFFFFF; // see tracee.GetEssentialEvents
+
     struct cgroup *dst_cgrp = (struct cgroup *) ctx->args[0];
     char *path = (char *) ctx->args[1];
 
@@ -4760,6 +4762,8 @@ int tracepoint__cgroup__cgroup_rmdir(struct bpf_raw_tracepoint_args *ctx)
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
         return 0;
+
+    p.event->context.matched_scopes = 0xFFFFFFFFFFFFFFFF; // see tracee.GetEssentialEvents
 
     struct cgroup *dst_cgrp = (struct cgroup *) ctx->args[0];
     char *path = (char *) ctx->args[1];

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -883,8 +883,6 @@ typedef struct config_entry {
     u64 uid_min;
     u64 pid_max;
     u64 pid_min;
-    // use 8*128 bits to describe up to 1024 events
-    u8 events_to_submit[128];
 } config_entry_t;
 
 typedef struct netconfig_entry {
@@ -1074,6 +1072,7 @@ BPF_HASH(uts_ns_filter, string_filter_t, eq_t, 256);               // filter eve
 BPF_HASH(comm_filter, string_filter_t, eq_t, 256);                 // filter events by command name
 BPF_HASH(cgroup_id_filter, u32, eq_t, 256);                        // filter events by cgroup id
 BPF_HASH(binary_filter, binary_t, eq_t, 256);                      // filter events by binary path and mount namespace
+BPF_HASH(events_map, u32, u64, MAX_EVENT_ID);                      // map to persist event configuration data (currently submit scopes)
 BPF_HASH(bin_args_map, u64, bin_args_t, 256);                      // persist args for send_bin funtion
 BPF_HASH(sys_32_to_64_map, u32, u32, 1024);                        // map 32bit to 64bit syscalls
 BPF_HASH(params_types_map, u32, u64, 1024);                        // encoded parameters types for event
@@ -2297,13 +2296,25 @@ static __always_inline u64 should_trace(program_data_t *p)
     return p->task_info->matched_scopes;
 }
 
-static __always_inline int should_submit(u32 event_id, config_entry_t *config)
+static __always_inline u64 should_submit(u32 event_id, program_data_t *p)
 {
-    volatile unsigned int index = event_id / 8;
-    unsigned int offset = event_id % 8;
-    u8 bitmap = config->events_to_submit[index % 128];
+    // use a map only with no submit cache from config.
+    // since this function is only ever called after a should_trace
+    // and in the context of a submit program/tail_call, any preemptive
+    // cache calculation before checking the map will 99% of times be
+    // redundant.
+    // a probe/tail call attach almost always implies at least one
+    // scope requires the event to be submitted.
+    u64 *event_scopes = bpf_map_lookup_elem(&events_map, &event_id);
+    // if scopes not set, don't submit
+    if (event_scopes == NULL) {
+        return 0;
+    }
 
-    return bitmap & (1 << offset);
+    // align with previously matched scopes
+    p->event->context.matched_scopes &= *event_scopes;
+
+    return p->event->context.matched_scopes;
 }
 
 // INTERNAL: BUFFERS -------------------------------------------------------------------------------
@@ -3103,7 +3114,7 @@ static __always_inline uint get_syscall_fd_num_from_arg(uint syscall_id, args_t 
         if (!init_program_data(&p, ctx))                                                           \
             return 0;                                                                              \
                                                                                                    \
-        if (!should_submit(id, p.config))                                                          \
+        if (!should_submit(id, &p))                                                                \
             return 0;                                                                              \
                                                                                                    \
         save_args_to_submit_buf(p->event, types, &args);                                           \
@@ -3566,6 +3577,8 @@ int sys_exit_submit(struct bpf_raw_tracepoint_args *ctx)
         // We can't use saved args after execve syscall, as pointers are
         // invalid To avoid showing execve event both on entry and exit, we
         // only output failed execs
+        if (!should_submit(id, &p))
+            return 0;
         u64 types = 0;
         u64 *saved_types = bpf_map_lookup_elem(&params_types_map, &id);
         if (!saved_types) {
@@ -3598,6 +3611,9 @@ int trace_sys_enter(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(RAW_SYS_ENTER, &p))
+        return 0;
+
     // always submit since this won't be attached otherwise
     int id = ctx->args[1];
     struct task_struct *task = (struct task_struct *) bpf_get_current_task();
@@ -3623,6 +3639,9 @@ int trace_sys_exit(struct bpf_raw_tracepoint_args *ctx)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(RAW_SYS_EXIT, &p))
         return 0;
 
     // always submit since this won't be attached otherwise
@@ -3655,7 +3674,7 @@ int syscall__execve(void *ctx)
         return -1;
     syscall_data_t *sys = &p.task_info->syscall_data;
 
-    if (!should_submit(SYSCALL_EXECVE, p.config))
+    if (!should_submit(SYSCALL_EXECVE, &p))
         return 0;
 
     save_str_to_buf(p.event, (void *) sys->args.args[0] /*filename*/, 0);
@@ -3678,7 +3697,7 @@ int syscall__execveat(void *ctx)
         return -1;
     syscall_data_t *sys = &p.task_info->syscall_data;
 
-    if (!should_submit(SYSCALL_EXECVEAT, p.config))
+    if (!should_submit(SYSCALL_EXECVEAT, &p))
         return 0;
 
     save_to_submit_buf(p.event, (void *) &sys->args.args[0] /*dirfd*/, sizeof(int), 0);
@@ -3694,7 +3713,7 @@ int syscall__execveat(void *ctx)
 
 static __always_inline int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd)
 {
-    if (!should_submit(SOCKET_DUP, p->config))
+    if (!should_submit(SOCKET_DUP, p))
         return 0;
 
     if (!check_fd_type(oldfd, S_IFSOCK)) {
@@ -3847,7 +3866,7 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     // follow every pid that passed the should_trace() checks (used by the follow filter)
     c_proc_info->follow_in_scopes = p.task_info->matched_scopes;
 
-    if (should_submit(SCHED_PROCESS_FORK, p.config) || p.config->options & OPT_PROCESS_INFO) {
+    if (should_submit(SCHED_PROCESS_FORK, &p) || p.config->options & OPT_PROCESS_INFO) {
         int parent_ns_pid = get_task_ns_pid(parent);
         int parent_ns_tgid = get_task_ns_tgid(parent);
         int child_ns_pid = get_task_ns_pid(child);
@@ -3923,7 +3942,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     // Follow this task for matched scopes
     proc_info->follow_in_scopes = p.task_info->matched_scopes;
 
-    if (!should_submit(SCHED_PROCESS_EXEC, p.config) &&
+    if (!should_submit(SCHED_PROCESS_EXEC, &p) &&
         (p.config->options & OPT_PROCESS_INFO) != OPT_PROCESS_INFO)
         return 0;
 
@@ -4035,7 +4054,7 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
 
     long exit_code = get_task_exit_code(p.event->task);
 
-    if (should_submit(SCHED_PROCESS_EXIT, p.config) || p.config->options & OPT_PROCESS_INFO) {
+    if (should_submit(SCHED_PROCESS_EXIT, &p) || p.config->options & OPT_PROCESS_INFO) {
         save_to_submit_buf(p.event, (void *) &exit_code, sizeof(long), 0);
         save_to_submit_buf(p.event, (void *) &group_dead, sizeof(bool), 1);
 
@@ -4145,7 +4164,7 @@ int tracepoint__sched__sched_switch(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace(&p))
         return 0;
 
-    if (!should_submit(SCHED_SWITCH, p.config))
+    if (!should_submit(SCHED_SWITCH, &p))
         return 0;
 
     struct task_struct *prev = (struct task_struct *) ctx->args[1];
@@ -4173,6 +4192,9 @@ int BPF_KPROBE(trace_filldir64)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(HIDDEN_INODES, &p))
+        return 0;
+
     char *process_name = (char *) PT_REGS_PARM2(ctx);
     unsigned long process_inode_number = (unsigned long) PT_REGS_PARM5(ctx);
     if (process_inode_number == 0) {
@@ -4190,6 +4212,9 @@ int BPF_KPROBE(trace_call_usermodehelper)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(CALL_USERMODE_HELPER, &p))
         return 0;
 
     void *path = (void *) PT_REGS_PARM1(ctx);
@@ -4213,6 +4238,9 @@ int BPF_KPROBE(trace_do_exit)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(DO_EXIT, &p))
         return 0;
 
     long code = PT_REGS_PARM1(ctx);
@@ -4499,7 +4527,7 @@ static __always_inline void *get_trace_probe_from_trace_event_call(struct trace_
 static __always_inline int
 send_bpf_attach(program_data_t *p, struct file *bpf_prog_file, struct file *perf_event_file)
 {
-    if (!should_submit(BPF_ATTACH, p->config)) {
+    if (!should_submit(BPF_ATTACH, p)) {
         return 0;
     }
 
@@ -4763,6 +4791,9 @@ int BPF_KPROBE(trace_security_bprm_check)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_BPRM_CHECK, &p))
+        return 0;
+
     struct linux_binprm *bprm = (struct linux_binprm *) PT_REGS_PARM1(ctx);
     struct file *file = get_file_ptr_from_bprm(bprm);
     dev_t s_dev = get_dev_from_file(file);
@@ -4784,6 +4815,9 @@ int BPF_KPROBE(trace_security_file_open)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_FILE_OPEN, &p))
         return 0;
 
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
@@ -4831,6 +4865,9 @@ int BPF_KPROBE(trace_security_sb_mount)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_SB_MOUNT, &p))
+        return 0;
+
     const char *dev_name = (const char *) PT_REGS_PARM1(ctx);
     struct path *path = (struct path *) PT_REGS_PARM2(ctx);
     const char *type = (const char *) PT_REGS_PARM3(ctx);
@@ -4856,6 +4893,9 @@ int BPF_KPROBE(trace_security_inode_unlink)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_UNLINK, &p))
+        return 0;
+
     // struct inode *dir = (struct inode *)PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     void *dentry_path = get_dentry_path_str(dentry);
@@ -4879,6 +4919,9 @@ int BPF_KPROBE(trace_commit_creds)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(COMMIT_CREDS, &p))
         return 0;
 
     struct cred *new = (struct cred *) PT_REGS_PARM1(ctx);
@@ -4970,6 +5013,9 @@ int BPF_KPROBE(trace_switch_task_namespaces)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SWITCH_TASK_NS, &p))
+        return 0;
+
     struct task_struct *task = (struct task_struct *) PT_REGS_PARM1(ctx);
     struct nsproxy *new = (struct nsproxy *) PT_REGS_PARM2(ctx);
 
@@ -5020,6 +5066,9 @@ int BPF_KPROBE(trace_cap_capable)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(CAP_CAPABLE, &p))
+        return 0;
+
     int cap = PT_REGS_PARM3(ctx);
     int cap_opt = PT_REGS_PARM4(ctx);
 
@@ -5041,6 +5090,9 @@ int BPF_KPROBE(trace_security_socket_create)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_CREATE, &p))
         return 0;
 
     int family = (int) PT_REGS_PARM1(ctx);
@@ -5066,6 +5118,9 @@ int BPF_KPROBE(trace_security_inode_symlink)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_SYMLINK, &p))
+        return 0;
+
     // struct inode *dir = (struct inode *)PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     const char *old_name = (const char *) PT_REGS_PARM3(ctx);
@@ -5088,6 +5143,9 @@ int BPF_KPROBE(trace_proc_create)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(PROC_CREATE, &p))
+        return 0;
+
     char *name = (char *) PT_REGS_PARM1(ctx);
     unsigned long proc_ops_addr = (unsigned long) PT_REGS_PARM4(ctx);
 
@@ -5105,6 +5163,9 @@ int BPF_KPROBE(trace_debugfs_create_file)
         return 0;
 
     if (!should_trace((&p)))
+        return 0;
+
+    if (!should_submit(DEBUGFS_CREATE_FILE, &p))
         return 0;
 
     char *name = (char *) PT_REGS_PARM1(ctx);
@@ -5131,6 +5192,9 @@ int BPF_KPROBE(trace_debugfs_create_dir)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(DEBUGFS_CREATE_DIR, &p))
+        return 0;
+
     char *name = (char *) PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     void *dentry_path = get_dentry_path_str(dentry);
@@ -5149,6 +5213,9 @@ int BPF_KPROBE(trace_security_socket_listen)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_LISTEN, &p))
         return 0;
 
     struct socket *sock = (struct socket *) PT_REGS_PARM1(ctx);
@@ -5174,6 +5241,9 @@ int BPF_KPROBE(trace_security_socket_connect)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_CONNECT, &p))
         return 0;
 
     struct sockaddr *address = (struct sockaddr *) PT_REGS_PARM2(ctx);
@@ -5226,12 +5296,15 @@ int BPF_KPROBE(trace_security_socket_accept)
     struct socket *new_sock = (struct socket *) PT_REGS_PARM2(ctx);
 
     // save sockets for "socket_accept event"
-    if (should_submit(SOCKET_ACCEPT, p.config)) {
+    if (should_submit(SOCKET_ACCEPT, &p)) {
         args_t args = {};
         args.args[0] = (unsigned long) sock;
         args.args[1] = (unsigned long) new_sock;
         save_args(&args, SOCKET_ACCEPT);
     }
+
+    if (!should_submit(SECURITY_SOCKET_ACCEPT, &p))
+        return 0;
 
     // Load the arguments given to the accept syscall (which eventually invokes this function)
     syscall_data_t *sys = &p.task_info->syscall_data;
@@ -5252,6 +5325,9 @@ int BPF_KPROBE(trace_security_socket_bind)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_BIND, &p))
         return 0;
 
     struct socket *sock = (struct socket *) PT_REGS_PARM1(ctx);
@@ -5319,6 +5395,9 @@ int BPF_KPROBE(trace_security_socket_setsockopt)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_SETSOCKOPT, &p))
         return 0;
 
     struct socket *sock = (struct socket *) PT_REGS_PARM1(ctx);
@@ -5498,6 +5577,7 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
     p->event->context.argnum = 0;
 
     u8 header[FILE_MAGIC_HDR_SIZE];
+    __builtin_memset(&header, 0, sizeof(header));
 
     save_str_to_buf(p->event, file_info->pathname_p, 0);
 
@@ -5508,6 +5588,7 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
             bpf_probe_read(header, FILE_MAGIC_HDR_SIZE, io_data.ptr);
     } else {
         struct iovec io_vec;
+        __builtin_memset(&io_vec, 0, sizeof(io_vec));
         bpf_probe_read(&io_vec, sizeof(struct iovec), io_data.ptr);
         if (header_bytes < FILE_MAGIC_HDR_SIZE)
             bpf_probe_read(header, header_bytes & FILE_MAGIC_MASK, io_vec.iov_base);
@@ -5523,11 +5604,11 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
     return events_perf_submit(p, MAGIC_WRITE, bytes_written);
 }
 
-static __always_inline bool should_submit_io_event(u32 event_id, config_entry_t *config)
+static __always_inline bool should_submit_io_event(u32 event_id, program_data_t *p)
 {
     return ((event_id == VFS_READ || event_id == VFS_READV || event_id == VFS_WRITE ||
              event_id == VFS_WRITEV || event_id == __KERNEL_WRITE) &&
-            should_submit(event_id, config));
+            should_submit(event_id, p));
 }
 
 /** do_file_io_operation - generic file IO (read and write) event creator.
@@ -5547,14 +5628,16 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
         return 0;
     }
 
-    int zero = 0;
-    config_entry_t *config = bpf_map_lookup_elem(&config_map, &zero);
-    if (config == NULL) {
+    program_data_t p = {};
+    if (!init_program_data(&p, ctx)) {
         del_args(event_id);
         return 0;
     }
 
-    if (!should_submit_io_event(event_id, config) && !should_submit(MAGIC_WRITE, config)) {
+    bool should_submit_magic_write = should_submit(MAGIC_WRITE, &p);
+    bool should_submit_io = should_submit_io_event(event_id, &p);
+
+    if (!should_submit_io && !should_submit_magic_write) {
         bpf_tail_call(ctx, &prog_array, tail_call_id);
         del_args(event_id);
         return 0;
@@ -5584,13 +5667,7 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
     if (start_pos != 0)
         start_pos -= io_bytes_amount;
 
-    program_data_t p = {};
-    if (!init_program_data(&p, ctx)) {
-        del_args(event_id);
-        return 0;
-    }
-
-    if (should_submit_io_event(event_id, p.config)) {
+    if (should_submit_io) {
         save_str_to_buf(p.event, file_info.pathname_p, 0);
         save_to_submit_buf(p.event, &file_info.device, sizeof(dev_t), 1);
         save_to_submit_buf(p.event, &file_info.inode, sizeof(unsigned long), 2);
@@ -5602,7 +5679,7 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
     }
 
     // magic_write event checks if the header of some file is changed
-    if (!is_read && should_submit(MAGIC_WRITE, config) && !char_dev && (start_pos == 0)) {
+    if (!is_read && should_submit_magic_write && !char_dev && (start_pos == 0)) {
         submit_magic_write(&p, &file_info, io_data, io_bytes_amount);
     }
 
@@ -5812,7 +5889,8 @@ int BPF_KPROBE(trace_mmap_alert)
 
     int prot = sys->args.args[2];
 
-    if ((prot & (VM_WRITE | VM_EXEC)) == (VM_WRITE | VM_EXEC)) {
+    if ((prot & (VM_WRITE | VM_EXEC)) == (VM_WRITE | VM_EXEC) &&
+        should_submit(MEM_PROT_ALERT, &p)) {
         u32 alert = ALERT_MMAP_W_X;
         int fd = sys->args.args[5];
         void *addr = (void *) sys->args.args[0];
@@ -5834,6 +5912,9 @@ int BPF_KPROBE(trace_ret_do_mmap)
 {
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
+        return 0;
+
+    if (!should_submit(DO_MMAP, &p))
         return 0;
 
     args_t saved_args;
@@ -5889,6 +5970,9 @@ int BPF_KPROBE(trace_security_mmap_file)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_MMAP_FILE, &p))
+        return 0;
+
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
     if (file == 0)
         return 0;
@@ -5906,14 +5990,14 @@ int BPF_KPROBE(trace_security_mmap_file)
     save_to_submit_buf(p.event, &ctime, sizeof(u64), 4);
 
     int id = -1;
-    if (should_submit(SHARED_OBJECT_LOADED, p.config)) {
+    if (should_submit(SHARED_OBJECT_LOADED, &p)) {
         id = get_task_syscall_id(p.event->task);
         if ((prot & VM_EXEC) == VM_EXEC && id == SYSCALL_MMAP) {
             events_perf_submit(&p, SHARED_OBJECT_LOADED, 0);
         }
     }
 
-    if (should_submit(SECURITY_MMAP_FILE, p.config)) {
+    if (should_submit(SECURITY_MMAP_FILE, &p)) {
         save_to_submit_buf(p.event, &prot, sizeof(unsigned long), 5);
         save_to_submit_buf(p.event, &mmap_flags, sizeof(unsigned long), 6);
         if (id == -1) { // if id wasn't checked yet, do so now.
@@ -5944,8 +6028,8 @@ int BPF_KPROBE(trace_security_file_mprotect)
         (sys->id != SYSCALL_MPROTECT && sys->id != SYSCALL_PKEY_MPROTECT))
         return 0;
 
-    int should_submit_mprotect = should_submit(SECURITY_FILE_MPROTECT, p.config);
-    int should_submit_mem_prot_alert = should_submit(MEM_PROT_ALERT, p.config);
+    int should_submit_mprotect = should_submit(SECURITY_FILE_MPROTECT, &p);
+    int should_submit_mem_prot_alert = should_submit(MEM_PROT_ALERT, &p);
 
     if (!should_submit_mprotect && !should_submit_mem_prot_alert) {
         return 0;
@@ -5977,7 +6061,7 @@ int BPF_KPROBE(trace_security_file_mprotect)
         events_perf_submit(&p, SECURITY_FILE_MPROTECT, 0);
     }
 
-    if (should_submit(MEM_PROT_ALERT, p.config)) {
+    if (should_submit_mem_prot_alert) {
         void *addr = (void *) sys->args.args[0];
         size_t len = sys->args.args[1];
 
@@ -6116,7 +6200,7 @@ int BPF_KPROBE(trace_security_bpf)
 
     int cmd = (int) PT_REGS_PARM1(ctx);
 
-    if (should_submit(SECURITY_BPF, p.config)) {
+    if (should_submit(SECURITY_BPF, &p)) {
         // 1st argument == cmd (int)
         save_to_submit_buf(p.event, (void *) &cmd, sizeof(int), 0);
 
@@ -6187,6 +6271,9 @@ int BPF_KPROBE(trace_security_bpf_map)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_BPF_MAP, &p))
         return 0;
 
     struct bpf_map *map = (struct bpf_map *) PT_REGS_PARM1(ctx);
@@ -6305,6 +6392,9 @@ int BPF_KPROBE(trace_security_kernel_read_file)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_KERNEL_READ_FILE, &p))
+        return 0;
+
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
@@ -6342,7 +6432,7 @@ int BPF_KPROBE(trace_security_kernel_post_read_file)
     enum kernel_read_file_id type_id = (enum kernel_read_file_id) PT_REGS_PARM4(ctx);
 
     // Send event if chosen
-    if (should_submit(SECURITY_POST_READ_FILE, p.config)) {
+    if (should_submit(SECURITY_POST_READ_FILE, &p)) {
         void *file_path = get_path_str(&file->f_path);
         save_str_to_buf(p.event, file_path, 0);
         save_to_submit_buf(p.event, &size, sizeof(loff_t), 1);
@@ -6382,6 +6472,9 @@ int BPF_KPROBE(trace_security_inode_mknod)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_MKNOD, &p))
+        return 0;
+
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     unsigned short mode = (unsigned short) PT_REGS_PARM3(ctx);
     unsigned int dev = (unsigned int) PT_REGS_PARM4(ctx);
@@ -6402,6 +6495,9 @@ int BPF_KPROBE(trace_device_add)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(DEVICE_ADD, &p))
         return 0;
 
     struct device *dev = (struct device *) PT_REGS_PARM1(ctx);
@@ -6434,6 +6530,9 @@ int BPF_KPROBE(trace_ret__register_chrdev)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(REGISTER_CHRDEV, &p))
         return 0;
 
     unsigned int major_number = (unsigned int) saved_args.args[0];
@@ -6531,7 +6630,7 @@ int BPF_KPROBE(trace_ret_do_splice)
     if (!should_trace(&p))
         return 0;
 
-    if (!should_submit(DIRTY_PIPE_SPLICE, p.config))
+    if (!should_submit(DIRTY_PIPE_SPLICE, &p))
         return 0;
 
     // Catch only successful splice
@@ -6653,6 +6752,8 @@ int BPF_KPROBE(trace_ret_do_init_module)
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
         return 0;
+    if (!should_submit(DO_INIT_MODULE, &p))
+        return 0;
 
     kmod_data_t *orig_module_data =
         bpf_map_lookup_elem(&module_init_map, &p.event->context.task.host_tid);
@@ -6714,7 +6815,7 @@ int BPF_KPROBE(trace_load_elf_phdrs)
     proc_info->interpreter.inode = get_inode_nr_from_file(loaded_elf);
     proc_info->interpreter.ctime = get_ctime_nanosec_from_file(loaded_elf);
 
-    if (should_submit(LOAD_ELF_PHDRS, p.config)) {
+    if (should_submit(LOAD_ELF_PHDRS, &p)) {
         save_str_to_buf(p.event, (void *) elf_pathname, 0);
         save_to_submit_buf(p.event, &proc_info->interpreter.device, sizeof(dev_t), 1);
         save_to_submit_buf(p.event, &proc_info->interpreter.inode, sizeof(unsigned long), 2);
@@ -6745,6 +6846,9 @@ int BPF_KPROBE(trace_security_file_permission)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(HOOKED_PROC_FOPS, &p))
         return 0;
 
     struct file_operations *fops = (struct file_operations *) READ_KERN(f_inode->i_fop);
@@ -6791,6 +6895,9 @@ int tracepoint__task__task_rename(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(TASK_RENAME, &p))
+        return 0;
+
     struct task_struct *tsk = (struct task_struct *) ctx->args[0];
     char old_name[TASK_COMM_LEN];
     bpf_probe_read_str(&old_name, TASK_COMM_LEN, tsk->comm);
@@ -6814,20 +6921,17 @@ int BPF_KPROBE(trace_security_inode_rename)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_RENAME, &p))
+        return 0;
+
     struct dentry *old_dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     struct dentry *new_dentry = (struct dentry *) PT_REGS_PARM4(ctx);
 
-    if (should_submit(SECURITY_INODE_RENAME, p.config)) {
-        void *old_dentry_path = get_dentry_path_str(old_dentry);
-        save_str_to_buf(p.event, old_dentry_path, 0);
-
-        void *new_dentry_path = get_dentry_path_str(new_dentry);
-        save_str_to_buf(p.event, new_dentry_path, 1);
-
-        events_perf_submit(&p, SECURITY_INODE_RENAME, 0);
-    }
-
-    return 0;
+    void *old_dentry_path = get_dentry_path_str(old_dentry);
+    void *new_dentry_path = get_dentry_path_str(new_dentry);
+    save_str_to_buf(p.event, old_dentry_path, 0);
+    save_str_to_buf(p.event, new_dentry_path, 1);
+    return events_perf_submit(&p, SECURITY_INODE_RENAME, 0);
 }
 
 SEC("kprobe/kallsyms_lookup_name")
@@ -6848,19 +6952,18 @@ int BPF_KPROBE(trace_ret_kallsyms_lookup_name)
         return 0;
     del_args(KALLSYMS_LOOKUP_NAME);
 
+    if (!should_submit(KALLSYMS_LOOKUP_NAME, &p))
+        return 0;
+
     char *name = (char *) saved_args.args[0];
     unsigned long address = PT_REGS_RC(ctx);
 
-    if (should_submit(KALLSYMS_LOOKUP_NAME, p.config)) {
-        save_str_to_buf(p.event, name, 0);
-        save_to_submit_buf(p.event, &address, sizeof(unsigned long), 1);
-        int id = get_task_syscall_id(p.event->task);
-        save_to_submit_buf(p.event, &id, sizeof(int), 2);
+    save_str_to_buf(p.event, name, 0);
+    save_to_submit_buf(p.event, &address, sizeof(unsigned long), 1);
+    int id = get_task_syscall_id(p.event->task);
+    save_to_submit_buf(p.event, &id, sizeof(int), 2);
 
-        events_perf_submit(&p, KALLSYMS_LOOKUP_NAME, 0);
-    }
-
-    return 0;
+    return events_perf_submit(&p, KALLSYMS_LOOKUP_NAME, 0);
 }
 
 SEC("kprobe/do_sigaction")
@@ -6871,6 +6974,9 @@ int BPF_KPROBE(trace_do_sigaction)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(DO_SIGACTION, &p))
         return 0;
 
     // Initialize all relevant arguments values
@@ -7116,32 +7222,32 @@ static __always_inline void set_net_task_context(event_data_t *event, net_task_c
 }
 
 static __always_inline void should_submit_net_event(net_event_context_t *neteventctx,
-                                                    config_entry_t *config)
+                                                    program_data_t *p)
 {
     // configure network events that should be sent to userland
 
-    if (should_submit(NET_PACKET_CAP_BASE, config))
+    if (should_submit(NET_PACKET_CAP_BASE, p))
         neteventctx->md.submit |= CAP_NET_PACKET;
 
-    if (should_submit(NET_PACKET_IP, config))
+    if (should_submit(NET_PACKET_IP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_IP;
 
-    if (should_submit(NET_PACKET_TCP, config))
+    if (should_submit(NET_PACKET_TCP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_TCP;
 
-    if (should_submit(NET_PACKET_UDP, config))
+    if (should_submit(NET_PACKET_UDP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_UDP;
 
-    if (should_submit(NET_PACKET_ICMP, config))
+    if (should_submit(NET_PACKET_ICMP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_ICMP;
 
-    if (should_submit(NET_PACKET_ICMPV6, config))
+    if (should_submit(NET_PACKET_ICMPV6, p))
         neteventctx->md.submit |= SUB_NET_PACKET_ICMPV6;
 
-    if (should_submit(NET_PACKET_DNS, config))
+    if (should_submit(NET_PACKET_DNS, p))
         neteventctx->md.submit |= SUB_NET_PACKET_DNS;
 
-    if (should_submit(NET_PACKET_HTTP, config))
+    if (should_submit(NET_PACKET_HTTP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_HTTP;
 }
 
@@ -7372,7 +7478,7 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
     neteventctx.bytes = 0; // no payload by default (changed inside skb prog)
 
     // mark network events to be submitted to userland
-    should_submit_net_event(&neteventctx, p.config);
+    should_submit_net_event(&neteventctx, &p);
 
     // (*) Use skb timestamp as the key for a map shared between this kprobe and
     // the skb ebpf program: this is **NOT SUPER** BUT, for older kernels, that

--- a/pkg/ebpf/errors.go
+++ b/pkg/ebpf/errors.go
@@ -1,0 +1,23 @@
+package ebpf
+
+import "fmt"
+
+func FilterScopeNilError() error {
+	return fmt.Errorf("filter scope cannot be nil")
+}
+
+func FilterScopeNotFoundError(idx int) error {
+	return fmt.Errorf("filter scope not found at index [%d]", idx)
+}
+
+func FilterScopesMaxExceededError() error {
+	return fmt.Errorf("filter scopes maximum exceeded [%d]", MaxFilterScopes)
+}
+
+func FilterScopesOutOfRangeError(idx int) error {
+	return fmt.Errorf("filter scopes index [%d] out-of-range [0-%d]", idx, MaxFilterScopes-1)
+}
+
+func FilterScopeAlreadySetWithDifferentIDError(scope *FilterScope, id int) error {
+	return fmt.Errorf("filter scope [%+v] already set with different id [%d]", scope, id)
+}

--- a/pkg/ebpf/errors.go
+++ b/pkg/ebpf/errors.go
@@ -18,6 +18,6 @@ func FilterScopesOutOfRangeError(idx int) error {
 	return fmt.Errorf("filter scopes index [%d] out-of-range [0-%d]", idx, MaxFilterScopes-1)
 }
 
-func FilterScopeAlreadySetWithDifferentIDError(scope *FilterScope, id int) error {
+func FilterScopeAlreadyExists(scope *FilterScope, id int) error {
 	return fmt.Errorf("filter scope [%+v] already set with different id [%d]", scope, id)
 }

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -409,6 +409,7 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 					default:
 						// Derived events might need filtering as well
 						if !t.shouldProcessEvent(&derivative) {
+							_ = t.stats.EventsFiltered.Increment()
 							continue
 						}
 					}

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -264,12 +264,6 @@ func (t *Tracee) computeScopes(event *trace.Event) uint64 {
 			continue
 		}
 
-		// TODO: check if the event is traceable to some scope using a BPF map
-		if !filterScope.IsEventTraceable(eventID) {
-			utils.ClearBit(&matchedScopes, bitOffset)
-			continue
-		}
-
 		if !filterScope.ContextFilter.Filter(*event) {
 			utils.ClearBit(&matchedScopes, bitOffset)
 			continue
@@ -433,7 +427,7 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 		for event := range in {
 			// Only emit events requested by the user
 			id := events.ID(event.EventID)
-			if !t.events[id].emit {
+			if (t.events[id].emit & event.MatchedScopes) == 0 {
 				continue
 			}
 

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -427,7 +427,8 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 		for event := range in {
 			// Only emit events requested by the user
 			id := events.ID(event.EventID)
-			if (t.events[id].emit & event.MatchedScopes) == 0 {
+			event.MatchedScopes &= t.events[id].emit
+			if event.MatchedScopes == 0 {
 				continue
 			}
 

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -383,10 +383,18 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 		for {
 			select {
 			case event := <-in:
+
+				// Get a copy of our event before sending it down the
+				// pipeline.
+				// This is needed because later modification of the event
+				// (in particular of the matched scopes) can affect
+				// the derivation and later pipeline logic acting on the derived
+				// event.
+				eventCopy := *event
 				out <- event
 
 				// Derive event before parse its arguments
-				derivatives, errors := derive.DeriveEvent(*event, t.eventDerivations)
+				derivatives, errors := derive.DeriveEvent(eventCopy, t.eventDerivations)
 
 				for _, err := range errors {
 					t.handleError(err)

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
 const (
@@ -18,8 +19,9 @@ const (
 	BinaryFilterMap      = "binary_filter"
 )
 
-type Filter struct {
-	EventsToTrace     []events.ID
+type FilterScope struct {
+	ID                int
+	EventsToTrace     map[events.ID]string
 	UIDFilter         *filters.BPFUIntFilter[uint32]
 	PIDFilter         *filters.BPFUIntFilter[uint32]
 	NewPidFilter      *filters.BoolFilter
@@ -36,4 +38,318 @@ type Filter struct {
 	ProcessTreeFilter *filters.ProcessTreeFilter
 	BinaryFilter      *filters.BPFBinaryFilter
 	Follow            bool
+}
+
+func NewFilterScope() *FilterScope {
+	return &FilterScope{
+		ID:                0,
+		EventsToTrace:     map[events.ID]string{},
+		UIDFilter:         filters.NewBPFUInt32Filter(UIDFilterMap),
+		PIDFilter:         filters.NewBPFUInt32Filter(PIDFilterMap),
+		NewPidFilter:      filters.NewBoolFilter(),
+		MntNSFilter:       filters.NewBPFUIntFilter(MntNSFilterMap),
+		PidNSFilter:       filters.NewBPFUIntFilter(PidNSFilterMap),
+		UTSFilter:         filters.NewBPFStringFilter(UTSFilterMap),
+		CommFilter:        filters.NewBPFStringFilter(CommFilterMap),
+		ContFilter:        filters.NewBoolFilter(),
+		NewContFilter:     filters.NewBoolFilter(),
+		ContIDFilter:      filters.NewContainerFilter(CgroupIdFilterMap),
+		RetFilter:         filters.NewRetFilter(),
+		ArgFilter:         filters.NewArgFilter(),
+		ContextFilter:     filters.NewContextFilter(),
+		ProcessTreeFilter: filters.NewProcessTreeFilter(ProcessTreeFilterMap),
+		BinaryFilter:      filters.NewBPFBinaryFilter(BinaryFilterMap),
+		Follow:            false,
+	}
+}
+
+const MaxFilterScopes = 64
+
+func isIDInRange(id int) bool {
+	return id >= 0 && id < MaxFilterScopes
+}
+
+func (fs FilterScope) IsEventTraceable(event events.ID) bool {
+	if _, found := fs.EventsToTrace[event]; found {
+		return true
+	}
+
+	return false
+}
+
+// TODO: add locking mechanism as scopes will change at runtime
+type FilterScopes struct {
+	filterScopesArray        [MaxFilterScopes]*FilterScope // underlying filter scopes array
+	filterScopesMap          map[*FilterScope]int          // stores only enabled scopes
+	filterScopesUserSpaceMap map[*FilterScope]int          // stores a reduced map with only user space filtered scopes
+
+	uidFilterMin             uint64
+	uidFilterMax             uint64
+	pidFilterMin             uint64
+	pidFilterMax             uint64
+	uidFilterableInUserSpace bool
+	pidFilterableInUserSpace bool
+
+	hasContainerFilterEnabled bool
+}
+
+func NewFilterScopes() *FilterScopes {
+	return &FilterScopes{
+		filterScopesArray:         [MaxFilterScopes]*FilterScope{},
+		filterScopesMap:           map[*FilterScope]int{},
+		filterScopesUserSpaceMap:  map[*FilterScope]int{},
+		uidFilterMin:              filters.MinNotSetUInt,
+		uidFilterMax:              filters.MaxNotSetUInt,
+		pidFilterMin:              filters.MinNotSetUInt,
+		pidFilterMax:              filters.MaxNotSetUInt,
+		uidFilterableInUserSpace:  false,
+		pidFilterableInUserSpace:  false,
+		hasContainerFilterEnabled: false,
+	}
+}
+
+func (fs FilterScopes) Count() int {
+	return len(fs.filterScopesMap)
+}
+
+func (fs FilterScopes) UIDFilterMin() uint64 {
+	return fs.uidFilterMin
+}
+
+func (fs FilterScopes) UIDFilterMax() uint64 {
+	return fs.uidFilterMax
+}
+
+func (fs FilterScopes) PIDFilterMin() uint64 {
+	return fs.pidFilterMin
+}
+
+func (fs FilterScopes) PIDFilterMax() uint64 {
+	return fs.pidFilterMax
+}
+
+func (fs FilterScopes) UIDFilterableInUserSpace() bool {
+	return fs.uidFilterableInUserSpace
+}
+
+func (fs FilterScopes) PIDFilterableInUserSpace() bool {
+	return fs.pidFilterableInUserSpace
+}
+
+func (fs FilterScopes) HasContainerFilterEnabled() bool {
+	return fs.hasContainerFilterEnabled
+}
+
+// Compute recalculates values, updates flags and fills the reduced user space map
+// It must be called at initialization and at every runtime scopes changes
+func (fs *FilterScopes) Compute() {
+	// update global min and max
+	fs.calculateGlobalMinMax()
+
+	// update enabled container filter flag
+	fs.updateContainerFilterEnabled()
+
+	userSpaceMap := make(map[*FilterScope]int)
+
+	for filterScope := range fs.filterScopesMap {
+		if filterScope.ArgFilter.Enabled() ||
+			filterScope.RetFilter.Enabled() ||
+			filterScope.ContextFilter.Enabled() ||
+			(filterScope.UIDFilter.Enabled() && fs.UIDFilterableInUserSpace()) ||
+			(filterScope.PIDFilter.Enabled() && fs.PIDFilterableInUserSpace()) {
+
+			userSpaceMap[filterScope] = filterScope.ID
+		}
+	}
+
+	fs.filterScopesUserSpaceMap = userSpaceMap
+}
+
+// set, if not err, always reassign values
+func (fs *FilterScopes) set(id int, scope *FilterScope) error {
+	if scope == nil {
+		return FilterScopeNilError()
+	}
+	if !isIDInRange(id) {
+		return FilterScopesOutOfRangeError(id)
+	}
+	if _, found := fs.filterScopesMap[scope]; found {
+		if scope.ID != id {
+			return FilterScopeAlreadySetWithDifferentIDError(scope, id)
+		}
+	}
+
+	scope.ID = id
+	fs.filterScopesArray[id] = scope
+	fs.filterScopesMap[scope] = id
+
+	fs.Compute()
+
+	return nil
+}
+
+// Add adds a scope to FilterScopes.
+// Its ID (index) is set to the first room found.
+// Returns nil if scope is already inserted.
+func (fs *FilterScopes) Add(scope *FilterScope) error {
+	if len(fs.filterScopesMap) == MaxFilterScopes {
+		return FilterScopesMaxExceededError()
+	}
+
+	for id := range fs.filterScopesArray {
+		if fs.filterScopesArray[id] == nil {
+			return fs.set(id, scope)
+		}
+	}
+
+	return nil
+}
+
+func (fs *FilterScopes) Set(id int, scope *FilterScope) error {
+	return fs.set(id, scope)
+}
+
+// Delete deletes a scope from FilterScopes.
+func (fs *FilterScopes) Delete(id int) error {
+	if !isIDInRange(id) {
+		return FilterScopesOutOfRangeError(id)
+	}
+	if len(fs.filterScopesMap) == 0 {
+		return nil
+	}
+
+	delete(fs.filterScopesMap, fs.filterScopesArray[id])
+	delete(fs.filterScopesUserSpaceMap, fs.filterScopesArray[id])
+	fs.filterScopesArray[id] = nil
+
+	fs.Compute()
+
+	return nil
+}
+
+func (fs FilterScopes) Lookup(id int) (*FilterScope, error) {
+	if !isIDInRange(id) {
+		return nil, FilterScopesOutOfRangeError(id)
+	}
+
+	scope := fs.filterScopesArray[id]
+	if scope == nil {
+		return nil, FilterScopeNotFoundError(id)
+	}
+	return scope, nil
+}
+
+func (fs FilterScopes) Map() map[*FilterScope]int {
+	return fs.filterScopesMap
+}
+
+func (fs *FilterScopes) updateContainerFilterEnabled() {
+	for filterScope := range fs.Map() {
+		if filterScope.ContainerFilterEnabled() {
+			fs.hasContainerFilterEnabled = true
+			return
+		}
+	}
+
+	fs.hasContainerFilterEnabled = false
+}
+
+// UserSpaceMap returns a reduced scopes map which must be filtered in
+// user space (ArgFilter, RetFilter, ContextFilter, UIDFilter and PIDFilter).
+func (fs FilterScopes) UserSpaceMap() map[*FilterScope]int {
+	return fs.filterScopesUserSpaceMap
+}
+
+// calculateGlobalMinMax sets the global min and max, to be checked in kernel space,
+// of the Minimum and Maximum enabled filters only if context filter types (e.g. BPFUIDFilter)
+// from all scopes have both Minimum and Maximum values set.
+// FilterScopes user space filter flags are also set (e.g. uidFilterableInUserSpace).
+//
+// The context filter types relevant for this function are just UIDFilter and PIDFilter.
+func (fs *FilterScopes) calculateGlobalMinMax() {
+	var (
+		uidMinFilterCount int
+		uidMaxFilterCount int
+		uidFilterCount    int
+		pidMinFilterCount int
+		pidMaxFilterCount int
+		pidFilterCount    int
+		scopeCount        int
+
+		uidMinFilterableInUserSpace bool
+		uidMaxFilterableInUserSpace bool
+		pidMinFilterableInUserSpace bool
+		pidMaxFilterableInUserSpace bool
+	)
+
+	for filterScope := range fs.Map() {
+		scopeCount++
+
+		if filterScope.UIDFilter.Enabled() {
+			uidFilterCount++
+
+			if filterScope.UIDFilter.Minimum() != filters.MinNotSetUInt {
+				uidMinFilterCount++
+			}
+			if filterScope.UIDFilter.Maximum() != filters.MaxNotSetUInt {
+				uidMaxFilterCount++
+			}
+		}
+		if filterScope.PIDFilter.Enabled() {
+			pidFilterCount++
+
+			if filterScope.PIDFilter.Minimum() != filters.MinNotSetUInt {
+				pidMinFilterCount++
+			}
+			if filterScope.PIDFilter.Maximum() != filters.MaxNotSetUInt {
+				pidMaxFilterCount++
+			}
+		}
+	}
+	uidMinFilterableInUserSpace = scopeCount > 1 && (uidMinFilterCount != uidFilterCount)
+	uidMaxFilterableInUserSpace = scopeCount > 1 && (uidMaxFilterCount != uidFilterCount)
+	pidMinFilterableInUserSpace = scopeCount > 1 && (pidMinFilterCount != pidFilterCount)
+	pidMaxFilterableInUserSpace = scopeCount > 1 && (pidMaxFilterCount != pidFilterCount)
+
+	// reset global min max
+	fs.uidFilterMax = filters.MaxNotSetUInt
+	fs.uidFilterMin = filters.MinNotSetUInt
+	fs.pidFilterMax = filters.MaxNotSetUInt
+	fs.pidFilterMin = filters.MinNotSetUInt
+
+	fs.uidFilterableInUserSpace = uidMinFilterableInUserSpace || uidMaxFilterableInUserSpace
+	fs.pidFilterableInUserSpace = pidMinFilterableInUserSpace || pidMaxFilterableInUserSpace
+
+	if fs.UIDFilterableInUserSpace() && fs.PIDFilterableInUserSpace() {
+		// there's no need to iterate filter scopes again since
+		// all uint events will be submitted from ebpf with no regards
+
+		return
+	}
+
+	// set a reduced range of uint values to be filtered in ebpf
+	for filterScope := range fs.filterScopesMap {
+		if filterScope.UIDFilter.Enabled() {
+			if !uidMinFilterableInUserSpace {
+				fs.uidFilterMin = utils.Min(fs.uidFilterMin, filterScope.UIDFilter.Minimum())
+			}
+			if !uidMaxFilterableInUserSpace {
+				fs.uidFilterMax = utils.Max(fs.uidFilterMax, filterScope.UIDFilter.Maximum())
+			}
+		}
+		if filterScope.PIDFilter.Enabled() {
+			if !pidMinFilterableInUserSpace {
+				fs.pidFilterMin = utils.Min(fs.pidFilterMin, filterScope.PIDFilter.Minimum())
+			}
+			if !pidMaxFilterableInUserSpace {
+				fs.pidFilterMax = utils.Max(fs.pidFilterMax, filterScope.PIDFilter.Maximum())
+			}
+		}
+	}
+}
+
+func (fs FilterScope) ContainerFilterEnabled() bool {
+	return (fs.ContFilter.Enabled() && fs.ContFilter.Value()) ||
+		(fs.NewContFilter.Enabled() && fs.NewContFilter.Value()) ||
+		fs.ContIDFilter.Enabled()
 }

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -54,6 +54,7 @@ func newEvent(id int, name string, s trace.Event) *trace.Event {
 		ReturnValue:         s.ReturnValue,
 		StackAddresses:      s.StackAddresses,
 		ContextFlags:        s.ContextFlags,
+		MatchedScopes:       s.MatchedScopes,
 		Args:                s.Args,
 	}
 }

--- a/pkg/ebpf/rule_engine.go
+++ b/pkg/ebpf/rule_engine.go
@@ -32,7 +32,7 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 				id := events.ID(event.EventID)
 
 				// if the event is marked as submit, we pass it to the engine
-				if t.events[id].submit {
+				if t.events[id].submit > 0 {
 					err := t.parseArguments(event)
 					if err != nil {
 						t.handleError(err)

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -252,7 +252,7 @@ func (t *Tracee) handleEventsDependencies(eventId events.ID, submitMap uint64) {
 			ec = eventConfig{}
 			t.handleEventsDependencies(dependentEvent.EventID, submitMap)
 		}
-		ec.submit = submitMap
+		ec.submit |= submitMap
 		t.events[dependentEvent.EventID] = ec
 	}
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -890,8 +890,8 @@ func (t *Tracee) computeConfigValues() []byte {
 		configVal[216+byteIndex] |= 1 << bitOffset
 	}
 
-	// Compute all filter scopes internals
-	t.config.FilterScopes.Compute()
+	// compute all filter scopes internals
+	t.config.FilterScopes.compute()
 
 	// uid_max
 	binary.LittleEndian.PutUint64(configVal[224:232], t.config.FilterScopes.UIDFilterMax())

--- a/pkg/ebpf/tracee_test.go
+++ b/pkg/ebpf/tracee_test.go
@@ -135,11 +135,11 @@ func Test_getTailCalls(t *testing.T) {
 		{
 			name: "happy path - some direct syscalls and syscall requiring events",
 			events: map[events.ID]eventConfig{
-				events.Ptrace:           {submit: true, emit: true},
-				events.ClockSettime:     {submit: true, emit: true},
-				events.SecurityFileOpen: {submit: true, emit: true},
-				events.MemProtAlert:     {submit: true, emit: true},
-				events.SocketDup:        {submit: true, emit: true},
+				events.Ptrace:           {submit: ^uint64(0), emit: ^uint64(0)},
+				events.ClockSettime:     {submit: ^uint64(0), emit: ^uint64(0)},
+				events.SecurityFileOpen: {submit: ^uint64(0), emit: ^uint64(0)},
+				events.MemProtAlert:     {submit: ^uint64(0), emit: ^uint64(0)},
+				events.SocketDup:        {submit: ^uint64(0), emit: ^uint64(0)},
 			},
 			expectedTailCalls: []events.TailCall{
 				{MapName: "sys_exit_tails", MapIndexes: []uint32{uint32(events.Dup), uint32(events.Dup2), uint32(events.Dup3)}, ProgName: "sys_dup_exit_tail"},

--- a/pkg/filters/errors.go
+++ b/pkg/filters/errors.go
@@ -6,6 +6,10 @@ func UnsupportedOperator(op Operator) error {
 	return fmt.Errorf("failed to add filter: unsupported operator %s", op.String())
 }
 
+func InvalidScope(filterScope string) error {
+	return fmt.Errorf("invalid filter scope: %s", filterScope)
+}
+
 func InvalidExpression(expression string) error {
 	return fmt.Errorf("invalid filter expression: %s", expression)
 }

--- a/pkg/filters/processtree.go
+++ b/pkg/filters/processtree.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"unsafe"
 
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
 type ProcessTreeFilter struct {
@@ -75,7 +77,7 @@ func (filter *ProcessTreeFilter) Parse(operatorAndValues string) error {
 	return nil
 }
 
-func (filter *ProcessTreeFilter) InitBPF(bpfModule *bpf.Module) error {
+func (filter *ProcessTreeFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID uint) error {
 	if !filter.Enabled() {
 		return nil
 	}
@@ -94,6 +96,27 @@ func (filter *ProcessTreeFilter) InitBPF(bpfModule *bpf.Module) error {
 	entries, err := procDir.Readdirnames(-1)
 	if err != nil {
 		return fmt.Errorf("could not read proc dir: %v", err)
+	}
+
+	updateBPF := func(shouldBeTraced bool, pid uint64) {
+		filterVal := make([]byte, 16)
+		var equalInScopes, equalitySetInScopes uint64
+		curVal, err := processTreeBPFMap.GetValue(unsafe.Pointer(&pid))
+		if err == nil {
+			equalInScopes = binary.LittleEndian.Uint64(curVal[0:8])
+			equalitySetInScopes = binary.LittleEndian.Uint64(curVal[8:16])
+		}
+
+		if shouldBeTraced {
+			utils.SetBit(&equalInScopes, filterScopeID)
+		} else {
+			utils.ClearBit(&equalInScopes, filterScopeID)
+		}
+		utils.SetBit(&equalitySetInScopes, filterScopeID)
+
+		binary.LittleEndian.PutUint64(filterVal[0:8], equalInScopes)
+		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
+		processTreeBPFMap.Update(unsafe.Pointer(&pid), unsafe.Pointer(&filterVal[0]))
 	}
 
 	// Iterate over each pid
@@ -122,8 +145,7 @@ func (filter *ProcessTreeFilter) InitBPF(bpfModule *bpf.Module) error {
 			}
 
 			if shouldBeTraced, ok := filter.PIDs[uint32(ppid)]; ok {
-				trace := boolToUInt32(shouldBeTraced)
-				processTreeBPFMap.Update(unsafe.Pointer(&pid), unsafe.Pointer(&trace))
+				updateBPF(shouldBeTraced, pid)
 				return
 			}
 			fn(uint32(ppid))
@@ -132,8 +154,7 @@ func (filter *ProcessTreeFilter) InitBPF(bpfModule *bpf.Module) error {
 	}
 
 	for pid, shouldBeTraced := range filter.PIDs {
-		trace := boolToUInt32(shouldBeTraced)
-		processTreeBPFMap.Update(unsafe.Pointer(&pid), unsafe.Pointer(&trace))
+		updateBPF(shouldBeTraced, uint64(pid))
 	}
 
 	return nil
@@ -149,11 +170,4 @@ func (filter *ProcessTreeFilter) FilterOut() bool {
 		filterIn = filterIn && v
 	}
 	return !filterIn
-}
-
-func boolToUInt32(b bool) uint32 {
-	if b {
-		return uint32(1)
-	}
-	return uint32(0)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,6 +41,10 @@ func ClearBit(n *uint64, offset uint) {
 	*n &= ^(1 << offset)
 }
 
+func ClearBits(n *uint64, mask uint64) {
+	*n &= ^mask
+}
+
 func SetBit(n *uint64, offset uint) {
 	*n |= (1 << offset)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,3 +32,29 @@ func ErrorFuncName(e error) error {
 
 	return nil
 }
+
+func HasBit(n uint64, offset uint) bool {
+	return (n & (1 << offset)) > 0
+}
+
+func ClearBit(n *uint64, offset uint) {
+	*n &= ^(1 << offset)
+}
+
+func SetBit(n *uint64, offset uint) {
+	*n |= (1 << offset)
+}
+
+func Min(x, y uint64) uint64 {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func Max(x, y uint64) uint64 {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/tests/e2e-net-rules/scripts/dns.sh
+++ b/tests/e2e-net-rules/scripts/dns.sh
@@ -14,9 +14,9 @@ command -v nslookup > /dev/null || exit_err "missing nslookup tool"
 # start dns test
 
 test() {
-    nslookup -type=mx $HOST $SERVER
-    nslookup -type=ns $HOST $SERVER
-    nslookup -type=soa $HOST $SERVER
+    nslookup -type=mx $HOST $SERVER > /dev/null
+    nslookup -type=ns $HOST $SERVER > /dev/null
+    nslookup -type=soa $HOST $SERVER > /dev/null
     sleep 1
 }
 

--- a/tests/integration/tester.sh
+++ b/tests/integration/tester.sh
@@ -10,9 +10,9 @@ do_ls() {
 }
 
 do_ls_uname() {
-    ls > /dev/null
-    uname > /dev/null
-}
+    # run on the same core to ensure event order
+    taskset -c 0 ls; uname
+} > /dev/null
 
 do_docker_run() {
     outputFileName=$1

--- a/tests/integration/tester.sh
+++ b/tests/integration/tester.sh
@@ -9,6 +9,11 @@ do_ls() {
     ls > /dev/null
 }
 
+do_ls_uname() {
+    ls > /dev/null
+    uname > /dev/null
+}
+
 do_docker_run() {
     outputFileName=$1
     output=$(docker run -d --rm alpine)


### PR DESCRIPTION
Due to https://github.com/aquasecurity/tracee/pull/2217#issuecomment-1275130338, closed #2217 and pushed this one.

8738fe4f addressing minor issues
efa5acf9 ebpf: fix network capture using multiscopes
7feb73be flags/filter: better help message for multiscopes
9923b011 filters: change var names for better understand
07c48e9a scopes: add all capture events to all 64 scopes
7f9db05b ebpf: lazy submit checks for net events
3422889b e2e: silence dns test prints
efff3762 fix: signature events + common events
80f1ade6 ebpf: check event submit by scope with map
f2a7ff25 pipeline: increment events filtered (derived)
f7674f85 fix: false container logic needs filter scopes out
af49f90d network: adjust multi scope for ingress packets
9b28fc0d feat: multi scopes (set) of filters

Fix: #2176

## Type of change

- [x] New feature (non-breaking change adding functionality).

## Steps

- [x] https://github.com/aquasecurity/tracee/issues/2301
  - [x] PR https://github.com/aquasecurity/tracee/pull/2302 raised 
- [x] Increase scopes to 64
- [x] Improve shouldProcessEvent() to only iterate through a reduced number scopes (enabled and filtered by type)
- [x] Tackle `// TODO:gg`
  - [x] Implement the new cli syntax parsing (under discussion)
- [x] Make sure that all flags are being checked in `Tracee.shouldProcessEvent()`
  - [x] Fix Greater and Less which turned bugged after rebases
  - [x] Check set flag (net is not available)
  - [x] Create/change tests
- [x] Change printer output column to the matchedScopes flag only (without fanciness)
- [x] Create json output field for matchedScopes.
- [x] Create tests for new trace flag syntax
- [x] Create tests for multi-scopes
- [x] Change scope flag syntax to `<scope>:filtername=`
- [x] Changes after reviews
- [x] Comment magical parts of the code
- [x] Network filtering
- Update documentation .md (postponed to after merge)