### PR TITLE
chore: add go signatures to the tar release

### DIFF
--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -157,7 +157,7 @@ release: \
 	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare
 	BTFHUB=1 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="all"
 	# create the tar ball and checksum files
-	$(CMD_TAR) --exclude="*.so" -czf $(OUT_ARCHIVE) $(RELEASE_FILES)
+	$(CMD_TAR) -czf $(OUT_ARCHIVE) $(RELEASE_FILES)
 	$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
 	# build official slim container image (CO-RE + BTFHUB)
 	BTFHUB=1 $(MAKE) -f builder/Makefile.tracee-container build-tracee


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tracee/issues/2508