### PR TITLE
disk_mount: don't whitelist runc process

### DIFF
--- a/signatures/golang/disk_mount.go
+++ b/signatures/golang/disk_mount.go
@@ -56,12 +56,16 @@ func (sig *DiskMount) OnEvent(event protocol.Event) error {
 
 	case "security_sb_mount":
 
+		if !eventObj.ContextFlags.ContainerStarted {
+			return nil
+		}
+
 		deviceName, err := helpers.GetTraceeStringArgumentByName(eventObj, "dev_name")
 		if err != nil {
 			return nil
 		}
 
-		if !isRunc(eventObj) && strings.HasPrefix(deviceName, sig.devDir) {
+		if strings.HasPrefix(deviceName, sig.devDir) {
 			metadata, err := sig.GetMetadata()
 			if err != nil {
 				return err
@@ -82,11 +86,3 @@ func (sig *DiskMount) OnSignal(s detect.Signal) error {
 	return nil
 }
 func (sig *DiskMount) Close() {}
-
-func isRunc(event trace.Event) bool {
-	if event.ThreadID == 1 && strings.HasPrefix(event.ProcessName, "runc:") {
-		return true
-	}
-
-	return false
-}

--- a/signatures/golang/disk_mount_test.go
+++ b/signatures/golang/disk_mount_test.go
@@ -20,9 +20,10 @@ func TestDiskMount(t *testing.T) {
 			Name: "should trigger detection",
 			Events: []trace.Event{
 				{
-					ProcessName: "mal",
-					ThreadID:    8,
-					EventName:   "security_sb_mount",
+					ProcessName:  "mal",
+					ThreadID:     8,
+					ContextFlags: trace.ContextFlags{ContainerStarted: true},
+					EventName:    "security_sb_mount",
 					Args: []trace.Argument{
 						{
 							ArgMeta: trace.ArgMeta{
@@ -37,9 +38,10 @@ func TestDiskMount(t *testing.T) {
 				"TRC-1014": {
 					Data: nil,
 					Event: trace.Event{
-						ProcessName: "mal",
-						ThreadID:    8,
-						EventName:   "security_sb_mount",
+						ProcessName:  "mal",
+						ThreadID:     8,
+						ContextFlags: trace.ContextFlags{ContainerStarted: true},
+						EventName:    "security_sb_mount",
 						Args: []trace.Argument{
 							{
 								ArgMeta: trace.ArgMeta{
@@ -68,12 +70,13 @@ func TestDiskMount(t *testing.T) {
 			},
 		},
 		{
-			Name: "should not trigger detection - runc",
+			Name: "should not trigger detection - container not started",
 			Events: []trace.Event{
 				{
-					ProcessName: "runc:[init]",
-					ThreadID:    1,
-					EventName:   "security_sb_mount",
+					ProcessName:  "runc:[init]",
+					ThreadID:     1,
+					ContextFlags: trace.ContextFlags{ContainerStarted: false},
+					EventName:    "security_sb_mount",
 					Args: []trace.Argument{
 						{
 							ArgMeta: trace.ArgMeta{
@@ -90,9 +93,10 @@ func TestDiskMount(t *testing.T) {
 			Name: "should not trigger detection - wrong path",
 			Events: []trace.Event{
 				{
-					ProcessName: "runc:[init]",
-					ThreadID:    8,
-					EventName:   "security_sb_mount",
+					ProcessName:  "runc:[init]",
+					ThreadID:     8,
+					ContextFlags: trace.ContextFlags{ContainerStarted: true},
+					EventName:    "security_sb_mount",
 					Args: []trace.Argument{
 						{
 							ArgMeta: trace.ArgMeta{


### PR DESCRIPTION
instead use the ContainerStarted context flag

## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Tue Jan 31 12:50:02 2023 +0200

    disk_mount: don't whitelist runc process

    instead use the ContainerStarted context flag
```

Fixes: #1611

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Reproduce the test by running:

- command 01: `./dist/tracee-ebpf -t e=security_sb_mount -o format:json | ./dist/tracee-rules --input-tracee file:stdin --input-tracee format:json`
- command 02: `docker run --rm -it ubuntu:latest`

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [x] I have made corresponding changes to the documentation.
- [x] My code follows the style guidelines (C and Go) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented all functions/methods created explaining what they do.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix, or feature, is effective.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [x] Subject starts with "subsystem|file: description".
- [x] Do not end the subject line with a period.
- [x] Limit the subject line to 50 characters.
- [x] Separate subject from body with a blank line.
- [x] Use the imperative mood in the subject line.
- [x] Wrap the body at 72 characters.
- [x] Use the body to explain what and why instead of how.
