### PR TITLE
Multiple printers

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -44,14 +44,14 @@ func main() {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
 
-			flags.PrintAndExitIfHelp(c)
+			flags.PrintAndExitIfHelp(c, false)
 
 			if c.Bool("list") {
 				cmd.PrintEventList(false) // list events
 				return nil
 			}
 
-			runner, err := urfave.GetTraceeRunner(c, version)
+			runner, err := urfave.GetTraceeRunner(c, version, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -47,7 +47,7 @@ func main() {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
 
-			flags.PrintAndExitIfHelp(c)
+			flags.PrintAndExitIfHelp(c, true)
 
 			// Rego command line flags
 
@@ -74,7 +74,7 @@ func main() {
 				return nil
 			}
 
-			runner, err := urfave.GetTraceeRunner(c, version)
+			runner, err := urfave.GetTraceeRunner(c, version, true)
 			if err != nil {
 				return err
 			}
@@ -123,7 +123,7 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:    "output",
 				Aliases: []string{"o"},
-				Value:   cli.NewStringSlice("format:table"),
+				Value:   cli.NewStringSlice("table"),
 				Usage:   "control how and where output is printed. run '--output help' for more info.",
 			},
 			&cli.StringSliceFlag{

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"github.com/aquasecurity/tracee/pkg/filters"
@@ -561,7 +562,7 @@ func TestPrepareCapture(t *testing.T) {
 	})
 }
 
-func TestPrepareOutput(t *testing.T) {
+func TestPrepareOutputOld(t *testing.T) {
 	testCases := []struct {
 		testName       string
 		outputSlice    []string
@@ -728,7 +729,7 @@ func TestPrepareOutput(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			output, err := flags.PrepareOutput(testcase.outputSlice)
+			output, err := flags.PrepareOutputOld(testcase.outputSlice)
 			if err != nil {
 				assert.Equal(t, testcase.expectedError, err)
 			} else {
@@ -736,6 +737,453 @@ func TestPrepareOutput(t *testing.T) {
 				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
 			}
 		})
+	}
+}
+
+func TestPrepareOutput(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		outputSlice    []string
+		expectedOutput flags.OutputConfig
+		expectedError  error
+	}{
+		// validations
+		{
+			testName:    "invalid output flag",
+			outputSlice: []string{"foo"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("invalid output flag: foo, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty option flag",
+			outputSlice: []string{"option"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("option flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty option flag 2",
+			outputSlice: []string{"option:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("option flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid option value",
+			outputSlice: []string{"option:foo"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("invalid output option: foo, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty file for format",
+			outputSlice: []string{"json:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("format flag can't be empty, use '--output help' for more info"),
+		},
+		// formats
+		{
+			testName:    "default format",
+			outputSlice: []string{},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table to stdout",
+			outputSlice: []string{"table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table to /tmp/table",
+			outputSlice: []string{"table:/tmp/table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "/tmp/table"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table to stdout, and to /tmp/table",
+			outputSlice: []string{"table", "table:/tmp/table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+					{Kind: "table", OutPath: "/tmp/table"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "json to stdout",
+			outputSlice: []string{"json"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "json to /tmp/json, and json to /tmp/json2",
+			outputSlice: []string{"json:/tmp/json", "json:/tmp/json2"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "/tmp/json"},
+					{Kind: "json", OutPath: "/tmp/json2"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gob to stdout",
+			outputSlice: []string{"gob"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gob", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gob to stdout",
+			outputSlice: []string{"gob"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gob", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gob to /tmp/gob1,/tmp/gob2",
+			outputSlice: []string{"gob:/tmp/gob1,/tmp/gob2"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gob", OutPath: "/tmp/gob1"},
+					{Kind: "gob", OutPath: "/tmp/gob2"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "table-verbose to stdout",
+			outputSlice: []string{"table-verbose"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table-verbose", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gotemplate to stdout",
+			outputSlice: []string{"gotemplate=template.tmpl"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gotemplate=template.tmpl", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gotemplate to multiple files",
+			outputSlice: []string{"gotemplate=template.tmpl:/tmp/gotemplate1,/tmp/gotemplate2"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate1"},
+					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate2"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName: "multiple formats",
+			outputSlice: []string{
+				"table",
+				"json:/tmp/json,/tmp/json2",
+				"gob:/tmp/gob1",
+				"gotemplate=template.tmpl:/tmp/gotemplate1",
+			},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+					{Kind: "json", OutPath: "/tmp/json"},
+					{Kind: "json", OutPath: "/tmp/json2"},
+					{Kind: "gob", OutPath: "/tmp/gob1"},
+					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate1"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "two formats for stdout",
+			outputSlice: []string{"table", "json"},
+			expectedOutput: flags.OutputConfig{
+				LogFile:      os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+			expectedError: errors.New("cannot use the same path for multiple outputs: stdout, use '--output help' for more info"),
+		},
+		{
+			testName:    "format for the same file twice",
+			outputSlice: []string{"table:/tmp/test,/tmp/test"},
+			expectedOutput: flags.OutputConfig{
+				LogFile:      os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+			expectedError: errors.New("cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+		},
+		{
+			testName:    "two differents formats for the same file",
+			outputSlice: []string{"table:/tmp/test", "json:/tmp/test"},
+			expectedOutput: flags.OutputConfig{
+				LogFile:      os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+			expectedError: errors.New("cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+		},
+		{
+			testName:    "none",
+			outputSlice: []string{"none"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "ignore", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "invalid value for none format",
+			outputSlice: []string{"none:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("none output does not support path. Use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid value for none format 2",
+			outputSlice: []string{"none:/tmp/test"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("none output does not support path. Use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid value for log-file",
+			outputSlice: []string{"log-file"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("log-file flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid value for log-file 2",
+			outputSlice: []string{"log-file:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("log-file flag can't be empty, use '--output help' for more info"),
+		},
+
+		// options
+		{
+			testName:    "option stack-addresses",
+			outputSlice: []string{"option:stack-addresses"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					StackAddresses: true,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option exec-env",
+			outputSlice: []string{"option:exec-env"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ExecEnv:        true,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option relative-time",
+			outputSlice: []string{"json", "option:relative-time"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout", RelativeTS: true},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					RelativeTime: true,
+				},
+			},
+		},
+		{
+			testName:    "option exec-hash",
+			outputSlice: []string{"option:exec-hash"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ExecHash:       true,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option parse-arguments",
+			outputSlice: []string{"json", "option:parse-arguments"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout"},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option parse-arguments-fds",
+			outputSlice: []string{"json", "option:parse-arguments-fds"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout"},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
+				},
+			},
+		},
+		{
+			testName:    "option sort-events",
+			outputSlice: []string{"option:sort-events"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+					EventsSorting:  true,
+				},
+			},
+		},
+		{
+			testName: "all options",
+			outputSlice: []string{
+				"json",
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+			},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout", RelativeTS: true},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					StackAddresses:    true,
+					ExecEnv:           true,
+					RelativeTime:      true,
+					ExecHash:          true,
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
+					EventsSorting:     true,
+				},
+			},
+		},
+	}
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			output, err := flags.PrepareOutput(testcase.outputSlice)
+			if err != nil {
+				assert.Equal(t, testcase.expectedError, err)
+			} else {
+				assert.Equal(t, testcase.expectedOutput.LogFile, output.LogFile)
+				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
+
+				assertPrinterConfigs(t, testcase.expectedOutput.PrinterConfigs, output.PrinterConfigs)
+
+			}
+		})
+	}
+}
+
+func assertPrinterConfigs(t *testing.T, expected []printer.Config, actual []printer.Config) {
+	// use a map to compare because the order of the printers is not guaranteed
+	printersMap := make(map[string]printer.Config)
+
+	for _, p := range expected {
+		printersMap[p.OutPath] = p
+	}
+
+	for _, p := range actual {
+		expectedPrinter, ok := printersMap[p.OutPath]
+		assert.True(t, ok)
+
+		assert.Equal(t, expectedPrinter.Kind, p.Kind)
+		assert.Equal(t, expectedPrinter.OutPath, p.OutPath)
+		assert.Equal(t, expectedPrinter.RelativeTS, p.RelativeTS)
+		assert.Equal(t, expectedPrinter.ContainerMode, p.ContainerMode)
 	}
 }
 

--- a/pkg/cmd/flags/help.go
+++ b/pkg/cmd/flags/help.go
@@ -7,16 +7,21 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func PrintAndExitIfHelp(ctx *cli.Context) {
+func PrintAndExitIfHelp(ctx *cli.Context, newBinary bool) {
 	keys := []string{
 		"crs",
 		"cache",
 		"capture",
 		"trace",
-		"output",
 		"capabilities",
 		"rego",
 		"log",
+	}
+
+	if newBinary {
+		keys = append(keys, "output")
+	} else {
+		keys = append(keys, "outputOld")
 	}
 
 	for _, k := range keys {
@@ -52,6 +57,8 @@ func getHelpString(key string) string {
 		return filterHelp()
 	case "output":
 		return outputHelp()
+	case "outputOld":
+		return outputHelpOld()
 	case "capabilities":
 		return capabilitiesHelp()
 	case "rego":

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,15 +13,18 @@ import (
 
 func outputHelp() string {
 	return `Control how and where output is printed.
-Possible options:
-[format:]table                                     output events in table format
-[format:]table-verbose                             output events in table format with extra fields per event
-[format:]json                                      output events in json format
-[format:]gob                                       output events in gob format
-[format:]gotemplate=/path/to/template              output events formatted using a given gotemplate file
-out-file:/path/to/file                             write the output to a specified file. create/trim the file if exists (default: stdout)
-log-file:/path/to/file                             write the logs to a specified file. create/trim the file if exists (default: stderr)
+Format options:
+table[:/path/to/file,...]                          output events in table format (default). The default path to file is stdout.
+table-verbose[:/path/to/file,...]                  output events in table format with extra fields per event. The default path to file is stdout.
+json[:/path/to/file,...]                           output events in json format. The default path to file is stdout.
+gob[:/path/to/file,...]                            output events in gob format. The default path to file is stdout.
+gotemplate=/path/to/template[:/path/to/file,...]   output events formatted using a given gotemplate file. The default path to file is stdout.
 none                                               ignore stream of events output, usually used with --capture
+
+Log options:
+log-file:/path/to/file                             write the logs to a specified file. create/trim the file if exists (default: stderr)
+
+Argument options:
 option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
                                                    augment output according to given options (default: none)
   stack-addresses                                  include stack memory addresses for each event
@@ -30,92 +34,82 @@ option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-ev
   parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
   parse-arguments-fds                              enable parse-arguments and enrich fd with its file path translation. This can cause pipeline slowdowns.
   sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
+
 Examples:
   --output json                                            | output as json to stdout
-  --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
-  --output out-file:/my/out --output log-file:/my/log      | output to /my/out and logs to /my/log
+  --output json:/my/out                                    | output as json to /my/out
+  --output gotemplate=/path/to/my.tmpl                     | output as the provided go template to stdout
+  --output gob:/my/out --output log-file:/my/log      	   | output gob to /my/out and logs to /my/log
+  --output json --output gob:/my/out                       | output as json to /my/out
+  --output json:/my/out1,/my/out2                          | output as json to both /my/out and /my/out2
   --output none                                            | ignore events output
+  --output table --output option:stack-addresses           | output as table with stack addresses
+
 Use this flag multiple times to choose multiple output options
 `
 }
 
 type OutputConfig struct {
-	TraceeConfig  *tracee.OutputConfig
-	PrinterConfig printer.Config
-	LogFile       *os.File
+	TraceeConfig   *tracee.OutputConfig
+	PrinterConfigs []printer.Config
+	LogFile        *os.File
 }
 
 func PrepareOutput(outputSlice []string) (OutputConfig, error) {
 	outConfig := OutputConfig{}
 	traceeConfig := &tracee.OutputConfig{}
-	printerConfig := printer.Config{}
 
-	var outPath string
 	var logPath string
-	printerKind := "table"
+
+	//outpath:format
+	printerMap := make(map[string]string)
 
 	for _, o := range outputSlice {
 		outputParts := strings.SplitN(o, ":", 2)
-		numParts := len(outputParts)
-		if numParts == 1 && outputParts[0] != "none" {
-			outputParts = append(outputParts, outputParts[0])
-			outputParts[0] = "format"
+
+		if strings.HasPrefix(outputParts[0], "gotemplate=") {
+			err := parseFormat(outputParts, printerMap)
+			if err != nil {
+				return outConfig, err
+			}
+			continue
 		}
 
 		switch outputParts[0] {
 		case "none":
-			printerKind = "ignore"
-		case "format":
-			printerKind = outputParts[1]
-			if err := validateFormat(printerKind); err != nil {
+			if len(outputParts) > 1 {
+				return outConfig, errors.New("none output does not support path. Use '--output help' for more info")
+			}
+			printerMap["stdout"] = "ignore"
+		case "table", "table-verbose", "json", "gob":
+			err := parseFormat(outputParts, printerMap)
+			if err != nil {
 				return outConfig, err
 			}
-		case "out-file":
-			outPath = outputParts[1]
 		case "log-file":
+			err := validateLogfile(outputParts)
+			if err != nil {
+				return outConfig, err
+			}
 			logPath = outputParts[1]
 		case "option":
-			switch outputParts[1] {
-			case "stack-addresses":
-				traceeConfig.StackAddresses = true
-			case "exec-env":
-				traceeConfig.ExecEnv = true
-			case "relative-time":
-				traceeConfig.RelativeTime = true
-				printerConfig.RelativeTS = true
-			case "exec-hash":
-				traceeConfig.ExecHash = true
-			case "parse-arguments":
-				traceeConfig.ParseArguments = true
-			case "parse-arguments-fds":
-				traceeConfig.ParseArgumentsFDs = true
-				traceeConfig.ParseArguments = true // no point in parsing file descriptor args only
-			case "sort-events":
-				traceeConfig.EventsSorting = true
-			default:
-				return outConfig, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
+			err := parseOption(outputParts, traceeConfig)
+			if err != nil {
+				return outConfig, err
 			}
 		default:
-			return outConfig, fmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
+			return outConfig, fmt.Errorf("invalid output flag: %s, use '--output help' for more info", outputParts[0])
 		}
 	}
 
-	if printerKind == "table" {
-		traceeConfig.ParseArguments = true
+	// default
+	if len(printerMap) == 0 {
+		printerMap["stdout"] = "table"
 	}
 
-	printerConfig.Kind = printerKind
-
-	if outPath == "" {
-		printerConfig.OutFile = os.Stdout
-	} else {
-		file, err := createFile(outPath)
-		if err != nil {
-			return outConfig, err
-		}
-
-		printerConfig.OutPath = outPath
-		printerConfig.OutFile = file
+	printerConfigs, err := getPrinterConfigs(printerMap, traceeConfig)
+	if err != nil {
+		return outConfig, err
 	}
 
 	if logPath == "" {
@@ -130,23 +124,114 @@ func PrepareOutput(outputSlice []string) (OutputConfig, error) {
 	}
 
 	outConfig.TraceeConfig = traceeConfig
-	outConfig.PrinterConfig = printerConfig
+	outConfig.PrinterConfigs = printerConfigs
 
 	return outConfig, nil
 }
 
-func validateFormat(printerKind string) error {
-	if printerKind != "table" &&
-		printerKind != "table-verbose" &&
-		printerKind != "json" &&
-		printerKind != "gob" &&
-		!strings.HasPrefix(printerKind, "gotemplate=") {
-		return fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
+// setOption sets the given option in the given config
+func setOption(config *tracee.OutputConfig, option string) error {
+	switch option {
+	case "stack-addresses":
+		config.StackAddresses = true
+	case "exec-env":
+		config.ExecEnv = true
+	case "relative-time":
+		config.RelativeTime = true
+	case "exec-hash":
+		config.ExecHash = true
+	case "parse-arguments":
+		config.ParseArguments = true
+	case "parse-arguments-fds":
+		config.ParseArgumentsFDs = true
+		config.ParseArguments = true // no point in parsing file descriptor args only
+	case "sort-events":
+		config.EventsSorting = true
+	default:
+		return fmt.Errorf("invalid output option: %s, use '--output help' for more info", option)
 	}
 
 	return nil
 }
 
+// getPrinterConfigs returns a slice of printer.Configs based on the given printerMap
+func getPrinterConfigs(printerMap map[string]string, traceeConfig *tracee.OutputConfig) ([]printer.Config, error) {
+	printerConfigs := make([]printer.Config, 0, len(printerMap))
+
+	for outPath, printerKind := range printerMap {
+		if printerKind == "table" {
+			setOption(traceeConfig, "parse-arguments")
+		}
+
+		outFile := os.Stdout
+		var err error
+
+		if outPath != "stdout" {
+			outFile, err = createFile(outPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		printerConfigs = append(printerConfigs, printer.Config{
+			Kind:       printerKind,
+			OutPath:    outPath,
+			OutFile:    outFile,
+			RelativeTS: traceeConfig.RelativeTime,
+		})
+	}
+
+	return printerConfigs, nil
+}
+
+// parseFormat parses the given format and sets it in the given printerMap
+func parseFormat(outputParts []string, printerMap map[string]string) error {
+	// if not file was passed, we use stdout
+	if len(outputParts) == 1 {
+		outputParts = append(outputParts, "stdout")
+	}
+
+	for _, outPath := range strings.Split(outputParts[1], ",") {
+
+		if outPath == "" {
+			return errors.New("format flag can't be empty, use '--output help' for more info")
+		}
+
+		if _, ok := printerMap[outPath]; ok {
+			return fmt.Errorf("cannot use the same path for multiple outputs: %s, use '--output help' for more info", outPath)
+		}
+		printerMap[outPath] = outputParts[0]
+	}
+
+	return nil
+}
+
+// parseOption parses the given option and sets it in the given config
+func parseOption(outputParts []string, traceeConfig *tracee.OutputConfig) error {
+	if len(outputParts) == 1 || outputParts[1] == "" {
+		return errors.New("option flag can't be empty, use '--output help' for more info")
+	}
+
+	for _, option := range strings.Split(outputParts[1], ",") {
+		err := setOption(traceeConfig, option)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateLogfile validates the given logfile
+func validateLogfile(outputParts []string) error {
+	if len(outputParts) == 1 || outputParts[1] == "" {
+		return errors.New("log-file flag can't be empty, use '--output help' for more info")
+	}
+
+	return nil
+}
+
+// creates *os.File for the given path
 func createFile(path string) (*os.File, error) {
 	fileInfo, err := os.Stat(path)
 	if err == nil && fileInfo.IsDir() {

--- a/pkg/cmd/flags/output_old.go
+++ b/pkg/cmd/flags/output_old.go
@@ -1,0 +1,137 @@
+package flags
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/cmd/printer"
+	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+)
+
+func outputHelpOld() string {
+	return `Control how and where output is printed.
+Possible options:
+[format:]table                                     output events in table format (default)
+[format:]table-verbose                             output events in table format with extra fields per event
+[format:]json                                      output events in json format
+[format:]gob                                       output events in gob format
+[format:]gotemplate=/path/to/template              output events formatted using a given gotemplate file
+out-file:/path/to/file                             write the output to a specified file. create/trim the file if exists (default: stdout)
+log-file:/path/to/file                             write the logs to a specified file. create/trim the file if exists (default: stderr)
+none                                               ignore stream of events output, usually used with --capture
+option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
+                                                   augment output according to given options (default: none)
+  stack-addresses                                  include stack memory addresses for each event
+  exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
+  relative-time                                    use relative timestamp instead of wall timestamp for events
+  exec-hash                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
+  parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
+  parse-arguments-fds                              enable parse-arguments and enrich fd with its file path translation. This can cause pipeline slowdowns.
+  sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
+Examples:
+  --output json                                            | output as json to stdout
+  --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
+  --output out-file:/my/out --output log-file:/my/log      | output to /my/out and logs to /my/log
+  --output none                                            | ignore events output
+Use this flag multiple times to choose multiple output options
+`
+}
+
+func PrepareOutputOld(outputSlice []string) (OutputConfig, error) {
+	outConfig := OutputConfig{}
+	traceeConfig := &tracee.OutputConfig{}
+
+	var outPath string
+	var logPath string
+
+	printerKind := "table"
+
+	for _, o := range outputSlice {
+		outputParts := strings.SplitN(o, ":", 2)
+		numParts := len(outputParts)
+		if numParts == 1 && outputParts[0] != "none" {
+			outputParts = append(outputParts, outputParts[0])
+			outputParts[0] = "format"
+		}
+
+		switch outputParts[0] {
+		case "none":
+			printerKind = "ignore"
+		case "format":
+			printerKind = outputParts[1]
+			if err := validateFormat(printerKind); err != nil {
+				return outConfig, err
+			}
+		case "out-file":
+			outPath = outputParts[1]
+		case "log-file":
+			logPath = outputParts[1]
+		case "option":
+			err := setOption(traceeConfig, outputParts[1])
+			if err != nil {
+				return outConfig, err
+			}
+		default:
+			return outConfig, fmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
+		}
+	}
+
+	printerConfigs := make([]printer.Config, 0)
+
+	if printerKind == "table" {
+		setOption(traceeConfig, "parse-arguments")
+	}
+
+	if outPath == "" {
+		stdoutConfig := printer.Config{
+			Kind:       printerKind,
+			OutFile:    os.Stdout,
+			RelativeTS: traceeConfig.RelativeTime,
+		}
+
+		printerConfigs = append(printerConfigs, stdoutConfig)
+	} else {
+		file, err := createFile(outPath)
+		if err != nil {
+			return outConfig, err
+		}
+
+		printerConfig := printer.Config{
+			Kind:       printerKind,
+			OutPath:    outPath,
+			OutFile:    file,
+			RelativeTS: traceeConfig.RelativeTime,
+		}
+
+		printerConfigs = append(printerConfigs, printerConfig)
+	}
+
+	if logPath == "" {
+		outConfig.LogFile = os.Stderr
+	} else {
+		file, err := createFile(logPath)
+		if err != nil {
+			return outConfig, err
+		}
+
+		outConfig.LogFile = file
+	}
+
+	outConfig.TraceeConfig = traceeConfig
+	outConfig.PrinterConfigs = printerConfigs
+
+	return outConfig, nil
+}
+
+func validateFormat(printerKind string) error {
+	if printerKind != "table" &&
+		printerKind != "table-verbose" &&
+		printerKind != "json" &&
+		printerKind != "gob" &&
+		!strings.HasPrefix(printerKind, "gotemplate=") {
+		return fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
+	}
+
+	return nil
+}

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -62,11 +62,11 @@ func TestPrepareOutputPrinterConfig(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			outputConfig, err := flags.PrepareOutput(testcase.outputSlice)
+			outputConfig, err := flags.PrepareOutputOld(testcase.outputSlice)
 			if err != nil {
 				assert.Equal(t, testcase.expectedError, err)
 			} else {
-				assert.Equal(t, testcase.expectedPrinter, outputConfig.PrinterConfig)
+				assert.Equal(t, testcase.expectedPrinter, outputConfig.PrinterConfigs[0])
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The code here is still a draft, but I want to discuss if you all agree with the syntax. This PR adds support for multiple printers, for example, a user can have `table` to `stdout`, and `json` to a file, or/and `gob` to a file.

Now, when you use `tracee` you are able to send the output to either `stdout`, or an output file. For example:

```
tracee  # prints table to stdout
tracee --output table # prints table to stdout
tracee --output json # prints json to stdout
tracee --output out-file:/tmp/test # prints table to /tmp/test
tracee --output json --output out-file:/tmp/test # prints json to /tmp/test
```

So, you can pick one format in which the default is `table` and one output path in which the default is `stdout`.

The PR allow you to have multiple printer with a new syntax. For example:

```
tracee # prints table to stdout
tracee --output format:table # prints table to stdout
tracee --output json # prints json to stdout

tracee --output out-file:/tmp/test # prints json to /tmp/test
tracee --output out-file:/tmp/test,format:table # prints table to /tmp/test
tracee --output out-file:/tmp/test,gob # prints gob to /tmp/test

tracee --output table --output out-file:/tmp/test # prints table to stdout, and prints json to /tmp/test
tracee --output table --output out-file:/tmp/test,gob # prints table to sdout, and prints gob to /tmp/test
tracee --output table --output out-file:/tmp/test,gob  --output out-file:/tmp/test2,format:json # prints table to sdout, and prints gob to /tmp/test, and prints json to /tmp/test2
``` 

For the new syntax, when you pass a format directly to output, it only reflects `stdout`, for `out-file` they have their own default which is json, and allow customization of this format with the syntax `out-file:FILE[,format]`

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
