### PR TITLE
k8s: make postee optional

### DIFF
--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -57,7 +57,7 @@ affinity: {}
 postee:
   # enabled is a flag to install Postee subchart and configure Tracee to forward
   # threat detections to the Postee webhook endpoint.
-  enabled: true
+  enabled: false
 
 signatures:
   # config defines Common Expression Language (CEL) signatures that are loaded

--- a/deploy/kubernetes/tracee/kustomization.yaml
+++ b/deploy/kubernetes/tracee/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tracee.yaml
+images:
+  - name: docker.io/aquasec/tracee
+    newName: tracee
+    newTag: latest

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: tracee
+    app.kubernetes.io/component: tracee
+    app.kubernetes.io/part-of: tracee
+  name: tracee
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tracee
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tracee
+      name: tracee
+    spec:
+      containers:
+      - name: tracee
+        image: docker.io/aquasec/tracee:0.8.3
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: LIBBPFGO_OSRELEASE_FILE
+            value: /etc/os-release-host
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: tmp-tracee
+          mountPath: /tmp/tracee
+        - name: etc-os-release
+          mountPath: /etc/os-release-host
+          readOnly: true
+        # NOTE: Resource consumption will vary between different use cases and
+        # workload characteristics. User should monitor tracee for resource
+        # consumption before enabling resource limits. Capping tracee
+        # resources may cause loss of events and miss detections. Golang
+        # signatures outperforms REGO signatures, use less HW resources,
+        # and are preferred if that is an option.
+        # resources:
+        # resources:
+        #   limits:
+        #     cpu: "1"
+        #     memory: 1Gi # tracee has a 512MB in-memory events cache enabled by default
+        #   requests:
+        #     cpu: "1"
+        #     memory: 1Gi
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+        - effect: NoExecute
+          operator: Exists
+      volumes:
+      - hostPath:
+          path: /tmp/tracee
+        name: tmp-tracee
+      - hostPath:
+          path: /etc/os-release
+        name: etc-os-release


### PR DESCRIPTION
## Initial Checklist

Fix https://github.com/aquasecurity/tracee/issues/2267

- postee optional on helm
- k8 tracee.yaml without posted or falco 