### PR TITLE
pkg/events: use RWMutex in sorting queue

### DIFF
--- a/pkg/events/sorting/queue.go
+++ b/pkg/events/sorting/queue.go
@@ -19,7 +19,7 @@ type eventsQueue struct {
 	pool  eventsPool
 	tail  *eventNode
 	head  *eventNode
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 // Put insert new event to the double linked list
@@ -75,8 +75,8 @@ func (eq *eventsQueue) Get() (*trace.Event, error) {
 }
 
 func (eq *eventsQueue) PeekHead() *trace.Event {
-	eq.mutex.Lock()
-	defer eq.mutex.Unlock()
+	eq.mutex.RLock()
+	defer eq.mutex.RUnlock()
 	if eq.head == nil {
 		return nil
 	}
@@ -84,8 +84,8 @@ func (eq *eventsQueue) PeekHead() *trace.Event {
 }
 
 func (eq *eventsQueue) PeekTail() *trace.Event {
-	eq.mutex.Lock()
-	defer eq.mutex.Unlock()
+	eq.mutex.RLock()
+	defer eq.mutex.RUnlock()
 	if eq.tail == nil {
 		return nil
 	}


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

By using RWMutex in the queue, we can reduce the time waisted by threads blocked by a lock.
Was just inspired by @NDStrahilevitz, tell me what do you think.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
