### PR TITLE
refactor: remove debug flag from pkg/server

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -206,7 +206,7 @@ func main() {
 			}
 
 			if server.ShouldStart(c) {
-				httpServer := server.New(c.String(server.ListenEndpointFlag), debug)
+				httpServer := server.New(c.String(server.ListenEndpointFlag))
 
 				if c.Bool(server.MetricsEndpointFlag) {
 					err := t.Stats().RegisterPrometheus()

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -139,7 +139,7 @@ func main() {
 			}
 
 			if server.ShouldStart(c) {
-				httpServer := server.New(c.String(server.ListenEndpointFlag), false)
+				httpServer := server.New(c.String(server.ListenEndpointFlag))
 
 				if c.Bool(server.MetricsEndpointFlag) {
 					err := e.Stats().RegisterPrometheus()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http/pprof"
 	"os"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/urfave/cli/v2"
 )
@@ -21,15 +22,13 @@ const (
 type Server struct {
 	mux        *http.ServeMux
 	listenAddr string
-	debug      bool
 }
 
 // New creates a new server
-func New(listenAddr string, debug bool) *Server {
+func New(listenAddr string) *Server {
 	return &Server{
 		mux:        http.NewServeMux(),
 		listenAddr: listenAddr,
-		debug:      debug,
 	}
 }
 
@@ -47,9 +46,7 @@ func (s *Server) EnableHealthzEndpoint() {
 
 // Start starts the http server on the listen addr
 func (s *Server) Start() {
-	if s.debug {
-		fmt.Fprintf(os.Stdout, "Serving metrics endpoint at %s\n", s.listenAddr)
-	}
+	logger.Debug(fmt.Sprintf("Serving metrics endpoint at %s\n", s.listenAddr))
 
 	if err := http.ListenAndServe(s.listenAddr, s.mux); err != http.ErrServerClosed {
 		fmt.Fprintf(os.Stderr, "Error serving metrics endpoint: %v\n", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	httpServer := New("", false)
+	httpServer := New("")
 
 	httpServer.EnableMetricsEndpoint()
 	httpServer.EnableHealthzEndpoint()


### PR DESCRIPTION
minor refactor, remove debug flag from server using `logger.Debug` 