### PR TITLE
types/trace: add PodSandbox field

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -34,6 +34,7 @@ type Event struct {
 	PodName             string       `json:"podName"`
 	PodNamespace        string       `json:"podNamespace"`
 	PodUID              string       `json:"podUID"`
+	PodSandbox          bool         `json:"podSandbox"`
 	EventID             int          `json:"eventId,string"`
 	EventName           string       `json:"eventName"`
 	ArgsNum             int          `json:"argsNum"`


### PR DESCRIPTION
Add a PodSandbox field to indicate wether the event is coming from a kubernetes sandbox container or not.