### PR TITLE
capabilities: raise caps ring for some privileged operations

### DIFF
--- a/pkg/ebpf/initialization/ksymbols.go
+++ b/pkg/ebpf/initialization/ksymbols.go
@@ -1,9 +1,10 @@
 package initialization
 
 import (
+	"unsafe"
+
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/helpers"
-	"unsafe"
 )
 
 var maxKsymNameLen = 64 // Most match the constant in the bpf code
@@ -33,11 +34,14 @@ func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helper
 	return nil
 }
 
-// ValidateKsymbolsTable check if the addresses in the table are valid by checking a specific symbol address.
-// The reason for the addresses to be invalid is if the capabilities required to read the kallsyms file are not given.
-// The chosen symbol used here is "security_file_open" because it is a must-have symbol for tracee to run.
+// ValidateKsymbolsTable checks if the addresses in the table are valid by
+// checking a specific symbol address. The reason for the addresses to be
+// invalid is if the capabilities required to read the kallsyms file are not
+// given. The chosen symbol used here is "security_file_open" because it is a
+// must-have symbol for tracee to run.
 func ValidateKsymbolsTable(ksyms *helpers.KernelSymbolTable) bool {
-	if sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "security_file_open"); err != nil || sym.Address == 0 {
+	sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "security_file_open")
+	if err != nil || sym.Address == 0 {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Description (git log)

Right before releasing v0.9.0, e2e tests failed because of the lack of capabilities of some events that are not being tested in github. 

Example on how to reproduce the issue:

```
sudo TRACEE_LOGGER_LVL=debug ./dist/tracee-ebpf --containers --output format:json --output option:parse-arguments --output option:detect-syscall --trace event=do_init_module,hooked_syscalls
...
{"level":"debug","ts":1666391078.532682,"msg":"capabilities change","pkg":"capabilities"}
{"level":"debug","ts":1666391078.532827,"msg":"capabilities change","pkg":"capabilities"}
{"level":"debug","ts":1666391078.5328455,"msg":"enabling","pkg":"capabilities","cap":"cap_sys_resource"}
{"level":"debug","ts":1666391078.532858,"msg":"enabling","pkg":"capabilities","cap":"cap_bpf"}
{"level":"debug","ts":1666391078.5328634,"msg":"enabling","pkg":"capabilities","cap":"cap_ipc_lock"}
{"level":"debug","ts":1666391078.532869,"msg":"enabling","pkg":"capabilities","cap":"cap_perfmon"}
invalid ksymbol table
{"level":"debug","ts":1666391078.959071,"msg":"capabilities change","pkg":"capabilities"}
invalid ksymbol table
```
And by tracing the stack we can see we were missing CAP_SYSLOG at:

```
invalid ksymbol table

goroutine 36 [running]:
runtime/debug.Stack()
        /usr/lib/go/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
        /usr/lib/go/src/runtime/debug/stack.go:16 +0x19
github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).updateKallsyms.func1()
        /home/rafaeldtinoco/work/ebpf/tracee/pkg/ebpf/tracee.go:1468 +0x7f
github.com/aquasecurity/tracee/pkg/capabilities.(*Capabilities).Required(0xc0001ad000, 0xc002622eb0?)
        /home/rafaeldtinoco/work/ebpf/tracee/pkg/capabilities/capabilities.go:159 +0xc4
github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).updateKallsyms(0x15c9920?)
        /home/rafaeldtinoco/work/ebpf/tracee/pkg/ebpf/tracee.go:1462 +0x3c
github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).processEvent(0xc000122240, 0xc00047c160)
        /home/rafaeldtinoco/work/ebpf/tracee/pkg/ebpf/events_processor.go:301 +0x2266
github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).processEvents.func1()
        /home/rafaeldtinoco/work/ebpf/tracee/pkg/ebpf/events_pipeline.go:246 +0x10e
created by github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).processEvents
        /home/rafaeldtinoco/work/ebpf/tracee/pkg/ebpf/events_pipeline.go:242 +0x115
```

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Will now make sure e2e tests pass with this PR before any new merge.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
