### PR TITLE
refactor: reset event args

### DIFF
--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -212,4 +212,11 @@ static __always_inline int init_tailcall_program_data(program_data_t *p, void *c
     return 1;
 }
 
+// use this function for programs that send more than one event
+static __always_inline void reset_event_args(program_data_t *p)
+{
+    p->event->buf_off = 0;
+    p->event->context.argnum = 0;
+}
+
 #endif


### PR DESCRIPTION
## Initial Checklist

- [ ] There is an issue describing the need for this PR.
- [ ] Git log contains summary of the change.
- [ ] Git log contains motivation and context of the change.
- [ ] If part of an EPIC, PR git log contains EPIC number.
- [ ] If part of an EPIC, PR was added to EPIC description.

## Description (git log)

When more than one event is being submitted in the same BPF program it may be required to reset the arguments buffer of the event. 
Create a function to handle this.

## Type of change

- [ ] Bug fix (non-breaking change fixing an issue, preferable).
- [x] Quick fix (minor non-breaking change requiring no issue, use with care)
- [ ] Code refactor (code improvement and/or code removal)
- [ ] New feature (non-breaking change adding functionality).
- [ ] Breaking change (cause existing functionality not to work as expected).

## How Has This Been Tested?

Tests being included in this PR:

- [ ] Test File A
- [ ] Test File B

Reproduce the test by running:

- command 01
- command 02

## Final Checklist:

Pick "Bug Fix" or "Feature", delete the other and mark appropriate checks.

- [ ] I have made corresponding changes to the documentation.
- [ ] My code follows the style guidelines (C and Go) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented all functions/methods created explaining what they do.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix, or feature, is effective.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published before.

## Git Log Checklist:

My commits logs have:

- [ ] Subject starts with "subsystem|file: description".
- [ ] Do not end the subject line with a period.
- [ ] Limit the subject line to 50 characters.
- [ ] Separate subject from body with a blank line.
- [ ] Use the imperative mood in the subject line.
- [ ] Wrap the body at 72 characters.
- [ ] Use the body to explain what and why instead of how.
