### PR TITLE
tracee-rules: use logger instead of Printf

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -95,7 +95,7 @@ func main() {
 				return nil
 			}
 
-			fmt.Printf("Loaded %d signature(s): %s\n", len(loadedSigIDs), loadedSigIDs)
+			logger.Info("Signatures loaded", "total", len(loadedSigIDs), "signatures", loadedSigIDs)
 
 			if c.Bool("list") {
 				listSigs(os.Stdout, sigs)


### PR DESCRIPTION
- [x] There is an issue describing the need for this PR.

## Description (git log)

commit fd13ead9caae67785101a0402bb9c164be7aefd1 

    tracee-rules: use logger instead of Printf

Fixes: #2532 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).

## How Has This Been Tested?

```shell
./dist/tracee-rules --input-tracee file:stdin --input-tracee format:json < <(cat /etc/passwd) 2>&1 | head -n 3
{"level":"info","ts":1673034598.8414884,"msg":"Signatures loaded","total":30,"signatures":["TRC-101","TRC-1013","TRC-109","TRC-1024","TRC-1019","TRC-1027","TRC-107","TRC-106","TRC-1012","TRC-1028","TRC-1029","TRC-1031","TRC-1010","TRC-1026","TRC-1011","TRC-1021","TRC-1023","TRC-1015","TRC-102","TRC-103","TRC-1025","TRC-1014","TRC-104","TRC-105","TRC-1016","TRC-1017","TRC-1018","TRC-1020","TRC-1030","TRC-1022"]}
{"level":"error","ts":1673034598.8416545,"msg":"invalid json in root:x:0:0::/root:/bin/bash: invalid character 'r' looking for beginning of value"}
{"level":"error","ts":1673034598.8416846,"msg":"invalid json in nobody:x:65534:65534:Nobody:/:/usr/bin/nologin: invalid character 'o' in literal null (expecting 'u')"}
```

To silence the `Signatures loaded`, use `warn` or greater level. More about this in https://github.com/aquasecurity/tracee/issues/2532#issuecomment-1374044495.

```shell
TRACEE_LOGGER_LVL=warn ./dist/tracee-rules --input-tracee file:stdin --input-tracee format:json < <(cat /etc/passwd) 2>&1 | head -n 3
{"level":"error","ts":1673034707.6753445,"msg":"invalid json in root:x:0:0::/root:/bin/bash: invalid character 'r' looking for beginning of value"}
{"level":"error","ts":1673034707.6753953,"msg":"invalid json in nobody:x:65534:65534:Nobody:/:/usr/bin/nologin: invalid character 'o' in literal null (expecting 'u')"}
{"level":"error","ts":1673034707.675397,"msg":"invalid json in dbus:x:81:81:System Message Bus:/:/usr/bin/nologin: invalid character 'd' looking for beginning of value"}
```