### PR TITLE
docs: add overview to docs, contributing sections

### DIFF
--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -1,0 +1,1 @@
+This section goes deep explaning Tracee's internals, and how to build Tracee on different platforms for the users interested in contributing.

--- a/docs/docs/overview.md
+++ b/docs/docs/overview.md
@@ -1,0 +1,14 @@
+# Docs
+
+This documentation details how to use Tracee to access the features listed below.
+
+## Features
+
+- Tracing
+	- Tracee event collection capabilities only, without involving the detection engine.
+- Capturing
+	- Tracee's unique feature that lets you capture interesting artifacts from running applications, using the --capture flag.
+- Detecting
+	- Tracee is a runtime security detection engine, more than an introspection tool (tracee-ebpf) only. tracee-rules is a rules engine that helps you detect suspicious behavioral patterns in streams of events.
+- Integrating
+	- Tracee integration with other techonologies, like Prometheus.


### PR DESCRIPTION
Add basic overview for sections docs, and contributing. Let me know if you want to add something, or we can keep it simple for now, just to make the release with some information, instead of blank pages. 