### PR TITLE
network: adjust capturing packets in many fronts

### DIFF
--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -347,6 +347,7 @@ func TestPrepareCapture(t *testing.T) {
 					OutputPath: "/tmp/tracee/out",
 					Net: pcaps.Config{
 						CaptureSingle: true,
+						CaptureLength: 96,
 					},
 				},
 			},
@@ -360,6 +361,7 @@ func TestPrepareCapture(t *testing.T) {
 						CaptureProcess:   true,
 						CaptureContainer: true,
 						CaptureCommand:   true,
+						CaptureLength:    96,
 					},
 				},
 			},
@@ -373,6 +375,21 @@ func TestPrepareCapture(t *testing.T) {
 						CaptureProcess:   false,
 						CaptureContainer: true,
 						CaptureCommand:   true,
+						CaptureLength:    96,
+					},
+				},
+			},
+			{
+				testName:     "capture network with multiple pcap types and snaplen",
+				captureSlice: []string{"network", "pcap:command,container", "pcap-snaplen:120b"},
+				expectedCapture: tracee.CaptureConfig{
+					OutputPath: "/tmp/tracee/out",
+					Net: pcaps.Config{
+						CaptureSingle:    false,
+						CaptureProcess:   false,
+						CaptureContainer: true,
+						CaptureCommand:   true,
+						CaptureLength:    120,
 					},
 				},
 			},

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -71,6 +71,11 @@ func (t *Tracee) processNetCapEvents(ctx gocontext.Context, in <-chan *trace.Eve
 	return errc
 }
 
+// processNetCapEvent processes network packets meant to be captured.
+//
+// TODO: usually networking parsing functions are big, still, this might need
+// some refactoring to make it smaller (code reuse might not be a key for the
+// refactor).
 func (t *Tracee) processNetCapEvent(event *trace.Event) {
 	eventId := events.ID(event.EventID)
 
@@ -79,8 +84,6 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 		var ok bool
 		var payload []byte
 		var layerType gopacket.LayerType
-		// var srcIP net.IP // keep for debug
-		// var dstIP net.IP // keep for debug
 
 		// sanity checks
 
@@ -121,30 +124,172 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 			return
 		}
 
-		// NOTE:
+		// amount of bytes the TCP header has based on data offset field
+
+		tcpDoff := func(l4 gopacket.TransportLayer) uint32 {
+			var doff uint32
+			if v, ok := l4.(*layers.TCP); ok {
+				doff = 20                    // TCP header default length is 20 bytes
+				if v.DataOffset > uint8(5) { // unless doff is set, then...
+					doff = uint32(v.DataOffset) * 4 // doff * 32bit words == tcp header length
+				}
+			}
+			return doff
+		}
+
+		// NOTES:
 		//
-		// We're capturing L3 packets only, but pcap needs a L2 header, as we
-		// are going to mix IPv4 and IPv6 packets in the same pcap file.
+		// 1) Fake Layer 2:
+		//
+		// Tracee captures L3 packets only, but pcap needs a L2 header, as it
+		// mixes IPv4 and IPv6 packets in the same pcap file.
 		//
 		// The easiest link type is "Null", which emulates a BSD loopback
 		// encapsulation (4-byte field differentiating IPv4 and IPv6 packets).
 		//
-		// So, from now on, instead of having the initial 32-bit as the
-		// "sizeof" (the event argument), it will become this "fake L2 header"
-		// as if it were the BSD loopback encapsulation header.
+		// So, from now on, instead of having the initial 32-bit as the "sizeof"
+		// (the event argument), it will become this "fake L2 header" as if it
+		// were the BSD loopback encapsulation header.
+		//
+		// 2) Fake IP header length Field:
+		//
+		// Tcpdump, when reading the generated pcap files, will complain about
+		// missing packet payload if the IP header says one length and the
+		// actual data in the payload is smaller (what happens when tracee
+		// pcap-snaplen option is not set to max). The code bellow changes IP
+		// length field to the length of the captured data.
 		//
 
