### PR TITLE
network: fix IPv4 packets being treated as IPv6 (net_packet_ipv6 only traced)

### DIFF
--- a/builder/Makefile.checkers
+++ b/builder/Makefile.checkers
@@ -74,6 +74,8 @@ help:
 # check formatting (clang-format, gofmt)
 #
 
+C_FILES_TO_BE_CHECKED = $(shell find ./pkg/ebpf/c/ -regextype posix-extended -regex '.*\.(h|c)' | xargs)
+
 .PHONY: fmt-check
 fmt-check: | \
 	.check_tree \
@@ -81,10 +83,10 @@ fmt-check: | \
 #
 	@errors=0
 	echo "Checking C and eBPF files and headers formatting..."
-	$(CMD_CLANG_FMT) --dry-run ./pkg/ebpf/c/*.h ./pkg/ebpf/c/*.c ./pkg/ebpf/c/common/* > /tmp/check-c-fmt 2>&1
+	$(CMD_CLANG_FMT) --dry-run $(C_FILES_TO_BE_CHECKED) > /tmp/check-c-fmt 2>&1
 	clangfmtamount=$$(cat /tmp/check-c-fmt | wc -l)
 	if [[ $$clangfmtamount -ne 0 ]]; then
-		head -n30 /tmp/check-c-fmt
+		cat /tmp/check-c-fmt
 		errors=1
 	fi
 	rm -f /tmp/check-c-fmt
@@ -114,7 +116,7 @@ fmt-fix: | \
 	.check_$(CMD_CLANG_FMT)
 #
 	@echo "Fixing C and eBPF files and headers formatting..."
-	$(CMD_CLANG_FMT) -i --verbose ./pkg/ebpf/c/*.h ./pkg/ebpf/c/*.c ./pkg/ebpf/c/common/* 
+	$(CMD_CLANG_FMT) -i --verbose $(C_FILES_TO_BE_CHECKED)
 #
 	echo "Fixing golang files formatting..."
 	gofmt -l -s -d . > /tmp/patch.$$

--- a/pkg/ebpf/c/missing_definitions.h
+++ b/pkg/ebpf/c/missing_definitions.h
@@ -4,88 +4,88 @@
 // NOTE: vmlinux.h contains kernel BTF information but not macros.
 
 #ifndef __TRACEE_MISSING_MACROS_H__
-#define __TRACEE_MISSING_MACROS_H__
+    #define __TRACEE_MISSING_MACROS_H__
 
-#define ULLONG_MAX (~0ULL)
+    #define ULLONG_MAX (~0ULL)
 
-#define inet_daddr     sk.__sk_common.skc_daddr
-#define inet_rcv_saddr sk.__sk_common.skc_rcv_saddr
-#define inet_dport     sk.__sk_common.skc_dport
-#define inet_num       sk.__sk_common.skc_num
+    #define inet_daddr     sk.__sk_common.skc_daddr
+    #define inet_rcv_saddr sk.__sk_common.skc_rcv_saddr
+    #define inet_dport     sk.__sk_common.skc_dport
+    #define inet_num       sk.__sk_common.skc_num
 
-#define sk_node             __sk_common.skc_node
-#define sk_nulls_node       __sk_common.skc_nulls_node
-#define sk_refcnt           __sk_common.skc_refcnt
-#define sk_tx_queue_mapping __sk_common.skc_tx_queue_mapping
+    #define sk_node             __sk_common.skc_node
+    #define sk_nulls_node       __sk_common.skc_nulls_node
+    #define sk_refcnt           __sk_common.skc_refcnt
+    #define sk_tx_queue_mapping __sk_common.skc_tx_queue_mapping
 
-#define sk_dontcopy_begin __sk_common.skc_dontcopy_begin
-#define sk_dontcopy_end   __sk_common.skc_dontcopy_end
-#define sk_hash           __sk_common.skc_hash
-#define sk_portpair       __sk_common.skc_portpair
-#define sk_num            __sk_common.skc_num
-#define sk_dport          __sk_common.skc_dport
-#define sk_addrpair       __sk_common.skc_addrpair
-#define sk_daddr          __sk_common.skc_daddr
-#define sk_rcv_saddr      __sk_common.skc_rcv_saddr
-#define sk_family         __sk_common.skc_family
-#define sk_state          __sk_common.skc_state
-#define sk_reuse          __sk_common.skc_reuse
-#define sk_reuseport      __sk_common.skc_reuseport
-#define sk_ipv6only       __sk_common.skc_ipv6only
-#define sk_net_refcnt     __sk_common.skc_net_refcnt
-#define sk_bound_dev_if   __sk_common.skc_bound_dev_if
-#define sk_bind_node      __sk_common.skc_bind_node
-#define sk_prot           __sk_common.skc_prot
-#define sk_net            __sk_common.skc_net
-#define sk_v6_daddr       __sk_common.skc_v6_daddr
-#define sk_v6_rcv_saddr   __sk_common.skc_v6_rcv_saddr
-#define sk_cookie         __sk_common.skc_cookie
-#define sk_incoming_cpu   __sk_common.skc_incoming_cpu
-#define sk_flags          __sk_common.skc_flags
-#define sk_rxhash         __sk_common.skc_rxhash
+    #define sk_dontcopy_begin __sk_common.skc_dontcopy_begin
+    #define sk_dontcopy_end   __sk_common.skc_dontcopy_end
+    #define sk_hash           __sk_common.skc_hash
+    #define sk_portpair       __sk_common.skc_portpair
+    #define sk_num            __sk_common.skc_num
+    #define sk_dport          __sk_common.skc_dport
+    #define sk_addrpair       __sk_common.skc_addrpair
+    #define sk_daddr          __sk_common.skc_daddr
+    #define sk_rcv_saddr      __sk_common.skc_rcv_saddr
+    #define sk_family         __sk_common.skc_family
+    #define sk_state          __sk_common.skc_state
+    #define sk_reuse          __sk_common.skc_reuse
+    #define sk_reuseport      __sk_common.skc_reuseport
+    #define sk_ipv6only       __sk_common.skc_ipv6only
+    #define sk_net_refcnt     __sk_common.skc_net_refcnt
+    #define sk_bound_dev_if   __sk_common.skc_bound_dev_if
+    #define sk_bind_node      __sk_common.skc_bind_node
+    #define sk_prot           __sk_common.skc_prot
+    #define sk_net            __sk_common.skc_net
+    #define sk_v6_daddr       __sk_common.skc_v6_daddr
+    #define sk_v6_rcv_saddr   __sk_common.skc_v6_rcv_saddr
+    #define sk_cookie         __sk_common.skc_cookie
+    #define sk_incoming_cpu   __sk_common.skc_incoming_cpu
+    #define sk_flags          __sk_common.skc_flags
+    #define sk_rxhash         __sk_common.skc_rxhash
 
-#define ICMP_ECHO     8
-#define ICMP_EXT_ECHO 42
+    #define ICMP_ECHO     8
+    #define ICMP_EXT_ECHO 42
 
-#define ICMPV6_ECHO_REQUEST 128
+    #define ICMPV6_ECHO_REQUEST 128
 
-#define PF_KTHREAD 0x00200000 /* I am a kernel thread */
+    #define PF_KTHREAD 0x00200000 /* I am a kernel thread */
 
