### PR TITLE
pkg/events: add API to derive multiple events from single function

### DIFF
--- a/pkg/events/derive/derive.go
+++ b/pkg/events/derive/derive.go
@@ -45,29 +45,61 @@ type deriveBase struct {
 
 // deriveArgsFunction defines the logic of deriving an Event.
 // It checks the base event and produces arguments for the derived event.
-// If an event can't be derived, the returned arguments should be nil.
+// If an event can't be derived, the returned arguments should be `nil`.
 type deriveArgsFunction func(event trace.Event) ([]interface{}, error)
+
+// multiDeriveArgsFunction defines the logic of deriving multiple Events.
+// It checks the event and produce the arguments of multiple derived event.
+// If no event is derived, then the returned args should equal `nil`.
+// To enable error handling of more than one failed derived events,
+// all errors while events derivation should be appended to a list.
+type multiDeriveArgsFunction func(event trace.Event) ([][]interface{}, []error)
 
 // deriveSingleEvent create an deriveFunction which generates a single derive trace.Event.
 // The event will be created using the original event information, the ID given and resulting
 // arguments from the function.
 // The arguments will be inserted in order, so they should match the resulting definition argument order.
 // If the returned arguments are nil - no event will be derived.
+// This function is an envelope for the deriveMultipleEvents function, to make it easier to create single event
+// derivation function.
 func deriveSingleEvent(id events.ID, deriveArgs deriveArgsFunction) deriveFunction {
+	singleDerive := func(event trace.Event) ([][]interface{}, []error) {
+		var multiArgs [][]interface{}
+		var errs []error
+		args, err := deriveArgs(event)
+		if args != nil {
+			multiArgs = append(multiArgs, args)
+		}
+		if err != nil {
+			errs = append(errs, err)
+		}
+		return multiArgs, errs
+	}
+	return deriveMultipleEvents(id, singleDerive)
+}
+
+// deriveMultipleEvents create an deriveFunction to generate multiple derive trace.Events.
+// The events will be created using the original event information, the ID given and the arguments given.
+// The order of the arguments given will match the order in the event definition, so make sure the order match
+// the order of the params in the events.event struct of the event under events.Definitions.
+// If the arguments given is nil, then no event will be derived.
+func deriveMultipleEvents(id events.ID, multiDeriveArgsFunc multiDeriveArgsFunction) deriveFunction {
 	skeleton := makeDeriveBase(id)
 	return func(event trace.Event) ([]trace.Event, []error) {
-		args, err := deriveArgs(event)
-		if err != nil {
-			return nil, []error{err}
+		multiArgs, errs := multiDeriveArgsFunc(event)
+		if multiArgs == nil {
+			return []trace.Event{}, errs
 		}
-		if args == nil {
-			return []trace.Event{}, nil
+		var derivedEvents []trace.Event
+		for _, args := range multiArgs {
+			de, err := buildDerivedEvent(&event, skeleton, args)
+			if err != nil {
+				errs = append(errs, err)
+			} else {
+				derivedEvents = append(derivedEvents, de)
+			}
 		}
-		de, err := buildDerivedEvent(&event, skeleton, args)
-		if err != nil {
-			return []trace.Event{}, []error{err}
-		}
-		return []trace.Event{de}, nil
+		return derivedEvents, errs
 	}
 }
 


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Until now, we had a function to support derivation of a single event from a single base event.
However, sometimes a single base event can trigger multiple instances of a single derived event (aka, one derive function that should derive multiple events in a single call).
We add support for it, and unite the two APIs to use the same code.

Fixes: #2383 

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
