### PR TITLE
events: print seconds of timespec

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -419,8 +419,13 @@ static __always_inline int save_args_to_submit_buf(event_data_t *event, u64 type
                 size = sizeof(int[2]);
                 rc = save_to_submit_buf(event, (void *) (args->args[i]), size, index);
                 break;
+            case TIMESPEC_T:
+                size = sizeof(struct __kernel_timespec);
+                rc = save_to_submit_buf(event, (void *) (args->args[i]), size, index);
+                break;
         }
-        if ((type != NONE_T) && (type != STR_T) && (type != SOCKADDR_T) && (type != INT_ARR_2_T)) {
+        if ((type != NONE_T) && (type != STR_T) && (type != SOCKADDR_T) && (type != INT_ARR_2_T) &&
+            (type != TIMESPEC_T)) {
             rc = save_to_submit_buf(event, (void *) &(args->args[i]), size, index);
         }
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -19,6 +19,7 @@
     #include <linux/signal.h>
     #include <linux/fs.h>
     #include <linux/mm_types.h>
+    #include <linux/time.h>
     #include <linux/mount.h>
     #include <linux/nsproxy.h>
     #include <linux/ns_common.h>

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -144,6 +144,7 @@ enum argument_type_e
     INT_ARR_2_T,
     UINT64_ARR_T,
     U8_T,
+    TIMESPEC_T,
     TYPE_MAX = 255UL
 };
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -603,6 +603,13 @@ struct timespec64 {
     long int tv_nsec;
 };
 
+typedef long long __kernel_time64_t;
+
+struct __kernel_timespec {
+    __kernel_time64_t tv_sec;
+    long long tv_nsec;
+};
+
 struct inode {
     umode_t i_mode;
     struct super_block *i_sb;


### PR DESCRIPTION
print the seconds of struct timespec instead of pointer address

issue: #2711 

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste your very well written git logs -->

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Sun Feb 12 17:13:17 2023 +0200

    events: print seconds of timespec
    
    print the seconds of struct timespec instead of pointer address
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

terminal 1: `./dist/tracee-ebpf -t e=clock_nanosleep`
terminal 2: `sleep 1`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
