### PR TITLE
pcap fixes before the release

### DIFF
--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -24,8 +24,16 @@ Possible options:
 dir:/path/to/dir                              path where tracee will save produced artifacts. the artifact will be saved into an 'out' subdirectory. (default: /tmp/tracee).
 profile                                       creates a runtime profile of program executions and their metadata for forensics use.
 clear-dir                                     clear the captured artifacts output dir before starting (default: false).
+
+Network:
+
 pcap:[single,process,container,command]       capture separate pcap files organized by single file, files per processes, containers and/or commands
-pcap-snaplen:[default, headers, max or SIZE]  sets captured payload from each packet (default=96b, headers, max, or 512b, 1kb, ...)
+pcap-snaplen:[default, headers, max or SIZE]  sets captured payload from each packet:
+                                              - default=96b (up to 96 bytes of payload if payload exists)
+											  - headers (up to layer 4, icmp & dns have full headers)
+											  - sizes ended in 'b' or 'kb' (for ipv4, ipv6, tcp, udp):
+											    256b, 512b, 1kb, 2kb, 4kb, ... (up to requested size)
+											  - max (entire packet)
 
 Examples:
   --capture exec                                           | capture executed files into the default output directory
@@ -34,10 +42,10 @@ Examples:
   --capture profile                                        | capture executed files and create a runtime profile in the output directory
   --capture net (or network)                               | capture network traffic. default: single pcap file containing all traced packets
   --capture net --capture pcap:process,command             | capture network traffic, save pcap files for processes and commands
-  --capture net --capture pcap-snaplen:1kb                 | capture network traffic, single pcap file (default), capture 1KB from each packet
+  --capture net --capture pcap-snaplen:1kb                 | capture network traffic, single pcap file (default), capture up to 1kb from each packet payload
   --capture net --capture pcap-snaplen:max                 | capture network traffic, single pcap file (default), capture full sized packets
-  --capture net --capture pcap-snaplen:headers             | capture network traffic, single pcap file (default), capture headers only from each packet
-  --capture net --capture pcap-snaplen:default             | capture network traffic, single pcap file (default), capture headers + 96 bytes from each packet
+  --capture net --capture pcap-snaplen:headers             | capture network traffic, single pcap file (default), capture headers only
+  --capture net --capture pcap-snaplen:default             | capture network traffic, single pcap file (default), capture headers + up to 96 bytes of payload
   --capture network --capture pcap:container,command       | capture network traffic, save pcap files for containers and commands
   --capture exec --output none                             | capture executed files into the default output directory not printing the stream of events
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4835,7 +4835,7 @@ int BPF_KPROBE(trace_security_file_open)
     // Load the arguments given to the open syscall (which eventually invokes this function)
     char empty_string[1] = "";
     void *syscall_pathname = &empty_string;
-    syscall_data_t *sys;
+    syscall_data_t *sys = NULL;
     bool syscall_traced = p.task_info->syscall_traced;
     if (syscall_traced) {
         sys = &p.task_info->syscall_data;
@@ -4856,7 +4856,8 @@ int BPF_KPROBE(trace_security_file_open)
     save_to_submit_buf(p.event, &inode_nr, sizeof(unsigned long), 3);
     save_to_submit_buf(p.event, &ctime, sizeof(u64), 4);
     save_str_to_buf(p.event, syscall_pathname, 5);
-    save_to_submit_buf(p.event, (void *) &sys->id, sizeof(int), 6);
+    if (sys)
+        save_to_submit_buf(p.event, (void *) &sys->id, sizeof(int), 6);
 
     return events_perf_submit(&p, SECURITY_FILE_OPEN, 0);
 }

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -7903,7 +7903,7 @@ CGROUP_SKB_HANDLE_FUNCTION(proto)
     //       filters + capture.
 
     if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP))
-        cgroup_skb_capture(); // capture tcp packets
+        cgroup_skb_capture(); // capture ipv4/ipv6 only packets
 
     return 1;
 }
@@ -7961,7 +7961,7 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_tcp)
 capture:
     if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP) ||
         should_submit_net_event(neteventctx, SUB_NET_PACKET_TCP))
-        cgroup_skb_capture(); // capture tcp packets
+        cgroup_skb_capture(); // capture ip or tcp packets
 
     return 1; // NOTE: might block TCP here if needed (return 0)
 }
@@ -8000,7 +8000,7 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_udp)
 capture:
     if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP) ||
         should_submit_net_event(neteventctx, SUB_NET_PACKET_UDP))
-        cgroup_skb_capture(); // capture tcp packets
+        cgroup_skb_capture(); // capture ip or udp packets
 
     return 1; // NOTE: might block UDP here if needed (return 0)
 }
@@ -8009,10 +8009,12 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_icmp)
 {
     // submit ICMP base event if needed (full packet)
 
-    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_ICMP)) {
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_ICMP))
         cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_ICMP, FULL);
-        cgroup_skb_capture(); // capture icmp packets
-    }
+
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP) ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_ICMP))
+        cgroup_skb_capture(); // capture ip or icmp packets
 
     return 1; // NOTE: might block ICMP here if needed (return 0)
 }
@@ -8021,10 +8023,13 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_icmpv6)
 {
     // submit ICMPv6 base event if needed (full packet)
 
-    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_ICMPV6)) {
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_ICMPV6))
         cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_ICMPV6, FULL);
