### PR TITLE
fix: don't trim event names in table printer

### DIFF
--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -104,7 +104,7 @@ func (p tableEventPrinter) Preamble() {
 		switch p.containerMode {
 		case ContainerModeDisabled:
 			fmt.Fprintf(p.out,
-				"%-16s %-17s %-17s %-13s %-12s %-12s %-6s %-16s %-7s %-7s %-7s %-16s %-20s %s",
+				"%-16s %-17s %-17s %-13s %-12s %-12s %-6s %-16s %-7s %-7s %-7s %-16s %-25s %s",
 				"TIME",
 				"SCOPES",
 				"UTS_NAME",
@@ -122,7 +122,7 @@ func (p tableEventPrinter) Preamble() {
 			)
 		case ContainerModeEnabled:
 			fmt.Fprintf(p.out,
-				"%-16s %-17s %-17s %-13s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s",
+				"%-16s %-17s %-17s %-13s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-25s %s",
 				"TIME",
 				"SCOPES",
 				"UTS_NAME",
@@ -140,7 +140,7 @@ func (p tableEventPrinter) Preamble() {
 			)
 		case ContainerModeEnriched:
 			fmt.Fprintf(p.out,
-				"%-16s %-17s %-17s %-13s %-16s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-20s %s",
+				"%-16s %-17s %-17s %-13s %-16s %-12s %-12s %-6s %-16s %-15s %-15s %-15s %-16s %-25s %s",
 				"TIME",
 				"SCOPES",
 				"UTS_NAME",
@@ -162,7 +162,7 @@ func (p tableEventPrinter) Preamble() {
 		switch p.containerMode {
 		case ContainerModeDisabled:
 			fmt.Fprintf(p.out,
-				"%-16s %-6s %-16s %-7s %-7s %-16s %-20s %s",
+				"%-16s %-6s %-16s %-7s %-7s %-16s %-25s %s",
 				"TIME",
 				"UID",
 				"COMM",
@@ -174,7 +174,7 @@ func (p tableEventPrinter) Preamble() {
 			)
 		case ContainerModeEnabled:
 			fmt.Fprintf(p.out,
-				"%-16s %-13s %-6s %-16s %-15s %-15s %-16s %-20s %s",
+				"%-16s %-13s %-6s %-16s %-15s %-15s %-16s %-25s %s",
 				"TIME",
 				"CONTAINER_ID",
 				"UID",
@@ -187,7 +187,7 @@ func (p tableEventPrinter) Preamble() {
 			)
 		case ContainerModeEnriched:
 			fmt.Fprintf(p.out,
-				"%-16s %-13s %-16s %-6s %-16s %-15s %-15s %-16s %-20s %s",
+				"%-16s %-13s %-16s %-6s %-16s %-15s %-15s %-16s %-25s %s",
 				"TIME",
 				"CONTAINER_ID",
 				"IMAGE",
@@ -221,15 +221,15 @@ func (p tableEventPrinter) Print(event trace.Event) {
 	}
 
 	eventName := event.EventName
-	if len(eventName) > 20 {
-		eventName = eventName[:17] + "..."
+	if len(eventName) > 25 {
+		eventName = eventName[:22] + "..."
 	}
 
 	if p.verbose {
 		switch p.containerMode {
 		case ContainerModeDisabled:
 			fmt.Fprintf(p.out,
-				"%-16s %016x  %-16s %-13s %-12d %-12d %-6d %-16s %-7d %-7d %-7d %-16d %-20s ",
+				"%-16s %016x  %-16s %-13s %-12d %-12d %-6d %-16s %-7d %-7d %-7d %-16d %-25s ",
 				timestamp,
 				event.MatchedScopes,
 				event.HostName,
@@ -246,7 +246,7 @@ func (p tableEventPrinter) Print(event trace.Event) {
 			)
 		case ContainerModeEnabled:
 			fmt.Fprintf(p.out,
-				"%-16s %016x  %-16s %-13s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				"%-16s %016x  %-16s %-13s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-25s ",
 				timestamp,
 				event.MatchedScopes,
 				event.HostName,
@@ -266,7 +266,7 @@ func (p tableEventPrinter) Print(event trace.Event) {
 			)
 		case ContainerModeEnriched:
 			fmt.Fprintf(p.out,
-				"%-16s %016x  %-16s %-13s %-16s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				"%-16s %016x  %-16s %-13s %-16s %-12d %-12d %-6d %-16s %-7d/%-7d %-7d/%-7d %-7d/%-7d %-16d %-25s ",
 				timestamp,
 				event.MatchedScopes,
 				event.HostName,
@@ -290,7 +290,7 @@ func (p tableEventPrinter) Print(event trace.Event) {
 		switch p.containerMode {
 		case ContainerModeDisabled:
 			fmt.Fprintf(p.out,
-				"%-16s %-6d %-16s %-7d %-7d %-16d %-20s ",
+				"%-16s %-6d %-16s %-7d %-7d %-16d %-25s ",
 				timestamp,
 				event.UserID,
 				event.ProcessName,
@@ -301,7 +301,7 @@ func (p tableEventPrinter) Print(event trace.Event) {
 			)
 		case ContainerModeEnabled:
 			fmt.Fprintf(p.out,
-				"%-16s %-13s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				"%-16s %-13s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-25s ",
 				timestamp,
 				containerId,
 				event.UserID,
@@ -315,7 +315,7 @@ func (p tableEventPrinter) Print(event trace.Event) {
 			)
 		case ContainerModeEnriched:
 			fmt.Fprintf(p.out,
-				"%-16s %-13s %-16s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-20s ",
+				"%-16s %-13s %-16s %-6d %-16s %-7d/%-7d %-7d/%-7d %-16d %-25s ",
 				timestamp,
 				containerId,
 				containerImage,


### PR DESCRIPTION
Since we changed the default set to include some security_socket_xxx events, it is now required to expand the space reserved for the event name or it gets trim.

Expand space from 20 to 25 chars.

## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

Copy and paste the git log here.

Fixes: #issue_number

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tests being included in this PR:

- [ ] Test File A
- [ ] Test File B

Reproduce the test by running:

- command 01
- command 02

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
