### PR TITLE
pkg/utils/sharedobjs: check open failure

### DIFF
--- a/pkg/utils/sharedobjs/host_symbols_loader.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader.go
@@ -102,11 +102,14 @@ func (soCache *dynamicSymbolsLRUCache) Add(obj ObjInfo, dynamicSymbols *dynamicS
 func loadSharedObjectDynamicSymbols(path string) (*dynamicSymbols, error) {
 	var loadedObject *elf.File
 
-	capabilities.GetInstance().Required(func() error {
+	err := capabilities.GetInstance().Required(func() error {
 		var e error
 		loadedObject, e = elf.Open(path)
 		return e
 	})
+	if err != nil {
+		return nil, err
+	}
 	defer loadedObject.Close()
 
 	dynamicSymbols, err := loadedObject.DynamicSymbols()

--- a/pkg/utils/sharedobjs/host_symbols_loader_test.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader_test.go
@@ -206,7 +206,7 @@ func TestHostSharedObjectSymbolsLoader_loadSOSymbols(t *testing.T) {
 	})
 }
 
-func TestLoadSharedObjectDynamicSymbols(t *testing.T) {
+func TestParseDynamicSymbols(t *testing.T) {
 	testCases := []struct {
 		Name          string
 		Input         []elf.Symbol


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

When changed the capabilities package usage, we didn't check capabilities callback return value (error).
This caused usage of open-failed files, which meant null pointer dereference.

Fixes: #2442

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
