### PR TITLE
fix: make inner aggregated logs usable

### DIFF
--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -200,10 +200,10 @@ func main() {
 				Usage: "Control event rego settings. run '--rego help' for more info.",
 				Value: cli.NewStringSlice(),
 			},
-			&cli.StringFlag{
+			&cli.StringSliceFlag{
 				Name:  "log",
-				Usage: "logger level. run '--log help' for more info.",
-				Value: "info",
+				Usage: "logger option. run '--log help' for more info.",
+				Value: cli.NewStringSlice("info"),
 			},
 		},
 	}

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -3,42 +3,99 @@ package flags
 import (
 	"fmt"
 	"io"
+	"strings"
+	"time"
+	"unicode"
 
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func logHelp() string {
-	return `Control logger level priority.
+	return `Control logger options - aggregation and level priority.
 
 Possible options:
-  --log debug               | debug log level
-  --log info                | information log level (default) 
-  --log warn                | warning log level
-  --log error               | error log level
-  --log panic               | panic log level
+  --log aggregate                | turns log aggregation on, delaying output (default is off)
+  --log aggregate:interval       | turns log aggregation on, delaying output to every 'interval' (s, m)
+  --log debug                    | debug log level
+  --log info                     | information log level (default)
+  --log warn                     | warning log level
+  --log error                    | error log level
+  --log panic                    | panic log level
+
+Examples:
+  --log debug                    | outputs debug level logs
+  --log debug --log aggregate    | outputs aggregated debug level logs every 3 seconds (default)
+  --log aggregate:5s             | outputs aggregated logs every 5 seconds
 `
 }
 
-func PrepareLogger(logLevel string, w io.Writer) error {
-	var lvl logger.Level
+func InvalidLogOption(opt string) error {
+	return fmt.Errorf("invalid log option: %s, use '--log help' for more info", opt)
+}
 
-	switch logLevel {
-	case "debug":
-		lvl = logger.DebugLevel
-	case "info":
-		lvl = logger.InfoLevel
-	case "warn":
-		lvl = logger.WarnLevel
-	case "error":
-		lvl = logger.ErrorLevel
-	case "fatal":
-		lvl = logger.FatalLevel
-	default:
-		return fmt.Errorf("invalid log level: %s, use '--log help' for more info", logLevel)
+func PrepareLogger(logOptions []string, w io.Writer) (*logger.LoggerConfig, error) {
+	var (
+		agg      bool
+		interval = logger.DefaultFlushInterval
+		lvl      = logger.DefaultLevel
+		err      error
+	)
+
+	for _, opt := range logOptions {
+		// parse aggregate option
+		if strings.HasPrefix(opt, "aggregate") {
+			if !strings.HasSuffix(opt, "aggregate") {
+				vals := strings.Split(opt, ":")
+				if len(vals) != 2 || len(vals[1]) <= 1 {
+					return nil, InvalidLogOption(opt)
+				}
+
+				// handle only seconds and minutes
+				timeSuffix := vals[1][len(vals[1])-1:][0]
+				if timeSuffix != 's' && timeSuffix != 'm' {
+					return nil, InvalidLogOption(opt)
+				}
+				prevByte := vals[1][len(vals[1])-2:][0]
+				if timeSuffix == 's' && !unicode.IsDigit(rune(prevByte)) {
+					return nil, InvalidLogOption(opt)
+				}
+
+				interval, err = time.ParseDuration(vals[1])
+				if err != nil {
+					return nil, InvalidLogOption(opt)
+				}
+			}
+			agg = true
+			continue
+		}
+
+		switch opt {
+		case "debug":
+			lvl = logger.DebugLevel
+		case "info":
+			lvl = logger.InfoLevel
+		case "warn":
+			lvl = logger.WarnLevel
+		case "error":
+			lvl = logger.ErrorLevel
+		case "fatal":
+			lvl = logger.FatalLevel
+		default:
+			return nil, InvalidLogOption(opt)
+		}
 	}
 
-	logger.SetLevel(lvl)
-	logger.SetWriter(w)
+	cfg := &logger.LoggerConfig{
+		Writer:        w,
+		Level:         lvl,
+		Aggregate:     agg,
+		FlushInterval: interval,
+	}
+	if lvl == logger.DebugLevel {
+		cfg.Encoder = logger.NewJSONEncoder(logger.NewDevelopmentEncoderConfig())
+	} else {
+		cfg.Encoder = logger.NewJSONEncoder(logger.NewProductionEncoderConfig())
+	}
 
-	return nil
+	return cfg, nil
 }

--- a/pkg/cmd/flags/logger_test.go
+++ b/pkg/cmd/flags/logger_test.go
@@ -1,0 +1,200 @@
+package flags_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareLogger(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		logOptions     []string
+		expectedReturn *logger.LoggerConfig
+		expectedError  error
+	}{
+		// valid log level
+		{
+			testName:   "valid log level",
+			logOptions: []string{"debug"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.DebugLevel,
+				Aggregate:     false,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log level",
+			logOptions: []string{"info"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.InfoLevel,
+				Aggregate:     false,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log level",
+			logOptions: []string{"warn"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.WarnLevel,
+				Aggregate:     false,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log level",
+			logOptions: []string{"error"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.ErrorLevel,
+				Aggregate:     false,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log level",
+			logOptions: []string{"fatal"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.FatalLevel,
+				Aggregate:     false,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		// invalid log level
+		{
+			testName:       "invalid log level",
+			logOptions:     []string{"invalid-level"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("invalid-level"),
+		},
+		{
+			testName:       "invalid log level",
+			logOptions:     []string{""},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption(""),
+		},
+
+		// valid log aggregate
+		{
+			testName:   "valid log aggregate",
+			logOptions: []string{"aggregate"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.DefaultLevel,
+				Aggregate:     true,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log aggregate",
+			logOptions: []string{"aggregate:10s"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.DefaultLevel,
+				Aggregate:     true,
+				FlushInterval: 10 * time.Second,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log aggregate",
+			logOptions: []string{"aggregate:2m"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.DefaultLevel,
+				Aggregate:     true,
+				FlushInterval: 2 * time.Minute,
+			},
+			expectedError: nil,
+		},
+		// invalid log aggregate
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"invalid-aggregate"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("invalid-aggregate"),
+		},
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"aggregate:"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("aggregate:"),
+		},
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"aggregate:s"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("aggregate:s"),
+		},
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"aggregate:-1"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("aggregate:-1"),
+		},
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"aggregate:abc"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("aggregate:abc"),
+		},
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"aggregate:15"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("aggregate:15"),
+		},
+		{
+			testName:       "invalid log aggregate",
+			logOptions:     []string{"aggregate:1ms"},
+			expectedReturn: nil,
+			expectedError:  flags.InvalidLogOption("aggregate:1ms"),
+		},
+
+		// valid log level + aggregate
+		{
+			testName:   "valid log level + aggregate",
+			logOptions: []string{"debug", "aggregate"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.DebugLevel,
+				Aggregate:     true,
+				FlushInterval: logger.DefaultFlushInterval,
+			},
+			expectedError: nil,
+		},
+		{
+			testName:   "valid log level + aggregate",
+			logOptions: []string{"debug", "aggregate:10s"},
+			expectedReturn: &logger.LoggerConfig{
+				Level:         logger.DebugLevel,
+				Aggregate:     true,
+				FlushInterval: 10 * time.Second,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			logCfg, err := flags.PrepareLogger(tc.logOptions, nil)
+			if tc.expectedError != nil {
+				require.Nil(t, logCfg)
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tc.expectedError.Error())
+			}
+			if tc.expectedError == nil {
+				require.Nil(t, err)
+				require.NotNil(t, logCfg)
+				assert.Equal(t, tc.expectedReturn.Level, logCfg.Level)
+				assert.Equal(t, tc.expectedReturn.Aggregate, logCfg.Aggregate)
+				assert.Equal(t, tc.expectedReturn.FlushInterval, logCfg.FlushInterval)
+			}
+		})
+	}
+}

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -34,10 +34,11 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Log command line flags
 
-	err = flags.PrepareLogger(c.String("log"), output.LogFile)
+	logCfg, err := flags.PrepareLogger(c.StringSlice("log"), output.LogFile)
 	if err != nil {
 		return runner, err
 	}
+	logger.Init(logCfg)
 
 	// OS release information
 


### PR DESCRIPTION
## Initial Checklist

- [x] There is an issue describing the need for this PR.

## Description (git log)

flags: introduce log unit tests
logger: flush logs periodically
logger: add aggregate option to --log

Fixes: #2570

## Type of change

- [x] Bug fix (non-breaking change fixing an issue, preferable).
- [x] New feature (non-breaking change adding functionality).

## How Has This Been Tested?

```shell
sudo ./dist/tracee -t comm=uname -log debug               
{"L":"DEBUG","T":"2023-02-03T20:51:43.131-0300","M":"osinfo","BUILD_ID":"rolling","KERNEL_RELEASE":"5.15.89-1-MANJARO","ARCH":"x86_64","PRETTY_NAME":"\"Manjaro Linux\"","ID":"manjaro","ID_LIKE":"arch","pkg":"urfave","file":"urfave.go","line":53}
{"L":"DEBUG","T":"2023-02-03T20:51:43.131-0300","M":"RuntimeSockets: failed to register default","socket":"containerd","error":"failed to register runtime socket stat /var/run/containerd/containerd.sock: no such file or directory","pkg":"flags","file":"containers.go","line":47}
{"L":"DEBUG","T":"2023-02-03T20:51:43.131-0300","M":"RuntimeSockets: failed to register default","socket":"crio","error":"failed to register runtime socket stat /var/run/crio/crio.sock: no such file or directory","pkg":"flags","file":"containers.go","line":47}
{"L":"DEBUG","T":"2023-02-03T20:51:43.131-0300","M":"RuntimeSockets: failed to register default","socket":"podman","error":"failed to register runtime socket stat /var/run/podman/podman.sock: no such file or directory","pkg":"flags","file":"containers.go","line":47}
{"L":"DEBUG","T":"2023-02-03T20:51:43.132-0300","M":"osinfo","security_lockdown":"none","pkg":"urfave","file":"urfave.go","line":118}
{"L":"DEBUG","T":"2023-02-03T20:51:43.134-0300","M":"BTF","bpfenv":false,"btfenv":false,"vmlinux":true,"pkg":"initialize","file":"bpfobject.go","line":40}
{"L":"DEBUG","T":"2023-02-03T20:51:43.134-0300","M":"BPF: using embedded BPF object","pkg":"initialize","file":"bpfobject.go","line":69}
{"L":"DEBUG","T":"2023-02-03T20:51:43.136-0300","M":"unpacked CO:RE bpf object file into memory","pkg":"initialize","file":"bpfobject.go","line":144}
{"L":"DEBUG","T":"2023-02-03T20:51:43.136-0300","M":"Enricher","error":"error registering enricher: unsupported runtime containerd","pkg":"containers","file":"containers.go","line":64}
{"L":"DEBUG","T":"2023-02-03T20:51:43.136-0300","M":"Enricher","error":"error registering enricher: unsupported runtime crio","pkg":"containers","file":"containers.go","line":68}
{"L":"DEBUG","T":"2023-02-03T20:51:43.136-0300","M":"Enricher","error":"error registering enricher: unsupported runtime podman","pkg":"containers","file":"containers.go","line":78}
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
```

```shell
sudo ./dist/tracee -t comm=uname -log debug -log aggregate
[sudo] password for gg: 
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS

# 3 seconds later

{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"BTF","origin":"/home/gg/code/tracee/pkg/cmd/initialize/bpfobject.go:40","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"Enricher","origin":"/home/gg/code/tracee/pkg/containers/containers.go:68","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"Enricher","origin":"/home/gg/code/tracee/pkg/containers/containers.go:78","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"RuntimeSockets: failed to register default","origin":"/home/gg/code/tracee/pkg/cmd/flags/containers.go:47","count":3}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"unpacked CO:RE bpf object file into memory","origin":"/home/gg/code/tracee/pkg/cmd/initialize/bpfobject.go:144","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"osinfo","origin":"/home/gg/code/tracee/pkg/cmd/urfave/urfave.go:118","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"Enricher","origin":"/home/gg/code/tracee/pkg/containers/containers.go:64","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"osinfo","origin":"/home/gg/code/tracee/pkg/cmd/urfave/urfave.go:53","count":1}
{"L":"DEBUG","T":"2023-02-03T20:51:22.277-0300","M":"BPF: using embedded BPF object","origin":"/home/gg/code/tracee/pkg/cmd/initialize/bpfobject.go:69","count":1}
```

```shell
sudo ./dist/tracee -t comm=uname -log debug -log aggregate:10s
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS

# 10 seconds later

{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"Enricher","origin":"/home/gg/code/tracee/pkg/containers/containers.go:68","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"RuntimeSockets: failed to register default","origin":"/home/gg/code/tracee/pkg/cmd/flags/containers.go:47","count":3}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"osinfo","origin":"/home/gg/code/tracee/pkg/cmd/urfave/urfave.go:119","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"BTF","origin":"/home/gg/code/tracee/pkg/cmd/initialize/bpfobject.go:39","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"Enricher","origin":"/home/gg/code/tracee/pkg/containers/containers.go:64","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"osinfo","origin":"/home/gg/code/tracee/pkg/cmd/urfave/urfave.go:54","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"Enricher","origin":"/home/gg/code/tracee/pkg/containers/containers.go:78","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"Failed in fetching process mount namespace","origin":"/home/gg/code/tracee/pkg/utils/proc/ns.go:40","count":3}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"BPF: using embedded BPF object","origin":"/home/gg/code/tracee/pkg/cmd/initialize/bpfobject.go:68","count":1}
{"L":"DEBUG","T":"2023-02-06T17:45:52.694-0300","M":"unpacked CO:RE bpf object file into memory","origin":"/home/gg/code/tracee/pkg/cmd/initialize/bpfobject.go:143","count":1}
