### PR TITLE
cmd/tracee: fix event channel go routine order

### DIFF
--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -65,20 +65,6 @@ func (r Runner) Run(ctx context.Context) error {
 		}
 	}()
 
-	// Print the preamble
-
-	go func() {
-		printer.Preamble()
-		for {
-			select {
-			case event := <-r.TraceeConfig.ChanEvents:
-				printer.Print(event)
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
 	// Print statistics at the end
 
 	defer func() {
@@ -93,6 +79,20 @@ func (r Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error initializing Tracee: %v", err)
 	}
+
+	// Print the preamble and start event channel reception
+
+	go func() {
+		printer.Preamble()
+		for {
+			select {
+			case event := <-r.TraceeConfig.ChanEvents:
+				printer.Print(event)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 
 	return t.Run(ctx) // return when context is cancelled by signal
 }


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.

## Description (git log)

commit 488e0a77eb07dad769a14fd696f41cd54a3ece2a

    cmd/tracee: fix go routine order
    
    The preamble was getting printed before the tracee was fully initialized
    what was causing intertwined logs.
    
    This reorders the go routine that prints the preamble and starts the
    event channel reception.

Fixes: #2485 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).

## How Has This Been Tested?

```shell
sudo ./dist/tracee-ebpf -t uid=1000 -t event=execve -t pid=new --log debug
{"level":"debug","ts":1673038239.7655802,"msg":"osinfo","KERNEL_RELEASE":"5.15.85-1-MANJARO","ARCH":"x86_64","PRETTY_NAME":"\"Manjaro Linux\"","ID":"manjaro","ID_LIKE":"arch","BUILD_ID":"rolling","pkg":"urfave","file":"urfave.go","line":53}
{"level":"debug","ts":1673038239.7656102,"msg":"RuntimeSockets: failed to register default","socket":"containerd","error":"failed to register runtime socket stat /var/run/containerd/containerd.sock: no such file or directory","pkg":"flags","file":"containers.go","line":45}
{"level":"debug","ts":1673038239.765622,"msg":"RuntimeSockets: failed to register default","socket":"crio","error":"failed to register runtime socket stat /var/run/crio/crio.sock: no such file or directory","pkg":"flags","file":"containers.go","line":45}
{"level":"debug","ts":1673038239.7656274,"msg":"RuntimeSockets: failed to register default","socket":"podman","error":"failed to register runtime socket stat /var/run/podman/podman.sock: no such file or directory","pkg":"flags","file":"containers.go","line":45}
{"level":"debug","ts":1673038239.765779,"msg":"osinfo","security_lockdown":"none","pkg":"urfave","file":"urfave.go","line":116}
{"level":"debug","ts":1673038239.7678087,"msg":"BTF","bpfenv":false,"btfenv":false,"vmlinux":true,"pkg":"initialize","file":"bpfobject.go","line":40}
{"level":"debug","ts":1673038239.7678204,"msg":"BPF: using embedded BPF object","pkg":"initialize","file":"bpfobject.go","line":69}
{"level":"debug","ts":1673038239.7697015,"msg":"unpacked CO:RE bpf object file into memory","pkg":"initialize","file":"bpfobject.go","line":144}
{"level":"debug","ts":1673038239.8859882,"msg":"could not parse task status","error":"readlink /proc/120096/task/120096/ns/mnt: no such file or directory","pkg":"procinfo","file":"procinfo.go","line":226}
{"level":"debug","ts":1673038239.942194,"msg":"Enricher","error":"error registering enricher: unsupported runtime containerd","pkg":"containers","file":"containers.go","line":64}
{"level":"debug","ts":1673038239.9422154,"msg":"Enricher","error":"error registering enricher: unsupported runtime crio","pkg":"containers","file":"containers.go","line":68}
{"level":"debug","ts":1673038240.3875396,"msg":"Failed in fetching process mount namespace","pid":120096,"error":"readlink /proc/120096/ns/net: no such file or directory","pkg":"proc","file":"ns.go","line":40}
TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
17:50:40:480462  1000   cpuUsage.sh      383008  383008  0                execve               pathname: /usr/bin/sed, argv: [sed -n s/^cpu\s//p /proc/stat]
17:50:40:482181  1000   cpuUsage.sh      383009  383009  0                execve               pathname: /usr/bin/cat, argv: [cat /proc/341527/stat]
17:50:40:744189  1000   code             383011  383011  0                execve               pathname: /bin/sh, argv: [/bin/sh -c which ps]
17:50:40:746176  1000   sh               383011  383011  0                execve               pathname: /usr/bin/which, argv: [which ps]
17:50:40:747181  1000   code             383012  383012  0                execve               pathname: /bin/sh, argv: [/bin/sh -c /usr/bin/ps -ax -o pid=,ppid=,pcpu=,pmem=,command=]
17:50:40:748140  1000   sh               383012  383012  0                execve               pathname: /usr/bin/ps, argv: [/usr/bin/ps -ax -o pid=,ppid=,pcpu=,pmem=,command=]
17:50:40:759196  1000   code             383013  383013  0                execve               pathname: /bin/sh, argv: [/bin/sh -c "/opt/visual-studio-code/resources/app/out/vs/base/node/cpuUsage.sh" 341527 382986 382987]
17:50:40:761962  1000   sh               383013  383013  0                execve               pathname: /opt/visual-studio-code/resources/app/out/vs/base/node/cpuUsage.sh, argv: [/opt/visual-studio-code/resources/app/out/vs/base/node/cpuUsage.sh 341527 382986 382987]
17:50:40:764071  1000   cpuUsage.sh      383014  383014  0                execve               pathname: /usr/bin/sed, argv: [sed -n s/^cpu\s//p /proc/stat]
17:50:40:765921  1000   cpuUsage.sh      383015  383015  0                execve               pathname: /usr/bin/cat, argv: [cat /proc/341527/stat]
17:50:40:766491  1000   cpuUsage.sh      383016  383016  0                execve               pathname: /usr/bin/cat, argv: [cat /proc/382986/stat]
17:50:40:767199  1000   cpuUsage.sh      383017  383017  0                execve               pathname: /usr/bin/cat, argv: [cat /proc/382987/stat]
17:50:40:767867  1000   cpuUsage.sh      383018  383018  0                execve               pathname: /usr/bin/sleep, argv: [sleep 1]
^C
End of events stream
Stats: {EventCount:13 EventsFiltered:0 NetEvCount:0 BPFLogsCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0 LostBPFLogsCount:0}

```
