### PR TITLE
Change tracee objects to support multiple modules

### DIFF
--- a/pkg/cmd/initialize/bpfobject.go
+++ b/pkg/cmd/initialize/bpfobject.go
@@ -135,8 +135,10 @@ func BpfObject(config *tracee.Config, kConfig *helpers.KernelConfig, OSInfo *hel
 
 out:
 	config.KernelConfig = kConfig
-	config.BPFObjPath = bpfFilePath
-	config.BPFObjBytes = bpfBytes
+	config.BPFObjConfigs[tracee.BPFModuleMain] = tracee.BPFObjConfig{
+		BPFObjPath:  bpfFilePath,
+		BPFObjBytes: bpfBytes,
+	}
 
 	return nil
 }

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -24,6 +24,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 		PerfBufferSize:     c.Int("perf-buffer-size"),
 		BlobPerfBufferSize: c.Int("blob-perf-buffer-size"),
 		ContainersEnrich:   c.Bool("containers"),
+		BPFObjConfigs:      make(map[tracee.TraceeBPFModuleID]tracee.BPFObjConfig),
 	}
 
 	if c.Bool("debug") {

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -21,12 +21,13 @@ import (
 
 // Containers contains information about running containers in the host.
 type Containers struct {
-	cgroups    *cgroup.Cgroups
-	cgroupsMap map[uint32]CgroupInfo
-	deleted    []uint64
-	mtx        sync.RWMutex // protecting both cgroups and deleted fields
-	enricher   runtimeInfoService
-	bpfMapName string
+	cgroups      *cgroup.Cgroups
+	cgroupsMap   map[uint32]CgroupInfo
+	deleted      []uint64
+	mtx          sync.RWMutex // protecting both cgroups and deleted fields
+	enricher     runtimeInfoService
+	bpfMapName   string
+	bpfMapModule *libbpfgo.Module
 }
 
 // CgroupInfo represents a cgroup dir (might describe a container cgroup dir).
@@ -394,7 +395,10 @@ const (
 )
 
 func (c *Containers) PopulateBpfMap(bpfModule *libbpfgo.Module) error {
-	containersMap, err := bpfModule.GetMap(c.bpfMapName)
+
+	c.bpfMapModule = bpfModule
+
+	containersMap, err := c.bpfMapModule.GetMap(c.bpfMapName)
 	if err != nil {
 		return err
 	}

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -1,6 +1,7 @@
 package ebpf
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -273,7 +274,11 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 			// If cgroupId is from a regular cgroup directory, and not the
 			// container base directory (from known runtimes), it should be
 			// removed from the containers bpf map.
-			t.containers.RemoveFromBpfMap(t.bpfModule, cgroupId, hId)
+			mainBPFModule, ok := t.bpfModules[BPFModuleMain]
+			if !ok {
+				return errors.New("error finding BPF module")
+			}
+			t.containers.RemoveFromBpfMap(mainBPFModule, cgroupId, hId)
 		}
 
 	case events.CgroupRmdir:

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -265,6 +265,7 @@ func Test_EventFilters(t *testing.T) {
 				Capabilities: &tracee.CapabilitiesConfig{
 					BypassCaps: true,
 				},
+				BPFObjConfigs: make(map[tracee.TraceeBPFModuleID]tracee.BPFObjConfig),
 			}
 			eventOutput := []trace.Event{}
 


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit 877d5bfca46906d89b1477f4e92a131b938042e8 (HEAD -> modular-bpf-objects, pfork/modular-bpf-objects)
Author: grantseltzer <grantseltzer@gmail.com>
Date:   Thu Nov 17 12:11:32 2022 -0500

    Change BPF object parsing logic to support multiple objects
    
    This changes the fields in Tracee's config and central
    data structure so that there are multiple possible BPF
    compiled BPF objects with their own paths and contents.
    
    This PR should not change any logic or behavior, but
    instead set tracee up for modular BPF objects where
    current 'main' BPF object is replaced by a series of
    modules such as for individual programs and maps.
    
    Signed-off-by: grantseltzer <grantseltzer@gmail.com>

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

- [ ] make test
- [ ] make test-integration