-#define TASK_COMM_LEN 16
+    #define TASK_COMM_LEN 16
 
-#define PROC_SUPER_MAGIC 0x9fa0
+    #define PROC_SUPER_MAGIC 0x9fa0
 
-// include/uapi/linux/const.h
-#define __AC(X, Y) (X##Y)
-#define _AC(X, Y)  __AC(X, Y)
-#define _UL(x)     (_AC(x, UL))
+    // include/uapi/linux/const.h
+    #define __AC(X, Y) (X##Y)
+    #define _AC(X, Y)  __AC(X, Y)
+    #define _UL(x)     (_AC(x, UL))
 
-// ioctl
-#define _IOC_NRBITS   8
-#define _IOC_TYPEBITS 8
+    // ioctl
+    #define _IOC_NRBITS   8
+    #define _IOC_TYPEBITS 8
 
-#ifndef _IOC_SIZEBITS
-    #define _IOC_SIZEBITS 14
-#endif
+    #ifndef _IOC_SIZEBITS
+        #define _IOC_SIZEBITS 14
+    #endif
 
-#define _IOC_NRSHIFT   0
-#define _IOC_TYPESHIFT (_IOC_NRSHIFT + _IOC_NRBITS)
-#define _IOC_SIZESHIFT (_IOC_TYPESHIFT + _IOC_TYPEBITS)
-#define _IOC_DIRSHIFT  (_IOC_SIZESHIFT + _IOC_SIZEBITS)
+    #define _IOC_NRSHIFT   0
+    #define _IOC_TYPESHIFT (_IOC_NRSHIFT + _IOC_NRBITS)
+    #define _IOC_SIZESHIFT (_IOC_TYPESHIFT + _IOC_TYPEBITS)
+    #define _IOC_DIRSHIFT  (_IOC_SIZESHIFT + _IOC_SIZEBITS)
 
