### PR TITLE
tracee: add new binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all | env
-all: tracee-ebpf tracee-rules rules
+all: tracee-ebpf tracee-rules rules tracee
 
 #
 # make
@@ -229,7 +229,8 @@ help:
 	@echo "    $$ make tracee-rules         	# build ./dist/tracee-rules"
 	@echo "    $$ make tracee-bench         	# build ./dist/tracee-bench"
 	@echo "    $$ make rules                	# build ./dist/rules"
-	@echo "    $$ make e2e-net-rules                # build ./dist/e2e-net-rules"
+	@echo "    $$ make e2e-net-rules          # build ./dist/e2e-net-rules"
+	@echo "    $$ make tracee                	# build ./dist/tracee"
 	@echo ""
 	@echo "# install"
 	@echo ""
@@ -245,6 +246,7 @@ help:
 	@echo "    $$ make clean-tracee-rules   	# wipe ./dist/tracee-rules"
 	@echo "    $$ make clean-tracee-bench   	# wipe ./dist/tracee-bench"
 	@echo "    $$ make clean-rules          	# wipe ./dist/rules"
+	@echo "    $$ make clean-tracee          	# wipe ./dist/tracee"
 	@echo ""
 	@echo "# test"
 	@echo ""
@@ -631,6 +633,43 @@ $(OUTPUT_DIR)/e2e-net-rules: \
 clean-e2e-net-rules:
 #
 	$(CMD_RM) -rf $(OUTPUT_DIR)/e2e-net-rules
+
+#
+# tracee
+#
+
+TRACEE_SRC_DIRS = ./cmd/tracee/ ./pkg/
+TRACEE_SRC = $(shell find $(TRACEE_SRC_DIRS) -type f -name '*.go' ! -name '*_test.go')
+
+.PHONY: tracee
+tracee: $(OUTPUT_DIR)/tracee
+
+$(OUTPUT_DIR)/tracee: \
+	$(OUTPUT_DIR)/tracee.bpf.core.o \
+	$(TRACEE_SRC) \
+	./embedded-ebpf.go \
+	| .checkver_$(CMD_GO) \
+	.checklib_$(LIB_ELF) \
+	.checklib_$(LIB_ZLIB) \
+	btfhub \
+	rules
+#
+	$(MAKE) $(OUTPUT_DIR)/btfhub
+	$(MAKE) btfhub
+	$(GO_ENV_EBPF) $(CMD_GO) build \
+		-tags $(GO_TAGS_EBPF) \
+		-ldflags="$(GO_DEBUG_FLAG) \
+			-extldflags \"$(CGO_EXT_LDFLAGS_EBPF)\" \
+			-X main.version=\"$(VERSION)\" \
+			" \
+		-v -o $@ \
+		./cmd/tracee
+
+.PHONY: clean-tracee
+clean-tracee:
+#
+	$(CMD_RM) -rf $(OUTPUT_DIR)/tracee
+	$(CMD_RM) -rf .*.md5
 
 #
 # tests

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -42,8 +42,8 @@
 
 # FLAVOR(s):
 #
-# tracee-core      entrypoint: tracee-ebpf + tracee-rules
-# tracee-nocore    entrypoint: install-bpf-nocore + tracee-ebpf + tracee-rules
+# tracee-core      entrypoint: tracee-ebpf + tracee-rules + tracee
+# tracee-nocore    entrypoint: install-bpf-nocore + tracee-ebpf + tracee-rules + tracee
 
 ARG BTFHUB=0
 ARG FLAVOR=tracee-ebpf-core
@@ -103,6 +103,7 @@ RUN make clean && \
     BTFHUB=$BTFHUB make tracee-ebpf && \
     make tracee-rules && \
     make rules && \
+    make tracee && \
     rm -rf ./3rdparty/btfhub/ && \
     rm -rf ./3rdparty/btfhub-archive/
 
@@ -116,6 +117,7 @@ USER root
 ENV HOME /tracee
 WORKDIR /tracee
 
+COPY --from=tracee-make /tracee/dist/tracee /tracee
 COPY --from=tracee-make /tracee/dist/tracee-ebpf /tracee
 COPY --from=tracee-make /tracee/dist/tracee-rules /tracee
 COPY --from=tracee-make /tracee/dist/rules/ /tracee/rules/
@@ -135,6 +137,7 @@ ENV HOME /tracee
 WORKDIR /tracee
 
 COPY --from=tracee-make /tracee /tracee/src