-        cgroup_skb_capture(); // capture icmpv6 packets
-    }
+
+
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP) ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_ICMPV6))
+        cgroup_skb_capture(); // capture ip or icmpv6 packets
 
     return 1; // NOTE: might block ICMPv6 here if needed (return 0)
 }
@@ -8036,10 +8041,14 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_icmpv6)
 CGROUP_SKB_HANDLE_FUNCTION(proto_tcp_dns)
 {
     // submit DNS base event if needed (full packet)
-    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_DNS)) {
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_DNS))
         cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_DNS, FULL);
-        cgroup_skb_capture(); // capture tcp dns packets
-    }
+
+
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP)  ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_TCP) ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_DNS))
+        cgroup_skb_capture(); // capture dns-tcp, tcp or ip packets
 
     return 1; // NOTE: might block DNS here if needed (return 0)
 }
@@ -8047,10 +8056,13 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_tcp_dns)
 CGROUP_SKB_HANDLE_FUNCTION(proto_udp_dns)
 {
     // submit DNS base event if needed (full packet)
-    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_DNS)) {
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_DNS))
         cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_DNS, FULL);
-        cgroup_skb_capture(); // capture udp dns packets
-    }
+
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP)  ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_UDP) ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_DNS))
+        cgroup_skb_capture(); // capture dns-udp, udp or ip packets
 
     return 1; // NOTE: might block DNS here if needed (return 0)
 }
@@ -8059,10 +8071,13 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_tcp_http)
 {
     // submit HTTP base event if needed (full packet)
 
-    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_HTTP)) {
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_HTTP))
         cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_HTTP, FULL);
-        cgroup_skb_capture(); // capture http packets
-    }
+
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP)  ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_TCP) ||
+        should_submit_net_event(neteventctx, SUB_NET_PACKET_HTTP))
+        cgroup_skb_capture(); // capture http-tcp, tcp or ip packets
 
     return 1; // NOTE: might block HTTP here if needed (return 0)
 }

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -166,11 +166,9 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 		layer3 := packet.NetworkLayer()
 		layer4 := packet.TransportLayer()
 
-		ipHeaderLength := uint32(0)     // IP header length is dynamic
-		icmpHeaderLength := uint32(8)   // ICMP header length is 8 bytes
-		icmpv6HeaderLength := uint32(4) // ICMPv6 header length is 4 bytes
-		udpHeaderLength := uint32(8)    // UDP header length is 8 bytes
-		tcpHeaderLength := uint32(0)    // TCP header length is dynamic
+		ipHeaderLength := uint32(0)  // IP header length is dynamic
+		udpHeaderLength := uint32(8) // UDP header length is 8 bytes
+		tcpHeaderLength := uint32(0) // TCP header length is dynamic
 
 		// will calculate L4 protocol headers length value
 		ipHeaderLengthValue := uint32(0)
@@ -189,7 +187,7 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 			switch v.Protocol {
 			case layers.IPProtocolICMPv4:
 				// ICMP
-				ipHeaderLengthValue += icmpHeaderLength
+				break // always has "headers" only (payload = 0)
 			case layers.IPProtocolUDP:
 				// UDP
 				udpHeaderLengthValue += udpHeaderLength
@@ -249,7 +247,7 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 			switch v.NextHeader {
 			case layers.IPProtocolICMPv6:
 				// ICMPv6
-				ipHeaderLengthValue += icmpv6HeaderLength
+				break // always has "headers" only (payload = 0)
 			case layers.IPProtocolUDP:
 				// UDP
 				udpHeaderLengthValue += udpHeaderLength


### PR DESCRIPTION
commit e0267e71 (HEAD -> pcap-fixes, rafaeldtinoco/pcap-fixes)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Jan 27 01:44:30 2023

    network: adjust capture length for known protocols
    
    The capture payload length (snaplen) for:
    
      - net_packet_icmp
      - net_packet_icmpv6
      - net_packet_dns
    
    does not make much sense. Keep snaplen for:
    
      - net_packet_ipv4
      - net_packet_ipv6
      - net_packet_udp
      - net_packet_tcp
      - net_packet_http

commit 129b7ce4
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Jan 27 00:35:45 2023

    network: capture underlying layers correctly

----

For testing:

```
sudo rm -rf /tmp/tracee/out/pcap && sudo ./dist/tracee-ebpf --log debug --install-path /tmp/tracee --output option:parse-arguments --capabilities bypass=false --trace event=net_packet_udp --output none --capture network --capture pcap:single,container,process,command --capture pcap-snaplen:headers
```

Change `snaplen`: headers, max, 0b, 12b, 24b, 128b, 1kb
Change `pcap`: single, container, process, command or "single,process" etc
Change `event`: net_packet_udp, net_packet_ipv4, net_packet_dns (or use 2 events: net_packet_udp,net_packet_dns) for example.

Test multiple scopes as well:

```
sudo rm -rf /tmp/tracee/out/pcap && sudo ./dist/tracee-ebpf --log debug --install-path /tmp/tracee --output option:parse-arguments --capabilities bypass=false --trace 1:event=net_packet_udp --trace 2:event=net_packet_icmp --output none --capture network --capture pcap:single,container,process,command --capture pcap-snaplen:headers
```

