### PR TITLE
events: pass uninitialized arguments

### DIFF
--- a/docs/contributing/events/format.md
+++ b/docs/contributing/events/format.md
@@ -16,7 +16,7 @@ Detailed description of the event. Should include:
 * K - Originated from kernel-space.
 * U - Originated from user space (for example, pointer to user space memory used to get it)
 * TOCTOU - Vulnerable to TOCTOU (time of check, time of use)
-* OPT - Optional argument - might not always be available
+* OPT - Optional argument - might not always be available (passed with null value)
 
 ## Hooks
 ### <hooked_func#1>

--- a/docs/docs/detecting/golang.md
+++ b/docs/docs/detecting/golang.md
@@ -70,7 +70,7 @@ There are 2 ways you can get your own golang signatures working with tracee.
         
         		switch e.EventName {
         		case "openat", "execve":
-        			arg, err := helpers.GetTraceeArgumentByName(e, "pathname")
+        			arg, err := helpers.GetTraceeArgumentByName(e, "pathname", helpers.GetArgOps{DefaultArgs: false})
         			if err != nil {
         				return err
         			}

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -167,7 +167,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		decoder := New(tc.input)
 		_, actual, err := ReadArgFromBuff(0, decoder, tc.params)
 		assert.Equal(t, tc.expectedError, err, tc.name)
-		assert.Equal(t, tc.expectedArg, actual, tc.name)
+		assert.Equal(t, tc.expectedArg, actual.Value, tc.name)
 
 		if tc.name == "unknown" {
 			continue

--- a/pkg/rules/benchmark/signature/golang/anti_debugging.go
+++ b/pkg/rules/benchmark/signature/golang/anti_debugging.go
@@ -52,7 +52,7 @@ func (sig *antiDebugging) OnEvent(event protocol.Event) error {
 	if ee.EventName != "ptrace" {
 		return nil
 	}
-	request, err := helpers.GetTraceeArgumentByName(ee, "request")
+	request, err := helpers.GetTraceeArgumentByName(ee, "request", helpers.GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return err
 	}

--- a/pkg/rules/benchmark/signature/golang/code_injection.go
+++ b/pkg/rules/benchmark/signature/golang/code_injection.go
@@ -65,12 +65,12 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	}
 	switch ee.EventName {
 	case "open", "openat":
-		flags, err := helpers.GetTraceeArgumentByName(ee, "flags")
+		flags, err := helpers.GetTraceeArgumentByName(ee, "flags", helpers.GetArgOps{DefaultArgs: false})
 		if err != nil {
 			return fmt.Errorf("%v %#v", err, ee)
 		}
 		if helpers.IsFileWrite(flags.Value.(string)) {
-			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname")
+			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname", helpers.GetArgOps{DefaultArgs: false})
 			if err != nil {
 				return err
 			}
@@ -87,7 +87,7 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 			}
 		}
 	case "ptrace":
-		request, err := helpers.GetTraceeArgumentByName(ee, "request")
+		request, err := helpers.GetTraceeArgumentByName(ee, "request", helpers.GetArgOps{DefaultArgs: false})
 		if err != nil {
 			return err
 		}
@@ -104,14 +104,14 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 		}
 		// TODO Commenting out the execve case to make it equivalent to Rego signature
 		//case "execve":
-		//	envs, err := helpers.GetTraceeArgumentByName(ee, "envp")
+		//	envs, err := helpers.GetTraceeArgumentByName(ee, "envp", helpers.GetArgOps{DefaultArgs: false})
 		//	if err != nil {
 		//		break
 		//	}
 		//	envsSlice := envs.Value.([]string)
 		//	for _, env := range envsSlice {
 		//		if strings.HasPrefix(env, "LD_PRELOAD") || strings.HasPrefix(env, "LD_LIBRARY_PATH") {
-		//			cmd, err := helpers.GetTraceeArgumentByName(ee, "argv")
+		//			cmd, err := helpers.GetTraceeArgumentByName(ee, "argv", helpers.GetArgOps{DefaultArgs: false})
 		//			if err != nil {
 		//				return err
 		//			}

--- a/pkg/rules/celsig/wrapper/wrapper.go
+++ b/pkg/rules/celsig/wrapper/wrapper.go
@@ -101,6 +101,14 @@ func toArg(event trace.Event, source trace.Argument) (*Argument, error) {
 		valueType = ValueType_UNKNOWN_VALUE_TYPE
 	}
 
+	if source.Value == nil {
+		return &Argument{
+			Name:      source.Name,
+			ValueType: valueType,
+			Value:     &Value{},
+		}, nil
+	}
+
 	var value Value
 
 	switch valueType {

--- a/signatures/helpers/arguments_helpers.go
+++ b/signatures/helpers/arguments_helpers.go
@@ -7,10 +7,18 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
+// GetArgOps represents options for arguments getters
+type GetArgOps struct {
+	DefaultArgs bool // Receive default args value (value equals 'nil'). If set to false, will return error if arg not initialized.
+}
+
 // GetTraceeArgumentByName fetches the argument in event with `Name` that matches argName
-func GetTraceeArgumentByName(event trace.Event, argName string) (trace.Argument, error) {
+func GetTraceeArgumentByName(event trace.Event, argName string, opts GetArgOps) (trace.Argument, error) {
 	for _, arg := range event.Args {
 		if arg.Name == argName {
+			if !opts.DefaultArgs && arg.Value == nil {
+				return arg, fmt.Errorf("argument %s is not initialized", argName)
+			}
 			return arg, nil
 		}
 	}
@@ -19,7 +27,7 @@ func GetTraceeArgumentByName(event trace.Event, argName string) (trace.Argument,
 
 // GetTraceeStringArgumentByName gets the argument matching the "argName" given from the event "argv" field, casted as string.
 func GetTraceeStringArgumentByName(event trace.Event, argName string) (string, error) {
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return "", err
 	}
@@ -33,7 +41,7 @@ func GetTraceeStringArgumentByName(event trace.Event, argName string) (string, e
 
 // GetTraceeIntArgumentByName gets the argument matching the "argName" given from the event "argv" field, casted as int.
 func GetTraceeIntArgumentByName(event trace.Event, argName string) (int, error) {
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return 0, err
 	}
@@ -47,7 +55,7 @@ func GetTraceeIntArgumentByName(event trace.Event, argName string) (int, error) 
 
 // GetTraceeSliceStringArgumentByName gets the argument matching the "argName" given from the event "argv" field, casted as []string.
 func GetTraceeSliceStringArgumentByName(event trace.Event, argName string) ([]string, error) {
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +69,7 @@ func GetTraceeSliceStringArgumentByName(event trace.Event, argName string) ([]st
 
 // GetTraceeBytesSliceArgumentByName gets the argument matching the "argName" given from the event "argv" field, casted as []byte.
 func GetTraceeBytesSliceArgumentByName(event trace.Event, argName string) ([]byte, error) {
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +92,7 @@ func GetTraceeBytesSliceArgumentByName(event trace.Event, argName string) ([]byt
 
 // GetRawAddrArgumentByName returns map[string]string of addr argument
 func GetRawAddrArgumentByName(event trace.Event, argName string) (map[string]string, error) {
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +117,7 @@ func GetRawAddrArgumentByName(event trace.Event, argName string) (map[string]str
 
 // GetTraceeHookedSymbolDataArgumentByName returns []trace.HookedSymbolData of hooked symbols for arg
 func GetTraceeHookedSymbolDataArgumentByName(event trace.Event, argName string) ([]trace.HookedSymbolData, error) {
-	hookedSymbolsPtr, err := GetTraceeArgumentByName(event, argName)
+	hookedSymbolsPtr, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return []trace.HookedSymbolData{}, err
 	}

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -209,7 +209,7 @@ func GetProtoIPv4ByName(
 	//
 	var ipv4 trace.ProtoIPv4
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoIPv4{}, err
 	}
@@ -305,7 +305,7 @@ func GetProtoIPv6ByName(
 
 	var ipv4 trace.ProtoIPv6
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoIPv6{}, err
 	}
@@ -407,7 +407,7 @@ func GetProtoUDPByName(
 
 	var icmp trace.ProtoUDP
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoUDP{}, err
 	}
@@ -475,7 +475,7 @@ func GetProtoTCPByName(
 
 	var icmp trace.ProtoTCP
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoTCP{}, err
 	}
@@ -595,7 +595,7 @@ func GetProtoICMPByName(
 
 	var icmp trace.ProtoICMP
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoICMP{}, err
 	}
@@ -655,7 +655,7 @@ func GetProtoICMPv6ByName(
 
 	var icmpv6 trace.ProtoICMPv6
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoICMPv6{}, err
 	}
@@ -729,7 +729,7 @@ func GetProtoDNSByName(
 	//
 	var dns trace.ProtoDNS
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoDNS{}, err
 	}
@@ -1334,7 +1334,7 @@ func GetProtoHTTPByName(
 ) {
 	var httpProto trace.ProtoHTTP
 
-	arg, err := GetTraceeArgumentByName(event, argName)
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
 	if err != nil {
 		return trace.ProtoHTTP{}, err
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -179,7 +179,7 @@ func checkSecurityFileOpenExecve(t *testing.T, gotOutput *[]trace.Event) {
 
 	syscallArgs := []events.ID{}
 	for _, evt := range *gotOutput {
-		arg, err := helpers.GetTraceeArgumentByName(evt, "syscall")
+		arg, err := helpers.GetTraceeArgumentByName(evt, "syscall", helpers.GetArgOps{DefaultArgs: false})
 		require.NoError(t, err)
 		syscallArgs = append(syscallArgs, events.ID(arg.Value.(int32)))
 	}
@@ -198,7 +198,7 @@ func checkScope42SecurityFileOpenLs(t *testing.T, gotOutput *[]trace.Event) {
 		// ls - scope 42
 		assert.Equal(t, "ls", evt.ProcessName)
 		assert.Equal(t, uint64(1<<41), evt.MatchedScopes)
-		arg, err := helpers.GetTraceeArgumentByName(evt, "pathname")
+		arg, err := helpers.GetTraceeArgumentByName(evt, "pathname", helpers.GetArgOps{DefaultArgs: false})
 		require.NoError(t, err)
 		assert.Contains(t, arg.Value, "integration")
 	}


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Not passing arguments when they are missing from the eBPF payload proved to be problematic, because of parsing errors and database tables building.
Now we always pass all arguments, with default `nil` value if they are missing.

Fixes: #2261

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
