### PR TITLE
derive: fix cgroupv1 hid false derives

### DIFF
--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -164,6 +164,7 @@ type Cgroup interface {
 	destroy() error
 	GetMountPoint() string
 	getDefaultHierarchyID() int
+	GetVersion() CgroupVersion
 }
 
 func NewCgroup(ver CgroupVersion) (Cgroup, error) {
@@ -227,6 +228,10 @@ func (c *CgroupV1) getDefaultHierarchyID() int {
 	return c.hid
 }
 
+func (c *CgroupV1) GetVersion() CgroupVersion {
+	return CgroupVersion1
+}
+
 // cgroupv2
 
 type CgroupV2 struct {
@@ -272,6 +277,10 @@ func (c *CgroupV2) GetMountPoint() string {
 
 func (c *CgroupV2) getDefaultHierarchyID() int {
 	return c.hid
+}
+
+func (c *CgroupV2) GetVersion() CgroupVersion {
+	return CgroupVersion2
 }
 
 //

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -86,6 +86,10 @@ func (c *Containers) GetDefaultCgroupHierarchyID() int {
 	return c.cgroups.GetDefaultCgroupHierarchyID()
 }
 
+func (c *Containers) GetCgroupVersion() cgroup.CgroupVersion {
+	return c.cgroups.GetDefaultCgroup().GetVersion()
+}
+
 // Populate populates Containers struct by reading mounted proc and cgroups fs.
 func (c *Containers) Populate() error {
 	return c.populate()

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -15,6 +15,10 @@ func ContainerRemove(containers *containers.Containers) deriveFunction {
 
 func deriveContainerRemoveArgs(containers *containers.Containers) deriveArgsFunction {
 	return func(event trace.Event) ([]interface{}, error) {
+		// if cgroup_id is from non default hid (v1 case), the cgroup info query will fail, so we skip
+		if check, err := isCgroupEventInHid(&event, containers); !check {
+			return nil, err
+		}
 		cgroupId, err := parse.ArgUint64Val(&event, "cgroup_id")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Thu Dec 8 11:08:17 2022 +0000

    derive: fix cgroupv1 hid false derives
    
    In cgroupv1 systems, cgroup_mkdir events come from many different
    hierarchies, some existing outside of cpuset, where we query for the
    container cgroups.
    Because these cgroup_mkdir events would go through a derive process
    anyway, for each controller in the system there would be a failed derive
    searching through the entire cpuset controller with no results.
    
    This fix adds a check in v1 systems to see if the hierarchy id is
    the default one, otherwise derivation is skipped.
```

Fixes: #issue_number

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tested with sonobuoy performance tests.
This bug:
1.  caused loss of events
2. a bottleneck in deriveEvents and subsequently decodeEvents due to missing cgroup caches

pprof tests were ran in cgroup v1 system on k8s.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
