### PR TITLE
ebpf: update ksymbols_map when updating kernelSymbols

### DIFF
--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -304,7 +304,7 @@ func (t *Tracee) processEvent(event *trace.Event) error {
 		_, ok2 := t.events[events.HookedSeqOps]
 		_, ok3 := t.events[events.HookedProcFops]
 		if ok1 || ok2 || ok3 {
-			err := t.updateKallsyms()
+			err := t.UpdateKallsyms()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
whenever kernelSymbols are updated, also update the ksymbols_map. this way bpf progs will use up-to-date kernel symbols.
i've moved the ksymbols.go out of `initialization` package because these methods are no longer used only in the initialization phase. they are now used also whenever an update the kernelSymbols is invoked. 

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Wed Dec 28 16:09:15 2022 +0200

    ebpf: update ksymbols_map when updating kernelSymbols
    
    whenever kernelSymbols are updated, also update the ksymbols_map.
    this way bpf progs will use up-to-date kernel symbols
```

Fixes: #2530

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

this has been tested locally using a kernel module that changes a required kernel symbol by the `dirty_pipe_splice` event.

Tests being included in this PR:

- [ ] Test File A
- [ ] Test File B

Reproduce the test by running:

- command 01: `./dist/tracee-ebpf -t e=dirty_pipe_splice`
- command 02: `bpftool map dump name ksymbols_map`
- command 03: `insmod my_module`
- command 04: `bpftool map dump name ksymbols_map`

the address of the symbol in the first invocation of `bpftool` should be different than in the second invocation.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
