### PR TITLE
tracee: fix args on signatures events

### DIFF
--- a/pkg/ebpf/finding_test.go
+++ b/pkg/ebpf/finding_test.go
@@ -35,7 +35,23 @@ func TestFindingToEvent(t *testing.T) {
 		PodUID:              "uid",
 		ReturnValue:         0,
 		MatchedScopes:       1,
-		ArgsNum:             0,
+		ArgsNum:             2,
+		Args: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{
+					Name: "arg1",
+					Type: "const char *",
+				},
+				Value: "value1",
+			},
+			{
+				ArgMeta: trace.ArgMeta{
+					Name: "arg2",
+					Type: "int",
+				},
+				Value: 1,
+			},
+		},
 		Metadata: &trace.Metadata{
 			Version:     "1",
 			Description: "description",

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -62,6 +62,11 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 					continue
 				}
 
+				if !t.shouldProcessEvent(event) {
+					t.stats.EventsFiltered.Increment()
+					continue
+				}
+
 				out <- event
 			case <-ctx.Done():
 				return

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -80,6 +80,17 @@ type Event struct {
 	Params       []trace.ArgMeta
 }
 
+func (e *Event) IsASignatureEvent() bool {
+
+	for _, s := range e.Sets {
+		if s == "signatures" {
+			return true
+		}
+	}
+
+	return false
+}
+
 // NewEventDefinition creates a new event definition
 func NewEventDefinition(name string, sets []string, depsID []ID) Event {
 	evt := Event{

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -100,7 +100,8 @@ func (filter *ArgFilter) Parse(filterName string, operatorAndValues string, even
 		}
 	}
 
-	if !argFound {
+	// if the event is a signature event, we allow filtering on dynamic argument
+	if !argFound && !eventDefinition.IsASignatureEvent() {
 		return InvalidEventArgument(argName)
 	}
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR changes signature events to use `finding.Data` as arguments instead of the original event arguments. 
Also, it fix the filtering based on such arguments for signature events.

This PR is part of epic: https://github.com/aquasecurity/tracee/issues/2355

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

The simplest way to test is to change an existing signature to include same [output data](https://github.com/aquasecurity/tracee/blob/main/signatures/golang/anti_debugging_ptraceme.go#L70), recompile tracee, and test out the feature, eg:

```
tracee --trace event=anti_debugging --trace anti_debugging.args.arg1=test
```

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