-#ifndef _IOC_WRITE
-    #define _IOC_WRITE 1U
-#endif
+    #ifndef _IOC_WRITE
+        #define _IOC_WRITE 1U
+    #endif
 
-#define _IOC(dir, type, nr, size)                                                                  \
-    (((dir) << _IOC_DIRSHIFT) | ((type) << _IOC_TYPESHIFT) | ((nr) << _IOC_NRSHIFT) |              \
-     ((size) << _IOC_SIZESHIFT))
+    #define _IOC(dir, type, nr, size)                                                              \
+        (((dir) << _IOC_DIRSHIFT) | ((type) << _IOC_TYPESHIFT) | ((nr) << _IOC_NRSHIFT) |          \
+         ((size) << _IOC_SIZESHIFT))
 
-#define _IOC_TYPECHECK(t)      (sizeof(t))
-#define _IOW(type, nr, size)   _IOC(_IOC_WRITE, (type), (nr), (_IOC_TYPECHECK(size)))
-#define PERF_EVENT_IOC_SET_BPF _IOW('$', 8, __u32)
+    #define _IOC_TYPECHECK(t)      (sizeof(t))
+    #define _IOW(type, nr, size)   _IOC(_IOC_WRITE, (type), (nr), (_IOC_TYPECHECK(size)))
+    #define PERF_EVENT_IOC_SET_BPF _IOW('$', 8, __u32)
 
-#define BPF_FUNC_probe_write_user 36
+    #define BPF_FUNC_probe_write_user 36
 
 enum perf_type_id
 {
@@ -99,85 +99,89 @@ enum perf_type_id
     PERF_TYPE_MAX, /* non-ABI */
 };
 
+    /*=============================== ARCH SPECIFIC ===========================*/
+    #if defined(__TARGET_ARCH_x86)
+
+        #define TS_COMPAT 0x0002 /* 32bit syscall active (64BIT)*/
+
+        // arch/x86/include/asm/page_64_types.h
+        #define KASAN_STACK_ORDER                                                                  \
+            0 /* We implicitly assume here that KASAN (memory debugger) is disabled */
+        #define THREAD_SIZE_ORDER (2 + KASAN_STACK_ORDER)
+        #define THREAD_SIZE       (PAGE_SIZE << THREAD_SIZE_ORDER)
+
+        #define PAGE_SHIFT 12
+        #define PAGE_SIZE  (_AC(1, UL) << PAGE_SHIFT)
+        #define PAGE_MASK  (~(PAGE_SIZE - 1))
+
+        #define TOP_OF_KERNEL_STACK_PADDING 0
+
+    #elif defined(__TARGET_ARCH_arm64)
+
+        // extern bool CONFIG_ARM64_PAGE_SHIFT __kconfig;
+        //  arch/arm64/include/asm/page-def.h
+        //#define PAGE_SHIFT        CONFIG_ARM64_PAGE_SHIFT
+        //  as a temporary workaround for failing builds, use the default value of PAGE_SHIFT
+        #define PAGE_SHIFT 12
+        #define PAGE_SIZE  (_AC(1, UL) << PAGE_SHIFT)
+
+        // arch/arm64/include/asm/thread_info.h
+        #define _TIF_32BIT (1 << 22)
+
+        // arch/arm64/include/asm/memory.h
+        //#define MIN_THREAD_SHIFT	(14 + KASAN_THREAD_SHIFT)
+        #define MIN_THREAD_SHIFT                                                                   \
+            14 // default value if KASAN is disabled (which it should be usually)
+
+        // this can also be PAGE_SHIFT if (MIN_THREAD_SHIFT < PAGE_SHIFT) however here 14 > 12
+        // so we choose MIN_THREAD_SHIFT
+        #define THREAD_SHIFT MIN_THREAD_SHIFT
+        #define THREAD_SIZE  (_UL(1) << THREAD_SHIFT)
+
+    #endif
+
 /*=============================== ARCH SPECIFIC ===========================*/
