### PR TITLE
Clang format 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
-.vscode
-.idea
-/dist
-coverage.txt
-.vagrant/
-
-# .check* files are needed so .PHONY dependencies in makefile
-# aren't built each time you try to make the target (only if
-# the target dependencies, like source files, changed)
+# .check* files are needed so .PHONY dependencies in makefile aren't
+# built each time you try to make the target (only if the target
+# dependencies, like source files, changed)
 .check*
 
 # needed for the makefile btfhub building logic
@@ -18,3 +12,15 @@ debian
 
 # ignore Helm subcharts
 deploy/helm/tracee/charts/
+
+# dev related files
+.vscode
+.idea
+coverage.txt
+compile_commands.json
+.cache*
+.trunk*
+.vagrant
+
+# binaries and build files
+dist

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ CMD_GO ?= go
 CMD_GREP ?= grep
 CMD_CAT ?= cat
 CMD_MD5 ?= md5sum
-CMD_OPA ?= opa # https://github.com/open-policy-agent/opa/releases/download/v0.44.0/opa_linux_amd64_static
+CMD_OPA ?= opa
 CMD_STATICCHECK ?= staticcheck
 
 .check_%:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 Vagrant.configure("2") do |config|
   # config.vm.box = "ubuntu/focal64"     # Ubuntu 20.04 Focal Fossa (non CO-RE)
   # config.vm.box = "ubuntu/hirsute64"   # Ubuntu 21.04 Hirsute Hippo (CO-RE)
-  # config.vm.box = "ubuntu/impish64"    #  Ubuntu 21.10 Impish Indri (CO-RE)
-  config.vm.box = "ubuntu/jammy64"       #  Ubuntu 22.04 Jammy Jellyfish (CO-RE)
+  # config.vm.box = "ubuntu/impish64"    # Ubuntu 21.10 Impish Indri (CO-RE)
+  config.vm.box = "ubuntu/jammy64"       # Ubuntu 22.04 Jammy Jellyfish (CO-RE)
 
   config.ssh.extra_args = ["-t", "cd /vagrant; bash --login"]
 
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     VAGRANT_HOME="/home/vagrant"
     GO_VERSION="1.18"
-    OPA_VERSION="v0.44.0"
+    OPA_VERSION="v0.48.0"
 
     apt-get update
     apt-get install --yes bsdutils

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -63,7 +63,7 @@ RUN apk --no-cache update && \
     apk --no-cache add sudo curl && \
     apk --no-cache add libelf zlib && \
     apk --no-cache add libc6-compat && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.44.0/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.48.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 #

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -6,7 +6,7 @@
 #
 ################################################################################
 
-FROM alpine:3.16
+FROM alpine:3.17
 
 ARG uid=1000
 ARG gid=1000
@@ -18,12 +18,21 @@ RUN apk --no-cache update && \
     apk --no-cache add bash git curl rsync && \
     apk --no-cache add musl-dev libc6-compat && \
     apk --no-cache add llvm clang go make gcc && \
+    apk --no-cache add clang-extra-tools && \
     apk --no-cache add linux-headers && \
     apk --no-cache add elfutils-dev && \
     apk --no-cache add libelf-static && \
     apk --no-cache add zlib-static && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.44.0/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.48.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
+
+# extra tools for testing things
+
+RUN apk --no-cache add man-pages man-pages-posix bash-completion vim && \
+    apk --no-cache add iproute2 vlan bridge-utils net-tools && \
+    apk --no-cache add netcat-openbsd iputils && \
+    apk --no-cache add wget lynx w3m && \
+    apk --no-cache add stress-ng
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo
 
@@ -43,6 +52,7 @@ RUN export uid=$uid gid=$gid && \
     chown ${uid}:${gid} -R /home/tracee && \
     echo "export PS1=\"\u@\h[\w]$ \"" > /home/tracee/.bashrc && \
     echo "alias ls=\"ls --color\"" >> /home/tracee/.bashrc && \
