### PR TITLE
chore: add MatchedScopes to Event

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -37,6 +37,7 @@ type Event struct {
 	PodSandbox          bool         `json:"podSandbox"`
 	EventID             int          `json:"eventId,string"`
 	EventName           string       `json:"eventName"`
+	MatchedScopes       uint64       `json:"matchedScopes"`
 	ArgsNum             int          `json:"argsNum"`
 	ReturnValue         int          `json:"returnValue"`
 	StackAddresses      []uint64     `json:"stackAddresses"`


### PR DESCRIPTION
MatchedScopes is a requirement for the multiscope effort #2238.

Since types is a different module this needs to enter first to make e2e happy.