### PR TITLE
events: always detect originated syscall

### DIFF
--- a/docs/contributing/events/kprobes/kallsyms_lookup_name.md
+++ b/docs/contributing/events/kprobes/kallsyms_lookup_name.md
@@ -12,7 +12,7 @@ It might be interesting in cases where a sensitive kernel symbol is looked-up.
 ## Arguments
 * `symbol_name`:`const char*`[K] - the symbol that is being looked-up.
 * `symbol_address`:`void*`[K] - the address of the symbol returned by the function. 0 if not found.
-* `syscall`:`int`[K,OPT] - the id of the syscall that invoked this lookup. present only if `detect-syscall` output option is on. If output option `parse-arguments` was chosen as well, the value will be transformed to the syscall name as a string type.
+* `syscall`:`int`[K] - the id of the syscall that invoked this lookup. If output option `parse-arguments` was chosen, the value will be transformed to the syscall name as a string type.
 
 ## Hooks
 ### kallsyms_lookup_name
@@ -22,4 +22,4 @@ kprobe + kretprobe
 tracing the kallsyms_lookup_name event
 
 ## Example Use Case
-`./dist/tracee-ebpf -t e=kallsyms_lookup_name -o option:detect-syscall`
+`./dist/tracee-ebpf -t e=kallsyms_lookup_name`

--- a/docs/docs/deep-dive/caching-events.md
+++ b/docs/docs/deep-dive/caching-events.md
@@ -48,7 +48,6 @@ $ sudo ./dist/tracee-ebpf \
     --cache mem-cache-size=1024 \
     --containers -o format:json \
     -o option:parse-arguments \
-    -o option:detect-syscall \
     -trace container \
     --crs docker:/var/run/docker.sock
 ```

--- a/docs/docs/deep-dive/ordering-events.md
+++ b/docs/docs/deep-dive/ordering-events.md
@@ -7,7 +7,6 @@ programs chronologically.
 sudo ./dist/tracee-ebpf \
     -o format:json \
     -o option:parse-arguments \
-    -o option:detect-syscall \
     -o option:sort-events
 ```
 

--- a/docs/docs/deep-dive/performance.md
+++ b/docs/docs/deep-dive/performance.md
@@ -69,7 +69,6 @@ generated the event:
 $ sudo ./dist/tracee-ebpf \
     --containers -o format:json \
     -o option:parse-arguments \
-    -o option:detect-syscall \
     -trace container \
     --crs docker:/var/run/docker.sock
 ```

--- a/docs/docs/detecting/go-cel.md
+++ b/docs/docs/detecting/go-cel.md
@@ -51,7 +51,6 @@ $ sudo ./dist/tracee-ebpf \
     --output json \
     --trace comm=bash \
     --trace follow \
-    --output option:detect-syscall \
     --output option:parse-arguments \
     -trace event=$(./dist/tracee-rules --rules Mine-0.1.0 --list-events) \
     | ./dist/tracee-rules \

--- a/docs/docs/detecting/golang.md
+++ b/docs/docs/detecting/golang.md
@@ -119,7 +119,6 @@ There are 2 ways you can get your own golang signatures working with tracee.
         --output json \
         --trace comm=bash \
         --trace follow \
-        --output option:detect-syscall \
         --output option:parse-arguments \
         -trace event=$(./dist/tracee-rules --rules Mine-0.1.0 --list-events) \
         | ./dist/tracee-rules \

--- a/docs/docs/detecting/index.md
+++ b/docs/docs/detecting/index.md
@@ -81,7 +81,6 @@ Check [getting tracee] in order to understand how to obtain **tracee-rules**.
          --output json \
          --trace comm=bash \
          --trace follow \
-         --output option:detect-syscall \
          --output option:parse-arguments \
          --trace event=$(./dist/tracee-rules --list-events) \
          | ./dist/tracee-rules \
@@ -154,7 +153,7 @@ meaningful events (for the loaded signature(s)) you may request from
     new processes happening as childs of all running `bash` processes.
 
     ```text
-    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --output option:detect-syscall --output option:parse-arguments --output option:exec-env --trace event=$(./dist/tracee-rules --rules TRC-2 --list-events) | ./dist/tracee-rules --input-tracee format:json --input-tracee file:stdin --rules TRC-2
+    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --output option:parse-arguments --output option:exec-env --trace event=$(./dist/tracee-rules --rules TRC-2 --list-events) | ./dist/tracee-rules --input-tracee format:json --input-tracee file:stdin --rules TRC-2
     Loaded 1 signature(s): [TRC-2]
     
     *** Detection ***

--- a/docs/docs/detecting/rego.md
+++ b/docs/docs/detecting/rego.md
@@ -75,7 +75,6 @@ $ sudo ./dist/tracee-ebpf \
     --output json \
     --trace comm=bash \
     --trace follow \
