### PR TITLE
network: add HTTP events

### DIFF
--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -80,6 +80,10 @@ func setupTraceeGobInputSource(opts *traceeInputOptions) (chan protocol.Event, e
 	gob.Register(trace.ProtoDNSMX{})
 	gob.Register(trace.ProtoDNSURI{})
 	gob.Register(trace.ProtoDNSOPT{})
+	// HTTP
+	gob.Register(trace.ProtoHTTP{})
+	gob.Register(trace.ProtoHTTPRequest{})
+	gob.Register(trace.ProtoHTTPResponse{})
 
 	res := make(chan protocol.Event)
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1
-	github.com/aquasecurity/tracee/types v0.0.0-20221221112139-2ca9fe896015
+	github.com/aquasecurity/tracee/types v0.0.0-20230111174955-02e89880d176
 	github.com/containerd/containerd v1.6.12
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1 h1
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/aquasecurity/tracee/types v0.0.0-20221221112139-2ca9fe896015 h1:TmTpBQCcRRZYlRWYrPf3Vs0ckwcJNC6AAHZu8hzwRi8=
 github.com/aquasecurity/tracee/types v0.0.0-20221221112139-2ca9fe896015/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
+github.com/aquasecurity/tracee/types v0.0.0-20230111174955-02e89880d176 h1:M+atlubRVWb/Lbn4a8CWPCDaBtJ7CYT76KXjLsAHbJY=
+github.com/aquasecurity/tracee/types v0.0.0-20230111174955-02e89880d176/go.mod h1:l8MikK8yNCxoFVFq+WqvRg3kiDUX4wDTQwo7oD7YnWM=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -283,6 +283,10 @@ func (p *gobEventPrinter) Init() error {
 	gob.Register(trace.ProtoDNSMX{})
 	gob.Register(trace.ProtoDNSURI{})
 	gob.Register(trace.ProtoDNSOPT{})
+	// HTTP
+	gob.Register(trace.ProtoHTTP{})
+	gob.Register(trace.ProtoHTTPRequest{})
+	gob.Register(trace.ProtoHTTPResponse{})
 
 	return nil
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -740,6 +740,20 @@ func (t *Tracee) initDerivationTable() error {
 				DeriveFunction: derive.NetPacketDNSResponse(),
 			},
 		},
+		events.NetPacketHTTPBase: {
+			events.NetPacketHTTP: {
+				Enabled:        t.events[events.NetPacketHTTP].submit,
+				DeriveFunction: derive.NetPacketHTTP(),
+			},
+			events.NetPacketHTTPRequest: {
+				Enabled:        t.events[events.NetPacketHTTPRequest].submit,
+				DeriveFunction: derive.NetPacketHTTPRequest(),
+			},
+			events.NetPacketHTTPResponse: {
+				Enabled:        t.events[events.NetPacketHTTPResponse].submit,
+				DeriveFunction: derive.NetPacketHTTPResponse(),
+			},
+		},
 	}
 
 	return nil

--- a/pkg/events/derive/net_packet_dns.go
+++ b/pkg/events/derive/net_packet_dns.go
@@ -2,12 +2,10 @@ package derive
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/types/trace"
 
-	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 )
 
@@ -147,127 +145,29 @@ func deriveDNSResponseEvents(event trace.Event) ([]interface{}, error) {
 	}, nil
 }
 
