### PR TITLE
sign container images with cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -19,7 +22,11 @@ jobs:
           submodules: true
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
-      - name: Login to docker.io and github
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.13.1'
+      - name: authenticate
         run: |
           gh auth login --with-token <<<'${{ secrets.GITHUB_TOKEN }}'
           docker login docker.io --username ${{ secrets.DOCKERHUB_USER }} --password-stdin <<<'${{ secrets.DOCKERHUB_TOKEN }}'

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -26,6 +26,7 @@ CMD_GIT ?= git
 CMD_RM ?= rm
 CMD_TOUCH ?= touch
 CMD_MKDIR ?= mkdir
+CMD_COSIGN ?= cosign
 
 .ONESHELL:
 .check_%:
@@ -181,8 +182,12 @@ ifneq ("$(SNAPSHOT)", "1")
 	# push container images to docker hub
 	#
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):latest
+
+	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell docker inspect --format='{{index .RepoDigests 0}}' $(PUSH_DOCKER_REPO):latest | awk -F'@' '{print $2}')
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(IMAGE_TAG)
+	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell docker inspect --format='{{index .RepoDigests 0}}' $(PUSH_DOCKER_REPO):full | awk -F'@' '{print $2}')
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):full
+	
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):full-$(IMAGE_TAG)
 	#
 	# create release notes


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

This PR aims to sign tracee container images with cosign using the keyless approach, which avoids the hassle of securely keeping our private keys.

PTAL @itaysk @dlorenc

> Thanks to @marcofranssen for helping me to fix the makefile; I've appealed to his wisdom about makefiles ! 

Fixes: #2115
