### PR TITLE
probes: fix lockup when nested raising privileges

### DIFF
--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	bpf "github.com/aquasecurity/libbpfgo"
-	"github.com/aquasecurity/tracee/pkg/capabilities"
-	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
 
 //
@@ -123,15 +121,14 @@ func Init(module *bpf.Module, netEnabled bool) (Probes, error) {
 		CgroupSKBEgress:            &cgroupProbe{programName: "cgroup_skb_egress", attachType: bpf.BPFAttachTypeCgroupInetEgress},
 	}
 
-	// disable autoload for network related eBPF programs in network is disabled
+	// disable autoload for tcProbes if network is disabled
+	// TODO: remove this once tcProbes are gone
 	if !netEnabled {
 		for _, p := range allProbes {
 			if tc, ok := p.(*tcProbe); ok {
 				tc.autoload(module, false)
 			}
 		}
-	} else {
-		capabilities.GetInstance().Require(cap.NET_ADMIN) // add to required
 	}
 
 	return &probes{

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1256,8 +1256,14 @@ func (t *Tracee) attachProbes() error {
 }
 
 func (t *Tracee) initBPF() error {
-
 	var err error
+
+	if t.netEnabled() {
+		// TODO: NET_ADMIN is needed by tcProbes, which are not declared as
+		// events so they don't have required capabilities. Once tcProbes gone
+		// we can remove this from the required capabilities set.
+		capabilities.GetInstance().Require(cap.NET_ADMIN)
+	}
 
 	// Execute code with higher privileges: ring1 (required)
 


### PR DESCRIPTION
## Description (git log)

Capabilities were being raised 2 times when tcProbes were enabled (because NET_ADMIN was being added as a required capability). Add NET_ADMIN as a required capability outside the escalation so no nested calls occur (which causes dead lock with capabilities package big lock).

Fixes: #2433

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

```
sudo ./dist/tracee-ebpf --install-path /tmp/tracee --cache cache-type=mem --cache mem-cache-size=512 --output format:json --output option:parse-arguments --output option:detect-syscall --capabilities bypass=false --trace net=docker0 --trace event=net_packet_ipv4
```


## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
