### PR TITLE
[FEAT] log ebpf errors

### DIFF
--- a/pkg/ebpf/bpf_error.go
+++ b/pkg/ebpf/bpf_error.go
@@ -1,0 +1,190 @@
+package ebpf
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+const BPFMaxErrFileLen = 72 // BPF_MAX_ERR_FILE_LEN
+
+type BPFErrorType uint32
+
+const (
+	BPFErrUnspec BPFErrorType = iota // BPF_ERR_UNSPEC
+
+	// tracee functions
+	BPFErrInitContext // BPF_ERR_INIT_CONTEXT
+
+	// bpf helpers functions
+	BPFErrMapUpdateElem  // BPF_ERR_MAP_UPDATE_ELEM
+	BPFErrMapDeleteElem  // BPF_ERR_MAP_DELETE_ELEM
+	BPFErrGetCurrentComm // BPF_ERR_GET_CURRENT_COMM
+	BPFErrTailCall       // BPF_ERR_TAIL_CALL
+)
+
+var stringMap = map[BPFErrorType]string{
+	BPFErrUnspec: "BPF_ERR_UNSPEC",
+
+	// tracee functions
+	BPFErrInitContext: "BPF_ERR_INIT_CONTEXT",
+
+	// bpf helpers functions
+	BPFErrMapUpdateElem:  "BPF_ERR_MAP_UPDATE_ELEM",
+	BPFErrMapDeleteElem:  "BPF_ERR_MAP_DELETE_ELEM",
+	BPFErrGetCurrentComm: "BPF_ERR_GET_CURRENT_COMM",
+	BPFErrTailCall:       "BPF_ERR_TAIL_CALL",
+}
+
+var errorMap = map[BPFErrorType]string{
+	BPFErrUnspec: "Unspecifed BPF error",
+
+	// tracee functions
+	BPFErrInitContext: "Failed to init context",
+
+	// bpf helpers functions
+	BPFErrMapUpdateElem:  "Failed to add or update a map element",
+	BPFErrMapDeleteElem:  "Failed to delete a map element",
+	BPFErrGetCurrentComm: "Failed to get current command",
+	BPFErrTailCall:       "Failed to tail call",
+}
+
+func (b BPFErrorType) String() string {
+	if bpfErr, found := stringMap[b]; found {
+		return bpfErr
+	}
+
+	return stringMap[BPFErrUnspec]
+}
+
+// BPFError struct contains aggregated data about a bpf error origin
+type BPFError struct {
+	id       BPFErrorType
+	logLevel logger.Level
+	count    uint32                 // percpu error occurrences
+	padding  uint32                 // empty space
+	ret      int64                  // return value
+	cpu      uint32                 // cpu number
+	line     uint32                 // line number
+	file     [BPFMaxErrFileLen]byte // filename
+}
+
+func (b BPFError) Error() string {
+	if bpfErr, found := errorMap[BPFErrorType(b.id)]; found {
+		return bpfErr
+	}
+
+	return errorMap[BPFErrUnspec]
+}
+
+func (b BPFError) ID() uint32 {
+	return uint32(b.id)
+}
+
+func (b BPFError) Type() BPFErrorType {
+	return BPFErrorType(b.id)
+}
+
+func (b BPFError) LogLevel() logger.Level {
+	return b.logLevel
+}
+
+func (b BPFError) Count() uint32 {
+	return b.count
+}
+
+func (b BPFError) Return() int64 {
+	return int64(b.ret)
+}
+
+func (b BPFError) CPU() uint32 {
+	return b.cpu
+}
+
+func (b BPFError) Line() uint32 {
+	return b.line
+}
+
+func (b BPFError) File() []byte {
+	return b.file[:]
+}
+
+func (b BPFError) FileAsString() string {
+	errFile := string(b.file[:])
+	errFileEnd := strings.Index(errFile, "\x00")
+
+	return errFile[:errFileEnd]
+}
+
+func (b BPFError) Size() int {
+	return int(unsafe.Sizeof(b.id)) +
+		int(unsafe.Sizeof(b.logLevel)) +
+		int(unsafe.Sizeof(b.count)) +
+		int(unsafe.Sizeof(b.padding)) +
+		int(unsafe.Sizeof(b.ret)) +
+		int(unsafe.Sizeof(b.id)) +
+		int(unsafe.Sizeof(b.cpu)) +
+		int(unsafe.Sizeof(b.line)) +
+		int(len(b.file))
+}
+
+func (b *BPFError) Decode(rawBuffer []byte) error {
+	if len(rawBuffer) < b.Size() {
+		return fmt.Errorf("can't decode error raw data - buffer of %d should have at least %d bytes", len(rawBuffer), b.Size())
+	}
+
+	b.id = BPFErrorType(binary.LittleEndian.Uint32(rawBuffer[0:4]))
+	b.logLevel = logger.Level(binary.LittleEndian.Uint32(rawBuffer[4:8])) // this is an int8 (zapcore.Level)
+	b.count = binary.LittleEndian.Uint32(rawBuffer[8:12])
+	b.padding = binary.LittleEndian.Uint32(rawBuffer[12:16])
+
+	// bpf_error
+	b.ret = int64(binary.LittleEndian.Uint64(rawBuffer[16:24]))
+	b.cpu = binary.LittleEndian.Uint32(rawBuffer[24:28])
+	b.line = binary.LittleEndian.Uint32(rawBuffer[28:32])
+	copy(b.file[:], rawBuffer[32:104])
+	// bpf_error
+
+	return nil
+}
+
+func (t *Tracee) processBPFErrors() {
+	for {
+		select {
+		case rawData := <-t.bpfErrorsChannel:
+			if len(rawData) == 0 {
+				continue
+			}
+
+			bpfErr := BPFError{}
+			if err := bpfErr.Decode(rawData); err != nil {
+				t.handleError(fmt.Errorf("consumeBPFErrorsChannel: decode - %v", err))
+				continue
+			}
+			// This logger timestamp in no way reflects the ebpf error original time
+			// since bpf errors channel is populated with aggregated logs
+			logger.BPFError(bpfErr.Error(), logger.Level(bpfErr.LogLevel()),
+				"id", bpfErr.ID(),
+				"type", bpfErr.Type().String(),
+				"ret", bpfErr.Return(),
+				"cpu", bpfErr.CPU(),
+				"file", bpfErr.FileAsString(),
+				"line", bpfErr.Line(),
+				"count", bpfErr.Count(),
+			)
+			t.stats.BPFErrorsCount.Increment(uint64(bpfErr.Count()))
+
+		case lost := <-t.lostBPFErrChannel:
+			// When terminating tracee-ebpf the lost channel receives multiple "0 lost events" events.
+			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
+			// https://github.com/aquasecurity/libbpfgo/issues/122
+			if lost > 0 {
+				t.stats.LostBPFErrCount.Increment(lost)
+				t.config.ChanErrors <- fmt.Errorf("lost %d ebpf error events", lost)
+			}
+		}
+	}
+}

