### PR TITLE
pkg/ebpf/tracee: fix capabilities for procfs reads

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -414,7 +414,7 @@ func (t *Tracee) Init() error {
 		return err
 	},
 		cap.DAC_READ_SEARCH,
-		cap.IPC_LOCK,
+		cap.SYS_PTRACE,
 	)
 
 	if err != nil {


### PR DESCRIPTION
Last merge had wrong permissions and there are still errors reading procfs when dropping capabilities. This commit fixes the issue.
