### PR TITLE
k8s: update tags to 0.9.3

### DIFF
--- a/deploy/helm/tracee/Chart.yaml
+++ b/deploy/helm/tracee/Chart.yaml
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.9.2"
+version: "0.9.3"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.2"
+appVersion: "0.9.3"
 
 dependencies:
   - name: postee

--- a/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
+++ b/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
@@ -17,7 +17,7 @@ spec:
       name: tracee
     spec:
       containers:
-      - image: docker.io/aquasec/tracee:0.9.2
+      - image: docker.io/aquasec/tracee:0.9.3
         imagePullPolicy: IfNotPresent
         args:
           - --webhook http://tracee-webhook:2801 --webhook-template ./templates/falcosidekick.tmpl --webhook-content-type application/json

--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: tracee
-        image: docker.io/aquasec/tracee:0.9.2
+        image: docker.io/aquasec/tracee:0.9.3
         imagePullPolicy: IfNotPresent
         args:
           - --webhook=http://postee-svc:8082

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: tracee
-        image: docker.io/aquasec/tracee:0.9.2
+        image: docker.io/aquasec/tracee:0.9.3
         imagePullPolicy: IfNotPresent
         env:
           - name: LIBBPFGO_OSRELEASE_FILE


### PR DESCRIPTION
Update kubernetes tags to reflect latest release: https://github.com/aquasecurity/tracee/releases/tag/v0.9.3