### PR TITLE
network: uncomment e2e network tests config script

### DIFF
--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -69,11 +69,11 @@ info "GO: $(go version)"
 info
 info "= SETUP NETWORK TESTING ENV  =================================="
 info
-# timeout --preserve-status 20 ./tests/e2e-net-rules/scripts/setup.sh
-# ret=$?
-# if [[ $ret -ne 0 ]]; then
-#     error_exit "could not setup network namespaces: error $ret"
-# fi
+timeout --preserve-status 20 ./tests/e2e-net-rules/scripts/setup.sh
+ret=$?
+if [[ $ret -ne 0 ]]; then
+    error_exit "could not setup network namespaces: error $ret"
+fi
 info
 info "= COMPILING TRACEE ============================================"
 info


### PR DESCRIPTION
commit: c11a39ce has accidentally commented the script responsible for te initial setup for the e2e network tests. This commit fixes it.

Fixes: #2491 (together with that commit)
