### PR TITLE
filters: expand binary filter to support mount ns

### DIFF
--- a/docs/docs/tracing/event-filtering.md
+++ b/docs/docs/tracing/event-filtering.md
@@ -144,11 +144,15 @@ expected.
 
     ```text
     1) --trace binary=/usr/bin/ls
+    2) --trace binary=host:/usr/bin/ls
+    3) --trace binary=4026532448:/usr/bin/ls
     ```
 
     !!! Note
-        Given path must be of an ELF binary, meaning that providing the path
-        of a symbolic link won't work
+        1. Mount namespace id or the special "host:" prefix can be used for finer filtering
+        2. Given path must be absolute; i.e starts with "/"
+        3. Only binaries that were executed after Tracee will be filtered
+        4. Symbolic link paths are not supported
 
 1. **PID** `(Operators: =, !=, <, > and "new")`
 

--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -74,6 +74,8 @@ Examples:
   --trace uts!=ab356bc4dd554                                   | don't trace events from uts name ab356bc4dd554
   --trace comm=ls                                              | only trace events from ls command
   --trace binary=/usr/bin/ls                                   | only trace events from /usr/bin/ls binary
+  --trace binary=host:/usr/bin/ls                              | only trace events from /usr/bin/ls binary in the host mount namespace
+  --trace binary=4026532448:/usr/bin/ls                        | only trace events from /usr/bin/ls binary in 4026532448 mount namespace
   --trace close.fd=5                                           | only trace 'close' events that have 'fd' equals 5
   --trace openat.args.pathname=/tmp*                           | only trace 'openat' events that have 'pathname' prefixed by "/tmp"
   --trace openat.args.pathname!=/tmp/1,/bin/ls                 | don't trace 'openat' events that have 'pathname' equals /tmp/1 or /bin/ls
@@ -97,7 +99,7 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 		PidNSFilter:       filters.NewBPFUIntFilter(tracee.PidNSFilterMap),
 		UTSFilter:         filters.NewBPFStringFilter(tracee.UTSFilterMap),
 		CommFilter:        filters.NewBPFStringFilter(tracee.CommFilterMap),
-		BinaryFilter:      filters.NewBPFStringFilter(tracee.BinaryFilterMap),
+		BinaryFilter:      filters.NewBPFBinaryFilter(tracee.BinaryFilterMap),
 		ContFilter:        filters.NewBoolFilter(),
 		NewContFilter:     filters.NewBoolFilter(),
 		ContIDFilter:      filters.NewContainerFilter(tracee.CgroupIdFilterMap),
@@ -176,7 +178,7 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 			continue
 		}
 
