### PR TITLE
fix: filters: uint can't be less than 0

### DIFF
--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -191,6 +191,10 @@ func (filter *UIntFilter[T]) Parse(operatorAndValues string) error {
 		if err != nil {
 			return InvalidValue(val)
 		}
+		// 'uint<0'
+		if operator == Lower && valInt == 0 {
+			return InvalidExpression(operatorAndValues)
+		}
 		err = filter.add(valInt, operator)
 		if err != nil {
 			return err


### PR DESCRIPTION
Return error in case of uint compared as less than zero.

## Initial Checklist

- [x] There is an issue describing the need for this PR.

Fixes: #450 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).

## How Has This Been Tested?

Tests being included in this PR:

```shell
sudo ./dist/tracee  -t 3:e=sched_process_fork,sched_switch -t 3:comm=kthreadd -t 3:'pid<0'
{"level":"fatal","ts":1675274360.603387,"msg":"app","error":"invalid filter expression: <0"}
```

```
sudo ./dist/tracee  -t 3:e=hooked_syscalls,sched_process_fork,sched_switch -t 3:comm=kthreadd -t 3:pid=2
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
21:00:00:000000  0                       0       0       0                hooked_syscalls           hooked_syscalls: []
14:58:36:217564  0      kthreadd         2       2       0                sched_process_fork        parent_tid: 2, parent_ns_tid: 2, parent_pid: 2, parent_ns_pid: 2, child_tid: 1670002, child_ns_tid: 1670002, child_pid: 1670002, child_ns_pid: 1670002, start_time: 1675274316217562486
14:58:36:217580  0      kthreadd         2       2       0                sched_switch              cpu: 13, prev_tid: 2, prev_comm: kthreadd, next_tid: 0, next_comm: swapper/13
14:58:38:897864  0      kthreadd         2       2       0                sched_process_fork        parent_tid: 2, parent_ns_tid: 2, parent_pid: 2, parent_ns_pid: 2, child_tid: 1670040, child_ns_tid: 1670040, child_pid: 1670040, child_ns_pid: 1670040, start_time: 1675274318897860478
14:58:38:897878  0      kthreadd         2       2       0                sched_switch              cpu: 13, prev_tid: 2, prev_comm: kthreadd, next_tid: 0, next_comm: swapper/13
```