### PR TITLE
docs: stop creating docs for patch versions

### DIFF
--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -41,4 +41,4 @@ jobs:
           if [ -z $VERSION ]; then
             VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/##g")
           fi
-          mike deploy --push --update-aliases $VERSION latest
+          mike deploy --push --update-aliases ${VERSION%.*} latest


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/tracee/issues/2273

Based on https://github.com/aquasecurity/trivy/pull/2824