+COPY --from=tracee-make /tracee/dist/tracee /tracee
 COPY --from=tracee-make /tracee/dist/tracee-ebpf /tracee
 COPY --from=tracee-make /tracee/dist/tracee-rules /tracee
 COPY --from=tracee-make /tracee/dist/rules/ /tracee/rules

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/aquasecurity/tracee/pkg/cmd"
+	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
+	"github.com/aquasecurity/tracee/pkg/cmd/urfave"
+	"github.com/aquasecurity/tracee/pkg/logger"
+
+	cli "github.com/urfave/cli/v2"
+)
+
+func init() {
+	// Avoiding to override package-level logger
+	// when it's already set by logger environment variables
+	if !logger.IsSetFromEnv() {
+		// Logger Setup
+		logger.Init(
+			&logger.LoggerConfig{
+				Writer:    os.Stderr,
+				Level:     logger.InfoLevel,
+				Encoder:   logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
+				Aggregate: false,
+			},
+		)
+	}
+}
+
+var version string
+
+func main() {
+	app := &cli.App{
+		Name:    "Tracee",
+		Usage:   "Trace OS events and syscalls using eBPF",
+		Version: version,
+		Action: func(c *cli.Context) error {
+
+			if c.NArg() > 0 {
+				return cli.ShowAppHelp(c) // no args, only flags supported
+			}
+
+			flags.PrintAndExitIfHelp(c)
+
+			if c.Bool("list") {
+				cmd.PrintEventList() // list events
+				return nil
+			}
+
+			runner, err := urfave.GetTraceeRunner(c, version)
+			if err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+
+			return runner.Run(ctx)
+
+		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "list",
+				Aliases: []string{"l"},
+				Value:   false,
+				Usage:   "just list tracable events",
+			},
+			&cli.StringSliceFlag{
+				Name:    "trace",
+				Aliases: []string{"t"},
+				Value:   nil,
+				Usage:   "select events to trace by defining trace expressions. run '--trace help' for more info.",
+			},
+			&cli.StringSliceFlag{
+				Name:    "capture",
+				Aliases: []string{"c"},
+				Value:   nil,
+				Usage:   "capture artifacts that were written, executed or found to be suspicious. run '--capture help' for more info.",
+			},
+			&cli.StringSliceFlag{
+				Name:    "capabilities",
+				Aliases: []string{"caps"},
+				Value:   nil,
+				Usage:   "define capabilities for tracee to run with. run '--capabilities help' for more info.",
+			},
+			&cli.StringSliceFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Value:   cli.NewStringSlice("format:table"),
+				Usage:   "Control how and where output is printed. run '--output help' for more info.",
+			},
+			&cli.StringSliceFlag{
+				Name:    "cache",
+				Aliases: []string{"a"},
+				Value:   cli.NewStringSlice("none"),
+				Usage:   "Control event caching queues. run '--cache help' for more info.",
+			},
+			&cli.StringSliceFlag{
+				Name:  "crs",
+				Usage: "Define connected container runtimes. run '--crs help' for more info.",
+				Value: cli.NewStringSlice(),
+			},
+			&cli.IntFlag{
+				Name:    "perf-buffer-size",
+				Aliases: []string{"b"},
+				Value:   1024, // 4 MB of contigous pages
+				Usage:   "size, in pages, of the internal perf ring buffer used to submit events from the kernel",
+			},
+			&cli.IntFlag{
+				Name:  "blob-perf-buffer-size",
+				Value: 1024, // 4 MB of contigous pages
+				Usage: "size, in pages, of the internal perf ring buffer used to send blobs from the kernel",
+			},
+			&cli.BoolFlag{
+				Name:  "debug",
+				Value: false,
+				Usage: "write verbose debug messages to standard output and retain intermediate artifacts. enabling will output debug messages to stdout, which will likely break consumers which expect to receive machine-readable events from stdout",
+			},
+			&cli.StringFlag{
+				Name:  "install-path",
+				Value: "/tmp/tracee",
+				Usage: "path where tracee will install or lookup it's resources",
+			},
+			&cli.BoolFlag{
+				Name:  server.MetricsEndpointFlag,
+				Usage: "enable metrics endpoint",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  server.HealthzEndpointFlag,
+				Usage: "enable healthz endpoint",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  server.PProfEndpointFlag,
+				Usage: "enables pprof endpoints",
+				Value: false,
+			},
+			&cli.StringFlag{
+				Name:  server.ListenEndpointFlag,
+				Usage: "listening address of the metrics endpoint server",
+				Value: ":3366",
+			},
+			&cli.BoolFlag{
+				Name:  "containers",
+				Usage: "enable container info enrichment to events. this feature is experimental and may cause unexpected behavior in the pipeline",
+			},
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		logger.Fatal("app", "error", err)
+	}
+}


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/2388

```
commit 10590adbd28b81b004a4c022a035334e9a16f8e2 (HEAD -> add-tracee-binary, origin/add-tracee-binary)
Author: Jose Donizetti <jdbjunior@gmail.com>
Date:   Wed Nov 30 16:36:50 2022 -0300

    tracee: add new binary
    
    Adds new binary tracee, which will join the experience of tracee-ebpf,
    and tracee-rules, where everything will be treated as an event.
```

The PR adds the binary as a copy of the existing `tracee-ebpf`. The duplication of flags here is intentional, the new binary will later diverge from the existing binaries on the flags it will expose, with new names and also features. So I prefer not to extract the flags to a common place for now. 

The PR also adds the new binary to the Docker image. 

For extra context, please check: https://github.com/aquasecurity/tracee/pull/2374