### PR TITLE
network: fix net_packet_dns_request and response

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -7343,6 +7343,7 @@ static __always_inline u64 sizeof_net_event_context_t(void)
 static __always_inline void set_net_task_context(event_data_t *data, net_task_context_t *netctx)
 {
     netctx->task = data->task;
+    __builtin_memset(&netctx->taskctx, 0, sizeof(task_context_t));
     __builtin_memcpy(&netctx->taskctx, &data->context.task, sizeof(task_context_t));
 }
 

--- a/pkg/events/derive/net_packet_dns.go
+++ b/pkg/events/derive/net_packet_dns.go
@@ -70,7 +70,7 @@ func deriveDNSRequestEvents(event trace.Event) ([]interface{}, error) {
 
 	// discover if it is a request or response
 
-	if dns.OpCode != "query" && dns.ANCount != 0 { // number of answers to expect
+	if dns.QR != 0 {
 		return nil, nil // not a dns request
 	}
 
@@ -87,7 +87,7 @@ func deriveDNSRequestEvents(event trace.Event) ([]interface{}, error) {
 	}
 
 	return []interface{}{
-		meta,
+		*meta,
 		requests,
 	}, nil
 }
@@ -118,7 +118,7 @@ func deriveDNSResponseEvents(event trace.Event) ([]interface{}, error) {
 
 	// discover if it is a request or response
 
-	if dns.OpCode != "query" || dns.ANCount == 0 { // number of answers to expect
+	if dns.QR != 1 {
 		return nil, nil // not a dns response
 	}
 
@@ -142,7 +142,7 @@ func deriveDNSResponseEvents(event trace.Event) ([]interface{}, error) {
 	}
 
 	return []interface{}{
-		meta,
+		*meta,
 		responses,
 	}, nil
 }


### PR DESCRIPTION
## Description (git log)

Fixes:

1. need to memset 0 the event struct in stack not to have garbage in comm

2. need to pass the object instead of a pointer as argument, the same as dns_request and dns_response events had.

3. only send dns_request event if there are no responses.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

----

## How Has This Been Tested?

IN A

![image](https://user-images.githubusercontent.com/7395852/208375927-c209ce2e-8fa6-4645-bbbc-e521b64f6d7f.png)

![image](https://user-images.githubusercontent.com/7395852/208375973-896cdc54-21ff-4176-8322-997b726a9ab6.png)

IN MX

(the old event dns_request has trashed command names, I solved that in the new one as well)

![image](https://user-images.githubusercontent.com/7395852/208377315-c64d37c4-6098-436e-8cbc-05dfefb61df5.png)

(looks like the old dns_response event did not pick the correct MX response, while the new one did)

![image](https://user-images.githubusercontent.com/7395852/208377569-abbd0fc8-85e9-44ed-b474-d91c56146cb2.png)

IN NS

![image](https://user-images.githubusercontent.com/7395852/208377857-7839cc7d-442c-4628-b9d7-1df86bc6e2d2.png)

![image](https://user-images.githubusercontent.com/7395852/208377961-8ccacbb3-7240-4672-88fb-6b5e7f697adf.png)

----

PS: For the "IN A" tests I have emulated 2 things:

1. pktlen from the new events is always 14 bytes shorter (that is because the new events only consider L3 layer and beyond, being agnostic to L2 type). 

![image](https://user-images.githubusercontent.com/7395852/208376720-2069cdd2-7302-44a3-a97d-10fa67a814c2.png)

2. the interface name was used as "docker0"
 
just to check if old and new events were the same.

----

@roikol FYI, could you please check this PR with the same tests you did and see if there are any differences from old and new events for your signatures ? Thank you!

@yanivagman if this fixes Roi's issues, then we should consider a new minor release for this fix (for CNDRs existing DNS signatures to work, if that is what they need/want).