### PR TITLE
Latest fixes

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -581,11 +581,12 @@ typedef s64 ktime_t;
 struct sk_buff {
     __u16 transport_header;
     __u16 network_header;
-    unsigned char *head;
     union {
         ktime_t tstamp;
         u64 skb_mstamp_ns;
     };
+    unsigned char *head;
+    unsigned char *data;
 };
 
 struct linux_binprm {

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -104,7 +104,6 @@ func Init(module *bpf.Module, netEnabled bool) (Probes, error) {
 		SecuritySocketSendmsg:      &traceProbe{eventName: "security_socket_sendmsg", probeType: kprobe, programName: "trace_security_socket_sendmsg"},
 		SecuritySocketRecvmsg:      &traceProbe{eventName: "security_socket_recvmsg", probeType: kprobe, programName: "trace_security_socket_recvmsg"},
 		CgroupBPFRunFilterSKB:      &traceProbe{eventName: "__cgroup_bpf_run_filter_skb", probeType: kprobe, programName: "cgroup_bpf_run_filter_skb"},
-		CgroupBPFRunFilterSKBRet:   &traceProbe{eventName: "__cgroup_bpf_run_filter_skb", probeType: kretprobe, programName: "ret_cgroup_bpf_run_filter_skb"},
 		CgroupSKBIngress:           &cgroupProbe{programName: "cgroup_skb_ingress", attachType: bpf.BPFAttachTypeCgroupInetIngress},
 		CgroupSKBEgress:            &cgroupProbe{programName: "cgroup_skb_egress", attachType: bpf.BPFAttachTypeCgroupInetEgress},
 		DoMmap:                     &traceProbe{eventName: "do_mmap", probeType: kprobe, programName: "trace_do_mmap"},
@@ -261,7 +260,6 @@ const (
 	SecuritySocketRecvmsg
 	SecuritySocketSendmsg
 	CgroupBPFRunFilterSKB
-	CgroupBPFRunFilterSKBRet
 	CgroupSKBIngress
 	CgroupSKBEgress
 	DoMmap

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -6120,7 +6120,6 @@ var Definitions = eventDefinitions{
 				{Handle: probes.SockAllocFile, Required: true},
 				{Handle: probes.SockAllocFileRet, Required: true},
 				{Handle: probes.CgroupBPFRunFilterSKB, Required: true},
-				{Handle: probes.CgroupBPFRunFilterSKBRet, Required: true},
 				{Handle: probes.SecuritySocketRecvmsg, Required: true},
 				{Handle: probes.SecuritySocketSendmsg, Required: true},
 			},


### PR DESCRIPTION
### 1. Explain what the PR does

commit 6da420d8 (HEAD -> net-corrupt-fix, rafaeldtinoco/latest-fixes)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sun Feb 12 04:09:15 2023

    network: fix network packets corruption
    
    Before this patch, the skb timestamp was used as the key for a map
    shared between cgroup/skp program and the kprobe program responsible
    for calling it. The reason why this is needed is because there is
    absolute no helper available inside the cgroup/skb context in kernels
    below 5.6. The technique used here is to pre-process all the event
    in a kprobe, before the ingress/egress cgroup/skb programs, and simply
    submit the result (together with the patcket headers/data) from the
    ingress/egress programs.
    
    Unfortunately preemption is enabled in between the kprobe and ingress
    or egress programs. This means that the map can't be a per cpu map,
    since the task can migrate cpus, and the key that indexes the
    pre-processed work has to be known inside the cgroup/skb program, which
    is very hard without having bpf helpers to use things such as host tid,
    and similar keys.
    
    Unfortunately only skb timestamp as the key is also not enough. There
    are times that the timestamp is zeroed and it would cause conflicts and
    make tracee to generate errors such as:
    
        {"L":"ERROR","T":"2023-02-10T16:31:57.883-0300","M":"tracee
            encountered an error","error":"failed to derive event 2006:
            resource record length exceeds data"}
    
        {"L":"ERROR","T":"2023-02-10T16:31:57.883-0300","M":"tracee
            encountered an error","error":"failed to derive event 2007:
            resource record length exceeds data"}
    
        {"L":"ERROR","T":"2023-02-10T16:31:57.883-0300","M":"tracee
            encountered an error","error":"failed to derive event 2008:
            resource record length exceeds data"}
    
    The only values shared in between the kprobe and the cgroup/skb programs
    are either the skb timestamp or skb data pointer value. So, instead of
    relying only on the skb timestamp, we also use the skb data pointer now
    to find the pre-processed work.
    
    Results filtering for net_packet_ipv4 seem satisfactory:
    
    [  5] local 127.0.0.1 port 33388 connected to 127.0.0.1 port 5201
    [ ID] Interval           Transfer     Bitrate         Retr  Cwnd
    [  5]   0.00-1.00   sec  1.25 GBytes  10.8 Gbits/sec    0    895 KBytes
    [  5]   1.00-2.00   sec  1.23 GBytes  10.6 Gbits/sec    0   1.75 MBytes
    [  5]   2.00-3.00   sec  1.26 GBytes  10.9 Gbits/sec    0   1.75 MBytes
    [  5]   3.00-4.00   sec  1.25 GBytes  10.8 Gbits/sec    0   1.75 MBytes
    [  5]   4.00-5.00   sec  1.31 GBytes  11.2 Gbits/sec    0   1.75 MBytes
    [  5]   5.00-6.00   sec   998 MBytes  8.38 Gbits/sec    0   1.75 MBytes
    [  5]   6.00-7.00   sec  1.08 GBytes  9.26 Gbits/sec    0   1.75 MBytes
    [  5]   7.00-8.00   sec  1.01 GBytes  8.68 Gbits/sec    0   1.75 MBytes
    [  5]   8.00-9.00   sec  1.33 GBytes  11.5 Gbits/sec    0   1.75 MBytes
    [  5]   9.00-10.00  sec  1.09 GBytes  9.32 Gbits/sec    0   1.81 MBytes
    - - - - - - - - - - - - - - - - - - - - - - - - -
    [ ID] Interval           Transfer     Bitrate         Retr
    [  5]   0.00-10.00  sec  11.8 GBytes  10.1 Gbits/sec    0   sender
    [  5]   0.00-10.00  sec  11.8 GBytes  10.1 Gbits/sec        receiver
    
    In regards to throughput and amount of packets processed (and lost due
    to this technique).
    
    This patch also removes the kretprobe after the cgroup/skb program runs,
    since it is not needed anymore.

commit 761bea50
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Feb 10 15:33:26 2023

    network: fix segfault in DNS parser
    
    A DNS packet might not have a question section, in cases where the
    event gets corrupted (because of N reasons). This patch fixes the
    issue.

### 2. Explain how to test it

Terminal 1, execute tracee:

```
$ sudo ./dist/tracee --pprof --metrics --log debug --install-path /tmp/tracee --output option:parse-arguments --capabilities bypass=false --output none --trace comm!=node --trace event=net_packet_dns,net_packet_dns_request,net_packet_dns_response,hooked_proc_fops,hooked_syscalls,init_module,magic_write,mem_prot_alert,process_vm_writev,ptrace,sched_process_exec,security_bprm_check,security_file_open,security_inode_rename,security_kernel_read_file,security_sb_mount,security_socket_connect,socket_dup
```

Terminal 2, 3, 4 and 5, execute a dig loop:

```
$ while true; do dig rafaeldtinoco.com; done
```

> make sure resolutions are made locally to systemd-resolved (to its fast).

Terminal 6 and 7, execute a "ps -ef" loop:

```
$ while true; do ps -ef; done
```

Let the workload run for some time and observe tracee output some errors like:

```
    {"L":"ERROR","T":"2023-02-10T16:31:57.883-0300","M":"tracee
        encountered an error","error":"failed to derive event 2006:
        resource record length exceeds data"}
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
