### PR TITLE
tracee: refactor signals done channel

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
@@ -54,7 +56,8 @@ func main() {
 				return err
 			}
 
-			ctx := context.Background()
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
 
 			return runner.Run(ctx)
 

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -153,7 +154,10 @@ func main() {
 				go httpServer.Start()
 			}
 
-			e.Start(sigHandler())
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			e.Start(ctx)
 
 			return nil
 		},
@@ -274,15 +278,4 @@ func listEvents(w io.Writer, sigs []detect.Signature) {
 
 	sort.Slice(events, func(i, j int) bool { return events[i] < events[j] })
 	fmt.Fprintln(w, strings.Join(events, ","))
-}
-
-func sigHandler() chan bool {
-	sigs := make(chan os.Signal, 1)
-	done := make(chan bool, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigs
-		done <- true
-	}()
-	return done
 }

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
@@ -98,7 +100,8 @@ func main() {
 				SignatureBufferSize: 1000,
 			}
 
-			ctx := context.Background()
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
 
 			return runner.Run(ctx)
 		},

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -3,10 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
@@ -48,22 +45,6 @@ func (r Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	// Create a context (cancelled by SIGINT/SIGTERM)
-	ctx, cancel := context.WithCancel(ctx)
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	defer func() {
-		signal.Stop(sig)
-		cancel()
-	}()
-	go func() {
-		select {
-		case <-sig:
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
 
 	// Print statistics at the end
 

--- a/pkg/ebpf/rule_engine.go
+++ b/pkg/ebpf/rule_engine.go
@@ -13,10 +13,9 @@ import (
 func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-chan *trace.Event, <-chan error) {
 	out := make(chan *trace.Event)
 	errc := make(chan error, 1)
-	done := make(chan bool)
 	engineInput := make(chan protocol.Event)
 
-	engineOutput := engine.StartPipeline(t.config.EngineConfig, engineInput, done)
+	engineOutput := engine.StartPipeline(ctx, t.config.EngineConfig, engineInput)
 
 	// TODO: in the upcoming releases, the rule engine should be changed to receive trace.Event,
 	// and return a trace.Event, which should remove the necessity of converting trace.Event to protocol.Event,
@@ -68,13 +67,6 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 				return
 			}
 		}
-	}()
-
-	go func() {
-		defer close(done)
-
-		<-ctx.Done()
-		done <- true
 	}()
 
 	return out, errc

--- a/pkg/rules/benchmark/benchmark_test.go
+++ b/pkg/rules/benchmark/benchmark_test.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -238,18 +239,18 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 	}
 }
 
-func waitForEventsProcessed(eventsCh chan protocol.Event) chan bool {
-	done := make(chan bool, 1)
+func waitForEventsProcessed(eventsCh chan protocol.Event) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		for {
 			if len(eventsCh) == 0 {
-				done <- true
+				cancel()
 				return
 			}
 			time.Sleep(1 * time.Millisecond)
 		}
 	}()
-	return done
+	return ctx
 }
 
 func ignoreFinding(_ detect.Finding) {

--- a/pkg/rules/engine/engine_test.go
+++ b/pkg/rules/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -405,7 +406,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		inputs := EventSources{}
 		inputs.Tracee = make(chan protocol.Event, 1)
 		outputChan := make(chan detect.Finding, 1)
-		done := make(chan bool, 1)
+		ctx, cancel := context.WithCancel(context.Background())
 		var logBuf []byte
 		loggerBuf := bytes.NewBuffer(logBuf)
 		if !logger.IsSetFromEnv() {
@@ -422,10 +423,9 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() {
 				// signal the end
-				done <- true
+				cancel()
 
 				// cleanup
-				close(done)
 				close(outputChan)
 				close(inputs.Tracee)
 			}()
@@ -450,7 +450,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			e, err := NewEngine(tc.config, inputs, outputChan)
 			require.NoError(t, err, "constructing engine")
 			go func() {
-				e.Start(done)
+				e.Start(ctx)
 			}()
 
 			// send a test event


### PR DESCRIPTION
To process signals we use a done channel which is passed down as an argument. But it would be best to use a Context. To fix it we are using `signal.NotifyContext` which returns a context that will be closed in case the expected signals are sent.

This refactor was discussed on https://github.com/aquasecurity/tracee/issues/2355

Task: https://github.com/aquasecurity/tracee/issues/2355