### PR TITLE
Allow tracee-ebpf to trace itself

### DIFF
--- a/cmd/tracee-ebpf/flags/filter.go
+++ b/cmd/tracee-ebpf/flags/filter.go
@@ -71,7 +71,8 @@ Examples:
   --trace openat.pathname=/tmp*                                | only trace 'openat' events that have 'pathname' prefixed by "/tmp"
   --trace openat.pathname!=/tmp/1,/bin/ls                      | don't trace 'openat' events that have 'pathname' equals /tmp/1 or /bin/ls
   --trace comm=bash --trace follow                             | trace all events that originated from bash or from one of the processes spawned by bash
-  --trace net=docker0 			                       | trace the net events over docker0 interface
+  --trace self                                                 | trace all events that originated from the running tracee process
+  --trace net=docker0                                          | trace the net events over docker0 interface
 
 
 Note: some of the above operators have special meanings in different shells.
@@ -274,6 +275,11 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 
 		if strings.HasPrefix("follow", filterFlag) {
 			filter.Follow = true
+			continue
+		}
+
+		if strings.HasPrefix("self", filterFlag) {
+			filter.TraceSelf = true
 			continue
 		}
 		return tracee.Filter{}, InvalidFilterOptionError(filterFlag)

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -38,6 +38,7 @@ type Filter struct {
 	ProcessTreeFilter *filters.ProcessTreeFilter
 	Follow            bool
 	NetFilter         *NetIfaces
+	TraceSelf         bool
 }
 
 type NetIfaces struct {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -778,7 +778,11 @@ func (t *Tracee) populateBPFMaps() error {
 
 	cZero := uint32(0)
 	configVal := make([]byte, 208)
-	binary.LittleEndian.PutUint32(configVal[0:4], uint32(os.Getpid()))
+	selfPid := 0
+	if !t.config.Filter.TraceSelf {
+		selfPid = os.Getpid()
+	}
+	binary.LittleEndian.PutUint32(configVal[0:4], uint32(selfPid))
 	binary.LittleEndian.PutUint32(configVal[4:8], t.getOptionsConfig())
 	binary.LittleEndian.PutUint32(configVal[8:12], t.getFiltersConfig())
 	binary.LittleEndian.PutUint32(configVal[12:16], uint32(t.containers.GetCgroupV1HID()))


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description

This adds a configuration option in the tracee filter config to allow tracee-ebpf to trace itself. This does not yet expose a flag at the command line for doing so but I can add it. The original motivation is for the sake of the second commit, allowing the integration tests to generate events, but it could make sense to want to run tracee this way. 

## git log

commit ce3fc067c7feef047aeb77c434ed0dbae045db20 (HEAD -> allow-self-trace, pfork/allow-self-trace)
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Tue Oct 18 19:27:58 2022 -0400

    Fix flaky magic_write test (wasn't triggering self)
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>

commit 1d3c06aac5e26069dc6ed2c253f9e19b9fcbc59d
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Tue Oct 18 19:27:33 2022 -0400

    Add an option to Tracee config for tracing own PID
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>

Fixes: #issue_number

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tests being included in this PR:

- [ ] integration_test.go

Reproduce the test by running:

- `make test-integration`
