### PR TITLE
flags: remove cache-events from output help

### DIFF
--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -30,7 +30,6 @@ option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-ev
   parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
   parse-arguments-fds                              enable parse-arguments and enrich fd with its file path translation. This can cause pipeline slowdowns.
   sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
-  cache-events                                     enable caching events to release perf-buffer pressure. This will decrease amount of event loss until cache is full.
 Examples:
   --output json                                            | output as json to stdout
   --output gotemplate=/path/to/my.tmpl                     | output as the provided go template


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

`tracee --output help` list an option for `cache-events` which the code ignores, this probably is an old flag that was replaced by higher level flag `tracee --cache help`

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
tracee --output help
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
