### PR TITLE
filters: populate proc_info_map with filtered binaries

### DIFF
--- a/docs/docs/tracing/event-filtering.md
+++ b/docs/docs/tracing/event-filtering.md
@@ -153,8 +153,7 @@ expected.
     !!! Note
         1. Mount namespace id or the special "host:" prefix can be used for finer filtering
         2. Given path must be absolute; i.e starts with "/"
-        3. Only binaries that were executed after Tracee will be filtered
-        4. Symbolic link paths are not supported
+        3. Symbolic link paths are not supported
 
 1. **PID** `(Operators: =, !=, <, > and "new")`
 

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -19,6 +19,7 @@ const (
 	CgroupIdFilterMap    = "cgroup_id_filter"
 	ContIdFilter         = "cont_id_filter"
 	BinaryFilterMap      = "binary_filter"
+	ProcInfoMap          = "proc_info_map"
 )
 
 type FilterScope struct {
@@ -60,7 +61,7 @@ func NewFilterScope() *FilterScope {
 		ArgFilter:         filters.NewArgFilter(),
 		ContextFilter:     filters.NewContextFilter(),
 		ProcessTreeFilter: filters.NewProcessTreeFilter(ProcessTreeFilterMap),
-		BinaryFilter:      filters.NewBPFBinaryFilter(BinaryFilterMap),
+		BinaryFilter:      filters.NewBPFBinaryFilter(BinaryFilterMap, ProcInfoMap),
 		Follow:            false,
 	}
 }

--- a/pkg/utils/proc/exe.go
+++ b/pkg/utils/proc/exe.go
@@ -1,0 +1,43 @@
+package proc
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// GetProcNS returns the namespace ID of a given namespace and process.
+// To do so, it requires access to the /proc file system of the host, and CAP_SYS_PTRACE capability.
+func GetProcBinary(pid uint) (string, error) {
+	binPath, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if err != nil {
+		return "", fmt.Errorf("could not read exe file: %v", err)
+	}
+	return binPath, nil
+}
+
+// GetProcNS returns the namespace ID of a given namespace and process.
+// To do so, it requires access to the /proc file system of the host, and CAP_SYS_PTRACE capability.
+func GetAllBinaryProcs() (map[string][]uint32, error) {
+	procDir, err := os.Open("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("could not open procfs dir: %v", err)
+	}
+	defer procDir.Close()
+	procs, err := procDir.Readdirnames(-1)
+	if err != nil {
+		return nil, fmt.Errorf("could not open procfs dir: %v", err)
+
+	}
+	binProcs := map[string][]uint32{}
+	for _, proc := range procs {
+		procUint, _ := strconv.ParseUint(proc, 10, 32)
+		bin, _ := GetProcBinary(uint(procUint))
+		if _, ok := binProcs[bin]; !ok {
+			binProcs[bin] = []uint32{}
+		}
+		binProcs[bin] = append(binProcs[bin], uint32(procUint))
+	}
+
+	return binProcs, nil
+}

--- a/tests/integration/tester.sh
+++ b/tests/integration/tester.sh
@@ -9,6 +9,10 @@ do_ls() {
     ls > /dev/null
 }
 
+do_which_ls() {
+    which ls > /dev/nul
+}
+
 do_ls_uname() {
     # run on the same core to ensure event order
     taskset -c 0 ls; uname
@@ -17,6 +21,12 @@ do_ls_uname() {
 do_docker_run() {
     outputFileName=$1
     output=$(docker run -d --rm alpine)
+    $(echo $output > $outputFileName)
+}
+
+get_dockerd_pid() {
+    outputFileName=$1
+    output=$(pidof dockerd)
     $(echo $output > $outputFileName)
 }
 


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

commit ebe6dc2436f8022e70aceb15cc678eda1df743c1
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Jan 11 12:59:02 2023 +0000

    integration: add test for binary filter
    
    Test confirms that `docker run` commands output with a filter on
    dockerd's binary path will include events with it's own PID.
    
    You can confirm this does not work by running the test without
    the previous commit.
```
commit 307b0fab783924d4419b7c9e2ddc96d32fddafe3
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Tue Jan 10 12:45:36 2023 +0000

    filters: populate proc_info_map with filtered binaries
    
    Previously, the binary filter could only practically filter new
    sub-processes of processes running before tracee has started.
    This is due to binary paths being enriched in eBPF code only on a
    sched_process_exec event.
    As such long running binaries such as most daemons could not be reliably
    filtered through the binary filter.
    
    This change solves this by prepopulating the proc_info_map with relevant
    binary paths from procfs.
    By the solution's nature it is suspectible to a race condition between
    populating the map and tracee starting to run.
```

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Added an integration test that should break when applied on top of current main.
Manual testing can be done by running a redis container and running tracee with
`tracee-ebpf -t bin=/usr/bin/redis-check-rdb` and confirming all events come from `redis-server`. This will not work in main.

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
