### PR TITLE
[DO NOT MERGE] ebpf: add webhook support

### DIFF
--- a/cmd/tracee-ebpf/flags/help.go
+++ b/cmd/tracee-ebpf/flags/help.go
@@ -15,6 +15,7 @@ func PrintAndExitIfHelp(ctx *cli.Context) {
 		"trace",
 		"output",
 		"capabilities",
+		"webhook",
 	}
 
 	for _, k := range keys {
@@ -47,6 +48,8 @@ func getHelpString(key string) string {
 		return outputHelp()
 	case "capabilities":
 		return capabilitiesHelp()
+	case "webhook":
+		return webhookHelp()
 	}
 	return ""
 }

--- a/cmd/tracee-ebpf/flags/webhook.go
+++ b/cmd/tracee-ebpf/flags/webhook.go
@@ -1,0 +1,64 @@
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aquasecurity/tracee/pkg/webhook"
+)
+
+func webhookHelp() string {
+	return `Send events to an webhook endpoint.
+possible options:
+url                             webhook endpoint url.
+timeout=1s                      request timeout, values too large might slow down the pipeline.
+format=json                     format payload as json.
+
+Examples:
+  --webhook url=http://test --webhook format=json                    | send webhook to http://test as json
+  --webhook url=http://test --webhook timeout=2s                     | send webhook to http://test with a timeout of 2s
+
+Use this flag multiple times to choose multiple output options
+`
+}
+
+func PrepareWebhook(webhookSlice []string) (webhook.Webhook, error) {
+	w := webhook.Webhook{
+		// defaults
+		Format:  "json",
+		Timeout: time.Second * 1,
+	}
+
+	for _, s := range webhookSlice {
+		optValue := strings.Split(s, "=")
+		switch optValue[0] {
+		case "url":
+			_, err := url.ParseRequestURI(optValue[1])
+			if err != nil {
+				return webhook.Webhook{}, fmt.Errorf("invalid webhook url %v", err.Error())
+			}
+
+			w.URL = optValue[1]
+		case "timeout":
+			timeout, err := time.ParseDuration(optValue[1])
+			if err != nil {
+				return webhook.Webhook{}, fmt.Errorf("invalid webhook timeout %v", err.Error())
+			}
+
+			w.Timeout = timeout
+		case "format":
+			if optValue[1] != "json" {
+				return webhook.Webhook{}, fmt.Errorf("invalid webhook format %q", optValue[1])
+			}
+
+			w.Format = optValue[1]
+		default:
+			return webhook.Webhook{}, errors.New("invalid webhook option specified, use '--webhook help' for more info")
+		}
+	}
+
+	return w, nil
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,56 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type Webhook struct {
+	URL     string
+	Format  string
+	Timeout time.Duration
+}
+
+func (w Webhook) Send(event trace.Event) error {
+	// ignore if empty
+	if w.URL == "" {
+		return nil
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	client := http.Client{Timeout: w.Timeout}
+
+	req, err := http.NewRequest(http.MethodPost, w.URL, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", w.getContentType())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		logger.Error(fmt.Sprintf("error sending webhook, http status: %d", resp.StatusCode))
+	}
+
+	_ = resp.Body.Close()
+
+	return nil
+}
+
+func (w Webhook) getContentType() string {
+	return "application/json"
+}


### PR DESCRIPTION
## Initial Checklist

This PR adds webhook support to `tracee-ebpf`, which is part of the task to have everything as an event, by merging `tracee-ebpf` and `tracee-rules`. The `--webhook` flag allows multiple values (currently limited) so we can extend it further later, also it is not a printer, because we should be able to print/send webhooks at the same time, plus webhook should evolve to much more complex than a printer later, eg:

- other formats (template? gob?)
- secret header value
- tls
- mutual tls (spiffe integration, etc)
- circuit break
- event filtering


## Description (git log)

```
commit 28ad426144834803a0093dcd67c0b57a34ca4d14 (HEAD -> add-webhook-tracee-ebpf, origin/add-webhook-tracee-ebpf)
Author: Jose Donizetti <jdbjunior@gmail.com>
Date:   Wed Nov 16 21:54:52 2022 -0300

    ebpf: add webhook support
```

Copy and paste the git log here.

Fixes: https://github.com/aquasecurity/tracee/issues/2362

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

```
sudo tracee-ebpf --webhook url=http://localhost:8080 --webhook timeout=5s --webhook format=json --trace event=execve
```

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
