### PR TITLE
ebpf: set context seq ops scopes to always on

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4388,6 +4388,8 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
     if (!init_program_data(&p, ctx))
         return 0;
 
+    p.event->context.matched_scopes = 0xFFFFFFFFFFFFFFFF;
+
     // uprobe was triggered from other tracee instance
     if (p.config->tracee_pid != trigger_pid)
         return 0;

--- a/pkg/events/trigger/context.go
+++ b/pkg/events/trigger/context.go
@@ -74,6 +74,7 @@ func (store *context) Apply(event trace.Event) (trace.Event, error) {
 	invoking.EventID = event.EventID
 	invoking.ReturnValue = 0
 	invoking.Args = make([]trace.Argument, len(event.Args))
+	invoking.MatchedScopes = event.MatchedScopes
 	copied := copy(invoking.Args, event.Args)
 	if copied != len(event.Args) {
 		return trace.Event{}, errors.New("failed to apply event's args")


### PR DESCRIPTION
As it's a self-triggered event, matchedScopes must be set to all leaving the matching to the user land.

Context: db12e661e

Test:

```shell
sudo ./dist/tracee-ebpf -t 4:e=hooked_seq_ops -o format:table-verbose
TIME             SCOPES            UTS_NAME          CONTAINER_ID  MNT_NS       PID_NS       UID    COMM             PID     TID     PPID    RET              EVENT                ARGS
11:11:43:092225  0000000000000008                                 0            0            0                       0       0       0       0                hooked_seq_ops       hooked_seq_ops: map[]
^C
End of events stream
Stats: {EventCount:1 EventsFiltered:0 NetEvCount:0 NetCapCount:0 BPFLogsCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0 LostNtCapCount:0 LostBPFLogsCount:0}
```