### PR TITLE
Add rules to the pipeline

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -45,7 +45,7 @@ func main() {
 			flags.PrintAndExitIfHelp(c)
 
 			if c.Bool("list") {
-				cmd.PrintEventList() // list events
+				cmd.PrintEventList(false) // list events
 				return nil
 			}
 

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -58,6 +58,12 @@ func main() {
 			// event names are parsed here because we need to know which signatures to load
 			eventNames := getEventNames(c)
 
+			// if list is enabled we set eventNames to nil, so every rule is loaded,
+			// and displayed on the list
+			if c.Bool("list") {
+				eventNames = nil
+			}
+
 			sigs, err := signature.Find(
 				rego.RuntimeTarget,
 				rego.PartialEval,
@@ -65,7 +71,6 @@ func main() {
 				eventNames,
 				rego.AIO,
 			)
-
 			if err != nil {
 				return err
 			}
@@ -73,7 +78,7 @@ func main() {
 			createEventsFromSignatures(events.StartRulesID, sigs)
 
 			if c.Bool("list") {
-				cmd.PrintEventList() // list events
+				cmd.PrintEventList(true) // list events
 				return nil
 			}
 
@@ -94,7 +99,6 @@ func main() {
 			ctx := context.Background()
 
 			return runner.Run(ctx)
-
 		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
@@ -240,7 +244,7 @@ func createEventsFromSignatures(startId events.ID, sigs []detect.Signature) {
 
 		event := events.NewEventDefinition(m.EventName, []string{"rules"}, dependencies)
 
-		err = events.Definitions.Add(events.ID(id), event)
+		err = events.Definitions.Add(id, event)
 		if err != nil {
 			logger.Error("failed to add event definition", "error", err)
 			continue
@@ -248,7 +252,6 @@ func createEventsFromSignatures(startId events.ID, sigs []detect.Signature) {
 
 		id++
 	}
-
 }
 
 func getEventNames(c *cli.Context) []string {

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -91,9 +91,11 @@ func main() {
 			runner.TraceeConfig.Output.ParseArguments = true
 
 			runner.TraceeConfig.EngineConfig = engine.Config{
-				Enabled:             true,
-				Signatures:          sigs,
-				SignatureBufferSize: c.Uint("sig-buffer"),
+				Enabled:    true,
+				Signatures: sigs,
+				// This used to be a flag, we have removed the flag from this binary to test
+				// if users do use it or not.
+				SignatureBufferSize: 1000,
 			}
 
 			ctx := context.Background()
@@ -199,11 +201,6 @@ func main() {
 				Name:  "rego",
 				Usage: "Control event rego settings. run '--rego help' for more info.",
 				Value: cli.NewStringSlice(),
-			},
-			&cli.UintFlag{
-				Name:  "sig-buffer", // TODO: rename to rules-buffer?
-				Usage: "size of the event channel's buffer consumed by signatures",
-				Value: 1000,
 			},
 		},
 	}

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -231,7 +231,7 @@ func createEventsFromSignatures(startId events.ID, sigs []detect.Signature) {
 		for _, s := range selectedEvents {
 			eventID, found := events.Definitions.GetID(s.Name)
 			if !found {
-				logger.Error("failed to load event depedency", "event", s.Name)
+				logger.Error("failed to load event dependency", "event", s.Name)
 				continue
 			}
 

--- a/cmd/tracee/main_test.go
+++ b/cmd/tracee/main_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_createEventsFromSigs(t *testing.T) {
+	tests := []struct {
+		startId        events.ID
+		signatures     []detect.Signature
+		expectedEvents []events.Event
+	}{
+		{
+			startId: events.ID(6001),
+			signatures: []detect.Signature{
+				newFakeSignature("fake_event_0", []string{"hooked_syscalls"}),
+			},
+			expectedEvents: []events.Event{
+				events.NewEventDefinition("fake_event_0", []string{"rules"}, []events.ID{events.HookedSyscalls}),
+			},
+		},
+		{
+			startId: events.ID(6010),
+			signatures: []detect.Signature{
+				newFakeSignature("fake_event_1", []string{"ptrace"}),
+				newFakeSignature("fake_event_2", []string{"security_file_open", "security_inode_rename"}),
+			},
+			expectedEvents: []events.Event{
+				events.NewEventDefinition("fake_event_1", []string{"rules"}, []events.ID{events.Ptrace}),
+				events.NewEventDefinition("fake_event_2", []string{"rules"}, []events.ID{events.SecurityFileOpen, events.SecurityInodeRename}),
+			},
+		},
+		{
+			startId: events.ID(6100),
+			signatures: []detect.Signature{
+				newFakeSignature("fake_event_3", []string{"sched_process_exec", "security_socket_connect"}),
+			},
+			expectedEvents: []events.Event{
+				events.NewEventDefinition("fake_event_3", []string{"rules"}, []events.ID{events.SchedProcessExec, events.SecuritySocketConnect}),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		createEventsFromSignatures(test.startId, test.signatures)
+
+		for _, expected := range test.expectedEvents {
+			eventID, ok := events.Definitions.GetID(expected.Name)
+			assert.True(t, ok)
+			event := events.Definitions.Get(eventID)
+			assert.Equal(t, expected, event)
+		}
+	}
+}
+
+func newFakeSignature(name string, deps []string) detect.Signature {
+	return fakeSignature{
+		getMetadata: func() (detect.SignatureMetadata, error) {
+			return detect.SignatureMetadata{
+				EventName: name,
+			}, nil
+
+		},
+		getSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
+			selectedEvents := make([]detect.SignatureEventSelector, 0, len(deps))
+
+			for _, d := range deps {
+				eventSelector := detect.SignatureEventSelector{Name: d}
+				selectedEvents = append(selectedEvents, eventSelector)
+			}
+
+			return selectedEvents, nil
+		},
+	}
+}
+
+type fakeSignature struct {
+	getMetadata       func() (detect.SignatureMetadata, error)
+	getSelectedEvents func() ([]detect.SignatureEventSelector, error)
+}
+
+func (fs fakeSignature) GetMetadata() (detect.SignatureMetadata, error) {
+	return fs.getMetadata()
+}
+
+func (fs fakeSignature) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
+	return fs.getSelectedEvents()
+}
+
+func (fs fakeSignature) Init(cb detect.SignatureHandler) error {
+	return nil
+}
+
+func (fs fakeSignature) OnEvent(event protocol.Event) error {
+	return nil
+}
+
+func (fs fakeSignature) OnSignal(signal detect.Signal) error {
+	return nil
+}
+func (fs fakeSignature) Close() {}

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -11,6 +11,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/rules/rego"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -595,3 +595,58 @@ func TestPrepareCache(t *testing.T) {
 		})
 	}
 }
+
+func TestPrepareRego(t *testing.T) {
+	t.Run("various rego options", func(t *testing.T) {
+		testCases := []struct {
+			testName      string
+			regoSlice     []string
+			expectedRego  rego.Config
+			expectedError error
+		}{
+			{
+				testName:      "invalid rego option",
+				regoSlice:     []string{"foo"},
+				expectedError: errors.New("invalid rego option specified, use '--rego help' for more info"),
+			},
+			{
+				testName:  "default options",
+				regoSlice: []string{},
+				expectedRego: rego.Config{
+					RuntimeTarget: "rego",
+					PartialEval:   false,
+					AIO:           false,
+				},
+			},
+			{
+				testName:  "configure partial-eval",
+				regoSlice: []string{"partial-eval"},
+				expectedRego: rego.Config{
+					RuntimeTarget: "rego",
+					PartialEval:   true,
+				},
+			},
+			{
+				testName:  "configure aio",
+				regoSlice: []string{"aio"},
+				expectedRego: rego.Config{
+					RuntimeTarget: "rego",
+					AIO:           true,
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.testName, func(t *testing.T) {
+				rego, err := flags.PrepareRego(tc.regoSlice)
+				if tc.expectedError == nil {
+					require.NoError(t, err)
+					assert.Equal(t, tc.expectedRego, rego, tc.testName)
+				} else {
+					require.Equal(t, tc.expectedError, err, tc.testName)
+					assert.Empty(t, rego, tc.testName)
+				}
+			})
+		}
+	})
+}

--- a/pkg/cmd/flags/help.go
+++ b/pkg/cmd/flags/help.go
@@ -15,6 +15,7 @@ func PrintAndExitIfHelp(ctx *cli.Context) {
 		"trace",
 		"output",
 		"capabilities",
+		"rego",
 	}
 
 	for _, k := range keys {
@@ -47,6 +48,8 @@ func getHelpString(key string) string {
 		return outputHelp()
 	case "capabilities":
 		return capabilitiesHelp()
+	case "rego":
+		return regoHelp()
 	}
 	return ""
 }

--- a/pkg/cmd/flags/rego.go
+++ b/pkg/cmd/flags/rego.go
@@ -1,0 +1,47 @@
+package flags
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/rules/rego"
+	"github.com/open-policy-agent/opa/compile"
+)
+
+func regoHelp() string {
+	return `Rego configurations.
+possible options:
+partial-eval            enable partial evaluation of rego rules.
+aio                     compile rego signatures altogether as an aggregate policy. By default each signature is compiled separately.
+Examples:
+  --rego partial-eval                               | enable partial evaluation
+  --rego partial-eval --rego aio                    | enable partial evaluation, and aggregate policy compilation.
+Use this flag multiple times to choose multiple output options
+`
+}
+
+func PrepareRego(regoSlice []string) (rego.Config, error) {
+	c := rego.Config{
+		RuntimeTarget: compile.TargetRego,
+		PartialEval:   false,
+		AIO:           false,
+	}
+
+	if len(regoSlice) == 0 {
+		return c, nil
+	}
+
+	for _, s := range regoSlice {
+		optValue := strings.TrimSpace(s)
+		switch optValue {
+		case "partial-eval":
+			c.PartialEval = true
+		case "aio":
+			c.AIO = true
+		default:
+			return rego.Config{}, errors.New("invalid rego option specified, use '--rego help' for more info")
+		}
+	}
+
+	return c, nil
+}

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -97,12 +97,20 @@ func (r Runner) Run(ctx context.Context) error {
 	return t.Run(ctx) // return when context is cancelled by signal
 }
 
-func PrintEventList() {
+func PrintEventList(printRulesSet bool) {
 	padChar, firstPadLen, secondPadLen := " ", 9, 36
 	titleHeaderPadFirst := getPad(padChar, firstPadLen)
 	titleHeaderPadSecond := getPad(padChar, secondPadLen)
 
 	var b strings.Builder
+
+	if printRulesSet {
+		b.WriteString("Rules: " + titleHeaderPadFirst + "Sets:" + titleHeaderPadSecond + "Arguments:\n")
+		b.WriteString("____________  " + titleHeaderPadFirst + "____ " + titleHeaderPadSecond + "_________" + "\n\n")
+		printEventGroup(&b, events.StartRulesID, events.MaxRulesID)
+		b.WriteString("\n")
+	}
+
 	b.WriteString("System Calls: " + titleHeaderPadFirst + "Sets:" + titleHeaderPadSecond + "Arguments:\n")
 	b.WriteString("____________  " + titleHeaderPadFirst + "____ " + titleHeaderPadSecond + "_________" + "\n\n")
 	printEventGroup(&b, 0, events.MaxSyscallID)

--- a/pkg/ebpf/events_engine.go
+++ b/pkg/ebpf/events_engine.go
@@ -1,0 +1,81 @@
+package ebpf
+
+import (
+	"context"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/rules/engine"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+// engineEvents stage in the pipeline allows rules detection to be executed in the pipeline
+func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-chan *trace.Event, <-chan error) {
+	out := make(chan *trace.Event)
+	errc := make(chan error, 1)
+	done := make(chan bool)
+	engineInput := make(chan protocol.Event)
+
+	engineOutput := engine.StartPipeline(t.config.EngineConfig, engineInput, done)
+
+	// TODO: in the upcoming releases, the rule engine should be changed to receive trace.Event,
+	// and return a trace.Event, which should remove the necessity of converting trace.Event to protocol.Event,
+	// and coverting detect.Finding into trace.Event
+
+	go func() {
+		defer close(out)
+		defer close(errc)
+		defer close(engineInput)
+
+		for {
+			select {
+			case event := <-in:
+				id := events.ID(event.EventID)
+
+				// if the even is marked as submit, we pass it to the engine
+				if t.events[id].submit {
+					err := t.parseArguments(event)
+					if err != nil {
+						t.handleError(err)
+						continue
+					}
+
+					// pass the event to the sink stage, if the event is also marked as emit
+					// it will be sent to print by the sink stage
+					out <- event
+
+					// send the event to the rule event
+					engineInput <- event.ToProtocol()
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case finding := <-engineOutput:
+				event, err := FindingToEvent(finding)
+				if err != nil {
+					t.handleError(err)
+					continue
+				}
+
+				out <- event
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer close(done)
+
+		<-ctx.Done()
+		done <- true
+	}()
+
+	return out, errc
+}

--- a/pkg/ebpf/events_engine.go
+++ b/pkg/ebpf/events_engine.go
@@ -20,7 +20,7 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 
 	// TODO: in the upcoming releases, the rule engine should be changed to receive trace.Event,
 	// and return a trace.Event, which should remove the necessity of converting trace.Event to protocol.Event,
-	// and coverting detect.Finding into trace.Event
+	// and converting detect.Finding into trace.Event
 
 	go func() {
 		defer close(out)

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -58,6 +58,13 @@ func (t *Tracee) handleEvents(ctx context.Context) {
 	eventsChan, errc = t.deriveEvents(ctx, eventsChan)
 	errcList = append(errcList, errc)
 
+	// Engine events stage
+	// In this stage events go through a signatures match
+	if t.config.EngineConfig.Enabled {
+		eventsChan, errc = t.engineEvents(ctx, eventsChan)
+		errcList = append(errcList, errc)
+	}
+
 	// Sink pipeline stage.
 	errc = t.sinkEvents(ctx, eventsChan)
 	errcList = append(errcList, errc)
@@ -323,30 +330,27 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 	go func() {
 		defer close(errc)
 		for event := range in {
-			// Only emit events requested by the user
+			//Only emit events requested by the user
 			id := events.ID(event.EventID)
-			if t.events[id].emit {
-				if t.config.Output.ParseArguments {
-					err := events.ParseArgs(event)
-					if err != nil {
-						t.handleError(err)
-						continue
-					}
-					if t.config.Output.ParseArgumentsFDs {
-						err := events.ParseArgsFDs(event, t.FDArgPathMap)
-						if err != nil {
-							t.handleError(err)
-							continue
-						}
-					}
+			if !t.events[id].emit {
+				continue
+			}
+
+			// if the rule engine is not enabled, we parse arguments here before sending
+			// the output to the printers
+			if !t.config.EngineConfig.Enabled {
+				err := t.parseArguments(event)
+				if err != nil {
+					t.handleError(err)
 				}
-				select {
-				case t.config.ChanEvents <- *event:
-					t.stats.EventCount.Increment()
-					event = nil
-				case <-ctx.Done():
-					return
-				}
+			}
+
+			select {
+			case t.config.ChanEvents <- *event:
+				t.stats.EventCount.Increment()
+				event = nil
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
@@ -427,4 +431,22 @@ func MergeErrors(cs ...<-chan error) <-chan error {
 func (t *Tracee) handleError(err error) {
 	t.stats.ErrorCount.Increment()
 	logger.Error("tracee encountered an error", "error", err)
+}
+
+// parseArguments is required by the rules engine,
+// if the rule engine staged is enabled, parseArguments will happen there,
+// before sending an event to be processed, if the rule engine is disabled,
+// parseArgumnets happens on the sink stage (because anyone pipeing the output to tracee-rules will need it)
+func (t *Tracee) parseArguments(e *trace.Event) error {
+	if t.config.Output.ParseArguments {
+		err := events.ParseArgs(e)
+		if err != nil {
+			return err
+		}
+		if t.config.Output.ParseArgumentsFDs {
+			return events.ParseArgsFDs(e, t.FDArgPathMap)
+		}
+	}
+
+	return nil
 }

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -330,7 +330,7 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 	go func() {
 		defer close(errc)
 		for event := range in {
-			//Only emit events requested by the user
+			// Only emit events requested by the user
 			id := events.ID(event.EventID)
 			if !t.events[id].emit {
 				continue
@@ -433,10 +433,9 @@ func (t *Tracee) handleError(err error) {
 	logger.Error("tracee encountered an error", "error", err)
 }
 
-// parseArguments is required by the rules engine,
-// if the rule engine staged is enabled, parseArguments will happen there,
-// before sending an event to be processed, if the rule engine is disabled,
-// parseArgumnets happens on the sink stage (because anyone pipeing the output to tracee-rules will need it)
+// parseArguments must happen before rules are evaluated.
+// For the new experience (cmd/tracee), it needs to happen in the the events_engine stage of the pipeline.
+// For the old experience (cmd/tracee-ebpf && cmd/tracee-rules), it happens on the sink stage of the pipeline.
 func (t *Tracee) parseArguments(e *trace.Event) error {
 	if t.config.Output.ParseArguments {
 		err := events.ParseArgs(e)

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
-// FindingToEvent converts a detect.Fcingin into a trace.Event
+// FindingToEvent converts a detect.Finding into a trace.Event
 // This is used because the pipeline expects trace.Event, but the rule engine returns detect.Finding
 func FindingToEvent(f detect.Finding) (*trace.Event, error) {
 	s, ok := f.Event.Payload.(trace.Event)

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -56,5 +56,4 @@ func newEvent(id int, name string, s trace.Event) *trace.Event {
 		ContextFlags:        s.ContextFlags,
 		Args:                s.Args,
 	}
-
 }

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -1,0 +1,60 @@
+package ebpf
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+// FindingToEvent converts a detect.Fcingin into a trace.Event
+// This is used because the pipeline expects trace.Event, but the rule engine returns detect.Finding
+func FindingToEvent(f detect.Finding) (*trace.Event, error) {
+	s, ok := f.Event.Payload.(trace.Event)
+
+	if !ok {
+		return nil, fmt.Errorf("error converting finding to event: %s", f.SigMetadata.ID)
+	}
+
+	eventID, found := events.Definitions.GetID(f.SigMetadata.EventName)
+	if !found {
+		return nil, fmt.Errorf("error finding event not found: %s", f.SigMetadata.EventName)
+	}
+
+	return newEvent(int(eventID), f.SigMetadata.EventName, s), nil
+}
+
+func newEvent(id int, name string, s trace.Event) *trace.Event {
+	return &trace.Event{
+		EventID:             id,
+		EventName:           name,
+		Timestamp:           s.Timestamp,
+		ThreadStartTime:     s.ThreadStartTime,
+		ProcessorID:         s.ProcessorID,
+		ProcessID:           s.ProcessID,
+		CgroupID:            s.CgroupID,
+		ThreadID:            s.ThreadID,
+		ParentProcessID:     s.ParentProcessID,
+		HostProcessID:       s.HostProcessID,
+		HostThreadID:        s.HostThreadID,
+		HostParentProcessID: s.HostParentProcessID,
+		UserID:              s.UserID,
+		MountNS:             s.MountNS,
+		PIDNS:               s.PIDNS,
+		ProcessName:         s.ProcessName,
+		HostName:            s.HostName,
+		ContainerID:         s.ContainerID,
+		ContainerImage:      s.ContainerImage,
+		ContainerName:       s.ContainerName,
+		PodName:             s.PodName,
+		PodNamespace:        s.PodNamespace,
+		PodUID:              s.PodUID,
+		ArgsNum:             s.ArgsNum,
+		ReturnValue:         s.ReturnValue,
+		StackAddresses:      s.StackAddresses,
+		ContextFlags:        s.ContextFlags,
+		Args:                s.Args,
+	}
+
+}

--- a/pkg/ebpf/rule_engine.go
+++ b/pkg/ebpf/rule_engine.go
@@ -32,7 +32,7 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 			case event := <-in:
 				id := events.ID(event.EventID)
 
-				// if the even is marked as submit, we pass it to the engine
+				// if the event is marked as submit, we pass it to the engine
 				if t.events[id].submit {
 					err := t.parseArguments(event)
 					if err != nil {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -37,6 +37,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/metrics"
 	"github.com/aquasecurity/tracee/pkg/procinfo"
+	"github.com/aquasecurity/tracee/pkg/rules/engine"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/pkg/utils/proc"
 	"github.com/aquasecurity/tracee/pkg/utils/sharedobjs"
@@ -70,6 +71,7 @@ type Config struct {
 	OSInfo             *helpers.OSInfo
 	Sockets            runtime.Sockets
 	ContainersEnrich   bool
+	EngineConfig       engine.Config
 }
 
 type CaptureConfig struct {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -103,7 +103,7 @@ type eventDefinitions struct {
 	events map[ID]Event
 }
 
-// Add add event to defitions
+// Add add event to definitions
 func (e *eventDefinitions) Add(eventId ID, evt Event) error {
 	if _, ok := e.events[eventId]; ok {
 		return fmt.Errorf("error event id already exist: %v", eventId)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -103,7 +103,7 @@ type eventDefinitions struct {
 	events map[ID]Event
 }
 
-// Add add event to definitions
+// Add adds an event to definitions
 func (e *eventDefinitions) Add(eventId ID, evt Event) error {
 	if _, ok := e.events[eventId]; ok {
 		return fmt.Errorf("error event id already exist: %v", eventId)
@@ -118,7 +118,7 @@ func (e *eventDefinitions) Add(eventId ID, evt Event) error {
 	return nil
 }
 
-// Get without checking for Event existance
+// Get gets the event without checking for Event existance
 func (e *eventDefinitions) Get(eventId ID) Event {
 	evt := e.events[eventId]
 	return evt

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,95 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEventDefinition(t *testing.T) {
+	expected := Event{
+		Name: "hooked_seq_ops2",
+		Dependencies: dependencies{
+			Events: []eventDependency{
+				{EventID: PrintNetSeqOps},
+				{EventID: DoInitModule},
+			},
+		},
+		Sets: []string{"rules"},
+	}
+
+	e := NewEventDefinition("hooked_seq_ops2", []string{"rules"}, []ID{PrintNetSeqOps, DoInitModule})
+
+	assert.Equal(t, expected.Name, e.Name)
+	assert.Equal(t, expected.Dependencies, e.Dependencies)
+}
+
+func TestAdd(t *testing.T) {
+	tests := []struct {
+		name string
+		evt  Event
+		err  string
+	}{
+		{
+			name: "new event",
+			evt: Event{
+				ID32Bit: ID(6000),
+				Name:    "new_event",
+				Dependencies: dependencies{
+					Events: []eventDependency{
+						{EventID: PrintNetSeqOps},
+						{EventID: DoInitModule},
+					},
+				},
+				Sets: []string{"rules"},
+			},
+		},
+		{
+			name: "event id already exist",
+			evt: Event{
+				ID32Bit: ID(700),
+				Name:    "new_event",
+				Dependencies: dependencies{
+					Events: []eventDependency{
+						{EventID: PrintNetSeqOps},
+						{EventID: DoInitModule},
+					},
+				},
+				Sets: []string{"rules"},
+			},
+			err: "error event id already exist: 700",
+		},
+		{
+			name: "event name already exist",
+			evt: Event{
+				ID32Bit: ID(6001),
+				Name:    "net_packet",
+				Dependencies: dependencies{
+					Events: []eventDependency{
+						{EventID: PrintNetSeqOps},
+						{EventID: DoInitModule},
+					},
+				},
+				Sets: []string{"rules"},
+			},
+			err: "error event name already exist: net_packet",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := Definitions.Add(test.evt.ID32Bit, test.evt)
+			if err != nil {
+				assert.Equal(t, test.err, err.Error())
+				return
+			}
+
+			id, ok := Definitions.GetID(test.evt.Name)
+			assert.True(t, ok)
+
+			event := Definitions.Get(id)
+			assert.Equal(t, test.evt, event)
+		})
+	}
+
+}

--- a/pkg/rules/engine/engine.go
+++ b/pkg/rules/engine/engine.go
@@ -78,7 +78,7 @@ func StartPipeline(cfg Config, input chan protocol.Event, done chan bool) <-chan
 	source := EventSources{Tracee: input}
 	engine, err := NewEngine(cfg, source, output)
 	if err != nil {
-		logger.Error("error creating engine: " + err.Error())
+		logger.Fatal("error creating engine: " + err.Error())
 	}
 
 	go func() {

--- a/pkg/rules/rego/rego.go
+++ b/pkg/rules/rego/rego.go
@@ -1,0 +1,11 @@
+package rego
+
+// Config represents configurations to the rego engine
+type Config struct {
+	// RuntimeTarget, currently only supports rego
+	RuntimeTarget string
+	// Rego Partial Evaluation of rules
+	PartialEval bool
+	// Aggregation Policy complication
+	AIO bool
+}

--- a/pkg/rules/signature/signature.go
+++ b/pkg/rules/signature/signature.go
@@ -49,7 +49,8 @@ func Find(target string, partialEval bool, rulesDir string, rules []string, aioE
 	} else {
 		for _, s := range sigs {
 			for _, r := range rules {
-				if m, err := s.GetMetadata(); err == nil && m.ID == r {
+				if m, err := s.GetMetadata(); err == nil &&
+					(m.ID == r || m.EventName == r) {
 					res = append(res, s)
 				}
 			}

--- a/pkg/rules/signature/signature_test.go
+++ b/pkg/rules/signature/signature_test.go
@@ -19,7 +19,28 @@ const (
 	exampleRulesDir = "testdata/signatures"
 )
 
-func TestFind(t *testing.T) {
+func TestFindByEventName(t *testing.T) {
+	sigs, err := Find(compile.TargetRego, false, exampleRulesDir, []string{"anti_debugging"}, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(sigs))
+
+	gotMetadata, err := sigs[0].GetMetadata()
+	require.NoError(t, err)
+	assert.Equal(t, detect.SignatureMetadata{
+		ID:          "TRC-2",
+		Version:     "0.1.0",
+		Name:        "Anti-Debugging",
+		EventName:   "anti_debugging",
+		Description: "Process uses anti-debugging technique to block debugger",
+		Tags:        []string{"linux", "container"},
+		Properties: map[string]interface{}{
+			"MITRE ATT&CK": "Defense Evasion: Execution Guardrails",
+			"Severity":     json.Number("3"),
+		},
+	}, gotMetadata)
+}
+
+func TestFindByRuleID(t *testing.T) {
 	sigs, err := Find(compile.TargetRego, false, exampleRulesDir, []string{"TRC-2"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sigs))


### PR DESCRIPTION
## Initial Checklist

This PRs adds the rule engine to the events pipeline.

Fixes: https://github.com/aquasecurity/tracee/issues/2441

## How Has This Been Tested?

```
# compiles
make

# test single rule event
./dist/tracee --trace event=anti_debugging
# test event with output json
./dist/tracee --trace event=anti_debugging --output format:json

# test single event with extra non rule event
./dist/tracee --trace event=anti_debugging,execve

# test single event with non rule dependency event
./dist/tracee --trace event=ptrace,anti_debugging

# test all events
./dist/tracee  --trace event=anti_debugging,aslr_inspection,cgroup_notify_on_release,cgroup_release_agent,core_pattern_modification,default_loader_mod,disk_mount,docker_abuse,dynamic_code_loading,fileless_execution,hidden_file_created,illegitimate_shell,k8s_api_connection,k8s_cert_theft,kernel_module_loading,ld_preload,process_vm_write_inject,proc_fops_hooking,proc_kcore_read,proc_mem_access,proc_mem_code_injection,ptrace_code_injection,rcd_modification,sched_debug_recon,scheduled_task_mod,stdio_over_socket,sudoers_modification,syscall_hooking,system_request_key_mod

# test rule event non exported, won't work because the event isn't exported
./dist/tracee --output format:json --trace event=dropped_executable
{"level":"fatal","ts":1670495492.8543997,"msg":"app","error":"invalid event to trace: dropped_executable"}

# list all events, including those that are rules
./dist/tracee --list
```