-#if defined(__TARGET_ARCH_x86)
 
-    #define TS_COMPAT 0x0002 /* 32bit syscall active (64BIT)*/
+    #define VM_NONE   0x00000000
+    #define VM_READ   0x00000001
+    #define VM_WRITE  0x00000002
+    #define VM_EXEC   0x00000004
+    #define VM_SHARED 0x00000008
 
-    // arch/x86/include/asm/page_64_types.h
-    #define KASAN_STACK_ORDER                                                                      \
-        0 /* We implicitly assume here that KASAN (memory debugger) is disabled */
-    #define THREAD_SIZE_ORDER (2 + KASAN_STACK_ORDER)
-    #define THREAD_SIZE       (PAGE_SIZE << THREAD_SIZE_ORDER)
+    #define TC_ACT_UNSPEC     (-1)
+    #define TC_ACT_OK         0
+    #define TC_ACT_RECLASSIFY 1
+    #define TC_ACT_SHOT       2
+    #define TC_ACT_PIPE       3
+    #define TC_ACT_STOLEN     4
+    #define TC_ACT_QUEUED     5
+    #define TC_ACT_REPEAT     6
+    #define TC_ACT_REDIRECT   7
 
-    #define PAGE_SHIFT 12
-    #define PAGE_SIZE  (_AC(1, UL) << PAGE_SHIFT)
-    #define PAGE_MASK  (~(PAGE_SIZE - 1))
+    #define ETH_P_IP   0x0800
+    #define ETH_P_IPV6 0x86DD
 
-    #define TOP_OF_KERNEL_STACK_PADDING 0
+    #define s6_addr   in6_u.u6_addr8
+    #define s6_addr16 in6_u.u6_addr16
+    #define s6_addr32 in6_u.u6_addr32
 
-#elif defined(__TARGET_ARCH_arm64)
-    // extern bool CONFIG_ARM64_PAGE_SHIFT __kconfig;
-    //  arch/arm64/include/asm/page-def.h
-    //#define PAGE_SHIFT        CONFIG_ARM64_PAGE_SHIFT
-    //  as a temporary workaround for failing builds, use the default value of PAGE_SHIFT
-    #define PAGE_SHIFT       12
-    #define PAGE_SIZE        (_AC(1, UL) << PAGE_SHIFT)
+    #define __user
 
-    // arch/arm64/include/asm/thread_info.h
-    #define _TIF_32BIT       (1 << 22)
+    #define S_IFMT   00170000
+    #define S_IFSOCK 0140000
+    #define S_IFLNK  0120000
+    #define S_IFREG  0100000
+    #define S_IFBLK  0060000
+    #define S_IFDIR  0040000
+    #define S_IFCHR  0020000
+    #define S_IFIFO  0010000
+    #define S_ISUID  0004000
+    #define S_ISGID  0002000
+    #define S_ISVTX  0001000
 
