### PR TITLE
logger: set libbpfgo logger callback

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
@@ -29,6 +30,28 @@ func init() {
 			},
 		)
 	}
+
+	// Set libbpfgo logging callbacks
+	libbpfgo.SetLoggerCbs(libbpfgo.Callbacks{
+		Log: func(libLevel int, msg string, keyValues ...interface{}) {
+			lvl := logger.ErrorLevel
+
+			switch libLevel {
+			case libbpfgo.LibbpfWarnLevel:
+				lvl = logger.WarnLevel
+			case libbpfgo.LibbpfInfoLevel:
+				lvl = logger.InfoLevel
+			case libbpfgo.LibbpfDebugLevel:
+				lvl = logger.DebugLevel
+			}
+
+			logger.Log(lvl, false, msg, keyValues...)
+		},
+		LogFilters: []func(libLevel int, msg string) bool{
+			libbpfgo.LogFilterLevel,
+			libbpfgo.LogFilterOutput,
+		},
+	})
 }
 
 var version string

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
@@ -33,6 +34,28 @@ func init() {
 			},
 		)
 	}
+
+	// Set libbpfgo logging callbacks
+	libbpfgo.SetLoggerCbs(libbpfgo.Callbacks{
+		Log: func(libLevel int, msg string, keyValues ...interface{}) {
+			lvl := logger.ErrorLevel
+
+			switch libLevel {
+			case libbpfgo.LibbpfWarnLevel:
+				lvl = logger.WarnLevel
+			case libbpfgo.LibbpfInfoLevel:
+				lvl = logger.InfoLevel
+			case libbpfgo.LibbpfDebugLevel:
+				lvl = logger.DebugLevel
+			}
+
+			logger.Log(lvl, false, msg, keyValues...)
+		},
+		LogFilters: []func(libLevel int, msg string) bool{
+			libbpfgo.LogFilterLevel,
+			libbpfgo.LogFilterOutput,
+		},
+	})
 }
 
 var version string

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230131113824-8a1e54e011c6
+	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1
 	github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07
 	github.com/containerd/containerd v1.6.18

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed h1:u
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230131113824-8a1e54e011c6 h1:GMuKveh/HRw4DVBYFigwTZNP8vm8dO11xZHleecepwQ=
 github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230131113824-8a1e54e011c6/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
+github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2 h1:26nRGlFZuVx2Rlx3mCjb20oc0T1fmjWPkaFtFD9tvNw=
+github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1 h1:pQQ/vb0z2dw3fFkvD4XDw6XGM82EjPfS93Cav77wjIo=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07 h1:6XkjmyQTMOpRQACGuBmKWBUjAqfmWsV7Qr1OznXQqJU=


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.

## Description (git log)

commit f965b789dde7a42f92919ae241a14e5434bc66e3

    libbpfgo: bump to 8f83f25
    
    From this hash, libbpfgo publicizes its log callback API.

commit f14050d2e9ec81013afd2388d27111729be14d54

    chore: set libbpfgo logger callback

## Depends on

- https://github.com/aquasecurity/libbpfgo/pull/284

## Type of change

- [x] New feature (non-breaking change adding functionality).

### Context

- https://github.com/aquasecurity/tracee/pull/2600

Fixes: #2417