### PR TITLE
chore: fix: default set container conflict

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5638,7 +5638,7 @@ var Definitions = eventDefinitions{
 			Dependencies: dependencies{
 				Events: []eventDependency{{EventID: CgroupMkdir}},
 			},
-			Sets: []string{"default", "containers"},
+			Sets: []string{"containers"},
 			Params: []trace.ArgMeta{
 				{Type: "const char*", Name: "runtime"},
 				{Type: "const char*", Name: "container_id"},
@@ -5657,7 +5657,7 @@ var Definitions = eventDefinitions{
 			Dependencies: dependencies{
 				Events: []eventDependency{{EventID: CgroupRmdir}},
 			},
-			Sets: []string{"default", "containers"},
+			Sets: []string{"containers"},
 			Params: []trace.ArgMeta{
 				{Type: "const char*", Name: "runtime"},
 				{Type: "const char*", Name: "container_id"},
@@ -5666,7 +5666,7 @@ var Definitions = eventDefinitions{
 		ExistingContainer: {
 			ID32Bit: sys32undefined,
 			Name:    "existing_container",
-			Sets:    []string{"default", "containers"},
+			Sets:    []string{"containers"},
 			Params: []trace.ArgMeta{
 				{Type: "const char*", Name: "runtime"},
 				{Type: "const char*", Name: "container_id"},


### PR DESCRIPTION
Some events

```
ContainerCreate
ContainerRemove
ExistingContainer
```

can't be mixed with `container=new`.

This fixes integration tests failures like:

`--- FAIL: Test_EventFilters/trace_only_events_from_new_containers`

Context:
- #2636
