### PR TITLE
Arg filter fixes

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -312,9 +312,17 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 				}
 
 				for _, derivative := range derivatives {
-					// derived events also might have filters
-					if !t.shouldProcessEvent(derivative) {
-						continue
+					// Skip events that don't work well with filtering due
+					// to missing types being handled and similar reasons.
+					// https://github.com/aquasecurity/tracee/issues/2486
+					switch events.ID(derivative.EventID) {
+					case events.SymbolsLoaded:
+					case events.SharedObjectLoaded:
+					default:
+						// Derived events might need filtering as well
+						if !t.shouldProcessEvent(derivative) {
+							continue
+						}
 					}
 					out <- &derivative
 				}

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -42,7 +42,7 @@ func (filter *ArgFilter) Filter(eventID events.ID, args []trace.Argument) bool {
 			}
 		}
 		if !found {
-			return true
+			return false // always filter if argument does not exist
 		}
 		// TODO: use type assertion instead of string conversion
 		if argName != "syscall" {


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit 4c047682 (HEAD -> arg-filter-fixes, rafaeldtinoco/arg-filter-fixes, main)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Dec 14 03:45:45 2022

    filters: if arg is missing do not process it
    
    When filtering an event for an argument that might not exist (because
    the eBPF code might not send it), the events missing the argument
    being filtered were being sent.
    
    One exampe is when openat filters for openat.args.pathname of
    /etc/passwd. Some openat events missing pathname might be sent out
    through printer.
    
    Do not process the event when an argument being filtered for does not
    exist in the event.
    
Fixes: #2487

commit cbc79bba
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Dec 14 03:44:14 2022

    filters: add []string type to args filters
    
    SymbolsLoaded event has a []string argument in tracee.Arguments and
    if any of those values has a filter, it must be considered.
    
Fixes: #2486

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tested by executing:

```
sudo ./dist/tracee-ebpf --output format:json --output option:parse-arguments --trace event=openat --trace openat.args.pathname=/etc/passwd 
```

and

```
sudo ./dist/tracee-ebpf --output option:parse-arguments --trace event=symbols_loaded --trace symbols_loaded.args.symbols=readdir,readdir64,open,link,rmdir,fopen,open64,fopen64 --trace symbols_loaded.args.library_path="libc"
```

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
