### PR TITLE
Start documentation changes for kubernetes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,11 +11,17 @@
 
 # Tracee: Runtime Security and Forensics using eBPF
 
-Tracee is a Runtime Security and forensics tool for Linux. It uses Linux **eBPF
-technology** to trace your system and applications **at runtime**, and analyzes
-collected events in order to detect **suspicious behavioral patterns**. It is
-usually delivered as a docker container, but there are other ways you can use
-it (even create your own customized tracee container).
+Tracee is a runtime security and forensics tool for Linux based cloud deployments.
+It uses **eBPF** to trace the host OS and applications **at runtime**, and analyzes
+collected events in order to detect **suspicious behavioral patterns**. It can be
+run as a daemon-set in your kubernetes environment, but is flexible to be run for
+many purposes any Linux based hosts. It can be delivered via helm, as a docker
+container, or as a small set of static binaries.
+
+The goal of Tracee is to serve as an easy to use and effective solution for learning 
+when cloud native attacks occur in your environment. By leveraging Aqua's advanced 
+security research, performant eBPF based detection, and cloud native first
+approach Tracee makes runtime detection accesible, powerful, and effective.
 
 Watch a quick video demo of Tracee:
 
@@ -23,7 +29,9 @@ Watch a quick video demo of Tracee:
 
 Check out the [Tracee video hub](https://info.aquasec.com/ebpf-runtime-security) for more videos.
 
-## Quickstart
+## Quickstart (docker)
+
+To get a feel for what tracee accomplishes, let's take a look at running the tracee container at the commanad line.
 
 Before you proceed, make sure you follow the [prerequiresites].
 
@@ -122,6 +130,21 @@ $ docker run \
 !!! note
     See documentation or add the `--help` flag for more.
 
+## Quickstart (kubernetes)
+
+Tracee is designed for use in Kubernetes deployments so the process for doing so is straightforward.
+
+1. Install tracee via helm.
+
+See the kubernetes [installation guide].
+
+2. FIXME:
+
+- How are users interacting with Tracee via Kubernetes?
+  - Are signature alerts printed to stderr and then collected via logs?
+  - Is Postee enabled by default and if so how is it configured?
+  - How are signatures configured?
+
 ## Components
 
 Tracee is composed of the following sub-projects, which are hosted in the
@@ -138,6 +161,7 @@ Join the community, and talk to us about any matter in [GitHub Discussion] or [S
 
 [Tracee-eBPF]: ./tracing/index.md
 [Tracee-Rules]: ./detecting/index.md
+[installation guide] ./installing/kubernetes.md
 
 [Aqua Security]: https://aquasec.com
 [GitHub Discussion]: https://github.com/aquasecurity/tracee/discussions

--- a/docs/installing/kubernetes.md
+++ b/docs/installing/kubernetes.md
@@ -29,8 +29,8 @@ the detections in your preferred way (e.g. Slack, E-mail, JIRA and more).
 
         ```text
         $ helm repo add aqua-charts https://aquasecurity.github.io/helm-charts
-        $ helm dependency update ./deploy/helm/tracee
-        $ helm install tracee ./deploy/helm/tracee \
+        $ helm dependency update
+        $ helm install tracee aqua/tracee \
             --namespace tracee-system --create-namespace \
             --set hostPID=true \
             --set postee.enabled=true

--- a/docs/tutorials/kubernetes-quickstart.md
+++ b/docs/tutorials/kubernetes-quickstart.md
@@ -1,0 +1,198 @@
+# Getting started with tracee in Kubernetes 
+
+This guide is focused on running tracee on Kubernetes. To demonstrate how to use Tracee we will use minikube, a distribution of kubernetes that can run on your local machine. 
+ 
+
+## Prerequisites 
+
+ 
+minikube - see installation instructions and dependencies [here](https://minikube.sigs.k8s.io/docs/start/). 
+ 
+
+Start minikube and ensure that it is running correctly:
+ 
+
+``` 
+
+minikube start 
+
+``` 
+
+```
+[*] kubectl get po -A 
+
+NAMESPACE     NAME                               READY   STATUS    RESTARTS   AGE 
+
+kube-system   coredns-565d847f94-kd9xx           1/1     Running   0          15s 
+
+kube-system   etcd-minikube                      1/1     Running   0          26s 
+
+kube-system   kube-apiserver-minikube            1/1     Running   0          26s 
+
+kube-system   kube-controller-manager-minikube   1/1     Running   0          26s 
+
+kube-system   kube-proxy-cvqjm                   1/1     Running   0          15s 
+
+kube-system   kube-scheduler-minikube            1/1     Running   0          26s 
+
+kube-system   storage-provisioner                1/1     Running   0          15s 
+
+``` 
+
+## Running tracee as a daemon set
+
+Tracee uses eBPF for host-based detections, meaning it has visibility into all processes running on a given host, regardless of them being separated into different containers or pods. Therefore, we want to have tracee running on each node. 
+
+The following kubernetes manifest can be used to run tracee as a daemon set. This tells Kubernetes to have a single tracee process on each node. 
+
+``` 
+
+--- 
+apiVersion: apps/v1 
+kind: DaemonSet 
+metadata: 
+  labels: 
+    app.kubernetes.io/name: tracee 
+    app.kubernetes.io/component: tracee 
+    app.kubernetes.io/part-of: tracee 
+  name: tracee 
+spec: 
+  selector: 
+    matchLabels: 
+      app.kubernetes.io/name: tracee 
+  template: 
+    metadata: 
+      labels: 
+        app.kubernetes.io/name: tracee 
+      name: tracee 
+    spec: 
+      containers: 
+      - name: tracee 
+        image: docker.io/aquasec/tracee:0.8.3 
+        imagePullPolicy: IfNotPresent 
+        env: 
+          - name: LIBBPFGO_OSRELEASE_FILE 
+            value: /etc/os-release-host 
+        securityContext: 
+          privileged: true 
+        volumeMounts: 
+        - name: tmp-tracee 
+          mountPath: /tmp/tracee 
+        - name: etc-os-release 
+          mountPath: /etc/os-release-host 
+          readOnly: true 
+        # NOTE: Resource consumption will vary between different use cases and 
+        # workload characteristics. User should monitor tracee for resource 
+        # consumption before enabling resource limits. Capping tracee 
+        # resources may cause loss of events and miss detections. 
+        # resources: 
+        #   limits: 
+        #     cpu: "1" 
+        #     memory: 1Gi # tracee has a 512MB in-memory events cache enabled by default 
+        #   requests: 
+        #     cpu: "1" 
+        #     memory: 1Gi 
+      tolerations: 
+        - effect: NoSchedule 
+          operator: Exists 
+        - effect: NoExecute 
+          operator: Exists 
+      volumes: 
+      - hostPath: 
+          path: /tmp/tracee 
+        name: tmp-tracee 
+      - hostPath: 
+          path: /etc/os-release 
+        name: etc-os-release 
+``` 
+ 
+
+After saving the above manifest into a file called `tracee.yml` you can install it via: 
+
+ 
+
+``` 
+[*] kubectl apply –f tracee.yml 
+``` 
+
+ 
+
+You can verify that the tracee daemon set is running via: 
+
+ 
+
+``` 
+[*] kubectl get nodes 
+
+NAME       STATUS   ROLES           AGE   VERSION 
+
+minikube   Ready    control-plane   17m   v1.25.2 
+
+  
+
+[*] kubectl get pods  
+
+NAME           READY   STATUS    RESTARTS   AGE 
+
+tracee-fcjmp   1/1     Running   0          4m11s 
+``` 
+
+You can see that we have a single pod running in our cluster, which has just a single node.  
+
+ 
+## Tracee in action 
+
+At this point tracee is running with default behavior. You can see this at the top of the pod’s logs: 
+
+``` 
+[*] kubectl logs tracee-fcjmp 
+
+INFO: probing tracee-ebpf capabilities... 
+
+INFO: starting tracee-ebpf... 
+
+INFO: starting tracee-rules... 
+
+Loaded 15 signature(s): [TRC-1 TRC-13 TRC-2 TRC-14 TRC-3 TRC-11 TRC-9 TRC-4 TRC-5 TRC-12 TRC-6 TRC-10 TRC-7 TRC-16 TRC-15] 
+
+``` 
+
+Each of the signatures listed above represent potentially malicious behaviors for tracee to detect and alert you on. You can see signature definitions [here](https://github.com/aquasecurity/tracee/tree/main/signatures). Tracee comes with these default signatures but also allows for you to write custom ones as well. More information can be found [here](docs/detecting/rules.md) 
+
+Let’s trigger one of the default signatures to see tracee in action. 
+ 
+We can start by launching a shell in the tracee pod (and therefore on the same node), and install `strace`, a debugging tool that should trigger the TRC-2 signature which detects use of PTRACE, and should not be running in your kubernetes cluster. 
+
+
+```
+[*] kubectl exec --stdin --tty tracee-fcjmp – sh 
+
+/tracee # apk add strace 
+  OK: 14 MiB in 32 packages 
+
+/tracee # strace ls 
+
+... 
+``` 
+
+Now to confirm that tracee caught this malicious behavior we can check the logs of the pod: 
+
+``` 
+[*] kubectl logs tracee-fcjmp –follow 
+ 
+
+*** Detection *** 
+
+Time: 2022-10-20T17:08:13Z 
+
+Signature ID: TRC-2 
+
+Signature: Anti-Debugging 
+
+Data: map[] 
+
+Command: strace 
+
+Hostname: tracee-fcjmp 
+
+```


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

This is the start of changes to documentation in tracee with a particular focus
on changing the entry to be towards the user and less so the contributor. The
idea is also to push the use case of tracee for kubernetes and less on running
locally with docker.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>