### PR TITLE
Fix processes root directory access

### DIFF
--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -39,8 +39,14 @@ func (cPathRes PathResolver) ResolveAbsolutePath(mountNSAbsolutePath string, mou
 		procRootPath := fmt.Sprintf("/proc/%d/root", int(pid))
 		// fs.FS interface requires relative paths, so the '/' prefix should be trimmed.
 		err := capabilities.GetInstance().Required(func() error {
-			_, err := fs.Stat(cPathRes.fs, strings.TrimPrefix(procRootPath, "/"))
-			return err
+			entries, err := fs.ReadDir(cPathRes.fs, strings.TrimPrefix(procRootPath, "/"))
+			if err != nil {
+				return err
+			}
+			if len(entries) == 0 {
+				return fmt.Errorf("empty directory")
+			}
+			return nil
 		})
 		if err == nil {
 			return fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath), nil


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.
- [x] Git log contains summary of the change.
- [x] Git log contains motivation and context of the change.
- [x] If part of an EPIC, PR git log contains EPIC number.
- [x] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

5a7dbb21 containers: resolve relative path of ns with legit root
ef716be0 utils: fix wrong stat file parsing


Fixes: #2670

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [ ] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Manually saw it fixed the first mount ns processes and emitted warnings no longer

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
