### PR TITLE
caps: raise privileges for cgroupv1 mount

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -405,10 +405,15 @@ func (t *Tracee) Init() error {
 
 	// Initialize containers enrichment logic
 
-	t.containers, err = containers.New(t.config.Sockets, "containers_map", t.config.Debug)
-	if err != nil {
-		return fmt.Errorf("error initializing containers: %w", err)
-	}
+	t.capabilities.Requested(func() error { // TODO: workaround until PR: #2233 is in place
+
+		t.containers, err = containers.New(t.config.Sockets, "containers_map", t.config.Debug)
+		if err != nil {
+			return fmt.Errorf("error initializing containers: %w", err)
+		}
+		return nil
+
+	}, cap.SYS_ADMIN)
 	if err := t.containers.Populate(); err != nil {
 		return fmt.Errorf("error initializing containers: %w", err)
 	}


### PR DESCRIPTION
## Description (git log)

This is a temporary mitigation, so cgroupv1 directory can be mounted during docker container initialization. The full code, mounting cgroupv1, cgroupv2 and unmounting them at the end of the execution is
being worked at PR: #2233.
