### PR TITLE
tracee-rules: bypass capabilities if user not root

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -51,7 +51,10 @@ func main() {
 
 			// Capabilities command line flags
 
-			err := capabilities.Initialize(c.Bool("allcaps"))
+			// if the user is not root, we will bypass capabilities raising,
+			// which means default capabilities will be used
+			bypass := c.Bool("allcaps") || !isRoot()
+			err := capabilities.Initialize(bypass)
 			if err != nil {
 				return err
 			}
@@ -284,4 +287,8 @@ func listEvents(w io.Writer, sigs []detect.Signature) {
 
 	sort.Slice(events, func(i, j int) bool { return events[i] < events[j] })
 	fmt.Fprintln(w, strings.Join(events, ","))
+}
+
+func isRoot() bool {
+	return os.Geteuid() == 0
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/2718

The [PR](https://github.com/aquasecurity/tracee/pull/2580) fixed a bug when `tracee-rules` was executed with `sudo`, though it introduced a bug for when `tracee-rules` is executed without `sudo`, it fails because it can't raise capabilities.

This PR fixes this bug. 

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
make
./dist/tracee-rules --list-events
sudo ./dist/tracee-rules --list-events
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
