### PR TITLE
network: default to capturing all network traffic

### DIFF
--- a/docs/docs/capturing/index.md
+++ b/docs/docs/capturing/index.md
@@ -119,12 +119,22 @@ Tracee can capture the following types of artifacts:
      Anytime a **network packet** is delivered to a process, traced by tracee,
      this packet might be captured into one or multiple pcap files.
 
+    !!! Attention
+        The default behavior when capturing network traffic is to capture
+        ALL traffic, despite given event filters. If you want to make
+        capture feature to follow the given event filters, like for example
+        capturing DNS events only, then you have to provide `--capture
+        pcap-options:filtered` argument in the command line. Then only
+        net_packet_XXX events will be captured (IPv4, IPv6, TCP, UDP,
+        ICMP, ICMPv6, DNS, HTTP, etc).
+
      A good way to test this behavior is to execute:
 
      ```text
      $ sudo ./dist/tracee-ebpf \
          --trace event=net_packet_ipv4 \
-         --capture network
+         --capture network \
+         --capture pcap-options:filtered
      ```
 
      and observe a single **pcap file** for all ipv4 packets created:
@@ -140,7 +150,8 @@ Tracee can capture the following types of artifacts:
      ```text
      $ sudo ./dist/tracee-ebpf \
          --trace event=net_packet_dns \
-         --capture network
+         --capture network \
+         --capture pcap-options:filtered
      ```
 
      and the file `/tmp/tracee/out/pcap/single.pcap` would only contain DNS
@@ -173,6 +184,7 @@ Tracee can capture the following types of artifacts:
      $ sudo ./dist/tracee-ebpf \
          --trace event=net_packet_icmp \
          --capture network \
+         --capture pcap-options:filtered \
          --capture pcap:process,container,command
      ```
 
@@ -257,11 +269,12 @@ Tracee can capture the following types of artifacts:
      In order to capture a specific payload size you may specify:
 
      ```
-      $ sudo ./dist/tracee-ebpf \
-          --trace event=net_packet_tcp \
-          --capture network \
-          --capture pcap:single,command \
-          --capture pcap-snaplen:default
+     $ sudo ./dist/tracee-ebpf \
+         --trace event=net_packet_tcp \
+         --capture network \
+         --capture pcap-options:filtered \
+         --capture pcap:single,command \
+         --capture pcap-snaplen:default
      ```
 
      To capture packet headers + 96 bytes of payload. Or replace `default` by:

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -307,8 +307,14 @@ typedef struct config_entry {
     u64 pid_min;
 } config_entry_t;
 
+enum capture_options_e
+{
+    NET_CAP_OPT_FILTERED = (1 << 0), // pcap should obey event filters
+};
+
 typedef struct netconfig_entry {
-    u32 capture_length; // amount of network packet payload to capture (pcap)
+    u32 capture_options; // bitmask of capture options (pcap)
+    u32 capture_length;  // amount of network packet payload to capture (pcap)
 } netconfig_entry_t;
 
 typedef struct event_data {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1012,8 +1012,14 @@ func (t *Tracee) populateBPFMaps() error {
 		if err != nil {
 			return err
 		}
-		netConfigVal := make([]byte, 4)
-		binary.LittleEndian.PutUint32(netConfigVal[0:4], t.config.Capture.Net.CaptureLength)
+
+		netConfigVal := make([]byte, 8) // u32 capture_options, u32 capture_length
+
+		options := pcaps.GetPcapOptions(t.config.Capture.Net)
+
+		binary.LittleEndian.PutUint32(netConfigVal[0:4], uint32(options))
+		binary.LittleEndian.PutUint32(netConfigVal[4:8], t.config.Capture.Net.CaptureLength)
+
 		if err = bpfNetConfigMap.Update(
 			unsafe.Pointer(&cZero),
 			unsafe.Pointer(&netConfigVal[0]),

--- a/pkg/pcaps/common.go
+++ b/pkg/pcaps/common.go
@@ -224,3 +224,13 @@ func PcapsEnabled(simple Config) bool {
 	config := configToPcapType(simple)
 	return config != None
 }
+
+func GetPcapOptions(c Config) PcapOption {
+	var options PcapOption
+
+	if c.CaptureFiltered {
+		options |= Filtered
+	}
+
+	return options
+}

--- a/pkg/pcaps/pcap.go
+++ b/pkg/pcaps/pcap.go
@@ -50,6 +50,12 @@ const (
 	Single    PcapType = 0x8
 )
 
+type PcapOption uint32
+
+const (
+	Filtered PcapOption = 0x1
+)
+
 // Pcap is a representation of a pcap file
 type Pcap struct {
 	writtenPkts int              // packets written before next sync

--- a/pkg/pcaps/pcaps.go
+++ b/pkg/pcaps/pcaps.go
@@ -30,6 +30,7 @@ type Config struct {
 	CaptureProcess   bool
 	CaptureContainer bool
 	CaptureCommand   bool
+	CaptureFiltered  bool
 	CaptureLength    uint32
 }
 


### PR DESCRIPTION
network: default to capturing all network traffic

- Before this change, only network traffic that was explicitly being traced by the user was captured.

- This change makes it so that all network traffic is captured by default and adds a command line option:

  --capture pcap-options:[none,filtered]

  to allow the old behavior, of capturing only traffic from the given filters, to still exist if "filtered" option is given.

Fixes: #2683