### PR TITLE
pkg/utils/proc: log errors as debug only

### DIFF
--- a/pkg/utils/proc/ns.go
+++ b/pkg/utils/proc/ns.go
@@ -37,13 +37,13 @@ func GetMountNSFirstProcesses() (map[int]int, error) {
 		}
 		procNS, err := GetProcNS(uint(pid))
 		if err != nil {
-			logger.Warn("Failed in fetching process mount namespace", "pid", pid, "error", err.Error())
+			logger.Debug("Failed in fetching process mount namespace", "pid", pid, "error", err.Error())
 			continue
 		}
 
 		processStartTime, err := GetProcessStartTime(uint(pid))
 		if err != nil {
-			logger.Warn("Failed in fetching process start time", "pid", pid, "error", err.Error())
+			logger.Debug("Failed in fetching process start time", "pid", pid, "error", err.Error())
 			continue
 		}
 


### PR DESCRIPTION
## Description (git log)

- Change Info to Debug to avoid errors such as:

{"level":"warn","ts":1669930709.794133,"msg":"Failed in fetching process
    mount namespace","pid":3861386,"error":"could not open ns dir: open
    /proc/3861386/ns: no such file or directory"}
{"level":"warn","ts":1669930709.7942631,"msg":"Failed in fetching
    process mount namespace","pid":3861387,"error":"could not open ns
    dir: open /proc/3861387/ns: no such file or directory"}
{"level":"warn","ts":1669930709.7942793,"msg":"Failed in fetching
    process mount namespace","pid":3861390,"error":"could not open ns
    dir: open /proc/3861390/ns: no such file or directory"}

If processes have vanished while tracee is trying to read their namespaces during initialization.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).
