### PR TITLE
rules: reenable dropped_executable

### DIFF
--- a/signatures/golang/dropped_executable.go
+++ b/signatures/golang/dropped_executable.go
@@ -38,7 +38,7 @@ func (sig *DroppedExecutable) GetMetadata() (detect.SignatureMetadata, error) {
 
 func (sig *DroppedExecutable) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{
-		{Source: "tracee", Name: "magic_write", Origin: "*"},
+		{Source: "tracee", Name: "magic_write", Origin: "container"},
 	}, nil
 }
 

--- a/signatures/golang/export.go
+++ b/signatures/golang/export.go
@@ -34,4 +34,5 @@ var ExportedSignatures = []detect.Signature{
 	&KubernetesCertificateTheftAttempt{},
 	&ProcFopsHooking{},
 	&SyscallTableHooking{},
+	&DroppedExecutable{},
 }


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tracee/issues/2444

Configures the Origin to be the same we used for rego: https://github.com/aquasecurity/tracee/blob/main/signatures/rego/dropped_executable.rego#L20

I've tested it on GKE and DO, adding the context to be containers fixes the false positives.
Note, I want to use this signatures+nginxrat malware to do the new tracee get started tutorial example -> https://github.com/aquasecurity/tracee/issues/2353