### PR TITLE
[FIX] network: do not run e2e-net-test for vanilla v4.19

### DIFF
--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -4,6 +4,20 @@
 # This test is executed by github workflows inside the action runners
 #
 
+error_info() {
+    echo -n "INFO: "
+    echo $@
+    exit 1
+}
+
+KERNEL=$(uname -r)
+KERNEL_MAJ=$(echo $KERNEL | cut -d'.' -f1)
+
+if [[ $KERNEL_MAJ -lt 5 && "$KERNEL" != *"el8"* ]]; then
+	error_info "skip test in kernels < 5.0 (and not RHEL)"
+	exit 0
+fi
+
 TRACEE_STARTUP_TIMEOUT=5
 SCRIPT_TMP_DIR=/tmp
 TRACEE_TMP_DIR=/tmp/tracee


### PR DESCRIPTION
commit 83121848 (HEAD -> no-e2e-tests-419, rafaeldtinoco/no-e2e-tests-419)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Thu Dec 8 15:06:55 2022

    network: do not run e2e-net-test for vanilla v4.19
    
    Network code isn't ready yet for v4.19, do not run the network tests for
    those kernels. The RHEL8 kernel, despite being v4.18, supports all the
    code and features (because of their backports).