### PR TITLE
tracee.bpf: arm64: fix var warning for bpf-nocore

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4719,7 +4719,9 @@ int BPF_KPROBE(trace_security_socket_connect)
         return 0;
 
     struct sockaddr *address = (struct sockaddr *) PT_REGS_PARM2(ctx);
+#if defined(__TARGET_ARCH_x86) // TODO: issue: #1129
     uint addr_len = (uint) PT_REGS_PARM3(ctx);
+#endif
 
     sa_family_t sa_fam = get_sockaddr_family(address);
     if ((sa_fam != AF_INET) && (sa_fam != AF_INET6) && (sa_fam != AF_UNIX)) {
@@ -4799,7 +4801,9 @@ int BPF_KPROBE(trace_security_socket_bind)
     struct sock *sk = get_socket_sock(sock);
 
     struct sockaddr *address = (struct sockaddr *) PT_REGS_PARM2(ctx);
+#if defined(__TARGET_ARCH_x86) // TODO: issue: #1129
     uint addr_len = (uint) PT_REGS_PARM3(ctx);
+#endif
 
     sa_family_t sa_fam = get_sockaddr_family(address);
     if ((sa_fam != AF_INET) && (sa_fam != AF_INET6) && (sa_fam != AF_UNIX)) {


### PR DESCRIPTION
## Description (git log)

commit a907a655 (HEAD -> fix-arm64-unused-vars, rafaeldtinoco/fix-arm64-unused-vars)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Dec 13 18:28:38 2022

    tracee.bpf: arm64: fix var warning for bpf-nocore
    
    ./pkg/ebpf/c/tracee.bpf.c:4663:10: warning: unused variable 'addr_len'
                                       [-Wunused-variable]
        uint addr_len = (uint) PT_REGS_PARM3(ctx);
             ^
    ./pkg/ebpf/c/tracee.bpf.c:4743:10: warning: unused variable 'addr_len'
                                       [-Wunused-variable]
        uint addr_len = (uint) PT_REGS_PARM3(ctx);
    
    Fixes: #2467