### PR TITLE
metrics: remove old net event stats

### DIFF
--- a/docs/docs/tracing/output-formats.md
+++ b/docs/docs/tracing/output-formats.md
@@ -19,7 +19,7 @@ Tracee supports different output formats for detected events:
     11:21:51:254418  1000   exa              1639459 1639459 3                openat               dirfd: -100, pathname: /lib/x86_64-linux-gnu/libm.so.6, flags: O_RDONLY|O_CLOEXEC, mode: 0
     
     End of events stream
-    Stats: {EventCount:6 EventsFiltered:0 NetEvCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0}
+    Stats: {EventCount:3 EventsFiltered:0 NetCapCount:0 BPFLogsCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCapCount:0 LostBPFLogsCount:0}
     ```
 
 2. **Table (Verbose)**
@@ -32,7 +32,7 @@ Tracee supports different output formats for detected events:
     11:22:16:970913  fujitsu                        4026531840   4026531836   1000   exa              1643836 1643836 3795408 3                openat               dirfd: -100, pathname: /lib/x86_64-linux-gnu/libm.so.6, flags: 524288, mode: 0
     
     End of events stream
-    Stats: {EventCount:6 EventsFiltered:0 NetEvCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCount:0}
+    Stats: {EventCount:3 EventsFiltered:0 NetCapCount:0 BPFLogsCount:0 ErrorCount:0 LostEvCount:0 LostWrCount:0 LostNtCapCount:0 LostBPFLogsCount:0}
     ```
 
 3. **JSON**

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -9,13 +9,11 @@ import (
 type Stats struct {
 	EventCount       counter.Counter
 	EventsFiltered   counter.Counter
-	NetEvCount       counter.Counter // TODO: remove (deprecated)
 	NetCapCount      counter.Counter // network capture events
 	BPFLogsCount     counter.Counter
 	ErrorCount       counter.Counter
 	LostEvCount      counter.Counter
 	LostWrCount      counter.Counter
-	LostNtCount      counter.Counter // TODO: remove (deprecated)
 	LostNtCapCount   counter.Counter // lost network capture events
 	LostBPFLogsCount counter.Counter
 }
@@ -37,16 +35,6 @@ func (stats *Stats) RegisterPrometheus() error {
 		Name:      "events_filtered",
 		Help:      "events filtered by tracee-ebpf in userspace",
 	}, func() float64 { return float64(stats.EventsFiltered.Read()) }))
-
-	if err != nil {
-		return err
-	}
-
-	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Namespace: "tracee_ebpf",
-		Name:      "netevents_total",
-		Help:      "net events collected by tracee-ebpf",
-	}, func() float64 { return float64(stats.NetEvCount.Read()) }))
 
 	if err != nil {
 		return err
@@ -77,16 +65,6 @@ func (stats *Stats) RegisterPrometheus() error {
 		Name:      "write_lostevents_total",
 		Help:      "events lost in the write buffer",
 	}, func() float64 { return float64(stats.LostWrCount.Read()) }))
-
-	if err != nil {
-		return err
-	}
-
-	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
-		Namespace: "tracee_ebpf",
-		Name:      "network_lostevents_total",
-		Help:      "events lost in the network buffer",
-	}, func() float64 { return float64(stats.LostNtCount.Read()) }))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Remove the old net event stats from the `Stats` struct so the table printer epilogue won't include it.