### PR TITLE
tracee: fix filters

### DIFF
--- a/cmd/tracee/main_test.go
+++ b/cmd/tracee/main_test.go
@@ -22,7 +22,7 @@ func Test_createEventsFromSigs(t *testing.T) {
 				newFakeSignature("fake_event_0", []string{"hooked_syscalls"}),
 			},
 			expectedEvents: []events.Event{
-				events.NewEventDefinition("fake_event_0", []string{"rules"}, []events.ID{events.HookedSyscalls}),
+				events.NewEventDefinition("fake_event_0", []string{"signatures"}, []events.ID{events.HookedSyscalls}),
 			},
 		},
 		{
@@ -32,8 +32,8 @@ func Test_createEventsFromSigs(t *testing.T) {
 				newFakeSignature("fake_event_2", []string{"security_file_open", "security_inode_rename"}),
 			},
 			expectedEvents: []events.Event{
-				events.NewEventDefinition("fake_event_1", []string{"rules"}, []events.ID{events.Ptrace}),
-				events.NewEventDefinition("fake_event_2", []string{"rules"}, []events.ID{events.SecurityFileOpen, events.SecurityInodeRename}),
+				events.NewEventDefinition("fake_event_1", []string{"signatures"}, []events.ID{events.Ptrace}),
+				events.NewEventDefinition("fake_event_2", []string{"signatures"}, []events.ID{events.SecurityFileOpen, events.SecurityInodeRename}),
 			},
 		},
 		{
@@ -42,7 +42,7 @@ func Test_createEventsFromSigs(t *testing.T) {
 				newFakeSignature("fake_event_3", []string{"sched_process_exec", "security_socket_connect"}),
 			},
 			expectedEvents: []events.Event{
-				events.NewEventDefinition("fake_event_3", []string{"rules"}, []events.ID{events.SchedProcessExec, events.SecuritySocketConnect}),
+				events.NewEventDefinition("fake_event_3", []string{"signatures"}, []events.ID{events.SchedProcessExec, events.SecuritySocketConnect}),
 			},
 		},
 	}


### PR DESCRIPTION


<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fixes TODO for https://github.com/aquasecurity/tracee/issues/2355

The unified binary create events for all signatures by default (add events to Definitions). The enabling of such events is handled by `tracee` default filtering logic. With this strategy we can support use cases like: 

--trace e=anti_debugging
--trace set=signatures
--trace set=signatures --trace e!=anti_debugging

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
tracee --trace e=anti_debugging
tracee --trace set=signatures
tracee --trace set=signatures --trace e!=anti_debugging
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
