### PR TITLE
events: bring back container create/remove events

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5638,7 +5638,7 @@ var Definitions = eventDefinitions{
 			Dependencies: dependencies{
 				Events: []eventDependency{{EventID: CgroupMkdir}},
 			},
-			Sets: []string{"containers"},
+			Sets: []string{"default", "containers"},
 			Params: []trace.ArgMeta{
 				{Type: "const char*", Name: "runtime"},
 				{Type: "const char*", Name: "container_id"},
@@ -5657,7 +5657,7 @@ var Definitions = eventDefinitions{
 			Dependencies: dependencies{
 				Events: []eventDependency{{EventID: CgroupRmdir}},
 			},
-			Sets: []string{"containers"},
+			Sets: []string{"default", "containers"},
 			Params: []trace.ArgMeta{
 				{Type: "const char*", Name: "runtime"},
 				{Type: "const char*", Name: "container_id"},

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -323,7 +323,7 @@ func Test_EventFilters(t *testing.T) {
 		},
 		{
 			name:       "trace only events from new containers",
-			filterArgs: []string{"container=new"},
+			filterArgs: []string{"container=new", "event!=container_create,container_remove"},
 			eventFunc:  checkNewContainers,
 		},
 		{


### PR DESCRIPTION
#2645 removed all container set events from the default set because they broke integration tests (in particular `existing_container`).
This PR brings back `container_create` and `container_remove`.