### PR TITLE
filters: flags: change mntns and pidns filter expressions

### DIFF
--- a/cmd/tracee-ebpf/flags/filter.go
+++ b/cmd/tracee-ebpf/flags/filter.go
@@ -209,6 +209,9 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 		}
 
 		if filterName == "mntns" {
+			if strings.ContainsAny(operatorAndValues, "<>") {
+				return tracee.Filter{}, filters.InvalidExpression(operatorAndValues)
+			}
 			err := filter.MntNSFilter.Parse(operatorAndValues)
 			if err != nil {
 				return tracee.Filter{}, err
@@ -217,6 +220,9 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 		}
 
 		if filterName == "pidns" {
+			if strings.ContainsAny(operatorAndValues, "<>") {
+				return tracee.Filter{}, filters.InvalidExpression(operatorAndValues)
+			}
 			err := filter.PidNSFilter.Parse(operatorAndValues)
 			if err != nil {
 				return tracee.Filter{}, err

--- a/docs/docs/tracing/event-filtering.md
+++ b/docs/docs/tracing/event-filtering.md
@@ -147,13 +147,13 @@ expected.
     1) --trace uts!=ab356bc4dd554 
     ```
 
-1. **PID Namespace** `(Operators: =, !=, <, >)`
+1. **PID Namespace** `(Operators: =, !=)`
 
     ```text
     1) --trace pidns!=4026531836
     ```
 
-1. **MOUNT Namespace** `(Operators: =, !=, <, >)`
+1. **MOUNT Namespace** `(Operators: =, !=)`
 
     ```text
     1) --trace mntns=4026531840


### PR DESCRIPTION
Only accept equality and inequality expressions for mntns and pidns. There's no real use cases for greater and less filtering.

Their removal is a step of performance improvement for multi-scope feature.

**P.S.: changes related to mntns and pidns minimum and maximum will happen through https://github.com/aquasecurity/tracee/pull/2238** 

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.

## Description (git log)

194f8af2 filters: flags: fail mntns and pidns greater/less

Fixes: #2301 

## Type of change

- [x] New feature (non-breaking change adding functionality).
- [x] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

```shell
❯ sudo ./dist/tracee-ebpf -t comm=uname -t 'mntns>10'
{"level":"fatal","ts":1666703509.1801474,"msg":"app","error":"invalid filter expression: >10"}

tracee on  2301-remove-greater-less [$!?] via 🐹 v1.19.2 via ⍱ v2.3.0 
❯ sudo ./dist/tracee-ebpf -t comm=uname -t 'mntns<10'
{"level":"fatal","ts":1666703516.6671994,"msg":"app","error":"invalid filter expression: <10"}

tracee on  2301-remove-greater-less [$!?] via 🐹 v1.19.2 via ⍱ v2.3.0 
❯ sudo ./dist/tracee-ebpf -t comm=uname -t 'pidns<10'
{"level":"fatal","ts":1666703521.4115121,"msg":"app","error":"invalid filter expression: <10"}

tracee on  2301-remove-greater-less [$!?] via 🐹 v1.19.2 via ⍱ v2.3.0 
❯ sudo ./dist/tracee-ebpf -t comm=uname -t 'pidns>10'
{"level":"fatal","ts":1666703524.479619,"msg":"app","error":"invalid filter expression: >10"}

tracee on  2301-remove-greater-less [$!?] via 🐹 v1.19.2 via ⍱ v2.3.0 
❯ sudo ./dist/tracee-ebpf -t comm=uname -t 'pidns=10'
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
^C
End of events stream
Stats: {EventCount:0 EventsFiltered:0 NetEvCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0}

tracee on  2301-remove-greater-less [$!?] via 🐹 v1.19.2 via ⍱ v2.3.0 took 2s 
❯ sudo ./dist/tracee-ebpf -t comm=uname -t 'mntns=10'
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
^C
End of events stream
Stats: {EventCount:0 EventsFiltered:0 NetEvCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0}
```

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