--- a/pkg/ebpf/bpf_error.go
+++ b/pkg/ebpf/bpf_error.go
@@ -183,7 +183,7 @@ func (t *Tracee) processBPFErrors() {
 			// https://github.com/aquasecurity/libbpfgo/issues/122
 			if lost > 0 {
 				t.stats.LostBPFErrCount.Increment(lost)
-				t.config.ChanErrors <- fmt.Errorf("lost %d ebpf error events", lost)
+				logger.Warn(fmt.Sprintf("lost %d ebpf error events", lost))
 			}
 		}
 	}

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -1071,7 +1071,12 @@ static __always_inline void do_tracee_error(
     err_output->err.ret = ret;
     err_output->err.cpu = bpf_get_smp_processor_id();
     err_output->err.line = line;
-    READ_KERN_STR_INTO(err_output->err.file, file);
+
+    u64 fsize = __builtin_strlen(file);
+    if (unlikely(fsize >= BPF_MAX_ERR_FILE_LEN))
+        fsize = BPF_MAX_ERR_FILE_LEN - 1;
+    __builtin_memcpy(err_output->err.file, file, fsize);
+    err_output->err.file[fsize] = '\0';
 
     bpf_error_count_t counter_buf = {};
     counter_buf.count = 1;

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -188,6 +188,25 @@ func isAggregateSetAndIsLogNotNew(skip int, l *Logger) bool {
 
 // Log functions
 
+// BPFError logs errors from bpf programs
+// It does not use the aggregation logic as the bpf errors are already aggregated on the bpf side
+func BPFError(msg string, logLevel Level, keysAndValues ...interface{}) {
+	switch logLevel {
+	case DebugLevel:
+		pkgLogger.l.Debugw(msg, keysAndValues...)
+	case InfoLevel:
+		pkgLogger.l.Infow(msg, keysAndValues...)
+	case WarnLevel:
+		pkgLogger.l.Warnw(msg, keysAndValues...)
+	case ErrorLevel:
+		pkgLogger.l.Errorw(msg, keysAndValues...)
+	default:
+		bpfInfoKVs := append(make([]interface{}, 0), "bpfLevel", int(logLevel), "bpfMsg", msg)
+		keysAndValues = append(bpfInfoKVs, keysAndValues...)
+		pkgLogger.l.Errorw("unspecified bpf error log level", keysAndValues...)
+	}
+}
+
 // Debug
 func debugw(skip int, l *Logger, msg string, keysAndValues ...interface{}) {
 	if isAggregateSetAndIsLogNotNew(skip+1, l) {

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -7,13 +7,15 @@ import (
 
 // When updating this struct, please make sure to update the relevant exporting functions
 type Stats struct {
-	EventCount     counter.Counter
-	EventsFiltered counter.Counter
-	NetEvCount     counter.Counter
-	ErrorCount     counter.Counter
-	LostEvCount    counter.Counter
-	LostWrCount    counter.Counter
-	LostNtCount    counter.Counter
+	EventCount      counter.Counter
+	EventsFiltered  counter.Counter
+	NetEvCount      counter.Counter
+	BPFErrorsCount  counter.Counter
+	ErrorCount      counter.Counter
+	LostEvCount     counter.Counter
+	LostWrCount     counter.Counter
+	LostNtCount     counter.Counter
+	LostBPFErrCount counter.Counter
 }
 
 // Register Stats to prometheus metrics exporter
@@ -73,6 +75,16 @@ func (stats *Stats) RegisterPrometheus() error {
 		Name:      "network_lostevents_total",
 		Help:      "events lost in the network buffer",
 	}, func() float64 { return float64(stats.LostNtCount.Read()) }))
+
+	if err != nil {
+		return err
+	}
+
+	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
+		Namespace: "tracee_ebpf",
+		Name:      "bpf_errors_total",
+		Help:      "errors collected by tracee-ebpf during ebpf execution",
+	}, func() float64 { return float64(stats.BPFErrorsCount.Read()) }))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description (git log)

