### PR TITLE
rules: add event name to rego signatures

### DIFF
--- a/pkg/rules/signature/signature_test.go
+++ b/pkg/rules/signature/signature_test.go
@@ -30,6 +30,7 @@ func TestFind(t *testing.T) {
 		ID:          "TRC-2",
 		Version:     "0.1.0",
 		Name:        "Anti-Debugging",
+		EventName:   "anti_debugging",
 		Description: "Process uses anti-debugging technique to block debugger",
 		Tags:        []string{"linux", "container"},
 		Properties: map[string]interface{}{
@@ -93,6 +94,7 @@ func Test_findRegoSigs(t *testing.T) {
 			ID:          "TRC-2",
 			Version:     "0.1.0",
 			Name:        "Anti-Debugging",
+			EventName:   "anti_debugging",
 			Description: "Process uses anti-debugging technique to block debugger",
 			Tags:        []string{"linux", "container"},
 			Properties: map[string]interface{}{

--- a/signatures/rego/anti_debugging_ptraceme.rego
+++ b/signatures/rego/anti_debugging_ptraceme.rego
@@ -4,6 +4,7 @@ __rego_metadoc__ := {
 	"id": "TRC-2",
 	"version": "0.1.0",
 	"name": "Anti-Debugging",
+	"eventName": "anti_debugging",
 	"description": "Process uses anti-debugging technique to block debugger",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/cgroup_release_agent_modification.rego
+++ b/signatures/rego/cgroup_release_agent_modification.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-14",
 	"version": "0.1.0",
 	"name": "CGroups Release Agent File Modification",
+	"eventName": "cgroup_release_agent",
 	"description": "An Attempt to modify CGroups release agent file was detected. CGroups are a Linux kernel feature which can change a process's resource limitations. Adversaries may use this feature for container escaping.",
 	"properties": {
 		"Severity": 3,

--- a/signatures/rego/code_injection.rego
+++ b/signatures/rego/code_injection.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-3",
 	"version": "0.1.0",
 	"name": "Code injection",
+	"eventName": "code_injection",
 	"description": "Possible code injection into another process",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/disk_mount.rego
+++ b/signatures/rego/disk_mount.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-11",
 	"version": "0.1.0",
 	"name": "Container Device Mount Detected",
+	"eventName": "disk_mount",
 	"description": "Container device filesystem mount detected. A mount of a host device filesystem can be exploited by adversaries to perform container escape.",
 	"tags": ["container"],
 	"properties": {

--- a/signatures/rego/dropped_executable.rego
+++ b/signatures/rego/dropped_executable.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-9",
 	"version": "0.1.0",
 	"name": "New Executable Was Dropped During Runtime",
+	"eventName": "dropped_executable",
 	"description": "An Executable file was dropped in your system during runtime. Usually container images are built with all binaries needed inside, a dropped binary may indicate an adversary infiltrated into your container.",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/dynamic_code_loading.rego
+++ b/signatures/rego/dynamic_code_loading.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-4",
 	"version": "0.1.0",
 	"name": "Dynamic Code Loading",
+	"eventName": "dynamic_code_loading",
 	"description": "Writing to executable allocated memory region",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/fileless_execution.rego
+++ b/signatures/rego/fileless_execution.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-5",
 	"version": "0.1.0",
 	"name": "Fileless Execution",
+	"eventName": "fileless_execution",
 	"description": "Executing a process from memory, without a file in the disk",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/illegitimate_shell.rego
+++ b/signatures/rego/illegitimate_shell.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-12",
 	"version": "0.1.0",
 	"name": "Illegitimate Shell",
+	"eventName":  "illegitimate_shell",
 	"description": "A program on your server spawned a shell program. Shell is the linux command-line program, server programs usually don't run shell programs, so this alert might indicate an adversary is exploiting a server program to spawn a shell on your server.",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/k8s_service_account_token.rego.disabled
+++ b/signatures/rego/k8s_service_account_token.rego.disabled
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-8",
 	"version": "0.1.0",
 	"name": "K8S Service Account Token Use Detected",
+	"eventName":   "k8s_service_account_token",
 	"description": "The Kubernetes service account token file was read on your container. This token is used to communicate with the K8S API server, Adversaries may try and communicate with the API server to gather information/credentials, or even run more containers and laterally expand their grip on your systems.",
 	"tags": ["container"],
 	"properties": {

--- a/signatures/rego/kernel_module_loading.rego
+++ b/signatures/rego/kernel_module_loading.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-6",
 	"version": "0.1.0",
 	"name": "kernel module loading",
+	"eventName": "kernel_module_loading",
 	"description": "Attempt to load a kernel module detection",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/kubernetes_certificate_theft_attempt.rego
+++ b/signatures/rego/kubernetes_certificate_theft_attempt.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-10",
 	"version": "0.1.0",
 	"name": "K8S TLS Certificate Theft Detected",
+	"eventName": "k8s_cert_theft",
 	"description": "Kubernetes TLS certificate theft was detected. TLS certificates are used to establish trust between systems, the kubernetes certificate is used to to enable secured communication between kubernetes components, like the kubelet, scheduler, controller and API server. An adversary may steal a kubernetes certificate on a compromised system to impersonate kuberentes components within the cluster.",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/ld_preload.rego
+++ b/signatures/rego/ld_preload.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-7",
 	"version": "0.1.0",
 	"name": "LD_PRELOAD",
+	"eventName": "ld_preload",
 	"description": "Usage of LD_PRELOAD to allow hooks on process",
 	"tags": ["linux", "container"],
 	"properties": {

--- a/signatures/rego/proc_fops_hooking.rego
+++ b/signatures/rego/proc_fops_hooking.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-16",
 	"version": "0.1.0",
 	"name": "Hooking proc file system file operations by overriding the function pointers",
+	"eventName": "proc_fops_hooking",
 	"description": "Usage of kernel modules to hook file operations",
 	"tags": ["linux"],
 	"properties": {

--- a/signatures/rego/syscall_table_hooking.rego
+++ b/signatures/rego/syscall_table_hooking.rego
@@ -6,6 +6,7 @@ __rego_metadoc__ := {
 	"id": "TRC-15",
 	"version": "0.1.0",
 	"name": "Hooking system calls by overriding the system call table entries",
+	"eventName": "syscall_hooking",
 	"description": "Usage of kernel modules to hook system calls",
 	"tags": ["linux"],
 	"properties": {


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tracee/issues/2411. This is not a mandatory change, because we are not using the rego signatures, though I would like to keep it consistent with the changes done on the golang signatures here -> https://github.com/aquasecurity/tracee/issues/2409