### PR TITLE
k8s: update helm chart lock

### DIFF
--- a/deploy/helm/tracee/Chart.lock
+++ b/deploy/helm/tracee/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postee
-  repository: https://aquasecurity.github.io/helm-charts/
+  repository: https://aquasecurity.github.io/helm-charts
   version: v2.8.4
-digest: sha256:f9e8a5b492d780d3faa7641f585873bf3b7c63a0b9ed3da76e68d331133621f3
-generated: "2022-12-16T15:29:20.340034Z"
+digest: sha256:71c441fabe80dcf95ff82cdf719bb99bf3f748143f5e7d5bee76f9267e7e0978
+generated: "2023-01-31T11:22:11.878313233-03:00"


### PR DESCRIPTION
The chart lock wasn't update, which failed the last publish: https://github.com/aquasecurity/tracee/actions/runs/4054901241