-    --output option:detect-syscall \
     --output option:parse-arguments \
     -trace event=$(./dist/tracee-rules --rules Mine-0.1.0 --list-events) \
     | ./dist/tracee-rules \

--- a/docs/docs/tracing/output-formats.md
+++ b/docs/docs/tracing/output-formats.md
@@ -50,9 +50,9 @@ Tracee supports different output formats for detected events:
         A good tip is to pipe **tracee-ebpf** json output to [jq]() tool, this way
         you can select fields, rename them, filter values, and many other things:
         > ```text
-        > sudo ./dist/tracee-ebpf -o format:json -o option:parse-arguments -o
-        > option:detect-syscall -trace comm=ping -capture net=lo | jq -c '. |
-        > {eventId, hostName,processName,hostProcessId,UserId}'
+        > sudo ./dist/tracee-ebpf -o format:json -o option:parse-arguments
+        > -trace comm=ping -capture net=lo | jq -c '. | {eventId, hostName
+        > ,processName,hostProcessId,UserId}'
         > ```
 
 4. **GOB**

--- a/docs/docs/tracing/output-options.md
+++ b/docs/docs/tracing/output-options.md
@@ -21,45 +21,14 @@ Tracee supports different output options for detected events:
     {"timestamp":1657291777566819000,"threadStartTime":616858353946737,"processorId":9,"processId":1948212,"cgroupId":1,"threadId":1948212,"parentProcessId":3795408,"hostProcessId":1948212,"hostThreadId":1948212,"hostParentProcessId":3795408,"userId":1000,"mountNamespace":4026531840,"pidNamespace":4026531836,"processName":"exa","hostName":"fujitsu","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","eventId":"257","eventName":"openat","argsNum":4,"returnValue":3,"stackAddresses":[140395297729336,140395297614210],"args":[{"name":"dirfd","type":"int","value":-100},{"name":"pathname","type":"const char*","value":"/etc/ld.so.cache"},{"name":"flags","type":"int","value":524288},{"name":"mode","type":"mode_t","value":0}]}
     ```
 
-2. **option:detect-syscall**
-
-    If you are filtering for an event that is not a syscall
-    ("security_file_open", for example), which sometimes is needed to avoid
-    [TOCTOU](https://blog.aquasec.com/linux-vulnerabilitie-tracee), you may
-    opt to also detect which syscall has generated that event.
-
-    ```text
-    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --trace event=security_file_open --output option:detect-syscall
-    ```
-
-    ```json
-    {"timestamp":1657291989963764000,"threadStartTime":617070752926681,"processorId":11,"processId":1986397,"cgroupId":1,"threadId":1986397,"parentProcessId":3795408,"hostProcessId":1986397,"hostThreadId":1986397,"hostParentProcessId":3795408,"userId":1000,"mountNamespace":4026531840,"pidNamespace":4026531836,"processName":"bash","hostName":"fujitsu","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","eventId":"722","eventName":"security_file_open","argsNum":7,"returnValue":0,"stackAddresses":null,"args":[{"name":"pathname","type":"const char*","value":"/usr/bin/exa"},{"name":"flags","type":"int","value":32800},{"name":"dev","type":"dev_t","value":271581185},{"name":"inode","type":"unsigned long","value":2493759},{"name":"ctime","type":"unsigned long","value":1653730234432691500},{"name":"syscall_pathname","type":"const char*","value":""},{"name":"syscall","type":"int","value":59}]}
-    {"timestamp":1657291989963871500,"threadStartTime":617070752926681,"processorId":11,"processId":1986397,"cgroupId":1,"threadId":1986397,"parentProcessId":3795408,"hostProcessId":1986397,"hostThreadId":1986397,"hostParentProcessId":3795408,"userId":1000,"mountNamespace":4026531840,"pidNamespace":4026531836,"processName":"bash","hostName":"fujitsu","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","eventId":"722","eventName":"security_file_open","argsNum":7,"returnValue":0,"stackAddresses":null,"args":[{"name":"pathname","type":"const char*","value":"/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"},{"name":"flags","type":"int","value":32800},{"name":"dev","type":"dev_t","value":271581185},{"name":"inode","type":"unsigned long","value":2752590},{"name":"ctime","type":"unsigned long","value":1653730015033811700},{"name":"syscall_pathname","type":"const char*","value":""},{"name":"syscall","type":"int","value":59}]}
-    ```
-
-    Observe that the event now has the following extra argument:
-
-    ```json
-    {"name":"syscall","type":"int","value":59}
-    ```
-
-    Which means the event that has generated that event was `sys_execve`
-    (syscall 59 in amd64 architecture).
-
-    !!! tip
-        If you pay attention to previous outputs, we have raw event data in
-        many places. Like the syscall example above, where we have to find out
-        which syscall it was referring to. Check **parse-arguments** option
-        below to improve your experience.
-
-3. **option:parse-arguments**
+2. **option:parse-arguments**
 
     In order to have a better experience with the output provided by
     **tracee-ebpf**, you may opt to parse event arguments to a **human
     *readable** format.
 
     ```text