-		if filterName == "binary" {
+		if filterName == "binary" || filterName == "bin" {
 			err := filter.BinaryFilter.Parse(operatorAndValues)
 			if err != nil {
 				return tracee.Filter{}, err

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -793,10 +793,16 @@ typedef struct file_info {
     u64 ctime;
 } file_info_t;
 
+typedef struct binary {
+    u32 mnt_id;
+    char path[MAX_BIN_PATH_SIZE];
+} binary_t;
+
 typedef struct proc_info {
     bool new_proc; // set if this process was started after tracee. Used with new_pid filter
     bool follow;   // set if this process was traced before. Used with the follow filter
-    char binary[MAX_BIN_PATH_SIZE];
+    struct binary binary;
+    u32 binary_no_mnt; // used in binary lookup when we don't care about mount ns. always 0.
     file_info_t interpreter;
 } proc_info_t;
 
@@ -822,10 +828,6 @@ typedef struct path_filter {
 typedef struct string_filter {
     char str[MAX_STR_FILTER_SIZE];
 } string_filter_t;
-
-typedef struct binary_filter {
-    char str[MAX_BIN_PATH_SIZE];
-} binary_filter_t;
 
 typedef struct ksym_name {
     char str[MAX_KSYM_NAME_SIZE];
@@ -1025,7 +1027,7 @@ BPF_HASH(pid_ns_filter, u64, u32, 256);                            // filter eve
 BPF_HASH(uts_ns_filter, string_filter_t, u32, 256);                // filter events by uts namespace name
 BPF_HASH(comm_filter, string_filter_t, u32, 256);                  // filter events by command name
 BPF_HASH(cgroup_id_filter, u32, u32, 256);                         // filter events by cgroup id
-BPF_HASH(binary_filter, binary_filter_t, u32, 256);                // filter events by binary path
+BPF_HASH(binary_filter, binary_t, u32, 256);                       // filter events by binary path and mount namespace
 BPF_HASH(bin_args_map, u64, bin_args_t, 256);                      // persist args for send_bin funtion
 BPF_HASH(sys_32_to_64_map, u32, u32, 1024);                        // map 32bit to 64bit syscalls
 BPF_HASH(params_types_map, u32, u64, 1024);                        // encoded parameters types for event
@@ -1876,7 +1878,9 @@ static __always_inline task_info_t *init_task_info(u32 tid, u32 pid)
     if (proc_info == NULL) {
         scratch->proc_info.new_proc = false;
         scratch->proc_info.follow = false;
-        __builtin_memset(scratch->proc_info.binary, 0, MAX_BIN_PATH_SIZE);
+        scratch->proc_info.binary.mnt_id = 0;
+        scratch->proc_info.binary_no_mnt = 0;
+        __builtin_memset(scratch->proc_info.binary.path, 0, MAX_BIN_PATH_SIZE);
         bpf_map_update_elem(&proc_info_map, &pid, &scratch->proc_info, BPF_NOEXIST);
     }
 
@@ -2101,7 +2105,16 @@ static __always_inline int do_should_trace(event_data_t *data)
 
     if (config & FILTER_BIN_PATH_ENABLED) {
         bool filter_out = (config & FILTER_BIN_PATH_OUT) == FILTER_BIN_PATH_OUT;
-        if (!equality_filter_matches(filter_out, &binary_filter, proc_info->binary))
+        // lookup by binary path only
+        u32 *equality = bpf_map_lookup_elem(&binary_filter, proc_info->binary.path);
+        if (equality != NULL)
+            return *equality;
+        // lookup by binary path and mount namespace
+        equality = bpf_map_lookup_elem(&binary_filter, &proc_info->binary);
+        if (equality != NULL)
+            return *equality;
+
+        if (!filter_out)
             return 0;
     }
 
@@ -3726,8 +3739,9 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     proc_info->new_proc = true;
 
     // extract the binary name to be used in should_trace
-    __builtin_memset(proc_info->binary, 0, MAX_BIN_PATH_SIZE);
-    bpf_probe_read_str(proc_info->binary, MAX_BIN_PATH_SIZE, file_path);
+    __builtin_memset(proc_info->binary.path, 0, MAX_BIN_PATH_SIZE);
+    bpf_probe_read_str(proc_info->binary.path, MAX_BIN_PATH_SIZE, file_path);
+    proc_info->binary.mnt_id = data.context.task.mnt_id;
 
     if (!should_trace(&data))
         return 0;

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -38,7 +38,7 @@ type Filter struct {
 	ArgFilter         *filters.ArgFilter
 	ContextFilter     *filters.ContextFilter
 	ProcessTreeFilter *filters.ProcessTreeFilter
-	BinaryFilter      *filters.BPFStringFilter
+	BinaryFilter      *filters.BPFBinaryFilter
 	Follow            bool
 	NetFilter         *NetIfaces
 }

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -1,0 +1,203 @@
+package filters
+
+import (
+	"encoding/binary"
+	"strconv"
+	"strings"
+	"unsafe"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/utils/proc"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+)
+
+type nsBinary struct {
+	mntNS uint32
+	path  string
+}
+
+type BinaryFilter struct {
+	equal    map[nsBinary]bool
+	notEqual map[nsBinary]bool
+	enabled  bool
+}
+
+func getHostMntNS() (uint32, error) {
+	var ns int
+	var err error
+
+	err = capabilities.GetInstance().Requested(func() error {
+		ns, err = proc.GetProcNS(1, "mnt")
+		return err
+	},
+		cap.DAC_READ_SEARCH,
+		cap.SYS_PTRACE,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(ns), nil
+}
+
+func NewBinaryFilter() *BinaryFilter {
+	return &BinaryFilter{
+		equal:    map[nsBinary]bool{},
+		notEqual: map[nsBinary]bool{},
+	}
+}
+
+func (f *BinaryFilter) Parse(operatorAndValues string) error {
+	if len(operatorAndValues) < 2 {
+		return InvalidExpression(operatorAndValues)
+	}
+	valuesString := string(operatorAndValues[1:])
+	operatorString := string(operatorAndValues[0])
+
+	if operatorString == "!" {
+		if len(operatorAndValues) < 3 {
+			return InvalidExpression(operatorAndValues)
+		}
+		operatorString = operatorAndValues[0:2]
+		valuesString = operatorAndValues[2:]
+	}
+
+	values := strings.Split(valuesString, ",")
+
+	var hostMntNS uint32
+	var err error
+
+	for _, val := range values {
+		mntAndPath := strings.Split(val, ":")
+		var bin nsBinary
+		if len(mntAndPath) == 1 {
+			bin.path = val
+		} else if len(mntAndPath) == 2 {
+			bin.path = mntAndPath[1]
+			if mntAndPath[0] == "host" {
+				if hostMntNS == 0 {
+					hostMntNS, err = getHostMntNS()
+					if err != nil {
+						return FailedToRetreiveHostNS()
+					}
+				}
+				bin.mntNS = hostMntNS
+			} else {
+				mntNS, err := strconv.Atoi(mntAndPath[0])
+				if err != nil {
+					return InvalidValue(val)
+				}
+				bin.mntNS = uint32(mntNS)
+			}
+		} else {
+			return InvalidValue(val)
+		}
+
+		if !strings.HasPrefix(bin.path, "/") {
+			return InvalidValue(val)
+		}
+
+		err := f.add(bin, stringToOperator(operatorString))
+		if err != nil {
+			return err
+		}
+	}
+
+	f.Enable()
+
+	return nil
+}
+
+func (f *BinaryFilter) add(bin nsBinary, operator Operator) error {
+	switch operator {
+	case Equal:
+		f.equal[bin] = true
+		return nil
+	case NotEqual:
+		f.notEqual[bin] = true
+		return nil
+	default:
+		return UnsupportedOperator(operator)
+	}
+}
+
+func (f *BinaryFilter) Enable() {
+	f.enabled = true
+}
+
+func (f *BinaryFilter) Disable() {
+	f.enabled = false
+}
+
+func (f *BinaryFilter) Enabled() bool {
+	return f.enabled
+}
+
+func (f *BinaryFilter) FilterOut() bool {
+	if len(f.equal) > 0 && len(f.notEqual) == 0 {
+		return false
+	} else {
+		return true
+	}
+}
+
+type BPFBinaryFilter struct {
+	BinaryFilter
+	binaryMapName string
+}
+
+func NewBPFBinaryFilter(binaryMapName string) *BPFBinaryFilter {
+	return &BPFBinaryFilter{
+		BinaryFilter:  *NewBinaryFilter(),
+		binaryMapName: binaryMapName,
+	}
+}
+
+func (f *BPFBinaryFilter) InitBPF(bpfModule *bpf.Module) error {
+	const (
+		maxBpfBinPathSize = 256 // maximum binary path size supported by BPF (MAX_BIN_PATH_SIZE)
+		bpfBinFilterSize  = 264 // the key size of the BPF binary filter map entry
+	)
+
+	if !f.Enabled() {
+		return nil
+	}
+
+	binMap, err := bpfModule.GetMap(f.binaryMapName)
+	if err != nil {
+		return err
+	}
+
+	fn := func(bin nsBinary, eqVal uint32) error {
+		if len(bin.path) > maxBpfBinPathSize {
+			return InvalidValue(bin.path)
+		}
+		binBytes := make([]byte, bpfBinFilterSize)
+		if bin.mntNS == 0 {
+			// If no mount namespace given, bpf map key is only the path
+			copy(binBytes, bin.path)
+		} else {
+			// otherwise, key is composed of the mount namespace and the path
+			binary.LittleEndian.PutUint32(binBytes, bin.mntNS)
+			copy(binBytes[4:], bin.path)
+		}
+		return binMap.Update(unsafe.Pointer(&binBytes[0]), unsafe.Pointer(&eqVal))
+	}
+
+	// first initialize notEqual values since equality should take precedence
+	for bin := range f.notEqual {
+		if err = fn(bin, uint32(filterNotEqual)); err != nil {
+			return err
+		}
+	}
+
+	// now - setup equality filters
+	for bin := range f.equal {
+		if err = fn(bin, uint32(filterEqual)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/filters/errors.go
+++ b/pkg/filters/errors.go
@@ -25,3 +25,7 @@ func InvalidEventArgument(argument string) error {
 func InvalidContextField(field string) error {
 	return fmt.Errorf("invalid event context field: %s", field)
 }
+
+func FailedToRetreiveHostNS() error {
+	return fmt.Errorf("failed to retreive host mount namespace")
+}


### PR DESCRIPTION
Currently the binary filter can not differentiate between binaries that have the same path but reside in different mount namespaces. Having the mount namespace is required to identify a specific binary to filter by.

Enable the user to provide the mount namespace in addition to the binary path and keep support of providing a binary without specifying a mount namespace.

To filter by path, the following syntax is used::
    --trace binary=/some/binary/path

To filter by path and a specific mount namespace (e.g. 4026532448), use:
    --trace binary=4026532448:/some/binary/path

Specifying the host mount namespace can be done using the "host" alias:
    --trace binary=host:/some/binary/path

Fixes: #2516
