### PR TITLE
rules: refactor signature name

### DIFF
--- a/signatures/golang/process_vm_write_code_injection.go
+++ b/signatures/golang/process_vm_write_code_injection.go
@@ -24,7 +24,7 @@ func (sig *ProcessVmWriteCodeInjection) GetMetadata() (detect.SignatureMetadata,
 		ID:          "TRC-1025",
 		Version:     "1",
 		Name:        "Code injection detected using process_vm_writev syscall",
-		EventName:   "process_vm_write_code_injection",
+		EventName:   "process_vm_write_inject",
 		Description: "Possible code injection into another process was detected. Code injection is an exploitation technique used to run malicious code, adversaries may use it in order to execute their malware.",
 		Properties: map[string]interface{}{
 			"Severity":             3,

--- a/signatures/golang/process_vm_write_code_injection_test.go
+++ b/signatures/golang/process_vm_write_code_injection_test.go
@@ -51,7 +51,7 @@ func TestProcessVmWriteCodeInjection(t *testing.T) {
 						ID:          "TRC-1025",
 						Version:     "1",
 						Name:        "Code injection detected using process_vm_writev syscall",
-						EventName:   "process_vm_write_code_injection",
+						EventName:   "process_vm_write_inject",
 						Description: "Possible code injection into another process was detected. Code injection is an exploitation technique used to run malicious code, adversaries may use it in order to execute their malware.",
 						Properties: map[string]interface{}{
 							"Severity":             3,


### PR DESCRIPTION
Refactor signature name, it was too big for typing. 