### PR TITLE
ebpf: add prog_override_return arg to bpf_attach

### DIFF
--- a/docs/contributing/events/security_alerts/bpf_attach.md
+++ b/docs/contributing/events/security_alerts/bpf_attach.md
@@ -16,6 +16,7 @@ as well as information about the probe itself.
 * `perf_symbol`:`const char*`[K] - name/path of the symbol the BPF program is being attached to.
 * `perf_addr`:`u64`[K] - address/offset of the symbol the BPF program is being attached to.
 * `prog_write_user`:`int`[K] - whether the BPF program uses the bpf_probe_write_user() helper function.
+* `prog_override_return`:`int`[K] - whether the BPF program uses the bpf_override_return() helper function.
 * `perf_type`:`int`[K] - the probe's type.
 
 ## Hooks
@@ -41,13 +42,13 @@ save data of the BPF program for when we output the event
 #### Type
 kprobe
 #### Purpose
-check whether the BPF program uses the bpf_probe_write_user() helper function
+check whether the BPF program uses helper functions of interest
 
 ### check_map_func_compatibility
 #### Type
 kprobe
 #### Purpose
-check whether the BPF program uses the bpf_probe_write_user() helper function
+check whether the BPF program uses helper functions of interest
 
 ## Example Use Case
 ./tracee-ebpf -t e=bpf_attach

--- a/pkg/ebpf/c/missing_definitions.h
+++ b/pkg/ebpf/c/missing_definitions.h
@@ -86,6 +86,7 @@
     #define PERF_EVENT_IOC_SET_BPF _IOW('$', 8, __u32)
 
     #define BPF_FUNC_probe_write_user 36
+    #define BPF_FUNC_override_return  58
 
 enum perf_type_id
 {

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -451,15 +451,16 @@ typedef struct kmod_data {
     u64 next;
 } kmod_data_t;
 
-enum bpf_write_user_e
+enum bpf_helper_usage_e
 {
-    WRITE_USER_FALSE,
-    WRITE_USER_TRUE,
-    WRITE_USER_UNKNOWN
+    HELPER_USAGE_FALSE,
+    HELPER_USAGE_TRUE,
+    HELPER_USAGE_UNKNOWN
 };
 
 typedef struct bpf_attach {
-    enum bpf_write_user_e write_user;
+    enum bpf_helper_usage_e write_user;
+    enum bpf_helper_usage_e override_return;
 } bpf_attach_t;
 
 // KERNEL STRUCTS ----------------------------------------------------------------------------------

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -6087,6 +6087,7 @@ var Definitions = eventDefinitions{
 				{Type: "const char*", Name: "perf_symbol"},
 				{Type: "u64", Name: "perf_addr"},
 				{Type: "int", Name: "prog_write_user"},
+				{Type: "int", Name: "prog_override_return"},
 				{Type: "int", Name: "perf_type"},
 			},
 		},

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -240,10 +240,19 @@ func ParseArgs(event *trace.Event) error {
 		}
 		if writeUserArg := GetArg(event, "prog_write_user"); writeUserArg != nil {
 			if writeUser, isInt := writeUserArg.Value.(int32); isInt {
-				perfTypestr, err := parseBpfAttachWriteUser(writeUser)
+				perfTypestr, err := parseBpfAttachHelperUsage(writeUser)
 				EmptyString(writeUserArg)
 				if err == nil {
 					writeUserArg.Value = perfTypestr
+				}
+			}
+		}
+		if overrideReturnArg := GetArg(event, "prog_override_return"); overrideReturnArg != nil {
+			if overrideReturn, isInt := overrideReturnArg.Value.(int32); isInt {
+				perfTypestr, err := parseBpfAttachHelperUsage(overrideReturn)
+				EmptyString(overrideReturnArg)
+				if err == nil {
+					overrideReturnArg.Value = perfTypestr
 				}
 			}
 		}
@@ -303,8 +312,8 @@ func (arg CustomFunctionArgument) Value() uint64 {
 	return arg.val
 }
 
-func parseBpfAttachWriteUser(writeUser int32) (string, error) {
-	switch writeUser {
+func parseBpfAttachHelperUsage(helperArg int32) (string, error) {
+	switch helperArg {
 	case 0:
 		return "false", nil
 	case 1:
@@ -312,7 +321,7 @@ func parseBpfAttachWriteUser(writeUser int32) (string, error) {
 	case 2:
 		return "unknown", nil
 	default:
-		return "", fmt.Errorf("unknown prog_write_user value got from bpf_attach event")
+		return "", fmt.Errorf("unknown value got from bpf_attach event for helper usage arg")
 	}
 }
 


### PR DESCRIPTION
add argument to the bpf_attach event indicating whether the bpf_override_return helper function is used.
this is to be used later on in the signatures phase.

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Tue Jan 10 15:29:23 2023 +0200

    ebpf: add prog_override_return arg to bpf_attach
    
    add argument to the bpf_attach event indicating whether the
    bpf_override_return helper function is used
```

Fixes: #2558

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

locally using my own sample of BPF program that uses the `bpf_override_return` helper.

Reproduce the test by running:

- command 01: `./dist/tracee-ebpf -t e=bpf_attach`

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
