### PR TITLE
network: remove leftovers from previous code

### DIFF
--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -108,9 +108,6 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 		ContextFilter:     filters.NewContextFilter(),
 		ProcessTreeFilter: filters.NewProcessTreeFilter(tracee.ProcessTreeFilterMap),
 		EventsToTrace:     []events.ID{},
-		NetFilter: &tracee.NetIfaces{
-			Ifaces: []string{},
-		},
 	}
 
 	eventFilter := cliFilter{
@@ -229,14 +226,6 @@ func PrepareFilter(filtersArr []string) (tracee.Filter, error) {
 
 		if strings.HasPrefix("event", filterName) {
 			err := eventFilter.Parse(operatorAndValues)
-			if err != nil {
-				return tracee.Filter{}, err
-			}
-			continue
-		}
-
-		if strings.HasPrefix(filterName, "net") {
-			err := filter.NetFilter.Parse(strings.TrimPrefix(operatorAndValues, "="))
 			if err != nil {
 				return tracee.Filter{}, err
 			}

--- a/pkg/ebpf/filters.go
+++ b/pkg/ebpf/filters.go
@@ -1,10 +1,6 @@
 package ebpf
 
 import (
-	"fmt"
-	"net"
-	"strings"
-
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 )
@@ -40,43 +36,4 @@ type Filter struct {
 	ProcessTreeFilter *filters.ProcessTreeFilter
 	BinaryFilter      *filters.BPFBinaryFilter
 	Follow            bool
-	NetFilter         *NetIfaces
-}
-
-type NetIfaces struct {
-	Ifaces []string
-}
-
-func (filter *NetIfaces) Parse(operatorAndValues string) error {
-	ifaces := strings.Split(operatorAndValues, ",")
-	filter.Ifaces = ifaces
-	for _, iface := range ifaces {
-		if _, err := net.InterfaceByName(iface); err != nil {
-			return fmt.Errorf("invalid network interface: %s", iface)
-		}
-		_, found := filter.Find(iface)
-		// if the interface is not already in the interface list, we want to add it
-		if !found {
-			filter.Ifaces = append(filter.Ifaces, iface)
-		}
-	}
-
-	return nil
-}
-
-func (ifaces *NetIfaces) Find(iface string) (int, bool) {
-	for idx, currIface := range ifaces.Ifaces {
-		if currIface == iface {
-			return idx, true
-		}
-	}
-
-	return -1, false
-}
-
-func (ifaces *NetIfaces) Interfaces() []string {
-	if ifaces.Ifaces == nil {
-		ifaces.Ifaces = []string{}
-	}
-	return ifaces.Ifaces
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -232,9 +232,6 @@ func GetCaptureEventsList(cfg Config) map[events.ID]eventConfig {
 	if cfg.Capture.Profile {
 		captureEvents[events.CaptureProfile] = eventConfig{}
 	}
-	if len(cfg.Filter.NetFilter.Ifaces) > 0 || logger.HasDebugLevel() {
-		captureEvents[events.SecuritySocketBind] = eventConfig{}
-	}
 	if pcaps.PcapsEnabled(cfg.Capture.Net) {
 		captureEvents[events.CaptureNetPacket] = eventConfig{}
 	}

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -76,7 +76,7 @@ func convertNetPairToPktMeta(net *netPair) *trace.PktMeta {
 		DstPort:   net.dstPort,
 		Protocol:  net.proto,
 		PacketLen: net.length,
-		Iface:     "any", // TODO: pick iface from network events
+		Iface:     "any", // TODO: pick iface index from the kernel ?
 	}
 }
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -278,11 +278,6 @@ const (
 	MaxRulesID   ID = 6999
 )
 
-const (
-	CaptureIface int32 = 1 << iota
-	TraceIface
-)
-
 var Definitions = eventDefinitions{
 	events: map[ID]Event{
 		Read: {

--- a/types/trace/network_trace.go
+++ b/types/trace/network_trace.go
@@ -12,7 +12,7 @@ type PktMeta struct {
 	DstPort   uint16 `json:"dst_port"`
 	Protocol  uint8  `json:"protocol"`
 	PacketLen uint32 `json:"packet_len"`
-	Iface     string `json:"iface"`
+	Iface     string `json:"iface"` // TODO: currently it is always "any"
 }
 
 type DnsQueryData struct {


### PR DESCRIPTION
network: remove leftovers from previous code

There is no reason to filter network interfaces anymore.
Remove some extra constants as well.