-    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --trace event=security_file_open --output option:detect-syscall --output option:parse-arguments
+    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --trace event=security_file_open --output option:parse-arguments
     ```
     ```json
     {"timestamp":1657292314817581101,"threadStartTime":617395606682013,"processorId":9,"processId":2045288,"cgroupId":1,"threadId":2045288,"parentProcessId":3795408,"hostProcessId":2045288,"hostThreadId":2045288,"hostParentProcessId":3795408,"userId":1000,"mountNamespace":4026531840,"pidNamespace":4026531836,"processName":"bash","hostName":"fujitsu","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","eventId":"722","eventName":"security_file_open","argsNum":7,"returnValue":0,"stackAddresses":null,"args":[{"name":"pathname","type":"const char*","value":"/usr/bin/exa"},{"name":"flags","type":"string","value":"O_RDONLY|O_LARGEFILE"},{"name":"dev","type":"dev_t","value":271581185},{"name":"inode","type":"unsigned long","value":2493759},{"name":"ctime","type":"unsigned long","value":1653730234432691496},{"name":"syscall_pathname","type":"const char*","value":""},{"name":"syscall","type":"int","value":"execve"}]}
@@ -73,14 +42,14 @@ Tracee supports different output options for detected events:
     {"name":"syscall","type":"int","value":"execve"}
     ```
 
-4. **option:parse-arguments-fds**
+3. **option:parse-arguments-fds**
 
     In order to have a better experience with the output provided by
     **tracee-ebpf**, you may opt to parse event fd arguments to be
     enriched with **file paths**. This option also enables `parse-arguments`.
 
     ```text
-    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --trace event=read --output option:detect-syscall --output option:parse-arguments-fds
+    $ sudo ./dist/tracee-ebpf --output json --trace comm=bash --trace follow --trace event=read --output option:parse-arguments-fds
     ```
 
     ```text
@@ -102,7 +71,7 @@ Tracee supports different output options for detected events:
     ```
 
 
-5. **option:exec-env**
+4. **option:exec-env**
 
     Sometimes it is also important to know the execution environment variables
     whenever an event is detected, specially when deteting **execve** event.
@@ -122,7 +91,7 @@ Tracee supports different output options for detected events:
     {"name":"envp","type":"const char*const*","value":["SHELL=/bin/bash","COLORTERM=truecolor","LESS=-RF --mouse","HISTCONTROL=ignoreboth","HISTSIZE=1000000","DEBFULLNAME=Rafael David Tinoco","EDITOR=nvim","PWD=/home/rafaeldtinoco/work/ebpf/tracee","LOGNAME=rafaeldtinoco","DEB_BUILD_PROFILES=parallel=36 nocheck nostrip noudeb doc","LINES=82","HOME=/home/rafaeldtinoco","LANG=C.UTF-8","COLUMNS=106","MANROFFOPT=-c","DEBEMAIL=rafaeldtinoco@ubuntu.com","LC_TERMINAL=iTerm2","PROMPT_COMMAND=echo -ne \"\\033]0;$what\\007\"; history -a","BAT_THEME=GitHub","TERM=screen-256color","USER=rafaeldtinoco","GIT_PAGER=batcat --theme=\"GitHub\" -p --pager=less --tabs 0","MANPAGER=bash -c 'col -bx | batcat --theme=\"GitHub\" -l man -p'","LC_TERMINAL_VERSION=3.5.0beta5","DEB_BUILD_OPTIONS=parallel=36 nocheck nostrip noudeb doc","SHLVL=2","PAGER=batcat --theme=\"GitHub\" -p --pager=less --tabs 0","BAT_STYLE=plain","PROMPT_DIRTRIM=2","SYSTEMD_PAGER=batcat --theme=\"GitHub\" -p --pager=less --tabs 0","LC_CTYPE=C.UTF-8","LESS_HISTFILE=/dev/null","PS1=\\u@\\h \\w $ ","PATH=/home/rafaeldtinoco/bin:/home/rafaeldtinoco/go/bin:.:/sbin:/bin:/usr/sbin:/usr/bin:/snap/bin:/snap/sbin:/usr/local/bin:/usr/local/sbin:/usr/games/","HISTFILESIZE=1000000","DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus","SSH_TTY=/dev/pts/3","OLDPWD=/home/rafaeldtinoco","_=/bin/ls"]}
     ```
 