commit cfd8611d

    pkg/ebpf: make string copy work in focal 4.19

commit ea4cac9b

    logger: warn event loss
    
    Due ChanErrors removal #2403, warn about it.

commit ff4c077b

    logger: ebpf errors
    
    Introduce EBPF error control mechanism - submission via perf buffer.
    EBPF errors are aggregated before being submitted and are later
    processed and logged by the processBPFErrors() go routine.
    
    This starts the use of bpf error mechanism through some type checking
    like BPF_ERR_MAP_UPDATE_ELEM, BPF_ERR_GET_CURRENT_COMM and
    BPF_ERR_INIT_CONTEXT.


Fixes: #2174 

## Type of change

- [x] New feature (non-breaking change adding functionality).

## How Has This Been Tested?

Toggled a checking (falsed an error) in the ebpf side to be able to send the error and get it in user space.

```shell
❯ TRACEE_LOGGER_LVL=debug sudo -E ./dist/tracee-ebpf -t comm=who
[sudo] password for gg: 
{"level":"debug","ts":1670529435.1558275,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":46,"OSReleaseField":"ID","OS_KERNEL_RELEASE":"manjaro"}
{"level":"debug","ts":1670529435.1558466,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":46,"OSReleaseField":"ID_LIKE","OS_KERNEL_RELEASE":"arch"}
{"level":"debug","ts":1670529435.155852,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":46,"OSReleaseField":"BUILD_ID","OS_KERNEL_RELEASE":"rolling"}
{"level":"debug","ts":1670529435.1558602,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":46,"OSReleaseField":"KERNEL_RELEASE","OS_KERNEL_RELEASE":"5.15.81-1-MANJARO"}
{"level":"debug","ts":1670529435.1558657,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":46,"OSReleaseField":"ARCH","OS_KERNEL_RELEASE":"x86_64"}
{"level":"debug","ts":1670529435.1558702,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":46,"OSReleaseField":"PRETTY_NAME","OS_KERNEL_RELEASE":"\"Manjaro Linux\""}
{"level":"debug","ts":1670529435.1560128,"msg":"osinfo","pkg":"urfave","file":"urfave.go","line":117,"security_lockdown":"none"}
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS


{"level":"debug","ts":1670529436.1772962,"msg":"Failed to add or update a map element","id":2,"type":"BPF_ERR_MAP_UPDATE_ELEM","ret":0,"cpu":12,"file":"./pkg/ebpf/c/tracee.bpf.c","line":3514,"count":1}
{"level":"debug","ts":1670529436.1775048,"msg":"Failed to add or update a map element","id":2,"type":"BPF_ERR_MAP_UPDATE_ELEM","ret":0,"cpu":14,"file":"./pkg/ebpf/c/tracee.bpf.c","line":3514,"count":1}
...
{"level":"debug","ts":1670529440.1198132,"msg":"Failed to add or update a map element","id":2,"type":"BPF_ERR_MAP_UPDATE_ELEM","ret":0,"cpu":0,"file":"./pkg/ebpf/c/tracee.bpf.c","line":3514,"count":4}
^C
End of events stream
Stats: {EventCount:0 EventsFiltered:0 NetEvCount:0 BPFErrorsCount:15 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0 LostBPFErrCount:0}
```
