### PR TITLE
events_pipeline: run filters for derived events

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -305,6 +305,10 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 				}
 
 				for _, derivative := range derivatives {
+					// derived events also might have filters
+					if !t.shouldProcessEvent(derivative) {
+						continue
+					}
 					out <- &derivative
 				}
 


### PR DESCRIPTION
## Description (git log)

When the cmdline has arg filters for derived events, for example, they are never filtered (Equal, NotEqual, Contains, NotContains) as their Event ID comes from the functions DeriveSingleEvent & DeriveMultiple Events, and not from the perfbuffer event, like regular events.

Their filtering stage should be done in a later stage in the pipeline, when derivatives (derived events) are obtained, and not in the decodeEvents phase. This patch fixes the issue by running all filters for the derived event being processed.

Fixes: #2462

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

After the patch is applied, the network events can be filtered by "src" and "dst" (at least, need to check other args). This makes it easier to check the events as network events sometimes can be too noisy.

```
$ sudo ./dist/tracee-ebpf --install-path /tmp/tracee --cache cache-type=mem --cache mem-cache-size=512 --output format:json --output option:parse-arguments --capabilities bypass=false --trace comm=ping --trace event=net_packet_ipv4 --trace net_packet_ipv4.args.dst=8.8.8.8
{"timestamp":1670531130757400611,"threadStartTime":266674446820342,"processorId":16,"processId":2393710,"cgroupId":155653,"threadId":2393710,"parentProcessId":2393482,"hostProcessId":2393710,"hostThreadId":2393710,"hostParentProcessId":2393482,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"ping","hostName":"fujitsu","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","eventId":"2007","eventName":"net_packet_ipv4","argsNum":3,"returnValue":0,"stackAddresses":[0],"contextFlags":{"containerStarted":false},"args":[{"name":"src","type":"const char*","value":"192.168.100.2"},{"name":"dst","type":"const char*","value":"8.8.8.8"},{"name":"proto_ipv4","type":"trace.ProtoIPv4","value":{"version":4,"IHL":5,"TOS":0,"length":84,"id":7740,"flags":2,"fragOffset":0,"TTL":64,"protocol":"ICMPv4","checksum":59314,"srcIP":"192.168.100.2","dstIP":"8.8.8.8"}}]}
{"timestamp":1670531131758246337,"threadStartTime":266674446820342,"processorId":16,"processId":2393710,"cgroupId":155653,"threadId":2393710,"parentProcessId":2393482,"hostProcessId":2393710,"hostThreadId":2393710,"hostParentProcessId":2393482,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"ping","hostName":"fujitsu","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","eventId":"2007","eventName":"net_packet_ipv4","argsNum":3,"returnValue":0,"stackAddresses":[0],"contextFlags":{"containerStarted":false},"args":[{"name":"src","type":"const char*","value":"192.168.100.2"},{"name":"dst","type":"const char*","value":"8.8.8.8"},{"name":"proto_ipv4","type":"trace.ProtoIPv4","value":{"version":4,"IHL":5,"TOS":0,"length":84,"id":7927,"flags":2,"fragOffset":0,"TTL":64,"protocol":"ICMPv4","checksum":59127,"srcIP":"192.168.100.2","dstIP":"8.8.8.8"}}]}
```

@NDStrahilevitz FYI, and I think that I'll need to create network filters as each network event has its own Type, right ? (So I can filter by ProtoIPv4, ProtoDNS, etc, arguments).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