+    echo "set -o vi" >> /home/tracee/.bashrc && \
     ln -s /home/tracee/.bashrc /home/tracee/.profile
 
 USER tracee

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -11,18 +11,37 @@ FROM ubuntu:jammy
 ARG uid=1000
 ARG gid=1000
 
+# ubuntu has been extremely slow with the default archive
+
+RUN echo "deb http://br.archive.ubuntu.com/ubuntu jammy main restricted universe multiverse" > /etc/apt/sources.list && \
+    echo "deb http://br.archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse" >> /etc/apt/sources.list
+
 # install needed environment
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y sudo coreutils findutils && \
     apt-get install -y bash git curl rsync && \
-    apt-get install -y llvm clang golang make gcc && \
+    apt-get install -y llvm clang clangd clang-format golang make gcc && \
+    apt-get install -y llvm-12 clang-12 clangd-12 clang-format-12 && \
+    apt-get install -y llvm-13 clang-13 clangd-13 clang-format-13 && \
     apt-get install -y linux-headers-generic && \
     apt-get install -y libelf-dev && \
     apt-get install -y zlib1g-dev && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.44.0/opa_linux_amd64_static && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 130 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-12 --slave /usr/bin/llc llc /usr/bin/llc-12 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-12 --slave /usr/bin/clangd clangd /usr/bin/clangd-12 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 130 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-13 --slave /usr/bin/llc llc /usr/bin/llc-13 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-13 --slave /usr/bin/clangd clangd /usr/bin/clangd-13 && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 140 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-14 --slave /usr/bin/llc llc /usr/bin/llc-14 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-14 --slave /usr/bin/clangd clangd /usr/bin/clangd-14 && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.48.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
+
+# extra tools for testing things
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y man bash-completion vim && \
+    apt-get install -y iproute2 vlan bridge-utils net-tools && \
+    apt-get install -y netcat-openbsd iputils-ping && \
+    apt-get install -y wget lynx w3m && \
+    apt-get install -y stress
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo
 
@@ -42,6 +61,7 @@ RUN export uid=$uid gid=$gid && \
     chown ${uid}:${gid} -R /home/tracee && \
     echo "export PS1=\"\u@\h[\w]$ \"" > /home/tracee/.bashrc && \
     echo "alias ls=\"ls --color\"" >> /home/tracee/.bashrc && \
+    echo "set -o vi" >> /home/tracee/.bashrc && \
     ln -s /home/tracee/.bashrc /home/tracee/.profile
 
 USER tracee

--- a/packaging/Dockerfile.fedora-packaging
+++ b/packaging/Dockerfile.fedora-packaging
@@ -25,7 +25,7 @@ RUN yum update -y && \
     yum install -y elfutils-libelf-devel && \
     yum install -y zlib-devel && \
     yum install -y rpm-build && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.44.0/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.48.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo

--- a/packaging/Dockerfile.ubuntu-packaging
+++ b/packaging/Dockerfile.ubuntu-packaging
@@ -28,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y build-essential devscripts ubuntu-dev-tools && \
     apt-get install -y debhelper dh-exec dpkg-dev pkg-config && \
     apt-get install -y software-properties-common && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.44.0/opa_linux_amd64_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.48.0/opa_linux_amd64_static && \
     chmod 755 /usr/bin/opa
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo


### PR DESCRIPTION
## Description (git log)

commit e49dc500 (HEAD -> clang-format-12, rafaeldtinoco/clang-format-12)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sun Jan 15 04:38:15 2023

    builder: adjust OPA version to latest in remaining

commit 53acf4b0
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sun Jan 15 04:30:12 2023

    builder: adjust tracee-make docker files
    
    - ubuntu: allow fix-fmt makefile rule to work inside tracee-make img
    - ubuntu: install multiple llvm/clang/clangd/clang-format versions
    
    - ubuntu & alpine: update opa to latest version to tracee-make img
    - ubuntu & alpine: add binaries for testing within tracee-make img

commit 06296884
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sun Jan 15 04:28:48 2023

    git: update .gitignore
    
    - add temp files related to development
