### PR TITLE
ebpf: fix error handling

### DIFF
--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -105,10 +105,15 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 	// Check kernel lockdown
 
 	lockdown, err := helpers.Lockdown()
+	if err != nil {
+		logger.Error("osinfo", "error", err)
+	}
+
 	if err == nil && lockdown == helpers.CONFIDENTIALITY {
 		return runner, fmt.Errorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs")
 
 	}
+
 	logger.Debug("osinfo", "security_lockdown", lockdown)
 
 	// Check if ftrace is enabled


### PR DESCRIPTION
```commit 691dd00ed10eed01146a2c4cc5ce3fe051a87f61 (HEAD -> fix-ignored-error, origin/fix-ignored-error)
Author: Jose Donizetti <jdbjunior@gmail.com>
Date:   Sat Nov 12 14:35:35 2022 -0300

    ebpf: fix error handling
    
    The error returned by kernel.Lockdown() was ignored.
```

ps: in case where we actually want to ignore the error, we should instead do `lockdown, _ := kernel.Lockdown()`