-    // arch/arm64/include/asm/memory.h
-    //#define MIN_THREAD_SHIFT	(14 + KASAN_THREAD_SHIFT)
-    #define MIN_THREAD_SHIFT 14 // default value if KASAN is disabled (which it should be usually)
-
-    // this can also be PAGE_SHIFT if (MIN_THREAD_SHIFT < PAGE_SHIFT) however here 14 > 12
-    // so we choose MIN_THREAD_SHIFT
-    #define THREAD_SHIFT     MIN_THREAD_SHIFT
-    #define THREAD_SIZE      (_UL(1) << THREAD_SHIFT)
-#endif
-/*=============================== ARCH SPECIFIC ===========================*/
-
-#define VM_NONE   0x00000000
-#define VM_READ   0x00000001
-#define VM_WRITE  0x00000002
-#define VM_EXEC   0x00000004
-#define VM_SHARED 0x00000008
-
-#define TC_ACT_UNSPEC     (-1)
-#define TC_ACT_OK         0
-#define TC_ACT_RECLASSIFY 1
-#define TC_ACT_SHOT       2
-#define TC_ACT_PIPE       3
-#define TC_ACT_STOLEN     4
-#define TC_ACT_QUEUED     5
-#define TC_ACT_REPEAT     6
-#define TC_ACT_REDIRECT   7
-
-#define ETH_P_IP   0x0800
-#define ETH_P_IPV6 0x86DD
-
-#define s6_addr   in6_u.u6_addr8
-#define s6_addr16 in6_u.u6_addr16
-#define s6_addr32 in6_u.u6_addr32
-
-#define __user
-
-#define S_IFMT   00170000
-#define S_IFSOCK 0140000
-#define S_IFLNK  0120000
-#define S_IFREG  0100000
-#define S_IFBLK  0060000
-#define S_IFDIR  0040000
-#define S_IFCHR  0020000
-#define S_IFIFO  0010000
-#define S_ISUID  0004000
-#define S_ISGID  0002000
-#define S_ISVTX  0001000
-
-#define CAP_OPT_NONE    0x0
-#define CAP_OPT_NOAUDIT 0b10
-#define CAP_OPT_INSETID 0b100
+    #define CAP_OPT_NONE    0x0
+    #define CAP_OPT_NOAUDIT 0b10
+    #define CAP_OPT_INSETID 0b100
 
 static inline bool ipv6_addr_any(const struct in6_addr *a)
 {
@@ -190,12 +194,12 @@ static inline struct inet_sock *inet_sk(const struct sock *sk)
     return (struct inet_sock *) sk;
 }
 
-#define PIPE_BUF_FLAG_CAN_MERGE 0x10 /* can merge buffers */
+    #define PIPE_BUF_FLAG_CAN_MERGE 0x10 /* can merge buffers */
 
-#define get_type_size(x) bpf_core_type_size(x)
-#define __get_node_addr(array, node_type, index)                                                   \
-    ((node_type *) ((void *) array + (index * get_type_size(node_type))))
-#define get_node_addr(array, index) __get_node_addr(array, typeof(*array), index)
+    #define get_type_size(x) bpf_core_type_size(x)
+    #define __get_node_addr(array, node_type, index)                                               \
+        ((node_type *) ((void *) array + (index * get_type_size(node_type))))
+    #define get_node_addr(array, index) __get_node_addr(array, typeof(*array), index)
 
 #endif
 
@@ -237,33 +241,33 @@ static inline struct inet_sock *inet_sk(const struct sock *sk)
 #define AF_XDP       PF_XDP
 
 #ifndef IPPROTO_IPIP
-#define IPPROTO_IPIP 4
+    #define IPPROTO_IPIP 4
 #endif
 
 #ifndef IPPROTO_DCCP
-#define IPPROTO_DCCP 33
+    #define IPPROTO_DCCP 33
 #endif
 
 #ifndef IPPROTO_IPV6
-#define IPPROTO_IPV6 41
+    #define IPPROTO_IPV6 41
 #endif
 
 #ifndef IPPROTO_ICMPV6
-#define IPPROTO_ICMPV6 58
+    #define IPPROTO_ICMPV6 58
 #endif
 
 #ifndef IPPROTO_SCTP
-#define IPPROTO_SCTP 132
+    #define IPPROTO_SCTP 132
 #endif
 
 #ifndef IPPROTO_UDPLITE
-#define IPPROTO_UDPLITE 136
+    #define IPPROTO_UDPLITE 136
 #endif
 