-6. **option:exec-hash**
+5. **option:exec-hash**
 
     This is a special output option for **sched_process_exec** so user can get
     the **file hash** and **process ctime** (particularly interesting if you

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -105,8 +105,8 @@ func TestPrepareFilter(t *testing.T) {
 			expectedError: filters.InvalidValue("-1"),
 		},
 		{
-			testName: "invalid uid 1",
-			filters: []string{"uid=	"},
+			testName:      "invalid uid 1",
+			filters:       []string{"uid=\t"},
 			expectedError: filters.InvalidValue("\t"),
 		},
 		{
@@ -489,17 +489,6 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "option detect-syscall",
-			outputSlice: []string{"option:detect-syscall"},
-			expectedOutput: flags.OutputConfig{
-				LogFile: os.Stderr,
-				OutputConfig: tracee.OutputConfig{
-					DetectSyscall:  true,
-					ParseArguments: true,
-				},
-			},
-		},
-		{
 			testName:    "option exec-env",
 			outputSlice: []string{"option:exec-env"},
 			expectedOutput: flags.OutputConfig{
@@ -534,12 +523,11 @@ func TestPrepareOutput(t *testing.T) {
 		},
 		{
 			testName:    "all options",
-			outputSlice: []string{"option:stack-addresses", "option:detect-syscall", "option:exec-env", "option:exec-hash", "option:sort-events"},
+			outputSlice: []string{"option:stack-addresses", "option:exec-env", "option:exec-hash", "option:sort-events"},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
 				OutputConfig: tracee.OutputConfig{
 					StackAddresses: true,
-					DetectSyscall:  true,
 					ExecEnv:        true,
 					ExecHash:       true,
 					ParseArguments: true,

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -21,10 +21,9 @@ Possible options:
 out-file:/path/to/file                             write the output to a specified file. create/trim the file if exists (default: stdout)
 log-file:/path/to/file                             write the logs to a specified file. create/trim the file if exists (default: stderr)
 none                                               ignore stream of events output, usually used with --capture
-option:{stack-addresses,detect-syscall,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
+option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
-  detect-syscall                                   when tracing kernel functions which are not syscalls, detect and show the original syscall that called that function
   exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
   relative-time                                    use relative timestamp instead of wall timestamp for events
   exec-hash                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
@@ -80,8 +79,6 @@ func PrepareOutput(outputSlice []string) (OutputConfig, printer.Config, error) {
 			switch outputParts[1] {
 			case "stack-addresses":
 				outcfg.StackAddresses = true
-			case "detect-syscall":
-				outcfg.DetectSyscall = true
 			case "exec-env":
 				outcfg.ExecEnv = true
 			case "relative-time":

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -90,7 +90,6 @@ type CapabilitiesConfig struct {
 
 type OutputConfig struct {
 	StackAddresses    bool
-	DetectSyscall     bool
 	ExecEnv           bool
 	RelativeTime      bool
 	ExecHash          bool
@@ -697,8 +696,7 @@ func (t *Tracee) initDerivationTable() error {
 
 // options config should match defined values in ebpf code
 const (
-	optDetectOrigSyscall uint32 = 1 << iota
-	optExecEnv
+	optExecEnv uint32 = 1 << iota
 	optCaptureFiles
 	optExtractDynCode
 	optStackAddresses
@@ -740,9 +738,6 @@ const (
 func (t *Tracee) getOptionsConfig() uint32 {
 	var cOptVal uint32
 
-	if t.config.Output.DetectSyscall {
-		cOptVal = cOptVal | optDetectOrigSyscall
-	}
 	if t.config.Output.ExecEnv {
 		cOptVal = cOptVal | optExecEnv
 	}

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -117,7 +117,6 @@ for TEST in $TESTS; do
         --cache mem-cache-size=512 \
         --output format:json \
         --output option:parse-arguments \
-        --output option:detect-syscall \
         --trace comm=ping,nc,nslookup,isc-net-0000,isc-worker0000 \
         --trace event=$events \
         2>$SCRIPT_TMP_DIR/ebpf-$$ \

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -44,9 +44,7 @@ func startTracee(t *testing.T, config tracee.Config, output *tracee.OutputConfig
 	}()
 
 	if output == nil {
-		output = &tracee.OutputConfig{
-			DetectSyscall: true,
-		}
+		output = &tracee.OutputConfig{}
 	}
 
 	config.Output = output

--- a/tests/kerneltest.sh
+++ b/tests/kerneltest.sh
@@ -99,7 +99,6 @@ for TEST in $TESTS; do
         --cache mem-cache-size=512 \
         --output format:gob \
         --output option:parse-arguments \
-        --output option:detect-syscall \
         --trace container=new \
         --trace event=$events \
         2>$SCRIPT_TMP_DIR/ebpf-$$ \


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Always evict the originated syscall argument for internal hooks events.
Remove the `detect-syscall` output option that was used to make it available.
Fix documentation to match new format.

Fixes: #2391 

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [x] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [x] Breaking change (cause existing functionality not to work as expected).


## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
