### PR TITLE
types: add EventName to SignatureMetadata

### DIFF
--- a/types/detect/detect.go
+++ b/types/detect/detect.go
@@ -24,6 +24,7 @@ type SignatureMetadata struct {
 	ID          string
 	Version     string
 	Name        string
+	EventName   string
 	Description string
 	Tags        []string
 	Properties  map[string]interface{}


### PR DESCRIPTION
Fix for https://github.com/aquasecurity/tracee/issues/2407


## Feature description

Add `EventName` to `detect.SignatureMetadata`. The new field will be used to definite the event name used when loading rules to the `events.Definitions` table.

More context for this issue can be found on the POC implementation: https://github.com/aquasecurity/tracee/pull/2374