-#define IPPROTO_HOPOPTS     0   /* IPv6 hop-by-hop options	*/
-#define IPPROTO_ROUTING     43  /* IPv6 routing header		*/
-#define IPPROTO_FRAGMENT    44  /* IPv6 fragmentation header	*/
-#define IPPROTO_ICMPV6      58  /* ICMPv6			*/
-#define IPPROTO_NONE        59  /* IPv6 no next header		*/
-#define IPPROTO_DSTOPTS     60  /* IPv6 destination options	*/
-#define IPPROTO_MH          135 /* IPv6 mobility header		*/
+#define IPPROTO_HOPOPTS  0   // IPv6 hop-by-hop options
+#define IPPROTO_ROUTING  43  // IPv6 routing header
+#define IPPROTO_FRAGMENT 44  // IPv6 fragmentation header
+#define IPPROTO_ICMPV6   58  // ICMPv6
+#define IPPROTO_NONE     59  // IPv6 no next header
+#define IPPROTO_DSTOPTS  60  // IPv6 destination options
+#define IPPROTO_MH       135 // IPv6 mobility header

--- a/pkg/ebpf/c/missing_definitions.h
+++ b/pkg/ebpf/c/missing_definitions.h
@@ -259,3 +259,11 @@ static inline struct inet_sock *inet_sk(const struct sock *sk)
 #ifndef IPPROTO_UDPLITE
 #define IPPROTO_UDPLITE 136
 #endif
+
+#define IPPROTO_HOPOPTS     0   /* IPv6 hop-by-hop options	*/
+#define IPPROTO_ROUTING     43  /* IPv6 routing header		*/
+#define IPPROTO_FRAGMENT    44  /* IPv6 fragmentation header	*/
+#define IPPROTO_ICMPV6      58  /* ICMPv6			*/
+#define IPPROTO_NONE        59  /* IPv6 no next header		*/
+#define IPPROTO_DSTOPTS     60  /* IPv6 destination options	*/
+#define IPPROTO_MH          135 /* IPv6 mobility header		*/

--- a/pkg/events/derive/net_packet_ipv4.go
+++ b/pkg/events/derive/net_packet_ipv4.go
@@ -43,7 +43,6 @@ func deriveNetPacketIPv4Args() deriveArgsFunction {
 			layers.LayerTypeIPv4,
 			gopacket.Default,
 		)
-
 		if packet == nil {
 			return []interface{}{}, parsePacketError()
 		}

--- a/pkg/events/derive/net_packet_ipv6.go
+++ b/pkg/events/derive/net_packet_ipv6.go
@@ -16,6 +16,11 @@ func deriveNetPacketIPv6Args() deriveArgsFunction {
 		var ok bool
 		var payload []byte
 
+		// event retval encodes layer 3 protocol type
+
+		if event.ReturnValue&familyIpv6 != familyIpv6 {
+			return nil, nil
+		}
 		// sanity checks
 
 		payloadArg := events.GetArg(&event, "payload")
@@ -28,12 +33,6 @@ func deriveNetPacketIPv6Args() deriveArgsFunction {
 		payloadSize := len(payload)
 		if payloadSize < 1 {
 			return nil, emptyPayloadError()
-		}
-
-		// event retval encodes layer 3 protocol type
-
-		if event.ReturnValue&familyIpv6 != familyIpv6 {
-			return nil, nil
 		}
 
 		// parse packet
@@ -55,8 +54,8 @@ func deriveNetPacketIPv6Args() deriveArgsFunction {
 			copyIPv6ToProtoIPv6(l3, &ipv6)
 
 			return []interface{}{
-				l3.SrcIP,
-				l3.DstIP,
+				l3.SrcIP.String(),
+				l3.DstIP.String(),
 				ipv6,
 			}, nil
 		}


### PR DESCRIPTION
network: fix retval for IPv6 packets

The event retval value works, for networking events, as a value to
tell userland (derivation) tips about what to do. Initial usecase was
to differentiate layer 3 protocols (IPv4 vs IPv6), but it gained more
meaning with http events.

This patch fixes the retval value for IPv6 packets, fixing issues seen
with net_packet_ipv6 events having zeroed values.