-//
-// Helper Functions
-//
-
-type netPair struct {
-	srcIP   net.IP
-	dstIP   net.IP
-	srcPort uint16
-	dstPort uint16
-	proto   uint8
-	length  uint32
-}
-
-const (
-	IPPROTO_TCP uint8 = 6
-	IPPROTO_UDP uint8 = 17
-)
-
 // eventToProtoDNS turns a trace event into a ProtoDNS type, a type used by the
 // new network code for DNS events
 func eventToProtoDNS(event *trace.Event) (*netPair, *trace.ProtoDNS, error) {
-	var ok bool
-	var payload []byte
-	var layerType gopacket.LayerType
-	var net netPair
+	var DnsNetPair netPair
 
-	// sanity checks
-
-	payloadArg := events.GetArg(event, "payload")
-	if payloadArg == nil {
-		return nil, nil, noPayloadError()
+	layer7, err := parseUntilLayer7(event, &DnsNetPair)
+	if err != nil {
+		return nil, nil, err
 	}
-	if payload, ok = payloadArg.Value.([]byte); !ok {
-		return nil, nil, nonByteArgError()
-	}
-	payloadSize := len(payload)
-	if payloadSize < 1 {
-		return nil, nil, emptyPayloadError()
-	}
-
-	// initial header type
-
-	switch event.ReturnValue { // event retval tells layer type
-	case AF_INET:
-		layerType = layers.LayerTypeIPv4
-	case AF_INET6:
-		layerType = layers.LayerTypeIPv6
-	default:
-		return nil, nil, nil
-	}
-
-	// parse packet
-
-	packet := gopacket.NewPacket(
-		payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
-		layerType,
-		gopacket.Default,
-	)
-	if packet == nil {
-		return nil, nil, parsePacketError()
-	}
-
-	layer3 := packet.NetworkLayer()
-
-	switch v := layer3.(type) {
-	case (*layers.IPv4):
-		net.srcIP = v.SrcIP
-		net.dstIP = v.DstIP
-		net.length = uint32(v.Length)
-	case (*layers.IPv6):
-		net.srcIP = v.SrcIP
-		net.dstIP = v.DstIP
-		net.length = uint32(v.Length)
-	default:
-		return nil, nil, nil
-	}
-
-	layer4 := packet.TransportLayer()
-
-	switch v := layer4.(type) {
-	case (*layers.TCP):
-		net.srcPort = uint16(v.SrcPort)
-		net.dstPort = uint16(v.DstPort)
-		net.proto = IPPROTO_TCP
-	case (*layers.UDP):
-		net.srcPort = uint16(v.SrcPort)
-		net.dstPort = uint16(v.DstPort)
-		net.proto = IPPROTO_UDP
-	default:
-		return nil, nil, nil
-	}
-
-	layer7 := packet.ApplicationLayer()
 
 	switch l7 := layer7.(type) {
 	case (*layers.DNS):
 		var dns trace.ProtoDNS
 		copyDNSToProtoDNS(l7, &dns)
-		return &net, &dns, nil
+		return &DnsNetPair, &dns, nil
 	default:
-		if net.srcPort != 53 && net.dstPort != 53 {
-			return &net, nil, notProtoPacketError("DNS") // TCP packets (connection related), no event
+		if DnsNetPair.srcPort != 53 && DnsNetPair.dstPort != 53 {
+			// TCP packets (connection related), no event
+			return &DnsNetPair, nil, notProtoPacketError("DNS")
 		}
 	}
 
-	return &net, nil, nil
-}
-
-// convertNetPairToPktMeta converts the local netPair type, used by this code,
-// to PktMeta type, expected by the old dns events, which, for now, we want the
-// new network packet simple dns events to be compatible with.
-func convertNetPairToPktMeta(net *netPair) *trace.PktMeta {
-	return &trace.PktMeta{
-		SrcIP:     net.srcIP.String(),
-		DstIP:     net.dstIP.String(),
-		SrcPort:   net.srcPort,
-		DstPort:   net.dstPort,
-		Protocol:  net.proto,
-		PacketLen: net.length,
-		Iface:     "any", // TODO: pick iface from network events
-	}
+	return &DnsNetPair, nil, nil
 }
 
 // convertProtoDNSQuestionToDnsRequest converts the network packet dns event

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -1,11 +1,30 @@
 package derive
 
-import "strings"
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
 
 // helpers for all supported protocol derivations
 
-const AF_INET = 2
-const AF_INET6 = 10
+// Event return value (retval) encodes network event related information, such
+// as the L3 layer protocol (impossible to know without a L2 header, since
+// cgroup_skb programs are L3 only). It might also encode some other
+// information, such as L7 flow direction (impossible to know without deriving
+// the network event. knowing in advance helps to derive correct event and not
+// all possible ones).
+const (
+	familyIpv4 int = 1 << iota
+	familyIpv6
+	protoHttpRequest
+	protoHttpResponse
+)
 
 func boolToUint8(b bool) uint8 {
 	if b {
@@ -26,4 +45,125 @@ func convertArrayOfBytes(given [][]byte) []string {
 
 func strToLower(given string) string {
 	return strings.ToLower(given)
+}
+
+//
+// Helper Functions
+//
+
+type netPair struct {
+	srcIP   net.IP
+	dstIP   net.IP
+	srcPort uint16
+	dstPort uint16
+	proto   uint8
+	length  uint32
+}
+
+const (
+	IPPROTO_TCP uint8 = 6
+	IPPROTO_UDP uint8 = 17
+)
+
+// convertNetPairToPktMeta converts the local netPair type, used by this code,
+// to PktMeta type, expected by the old dns events, which, for now, we want the
+// new network packet simple dns events to be compatible with.
+func convertNetPairToPktMeta(net *netPair) *trace.PktMeta {
+	return &trace.PktMeta{
+		SrcIP:     net.srcIP.String(),
+		DstIP:     net.dstIP.String(),
+		SrcPort:   net.srcPort,
+		DstPort:   net.dstPort,
+		Protocol:  net.proto,
+		PacketLen: net.length,
+		Iface:     "any", // TODO: pick iface from network events
+	}
+}
+
+func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLayer, error) {
+	var ok bool
+	var payload []byte
+	var layerType gopacket.LayerType
+
+	// sanity checks
+
+	payloadArg := events.GetArg(event, "payload")
+	if payloadArg == nil {
+		return nil, noPayloadError()
+	}
+	if payload, ok = payloadArg.Value.([]byte); !ok {
+		return nil, nonByteArgError()
+	}
+	payloadSize := len(payload)
+	if payloadSize < 1 {
+		return nil, emptyPayloadError()
+	}
+
+	// event retval encodes layer 3 protocol
+
+	if event.ReturnValue&familyIpv4 == familyIpv4 {
+		layerType = layers.LayerTypeIPv4
+	} else if event.ReturnValue&familyIpv6 == familyIpv6 {
+		layerType = layers.LayerTypeIPv6
+	} else {
+		return nil, fmt.Errorf("base layer type not supported: %d", event.ReturnValue)
+	}
+
+	// parse packet with gopacket
+
+	packet := gopacket.NewPacket(
+		payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+		layerType,
+		gopacket.Default,
+	)
+	if packet == nil {
+		return nil, parsePacketError()
+	}
+
+	// network layer
+
+	layer3 := packet.NetworkLayer()
+
+	switch v := layer3.(type) {
+	case (*layers.IPv4):
+		pair.srcIP = v.SrcIP
+		pair.dstIP = v.DstIP
+		pair.length = uint32(v.Length)
+	case (*layers.IPv6):
+		pair.srcIP = v.SrcIP
+		pair.dstIP = v.DstIP
+		pair.length = uint32(v.Length)
+	default:
+		return nil, fmt.Errorf("layer 3 not supported: %v", layer3)
+	}
+
+	// transport layer
+
+	layer4 := packet.TransportLayer()
+
+	switch v := layer4.(type) {
+	case (*layers.TCP):
+		pair.srcPort = uint16(v.SrcPort)
+		pair.dstPort = uint16(v.DstPort)
+		pair.proto = IPPROTO_TCP
+	case (*layers.UDP):
+		pair.srcPort = uint16(v.SrcPort)
+		pair.dstPort = uint16(v.DstPort)
+		pair.proto = IPPROTO_UDP
+	default:
+		return nil, fmt.Errorf("layer 4 not supported: %v", layer4)
+	}
+
+	// check partial packet decoding
+
+	errorLayer := packet.ErrorLayer()
+	if errorLayer != nil {
+		return nil, errorLayer.Error()
+	}
+
+	// application layer
+
+	layer7 := packet.ApplicationLayer()
+
+	return layer7, nil
 }

--- a/pkg/events/derive/net_packet_http.go
+++ b/pkg/events/derive/net_packet_http.go
@@ -1,0 +1,264 @@
+package derive
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+const httpMinLen int = 7 // longest http command is "DELETE "
+
+//
+// NetPacketHTTP
+//
+
+func NetPacketHTTP() deriveFunction {
+	return deriveSingleEvent(events.NetPacketHTTP, deriveHTTP())
+}
+
+func deriveHTTP() deriveArgsFunction {
+	return deriveHTTPEvents
+}
+
+func deriveHTTPEvents(event trace.Event) ([]interface{}, error) {
+	net, http, err := eventToProtoHTTP(&event)
+	if err != nil {
+		return nil, err
+	}
+	if http == nil {
+		return nil, nil // connection related packets
+	}
+	if net == nil {
+		return nil, parsePacketError()
+	}
+
+	return []interface{}{
+		net.srcIP,
+		net.dstIP,
+		net.srcPort,
+		net.dstPort,
+		http,
+	}, nil
+}
+
+//
+// NetPacketHTTPRequest
+//
+
+func NetPacketHTTPRequest() deriveFunction {
+	return deriveSingleEvent(events.NetPacketHTTPRequest, deriveHTTPRequest())
+}
+
+func deriveHTTPRequest() deriveArgsFunction {
+	return deriveHTTPRequestEvents
+}
+
+func deriveHTTPRequestEvents(event trace.Event) ([]interface{}, error) {
+	net, http, err := eventToProtoHTTPRequest(&event)
+	if err != nil {
+		return nil, err
+	}
+	if http == nil {
+		return nil, nil // not a request
+	}
+	if net == nil {
+		return nil, err
+	}
+
+	meta := convertNetPairToPktMeta(net)
+
+	return []interface{}{
+		*meta,
+		http,
+	}, nil
+}
+
+//
+// NetPacketHTTPResponse
+//
+
+func NetPacketHTTPResponse() deriveFunction {
+	return deriveSingleEvent(events.NetPacketHTTPResponse, deriveHTTPResponse())
+}
+
+func deriveHTTPResponse() deriveArgsFunction {
+	return deriveHTTPResponseEvents
+}
+
+func deriveHTTPResponseEvents(event trace.Event) ([]interface{}, error) {
+	net, http, err := eventToProtoHTTPResponse(&event)
+	if err != nil {
+		return nil, err
+	}
+	if http == nil {
+		return nil, nil // // not a response
+	}
+	if net == nil {
+		return nil, err
+	}
+
+	meta := convertNetPairToPktMeta(net)
+
+	return []interface{}{
+		*meta,
+		http,
+	}, nil
+}
+
+func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
+	var httpNetPair netPair
+
+	layer7, err := parseUntilLayer7(event, &httpNetPair)
+	if err != nil {
+		return nil, nil, err
+	}
+	if layer7 == nil {
+		return nil, nil, nil
+	}
+	layer7Payload := layer7.Payload()
+
+	if len(layer7Payload) > httpMinLen {
+		var httpReq *http.Request
+		var httpRes *http.Response
+		var protoHttp trace.ProtoHTTP
+
+		reader := bufio.NewReader(bytes.NewReader(layer7Payload))
+
+		// event retval encodes HTTP direction
+		if event.ReturnValue&protoHttpRequest == protoHttpRequest {
+
+			httpReq, err = http.ReadRequest(reader)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			copyHTTPReqToProtoHTTP(httpReq, &protoHttp)
+
+		} else if event.ReturnValue&protoHttpResponse == protoHttpResponse {
+
+			httpRes, err = http.ReadResponse(reader, nil)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			copyHTTPResToProtoHTTP(httpRes, &protoHttp)
+
+		} else {
+			return &httpNetPair, nil, fmt.Errorf("unspecified direction for HTTP packet")
+		}
+
+		return &httpNetPair, &protoHttp, nil
+	}
+
+	return &httpNetPair, nil, notProtoPacketError("HTTP")
+}
+
+func eventToProtoHTTPRequest(event *trace.Event) (*netPair, *trace.ProtoHTTPRequest, error) {
+	var httpNetPair netPair
+
+	layer7, err := parseUntilLayer7(event, &httpNetPair)
+	if err != nil {
+		return nil, nil, err
+	}
+	if layer7 == nil {
+		return nil, nil, nil
+	}
+	layer7Payload := layer7.Payload()
+
+	if len(layer7Payload) > httpMinLen {
+		// event retval encodes HTTP direction
+		if event.ReturnValue&protoHttpRequest != protoHttpRequest {
+			return nil, nil, nil
+		}
+
+		reader := bufio.NewReader(bytes.NewReader(layer7Payload))
+
+		httpReq, err := http.ReadRequest(reader)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var httpRequest trace.ProtoHTTPRequest
+
+		copyHTTPReqToProtoHTTPRequest(httpReq, &httpRequest)
+
+		return &httpNetPair, &httpRequest, nil
+	}
+
+	return &httpNetPair, nil, notProtoPacketError("HTTP")
+}
+
+func eventToProtoHTTPResponse(event *trace.Event) (*netPair, *trace.ProtoHTTPResponse, error) {
+	var httpNetPair netPair
+
+	layer7, err := parseUntilLayer7(event, &httpNetPair)
+	if err != nil {
+		return nil, nil, err
+	}
+	if layer7 == nil {
+		return nil, nil, nil
+	}
+	layer7Payload := layer7.Payload()
+
+	if len(layer7Payload) > httpMinLen {
+		// event retval encodes HTTP direction
+		if event.ReturnValue&protoHttpResponse != protoHttpResponse {
+			return nil, nil, nil
+		}
+
+		reader := bufio.NewReader(bytes.NewReader(layer7Payload))
+
+		httpRes, err := http.ReadResponse(reader, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var httpResponse trace.ProtoHTTPResponse
+
+		copyHTTPResToProtoHTTPResponse(httpRes, &httpResponse)
+
+		return &httpNetPair, &httpResponse, nil
+	}
+
+	return &httpNetPair, nil, notProtoPacketError("HTTP")
+}
+
+func copyHTTPReqToProtoHTTP(httpReq *http.Request, proto *trace.ProtoHTTP) {
+	proto.Direction = "request"
+	proto.Method = httpReq.Method
+	proto.Protocol = httpReq.Proto
+	proto.Host = httpReq.Host
+	proto.URIPath = httpReq.URL.Path
+	proto.Headers = httpReq.Header
+	proto.ContentLength = httpReq.ContentLength
+}
+
+func copyHTTPResToProtoHTTP(httpRes *http.Response, proto *trace.ProtoHTTP) {
+	proto.Direction = "response"
+	proto.Status = httpRes.Status
+	proto.StatusCode = httpRes.StatusCode
+	proto.Protocol = httpRes.Proto
+	proto.Headers = httpRes.Header
+	proto.ContentLength = httpRes.ContentLength
+}
+
+func copyHTTPReqToProtoHTTPRequest(httpReq *http.Request, proto *trace.ProtoHTTPRequest) {
+	proto.Method = httpReq.Method
+	proto.Protocol = httpReq.Proto
+	proto.Host = httpReq.Host
+	proto.URIPath = httpReq.URL.Path
+	proto.Headers = httpReq.Header
+	proto.ContentLength = httpReq.ContentLength
+}
+
+func copyHTTPResToProtoHTTPResponse(httpRes *http.Response, proto *trace.ProtoHTTPResponse) {
+	proto.Status = httpRes.Status
+	proto.StatusCode = httpRes.StatusCode
+	proto.Protocol = httpRes.Proto
+	proto.Headers = httpRes.Header
+	proto.ContentLength = httpRes.ContentLength
+}

--- a/pkg/events/derive/net_packet_icmp.go
+++ b/pkg/events/derive/net_packet_icmp.go
@@ -36,7 +36,8 @@ func deriveNetPacketICMPArgs() deriveArgsFunction {
 
 		// initial header type
 
-		if event.ReturnValue != AF_INET {
+		// event retval encodes layer type
+		if event.ReturnValue&familyIpv4 != familyIpv4 {
 			return nil, nil
 		}
 

--- a/pkg/events/derive/net_packet_icmpv6.go
+++ b/pkg/events/derive/net_packet_icmpv6.go
@@ -36,7 +36,8 @@ func deriveNetPacketICMPv6Args() deriveArgsFunction {
 
 		// initial header type
 
-		if event.ReturnValue != AF_INET6 {
+		// event retval encodes layer type
+		if event.ReturnValue&familyIpv6 != familyIpv6 {
 			return nil, nil
 		}
 

--- a/pkg/events/derive/net_packet_ipv4.go
+++ b/pkg/events/derive/net_packet_ipv4.go
@@ -18,7 +18,8 @@ func deriveNetPacketIPv4Args() deriveArgsFunction {
 
 		// initial header type
 
-		if event.ReturnValue != AF_INET {
+		// event retval encodes layer type
+		if event.ReturnValue&familyIpv4 != familyIpv4 {
 			return nil, nil
 		}
 

--- a/pkg/events/derive/net_packet_ipv6.go
+++ b/pkg/events/derive/net_packet_ipv6.go
@@ -32,7 +32,8 @@ func deriveNetPacketIPv6Args() deriveArgsFunction {
 
 		// initial header type
 
-		if event.ReturnValue != AF_INET6 {
+		// event retval encodes layer type
+		if event.ReturnValue&familyIpv6 != familyIpv6 {
 			return nil, nil
 		}
 

--- a/pkg/events/derive/net_packet_tcp.go
+++ b/pkg/events/derive/net_packet_tcp.go
@@ -37,12 +37,12 @@ func deriveNetPacketTCPArgs() deriveArgsFunction {
 
 		// initial header type
 
-		switch event.ReturnValue { // event retval tells layer type
-		case AF_INET:
+		// event retval encodes layer type
+		if event.ReturnValue&familyIpv4 == familyIpv4 {
 			layerType = layers.LayerTypeIPv4
-		case AF_INET6:
+		} else if event.ReturnValue&familyIpv6 == familyIpv6 {
 			layerType = layers.LayerTypeIPv6
-		default:
+		} else {
 			return nil, nil
 		}
 

--- a/pkg/events/derive/net_packet_udp.go
+++ b/pkg/events/derive/net_packet_udp.go
@@ -37,12 +37,12 @@ func deriveNetPacketUDPArgs() deriveArgsFunction {
 
 		// initial header type
 
-		switch event.ReturnValue { // event retval tells layer type
-		case 2:
+		// event retval encodes layer type
+		if event.ReturnValue&familyIpv4 == familyIpv4 {
 			layerType = layers.LayerTypeIPv4
-		case 10:
+		} else if event.ReturnValue&familyIpv6 == familyIpv6 {
 			layerType = layers.LayerTypeIPv6
-		default:
+		} else {
 			return nil, nil
 		}
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -233,6 +233,7 @@ const (
 	NetPacketICMPv6Base // TODO: move this event into range for network events
 	NetPacketDNSBase    // TODO: move this event into range for network events
 	DoMmap
+	NetPacketHTTPBase // TODO: move this event into range for network events
 	MaxCommonID
 )
 
@@ -254,6 +255,9 @@ const (
 	NetPacketDNS
 	NetPacketDNSRequest
 	NetPacketDNSResponse
+	NetPacketHTTP
+	NetPacketHTTPRequest
+	NetPacketHTTPResponse
 	MaxUserSpace
 )
 
@@ -6422,6 +6426,65 @@ var Definitions = eventDefinitions{
 			Params: []trace.ArgMeta{
 				{Type: "trace.PktMeta", Name: "metadata"},
 				{Type: "[]trace.DnsResponseData", Name: "dns_response"},
+			},
+		},
+		NetPacketHTTPBase: {
+			ID32Bit:  sys32undefined,
+			Name:     "net_packet_http_base",
+			Internal: true,
+			Dependencies: dependencies{
+				Events: []eventDependency{
+					{EventID: NetPacketBase},
+				},
+			},
+			Sets: []string{"network_events"},
+			Params: []trace.ArgMeta{
+				{Type: "bytes", Name: "payload"},
+			},
+		},
+		NetPacketHTTP: {
+			ID32Bit: sys32undefined,
+			Name:    "net_packet_http", // preferred event to write signatures
+			Dependencies: dependencies{
+				Events: []eventDependency{
+					{EventID: NetPacketHTTPBase},
+				},
+			},
+			Sets: []string{"network_events"},
+			Params: []trace.ArgMeta{
+				{Type: "const char*", Name: "src"},
+				{Type: "const char*", Name: "dst"},
+				{Type: "u16", Name: "src_port"},
+				{Type: "u16", Name: "dst_port"},
+				{Type: "trace.ProtoHTTP", Name: "proto_http"},
+			},
+		},
+		NetPacketHTTPRequest: {
+			ID32Bit: sys32undefined,
+			Name:    "net_packet_http_request",
+			Dependencies: dependencies{
+				Events: []eventDependency{
+					{EventID: NetPacketHTTPBase},
+				},
+			},
+			Sets: []string{"network_events"},
+			Params: []trace.ArgMeta{
+				{Type: "trace.PktMeta", Name: "metadata"},
+				{Type: "trace.ProtoHTTPRequest", Name: "http_request"},
+			},
+		},
+		NetPacketHTTPResponse: {
+			ID32Bit: sys32undefined,
+			Name:    "net_packet_http_response",
+			Dependencies: dependencies{
+				Events: []eventDependency{
+					{EventID: NetPacketHTTPBase},
+				},
+			},
+			Sets: []string{"network_events"},
+			Params: []trace.ArgMeta{
+				{Type: "trace.PktMeta", Name: "metadata"},
+				{Type: "trace.ProtoHTTPResponse", Name: "http_response"},
 			},
 		},
 	},


### PR DESCRIPTION
## This is a rebase of https://github.com/aquasecurity/tracee/pull/2538

made by @roikol and approved by me.

## Description (git log)

network: add HTTP events

Introduce the new HTTP, HTTP request and HTTP response events.

- event retval now encodes more than just layer3 protocol types.
- BPF logic for HTTP events and L7 parsing in kernel (reduce num of events)
- derivation logic for HTTP events.
- generic layer 7 parsing function used by DNS and HTTP now.

![image](https://user-images.githubusercontent.com/7395852/211982453-76c2a9c1-3b61-4c86-b254-624e085e1bf5.png)

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [x] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).
