### PR TITLE
signatures: add path to dropped_executable data

### DIFF
--- a/signatures/golang/dropped_executable.go
+++ b/signatures/golang/dropped_executable.go
@@ -71,7 +71,9 @@ func (sig *DroppedExecutable) OnEvent(event protocol.Event) error {
 			sig.cb(detect.Finding{
 				SigMetadata: metadata,
 				Event:       event,
-				Data:        nil,
+				Data: map[string]interface{}{
+					"path": pathname,
+				},
 			})
 		}
 

--- a/signatures/golang/dropped_executable_test.go
+++ b/signatures/golang/dropped_executable_test.go
@@ -39,7 +39,7 @@ func TestDroppedExecutable(t *testing.T) {
 			},
 			Findings: map[string]detect.Finding{
 				"TRC-1022": {
-					Data: nil,
+					Data: map[string]interface{}{"path": "/bin/malware"},
 					Event: trace.Event{
 						EventName: "magic_write",
 						Args: []trace.Argument{


### PR DESCRIPTION
Got a trigger for this signature on a personal cluster, and without the path of the dropped executable not easy to understand what to check on the container:

before:

```
*** Detection ***
Time: 2023-02-08T22:06:22Z
Signature ID: TRC-1022
Signature: New executable dropped
Data: map[]
Command: curl
Hostname: app-8bf6f79d9-q
```

after:
```


*** Detection ***
Time: 2023-02-08T22:13:59Z
Signature ID: TRC-1022
Signature: New executable dropped
Data: map[path:/minikube-linux-amd64]
Command: curl
Hostname: app-8bf6f79d9-q

```