-		layer3 := packet.NetworkLayer()
+		captureLength := t.config.Capture.Net.CaptureLength // after last known header
 
-		switch layer3.(type) {
+		// parse packet
+		layer3 := packet.NetworkLayer()
+		layer4 := packet.TransportLayer()
+
+		ipHeaderLength := uint32(0)     // IP header length is dynamic
+		icmpHeaderLength := uint32(8)   // ICMP header length is 8 bytes
+		icmpv6HeaderLength := uint32(4) // ICMPv6 header length is 4 bytes
+		udpHeaderLength := uint32(8)    // UDP header length is 8 bytes
+		tcpHeaderLength := uint32(0)    // TCP header length is dynamic
+
+		// will calculate L4 protocol headers length value
+		ipHeaderLengthValue := uint32(0)
+		udpHeaderLengthValue := uint32(0)
+
+		switch v := layer3.(type) {
+
 		case (*layers.IPv4):
-			binary.BigEndian.PutUint32(payload, 2) // L2 header: IPv4 (BSD encap header spec)
-			// srcIP = v.SrcIP // keep for debug
-			// dstIP = v.DstIP // keep for debug
+			// Fake L2 header: IPv4 (BSD encap header spec)
+			binary.BigEndian.PutUint32(payload, 2) // set value 2 to first 4 bytes (uint32)
+
+			// IP header depends on IHL flag (default: 5 * 4 = 20 bytes)
+			ipHeaderLength += uint32(v.IHL) * 4
+			ipHeaderLengthValue += ipHeaderLength
+
+			switch v.Protocol {
+			case layers.IPProtocolICMPv4:
+				// ICMP
+				ipHeaderLengthValue += icmpHeaderLength
+			case layers.IPProtocolUDP:
+				// UDP
+				udpHeaderLengthValue += udpHeaderLength
+				ipHeaderLengthValue += udpHeaderLength
+			case layers.IPProtocolTCP:
+				// TCP
+				tcpHeaderLength = tcpDoff(layer4)
+				ipHeaderLengthValue += tcpHeaderLength
+			}
+
+			// add capture length (length to capture after last known proto header)
+			ipHeaderLengthValue += captureLength
+			udpHeaderLengthValue += captureLength
+
+			// capture length is bigger than the pkt payload: no need for mangling
+			if ipHeaderLengthValue != uint32(len(payload[4:])) {
+				break
+			} // else: mangle the packet (below) due to capture length
+
+			// sanity check for max uint16 size in IP header length field
+			if ipHeaderLengthValue >= (1 << 16) {
+				ipHeaderLengthValue = (1 << 16) - 1
+			}
+
+			// change IPv4 total length field for the correct (new) packet size
+			binary.BigEndian.PutUint16(payload[6:], uint16(ipHeaderLengthValue))
+			// no flags, frag offset OR checksum changes (tcpdump does not complain)
+
+			switch v.Protocol {
+			// TCP does not have a length field (uses checksum to verify)
+			// no checksum recalculation (tcpdump does not complain)
+			case layers.IPProtocolUDP:
+				// NOTE: tcpdump might complain when parsing UDP packets that
+				//       are meant for a specific L7 protocol, like DNS, for
+				//       example, if their port is the protocol port and user
+				//       is only capturing "headers". That happens because it
+				//       tries to parse the DNS header and, if it does not
+				//       exist, it causes an error. To avoid that, one can run
+				//       tcpdump -q -r ./file.pcap, so it does not try to parse
+				//       upper layers in detail. That is the reason why the
+				//       default pcap snaplen is 96b.
+				//
+				// change UDP header length field for the correct (new) size
+				binary.BigEndian.PutUint16(
+					payload[4+ipHeaderLength+4:],
+					uint16(udpHeaderLengthValue),
+				)
+			}
+
 		case (*layers.IPv6):
-			binary.BigEndian.PutUint32(payload, 28) // L2 header: IPv6 (BSD encap header spec)
-			// srcIP = v.SrcIP // keep for debug
-			// dstIP = v.DstIP // keep for debug
+			// Fake L2 header: IPv6 (BSD encap header spec)
+			binary.BigEndian.PutUint32(payload, 28) // set value 28 to first 4 bytes (uint32)
+
+			ipHeaderLength = uint32(40) // IPv6 does not have an IHL field
+			ipHeaderLengthValue += ipHeaderLength
+
+			switch v.NextHeader {
+			case layers.IPProtocolICMPv6:
+				// ICMPv6
+				ipHeaderLengthValue += icmpv6HeaderLength
+			case layers.IPProtocolUDP:
+				// UDP
+				udpHeaderLengthValue += udpHeaderLength
+				ipHeaderLengthValue += udpHeaderLength
+			case layers.IPProtocolTCP:
+				// TCP
+				tcpHeaderLength = tcpDoff(layer4)
+				ipHeaderLengthValue += tcpHeaderLength
+			}
+
+			// add capture length (length to capture after last known proto header)
+			ipHeaderLengthValue += captureLength
+			udpHeaderLengthValue += captureLength
+
+			// capture length is bigger than the pkt payload: no need for mangling
+			if ipHeaderLengthValue != uint32(len(payload[4:])) {
+				break
+			} // else: mangle the packet (below) due to capture length
+
+			// sanity check for max uint16 size in IP header length field
+			if ipHeaderLengthValue >= (1 << 16) {
+				ipHeaderLengthValue = (1 << 16) - 1
+			}
+
+			// change IPv6 payload length field for the correct (new) packet size
+			binary.BigEndian.PutUint16(payload[12:], uint16(ipHeaderLengthValue))
+			// no flags, frag offset OR checksum changes (tcpdump does not complain)
+
+			switch v.NextHeader {
+			// TCP does not have a length field (uses checksum to verify)
+			// no checksum recalculation (tcpdump does not complain)
+			case layers.IPProtocolUDP:
+				// NOTE: same as IPv4 note
+				// change UDP header length field for the correct (new) size
+				binary.BigEndian.PutUint16(
+					payload[4+ipHeaderLength+4:],
+					uint16(udpHeaderLengthValue),
+				)
+			}
+
 		default:
 			return
 		}

--- a/pkg/pcaps/pcaps.go
+++ b/pkg/pcaps/pcaps.go
@@ -30,6 +30,7 @@ type Config struct {
 	CaptureProcess   bool
 	CaptureContainer bool
 	CaptureCommand   bool
+	CaptureLength    uint32
 }
 
 // Pcaps holds all Pcap for different PcapTypes


### PR DESCRIPTION
1. Tracee would capture any network packet independently of given event filters. That wouldn't allow users to specify a single protocol to be captured, for example. Now, consider the following command:

    tracee-ebpf --output none \
        --trace event=net_packet_dns,net_packet_icmp \
        --capture network

   Tracee is able to capture ICMP and DNS packets only, for example.

2. Tracee would capture all PCAP files using the entire packet payloads. That would lead a situation where the user wouldn't be able to run tracee, with the capturing option, for too long in a higher data transfer environment, as the PCAP file would grow in a very fast pace.

   Considering the following command:

    tracee-ebpf --output none \
        --trace event=net_packet_dns,net_packet_icmp \
        --capture network
        --capture pcap:command
        --capture pcap-snaplen:{headers,max,128b,256b,512b,1k,2k,4k,...}

   The user is now capable of selecting how much data they want to include on each captured packet:

   - headers: capture only up to layer 4 headers and no payload
   - max: capture the entire packet payload (heavy)
   - size + b: size in bytes of the amount of data after the L4 header to capture
   - size + kb: size in KBS of the amount of data after the L4 header to capture

   There are still some improvements to be made:

   - If capturing net_packet_ipv4, the IPv6 packets will also be captured. Some userland filtering will have to take its place in userland for derived network packet events.

   - After multi scopes are merged, each scope might have its own PCAP files, this way each scope might have a set of its own artifacts files for introspection.