### PR TITLE
[FEAT] logger: debug output enrichment

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -192,6 +193,11 @@ func debugw(skip int, l *Logger, msg string, keysAndValues ...interface{}) {
 	if isAggregateSetAndIsLogNotNew(skip+1, l) {
 		return
 	}
+
+	pkg, file, line := getCallerInfo(skip + 1)
+	var originInfoKVs []interface{}
+	originInfoKVs = append(originInfoKVs, "pkg", pkg, "file", filepath.Base(file), "line", line)
+	keysAndValues = append(originInfoKVs, keysAndValues...)
 
 	l.l.Debugw(msg, keysAndValues...)
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -189,10 +189,6 @@ func isAggregateSetAndIsLogNotNew(skip int, l *Logger) bool {
 
 // Debug
 func debugw(skip int, l *Logger, msg string, keysAndValues ...interface{}) {
-	if l.cfg.Level > DebugLevel {
-		return
-	}
-
 	if isAggregateSetAndIsLogNotNew(skip+1, l) {
 		return
 	}
@@ -227,11 +223,8 @@ func (l *Logger) Info(msg string, keysAndValues ...interface{}) {
 
 // Warn
 func warnw(skip int, l *Logger, msg string, keysAndValues ...interface{}) {
-	if l.cfg.Aggregate {
-		_, file, line := getCallerInfo(skip + 1)
-		if new := l.updateCounter(file, line); !new {
-			return
-		}
+	if isAggregateSetAndIsLogNotNew(skip+1, l) {
+		return
 	}
 
 	l.l.Warnw(msg, keysAndValues...)


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.

## Description (git log)

72c38284 logger: enrich debug level logs
ffa109a0 logger: refactor

Fixes: #2248 

## Type of change

- [x] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).

## How Has This Been Tested?

```shell
❯ sudo TRACEE_LOGGER_LVL=debug ./dist/tracee-ebpf -t comm=ls
{"level":"debug","ts":1666192669.9143562,"msg":"osinfo","pkg":"main","file":"main.go","line":85,"OSReleaseField":"BUILD_ID","OS_KERNEL_RELEASE":"rolling"}
{"level":"debug","ts":1666192669.9146245,"msg":"osinfo","pkg":"main","file":"main.go","line":85,"OSReleaseField":"PRETTY_NAME","OS_KERNEL_RELEASE":"\"Manjaro Linux\""}
{"level":"debug","ts":1666192669.9146755,"msg":"osinfo","pkg":"main","file":"main.go","line":85,"OSReleaseField":"KERNEL_RELEASE","OS_KERNEL_RELEASE":"5.15.74-3-MANJARO"}
{"level":"debug","ts":1666192669.9147034,"msg":"osinfo","pkg":"main","file":"main.go","line":85,"OSReleaseField":"ARCH","OS_KERNEL_RELEASE":"x86_64"}
{"level":"debug","ts":1666192669.9147112,"msg":"osinfo","pkg":"main","file":"main.go","line":85,"OSReleaseField":"ID","OS_KERNEL_RELEASE":"manjaro"}
{"level":"debug","ts":1666192669.9147198,"msg":"osinfo","pkg":"main","file":"main.go","line":85,"OSReleaseField":"ID_LIKE","OS_KERNEL_RELEASE":"arch"}
{"level":"debug","ts":1666192669.9160993,"msg":"osinfo","pkg":"main","file":"main.go","line":152,"security_lockdown":"none"}
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
```