### PR TITLE
filterscopes: create a filterscopes pkg

### DIFF
--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/filterscope"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -173,8 +173,8 @@ func parseFilterFlag(flag string) (*filterFlag, error) {
 
 		// now consider it as a scope index
 		scopeID--
-		if scopeID < 0 || scopeID > tracee.MaxFilterScopes-1 {
-			return nil, filters.InvalidScope(fmt.Sprintf("%s - scopes must be between 1 and %d", flag, tracee.MaxFilterScopes))
+		if scopeID < 0 || scopeID > filterscope.MaxFilterScopes-1 {
+			return nil, filters.InvalidScope(fmt.Sprintf("%s - scopes must be between 1 and %d", flag, filterscope.MaxFilterScopes))
 		}
 
 		filterNameIdx = scopeEndIdx + 1
@@ -210,7 +210,7 @@ func parseFilterFlag(flag string) (*filterFlag, error) {
 	}, nil
 }
 
-func PrepareFilterScopes(filtersArr []string) (*tracee.FilterScopes, error) {
+func PrepareFilterScopes(filtersArr []string) (*filterscope.FilterScopes, error) {
 	eventsNameToID := events.Definitions.NamesToIDs()
 	// remove internal events since they shouldn't be accesible by users
 	for event, id := range eventsNameToID {
@@ -234,9 +234,9 @@ func PrepareFilterScopes(filtersArr []string) (*tracee.FilterScopes, error) {
 		)
 	}
 
-	filterScopes := tracee.NewFilterScopes()
+	filterScopes := filterscope.NewFilterScopes()
 	for scopeIdx, fsFlags := range parsedMap {
-		filterScope := tracee.NewFilterScope()
+		filterScope := filterscope.NewFilterScope()
 		eventFilter := cliFilter{
 			Equal:    []string{},
 			NotEqual: []string{},
@@ -441,7 +441,7 @@ func PrepareFilterScopes(filtersArr []string) (*tracee.FilterScopes, error) {
 		}
 
 		var err error
-		newScope := tracee.NewFilterScope()
+		newScope := filterscope.NewFilterScope()
 		newScope.EventsToTrace, err = prepareEventsToTrace(eventFilter, setFilter, eventsNameToID)
 		if err != nil {
 			return nil, err

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -10,6 +10,7 @@ import (
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/filterscope"
 	"github.com/aquasecurity/tracee/pkg/pcaps"
 	"github.com/aquasecurity/tracee/pkg/rules/rego"
 	"github.com/stretchr/testify/assert"
@@ -35,8 +36,8 @@ func TestPrepareFilterScope(t *testing.T) {
 		},
 		{
 			testName:      "invalid scope id 3",
-			filters:       []string{fmt.Sprintf("%d:comm=bash", tracee.MaxFilterScopes+1)},
-			expectedError: filters.InvalidScope(fmt.Sprintf("%d:comm=bash", tracee.MaxFilterScopes+1)),
+			filters:       []string{fmt.Sprintf("%d:comm=bash", filterscope.MaxFilterScopes+1)},
+			expectedError: filters.InvalidScope(fmt.Sprintf("%d:comm=bash", filterscope.MaxFilterScopes+1)),
 		},
 		{
 			testName:      "invalid argfilter 1",

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -31,6 +31,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events/sorting"
 	"github.com/aquasecurity/tracee/pkg/events/trigger"
 	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/filterscope"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/metrics"
 	"github.com/aquasecurity/tracee/pkg/pcaps"
@@ -53,7 +54,7 @@ const (
 
 // Config is a struct containing user defined configuration of tracee
 type Config struct {
-	FilterScopes       *FilterScopes
+	FilterScopes       *filterscope.FilterScopes
 	Capture            *CaptureConfig
 	Capabilities       *CapabilitiesConfig
 	Output             *OutputConfig
@@ -870,7 +871,7 @@ func (t *Tracee) computeConfigValues() []byte {
 	}
 
 	// compute all filter scopes internals
-	t.config.FilterScopes.compute()
+	t.config.FilterScopes.Compute()
 
 	// uid_max
 	binary.LittleEndian.PutUint64(configVal[224:232], t.config.FilterScopes.UIDFilterMax())
@@ -1029,14 +1030,14 @@ func (t *Tracee) populateBPFMaps() error {
 		scopeID := uint(filterScope.ID)
 		errMap := make(map[string]error, 0)
 
-		errMap[UIDFilterMap] = filterScope.UIDFilter.UpdateBPF(t.bpfModule, scopeID)
-		errMap[PIDFilterMap] = filterScope.PIDFilter.UpdateBPF(t.bpfModule, scopeID)
-		errMap[MntNSFilterMap] = filterScope.MntNSFilter.UpdateBPF(t.bpfModule, scopeID)
-		errMap[PidNSFilterMap] = filterScope.PidNSFilter.UpdateBPF(t.bpfModule, scopeID)
-		errMap[UTSFilterMap] = filterScope.UTSFilter.UpdateBPF(t.bpfModule, scopeID)
-		errMap[CommFilterMap] = filterScope.CommFilter.UpdateBPF(t.bpfModule, scopeID)
-		errMap[ContIdFilter] = filterScope.ContIDFilter.UpdateBPF(t.bpfModule, t.containers, scopeID)
-		errMap[BinaryFilterMap] = filterScope.BinaryFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.UIDFilterMap] = filterScope.UIDFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.PIDFilterMap] = filterScope.PIDFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.MntNSFilterMap] = filterScope.MntNSFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.PidNSFilterMap] = filterScope.PidNSFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.UTSFilterMap] = filterScope.UTSFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.CommFilterMap] = filterScope.CommFilter.UpdateBPF(t.bpfModule, scopeID)
+		errMap[filterscope.ContIdFilter] = filterScope.ContIDFilter.UpdateBPF(t.bpfModule, t.containers, scopeID)
+		errMap[filterscope.BinaryFilterMap] = filterScope.BinaryFilter.UpdateBPF(t.bpfModule, scopeID)
 
 		for k, v := range errMap {
 			if v != nil {

--- a/pkg/filterscope/errors.go
+++ b/pkg/filterscope/errors.go
@@ -1,4 +1,4 @@
-package ebpf
+package filterscope
 
 import "fmt"
 

--- a/pkg/filterscope/filterscope.go
+++ b/pkg/filterscope/filterscope.go
@@ -1,0 +1,70 @@
+package filterscope
+
+import (
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/filters"
+)
+
+const (
+	UIDFilterMap         = "uid_filter"
+	PIDFilterMap         = "pid_filter"
+	MntNSFilterMap       = "mnt_ns_filter"
+	PidNSFilterMap       = "pid_ns_filter"
+	UTSFilterMap         = "uts_ns_filter"
+	CommFilterMap        = "comm_filter"
+	ProcessTreeFilterMap = "process_tree_map"
+	CgroupIdFilterMap    = "cgroup_id_filter"
+	ContIdFilter         = "cont_id_filter"
+	BinaryFilterMap      = "binary_filter"
+	ProcInfoMap          = "proc_info_map"
+)
+
+type FilterScope struct {
+	ID                int
+	EventsToTrace     map[events.ID]string
+	UIDFilter         *filters.BPFUIntFilter[uint32]
+	PIDFilter         *filters.BPFUIntFilter[uint32]
+	NewPidFilter      *filters.BoolFilter
+	MntNSFilter       *filters.BPFUIntFilter[uint64]
+	PidNSFilter       *filters.BPFUIntFilter[uint64]
+	UTSFilter         *filters.BPFStringFilter
+	CommFilter        *filters.BPFStringFilter
+	ContFilter        *filters.BoolFilter
+	NewContFilter     *filters.BoolFilter
+	ContIDFilter      *filters.ContainerFilter
+	RetFilter         *filters.RetFilter
+	ArgFilter         *filters.ArgFilter
+	ContextFilter     *filters.ContextFilter
+	ProcessTreeFilter *filters.ProcessTreeFilter
+	BinaryFilter      *filters.BPFBinaryFilter
+	Follow            bool
+}
+
+func NewFilterScope() *FilterScope {
+	return &FilterScope{
+		ID:                0,
+		EventsToTrace:     map[events.ID]string{},
+		UIDFilter:         filters.NewBPFUInt32Filter(UIDFilterMap),
+		PIDFilter:         filters.NewBPFUInt32Filter(PIDFilterMap),
+		NewPidFilter:      filters.NewBoolFilter(),
+		MntNSFilter:       filters.NewBPFUIntFilter(MntNSFilterMap),
+		PidNSFilter:       filters.NewBPFUIntFilter(PidNSFilterMap),
+		UTSFilter:         filters.NewBPFStringFilter(UTSFilterMap),
+		CommFilter:        filters.NewBPFStringFilter(CommFilterMap),
+		ContFilter:        filters.NewBoolFilter(),
+		NewContFilter:     filters.NewBoolFilter(),
+		ContIDFilter:      filters.NewContainerFilter(CgroupIdFilterMap),
+		RetFilter:         filters.NewRetFilter(),
+		ArgFilter:         filters.NewArgFilter(),
+		ContextFilter:     filters.NewContextFilter(),
+		ProcessTreeFilter: filters.NewProcessTreeFilter(ProcessTreeFilterMap),
+		BinaryFilter:      filters.NewBPFBinaryFilter(BinaryFilterMap, ProcInfoMap),
+		Follow:            false,
+	}
+}
+
+const MaxFilterScopes = 64
+
+func isIDInRange(id int) bool {
+	return id >= 0 && id < MaxFilterScopes
+}


### PR DESCRIPTION
### 1. Explain what the PR does

filterscopes: create a filterscopes pkg

A filterscopes pkg is needed so that the it can be used outside of the ebpf pkg. This is needed for the upcoming refactors such as the one that will allow the filterscopes to be used by the "load objects" and "symbols collision" events.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

@geyslan please check if this brakes your current work too much, and, if you can accept it and rebase your code, I'll be able to continue a refactor proposal to "ld SO symbols collision" (https://github.com/aquasecurity/tracee/pull/2053/) PR so the derivation table initialization does not get specific event initialization at its top.
