### PR TITLE
Run integration test triggers in own PID

### DIFF
--- a/tests/integration/tester.sh
+++ b/tests/integration/tester.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+do_magic_write() {
+    tmpFileName=$1
+    echo "AAAAA" > $tmpFileName
+}
+
+do_ls() {
+    ls > /dev/null
+}
+
+do_docker_run() {
+    outputFileName=$1
+    output=$(docker run -d --rm alpine)
+    $(echo $output > $outputFileName)
+}
+
+# $1 is the function to call
+# $2 is the temp file to optionally output to
+$1 $2


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

This is a change to the integration tests so that the commands which are meant to trigger events that the tests look for, are actually picked up by tracee. In order for this to happen, the events can't be the same PID as tracee. This is accomplished using syscall.ForkExec() which runs functions in a shell script.

Signed-off-by: grantseltzer <grantseltzer@gmail.com>

Fixes #2073 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

`sudo make test-integration`