### PR TITLE
docs: update required docker flags

### DIFF
--- a/docs/getting-started/installing/prerequisites.md
+++ b/docs/getting-started/installing/prerequisites.md
@@ -38,7 +38,7 @@ capabilities:
 * On cgroup v1 environments, `CAP_SYS_ADMIN` is recommended if running from a
   container in order to allow tracee to mount the cpuset cgroup controller.
 
-> Alternatively, run as `root` or with the `--privileged` flag of Docker.
+> Alternatively, run as `root` or with **Docker** `--pid=host --cgroupns=host --privileged` flags.
 
 [libbpf CO-RE documentation]: https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere
 [BTFHUB]: https://github.com/aquasecurity/btfhub-archive


### PR DESCRIPTION
Update prerequisites permission section with required docker flags '--pid=host --cgroupns=host --privileged'.

## Initial Checklist

- [x] There is an issue describing the need for this PR.

Fixes: #1211 

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).

## How Has This Been Tested?

```shell
make -f builder/Makefile.mkdocs mkdocs-build
docker build \
        -f builder/Dockerfile.mkdocs \
        -t tracee-mkdocs:latest \
        .
Sending build context to Docker daemon  42.35MB
Step 1/2 : FROM squidfunk/mkdocs-material:8.3.0
 ---> 585d64194fff
Step 2/2 : RUN pip install --upgrade pip &&     pip install mike &&     pip install mkdocs-macros-plugin
 ---> Using cache
 ---> de4b86c1ce83
Successfully built de4b86c1ce83
Successfully tagged tracee-mkdocs:latest
```

![image](https://user-images.githubusercontent.com/3372117/216356108-75cb7718-6973-4857-9563-36d27617786d.png)
