### PR TITLE
refactor: simplify output flags

### DIFF
--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -606,7 +606,7 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:stack-addresses"},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
-				OutputConfig: tracee.OutputConfig{
+				TraceeConfig: &tracee.OutputConfig{
 					StackAddresses: true,
 					ParseArguments: true,
 				},
@@ -617,7 +617,7 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:exec-env"},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
-				OutputConfig: tracee.OutputConfig{
+				TraceeConfig: &tracee.OutputConfig{
 					ExecEnv:        true,
 					ParseArguments: true,
 				},
@@ -628,7 +628,7 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:exec-hash"},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
-				OutputConfig: tracee.OutputConfig{
+				TraceeConfig: &tracee.OutputConfig{
 					ExecHash:       true,
 					ParseArguments: true,
 				},
@@ -639,7 +639,7 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:sort-events"},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
-				OutputConfig: tracee.OutputConfig{
+				TraceeConfig: &tracee.OutputConfig{
 					ParseArguments: true,
 					EventsSorting:  true,
 				},
@@ -650,7 +650,7 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{"option:stack-addresses", "option:exec-env", "option:exec-hash", "option:sort-events"},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
-				OutputConfig: tracee.OutputConfig{
+				TraceeConfig: &tracee.OutputConfig{
 					StackAddresses: true,
 					ExecEnv:        true,
 					ExecHash:       true,
@@ -662,11 +662,12 @@ func TestPrepareOutput(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			output, _, err := flags.PrepareOutput(testcase.outputSlice)
+			output, err := flags.PrepareOutput(testcase.outputSlice)
 			if err != nil {
 				assert.Equal(t, testcase.expectedError, err)
 			} else {
-				assert.Equal(t, testcase.expectedOutput, output)
+				assert.Equal(t, testcase.expectedOutput.LogFile, output.LogFile)
+				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
 			}
 		})
 	}

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -600,7 +600,26 @@ func TestPrepareOutput(t *testing.T) {
 			},
 			expectedError: errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info"),
 		},
-
+		{
+			testName:    "default format",
+			outputSlice: []string{},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table format always parse arguments",
+			outputSlice: []string{"table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
 		{
 			testName:    "option stack-addresses",
 			outputSlice: []string{"option:stack-addresses"},
@@ -624,13 +643,48 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
+			testName:    "option relative-time",
+			outputSlice: []string{"json", "option:relative-time"},
+			expectedOutput: flags.OutputConfig{
+
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					RelativeTime: true,
+				},
+			},
+		},
+		{
 			testName:    "option exec-hash",
 			outputSlice: []string{"option:exec-hash"},
 			expectedOutput: flags.OutputConfig{
+
 				LogFile: os.Stderr,
 				TraceeConfig: &tracee.OutputConfig{
 					ExecHash:       true,
 					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option parse-arguments",
+			outputSlice: []string{"json", "option:parse-arguments"},
+			expectedOutput: flags.OutputConfig{
+
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option parse-arguments-fds",
+			outputSlice: []string{"json", "option:parse-arguments-fds"},
+			expectedOutput: flags.OutputConfig{
+
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
 				},
 			},
 		},
@@ -646,16 +700,27 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "all options",
-			outputSlice: []string{"option:stack-addresses", "option:exec-env", "option:exec-hash", "option:sort-events"},
+			testName: "all options",
+			outputSlice: []string{
+				"json",
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+			},
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
 				TraceeConfig: &tracee.OutputConfig{
-					StackAddresses: true,
-					ExecEnv:        true,
-					ExecHash:       true,
-					ParseArguments: true,
-					EventsSorting:  true,
+					StackAddresses:    true,
+					ExecEnv:           true,
+					RelativeTime:      true,
+					ExecHash:          true,
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
+					EventsSorting:     true,
 				},
 			},
 		},

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -62,11 +62,11 @@ func TestPrepareOutputPrinterConfig(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			_, printerCfg, err := flags.PrepareOutput(testcase.outputSlice)
+			outputConfig, err := flags.PrepareOutput(testcase.outputSlice)
 			if err != nil {
 				assert.Equal(t, testcase.expectedError, err)
 			} else {
-				assert.Equal(t, testcase.expectedPrinter, printerCfg)
+				assert.Equal(t, testcase.expectedPrinter, outputConfig.PrinterConfig)
 			}
 		})
 	}

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -27,7 +27,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Output command line flags
 
-	output, printerConfig, err := flags.PrepareOutput(c.StringSlice("output"))
+	output, err := flags.PrepareOutput(c.StringSlice("output"))
 	if err != nil {
 		return runner, err
 	}
@@ -100,8 +100,9 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Container information printer flag
 
+	printerConfig := output.PrinterConfig
 	printerConfig.ContainerMode = cmd.GetContainerMode(cfg)
-	cfg.Output = &output.OutputConfig
+	cfg.Output = output.TraceeConfig
 
 	// Check kernel lockdown
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Simplify output logic in order to add multiple printer support in a follow-up pr. Also increase test coverage. 

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

compile `tracee`, and test --output
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

This is a refactor in order to add multiple printers supported, required by the new binary.
https://github.com/aquasecurity/tracee/issues/2355



<!--
Links? References? Anything pointing to more context about the change. 
-->