### PR TITLE
pkg/ebpf: fix multi use of string buf in seched_process_exec

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3467,7 +3467,6 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
 
     struct file *stdin_file = get_struct_file_from_fd(0);
     unsigned short stdin_type = get_inode_mode_from_file(stdin_file) & S_IFMT;
-    void *stdin_path = get_path_str(GET_FIELD_ADDR(stdin_file->f_path));
 
     // Note: Starting from kernel 5.9, there are two new interesting fields in bprm that we should
     // consider adding:
@@ -3486,6 +3485,8 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
         save_to_submit_buf(&data, &invoked_from_kernel, sizeof(int), 6);
         save_to_submit_buf(&data, &ctime, sizeof(u64), 7);
         save_to_submit_buf(&data, &stdin_type, sizeof(unsigned short), 8);
+
+        void *stdin_path = get_path_str(GET_FIELD_ADDR(stdin_file->f_path));
         save_str_to_buf(&data, stdin_path, 9);
         save_to_submit_buf(&data, &inode_mode, sizeof(umode_t), 10);
         save_str_to_buf(&data, (void *) interp, 11);


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

We use a single buffer from buffer map per CPU to store strings in eBPF programs between inner functions.
This expose us to bug like the current one - double use of the buffer overwrite previous string there before it has been used. Now get second string only after sending the first one to different buffer.

Fixes: #2344

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
