### PR TITLE
ebpf: turn has_prefix() to macro using compound expr

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2480,10 +2480,40 @@ static __always_inline int events_perf_submit(program_data_t *p, u32 id, long re
 
 // INTERNAL: STRINGS -------------------------------------------------------------------------------
 
+// Workaround: Newer LLVM versions might fail to optimize has_prefix()
+// loop unrolling with the following error:
+//
+//     warning: loop not unrolled: the optimizer was unable to perform
+//     the requested transformation; the transformation might be
+//     disabled or specified as part of an unsupported transformation
+//     ordering
+//
+
+#if defined(__clang__) && __clang_major__ > 13
+
+    #define has_prefix(p, s, n)                                                                    \
+        ({                                                                                         \
+            int rc = 0;                                                                            \
+            char *pre = p, *str = s;                                                               \
+            _Pragma("unroll") for (int z = 0; z < n; pre++, str++, z++)                            \
+            {                                                                                      \
+                if (!*pre) {                                                                       \
+                    rc = 1;                                                                        \
+                    break;                                                                         \
+                } else if (*pre != *str) {                                                         \
+                    rc = 0;                                                                        \
+                    break;                                                                         \
+                }                                                                                  \
+            }                                                                                      \
+            rc;                                                                                    \
+        })
+
+#else
+
 static __inline int has_prefix(char *prefix, char *str, int n)
 {
     int i;
-#pragma unroll
+    #pragma unroll
     for (i = 0; i < n; prefix++, str++, i++) {
         if (!*prefix)
             return 1;
@@ -2495,6 +2525,8 @@ static __inline int has_prefix(char *prefix, char *str, int n)
     // prefix is too long
     return 0;
 }
+
+#endif
 
 // HELPERS: VFS ------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description (git log)

Newer LLVM versions might fail to optimize the has_string() loop unrolling with the following error:

./pkg/ebpf/c/tracee.bpf.c:2487:5: warning: loop not unrolled: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]

By replacing the has_string() inline function with a macro compound statement, it is possible to mitigate that issue and make the eBPF binary properly optimized.

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Compile Tracee with clang-12, clang-13, and clang-14. Check if all tests pass and no compiler warnings happen.
