### PR TITLE
adjust recently merged symbols_collision event and better document it

### DIFF
--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -91,7 +91,7 @@ Events that match all trace expressions within a single scope will be traced.
 To find out which scopes an event is related to, read the bitmask in one of these ways:
 
 - using '-o format:json', matchedScopes JSON field (in decimal)
-- using '-o format:table-verbose', SCOPES collumn (in hexadecimal)
+- using '-o format:table-verbose', SCOPES column (in hexadecimal)
 
 Examples:
 
@@ -212,7 +212,7 @@ func parseFilterFlag(flag string) (*filterFlag, error) {
 
 func PrepareFilterScopes(filtersArr []string) (*filterscope.FilterScopes, error) {
 	eventsNameToID := events.Definitions.NamesToIDs()
-	// remove internal events since they shouldn't be accesible by users
+	// remove internal events since they shouldn't be accessible by users
 	for event, id := range eventsNameToID {
 		if events.Definitions.Get(id).Internal {
 			delete(eventsNameToID, event)

--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -18,9 +18,9 @@ type ContainerPathResolver struct {
 	mountNSPIDsCache *bucketscache.BucketsCache
 }
 
-// InitContainerPathResolver create a resolver for paths from within containers.
-func InitContainerPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) ContainerPathResolver {
-	return ContainerPathResolver{
+// InitContainerPathResolver creates a resolver for paths from within containers.
+func InitContainerPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) *ContainerPathResolver {
+	return &ContainerPathResolver{
 		fs:               os.DirFS("/"),
 		mountNSPIDsCache: mountNSPIDsCache,
 	}
@@ -31,7 +31,7 @@ func InitContainerPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) Cont
 func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string, mountNS int) (
 	string, error,
 ) {
-	// path should be absolute, except for e.g memfd_create files
+	// path should be absolute, except, for example, memfd_create files
 	if mountNSAbsolutePath == "" || mountNSAbsolutePath[0] != '/' {
 		return "", fmt.Errorf("file path is not absolute in its container mount point")
 	}

--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -10,30 +10,33 @@ import (
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 )
 
-// PathResolver generates an accessible absolute path from the root mount namespace to a relative
-// path in a container. **NOTE**: to resolve host mount namespace, tracee reads from /proc/1/ns,
-// requiring CAP_SYS_PTRACE capability.
-type PathResolver struct {
+// ContainerPathResolver generates an accessible absolute path from the root mount namespace to a
+// relative path in a container. **NOTE**: to resolve host mount namespace, tracee reads from
+// /proc/1/ns, requiring CAP_SYS_PTRACE capability.
+type ContainerPathResolver struct {
 	fs               fs.FS
 	mountNSPIDsCache *bucketscache.BucketsCache
 }
 
-// InitPathResolver create a resolver for paths from within containers.
-func InitPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) PathResolver {
-	return PathResolver{
+// InitContainerPathResolver create a resolver for paths from within containers.
+func InitContainerPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) ContainerPathResolver {
+	return ContainerPathResolver{
 		fs:               os.DirFS("/"),
 		mountNSPIDsCache: mountNSPIDsCache,
 	}
 }
 
-// ResolveAbsolutePath resolves an absolute path, which might be inside a container, to an absolute path
-// within the host mount namespace.
-func (cPathRes PathResolver) ResolveAbsolutePath(mountNSAbsolutePath string, mountNS int) (string, error) {
+// GetHostAbsPath translates an absolute path, which might be inside a container, to the
+// correspondent abs path in the host mount namespace.
+func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string, mountNS int) (
+	string, error,
+) {
 	// path should be absolute, except for e.g memfd_create files
 	if mountNSAbsolutePath == "" || mountNSAbsolutePath[0] != '/' {
 		return "", fmt.Errorf("file path is not absolute in its container mount point")
 	}
-	// try to access the root fs via another process in the same mount namespace (since the current process might have already died)
+	// try to access the root fs via another process in the same mount namespace
+	// (since the current process might have already died)
 	pids := cPathRes.mountNSPIDsCache.GetBucket(uint32(mountNS))
 	for _, pid := range pids {
 		procRootPath := fmt.Sprintf("/proc/%d/root", int(pid))
@@ -52,5 +55,5 @@ func (cPathRes PathResolver) ResolveAbsolutePath(mountNSAbsolutePath string, mou
 			return fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath), nil
 		}
 	}
-	return "", fmt.Errorf("has no access to container fs - no recorded living process of mount namespace %d", mountNS)
+	return "", fmt.Errorf("has no access to container fs - no living task of mountns %d", mountNS)
 }

--- a/pkg/containers/path_resolver_test.go
+++ b/pkg/containers/path_resolver_test.go
@@ -80,9 +80,9 @@ func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
 					}
 				}
 
-				pres := InitPathResolver(&bucket)
+				pres := InitContainerPathResolver(&bucket)
 				pres.fs = mfs
-				_, err := pres.ResolveAbsolutePath(testFilePath, testMntNS)
+				_, err := pres.GetHostAbsPath(testFilePath, testMntNS)
 				if testCase.ExpectedError {
 					assert.Error(t, err)
 				} else {
@@ -137,9 +137,9 @@ func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
 					mfs[fmt.Sprintf("proc/%d/root/%s", testPID, testCase.path)] = &fstest.MapFile{}
 				}
 
-				pres := InitPathResolver(&bucket)
+				pres := InitContainerPathResolver(&bucket)
 				pres.fs = mfs
-				_, err := pres.ResolveAbsolutePath(testCase.path, testMntNS)
+				_, err := pres.GetHostAbsPath(testCase.path, testMntNS)
 				if testCase.expectedError {
 					assert.Error(t, err)
 				} else {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -579,7 +579,7 @@ func (t *Tracee) initDerivationTable() error {
 		return fmt.Errorf("nil tracee containers")
 	}
 
-	pathResolver := containers.InitPathResolver(&t.pidsInMntns)
+	pathResolver := containers.InitContainerPathResolver(&t.pidsInMntns)
 	soLoader := sharedobjs.InitContainersSymbolsLoader(&pathResolver, 1024)
 
 	symbolsLoadedFilters := map[string]filters.Filter{}

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -2,231 +2,329 @@ package derive
 
 import (
 	"fmt"
+
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/filterscope"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils/sharedobjs"
 	"github.com/aquasecurity/tracee/types/trace"
 	"github.com/hashicorp/golang-lru/simplelru"
+	"golang.org/x/exp/maps"
 )
 
-// SymbolsCollision generate events for collisions between symbols exported by shared objects loaded to the same
-// process.
-// The event is triggered by the loading of a shared object, and an event will be created for each shared object
-// which has collisions with the newly loaded one.
-// For efficiency reasons, the event uses caching that require the `sched_process_exec` event for handling.
-func SymbolsCollision(
-	soLoader sharedobjs.DynamicSymbolsLoader,
-	symbolsBlackList []string,
-	symbolsWhiteList []string) DeriveFunction {
-	gen := initSOCollisionsEventGenerator(soLoader, symbolsBlackList, symbolsWhiteList)
+//
+// SymbolsCollision --------------------------------------------------------------------------------
+//
+// Generates events for collisions between symbols exported by shared objects loaded to the same
+// process virtual memory address space.
+//
+// One event is created for each symbol collision, and all of them are triggered by the loading of a
+// shared object to a process. For efficiency reasons, the event uses caching that require the
+// `sched_process_exec` event for handling.
+//
+
+func SymbolsCollision(soLoader sharedobjs.DynamicSymbolsLoader, fScopes *filterscope.FilterScopes,
+) DeriveFunction {
+
+	symbolsCollisionFilters := map[string]filters.Filter{}
+
+	// pick white and black lists from the filters (TODO: change this)
+	for fScope := range fScopes.Map() {
+		f := fScope.ArgFilter.GetEventFilters(events.SymbolsCollision)
+		maps.Copy(symbolsCollisionFilters, f)
+	}
+
+	symbolsWhitelist := []string{}
+	symbolsBlacklist := []string{}
+
+	filter, ok := symbolsCollisionFilters["symbols"].(*filters.StringFilter)
+	if filter != nil && ok {
+		symbolsWhitelist = filter.Equal()
+		symbolsBlacklist = filter.NotEqual()
+	}
+
+	gen := initSOCollisionsEventGenerator(soLoader, symbolsBlacklist, symbolsWhitelist)
+
 	return deriveMultipleEvents(events.SymbolsCollision, gen.deriveArgs)
 }
 
-// SymbolsCollisionArgsGenerator is the struct responsible to create the SO symbols collisions derived event.
-// To do so, it uses multiple caches to accelerate performance and reduce chances for failure.
+//
+// SymbolsCollisionArgsGenerator -------------------------------------------------------------------
+//
+
+// SymbolsCollisionArgsGenerator creates the shared object symbols collisions derived events. To do
+// so, it uses multiple caches to accelerate performance and reduce chances for failure.
 type SymbolsCollisionArgsGenerator struct {
-	soLoader          sharedobjs.DynamicSymbolsLoader
-	processesSOsCache processesLoadedObjectsCache
-	collisionsCache   sharedObjectsCollisionsCache
-	symbolsBlackList  map[string]bool
-	symbolsWhiteList  map[string]bool
-	returnedErrors    map[string]bool
+	soLoader               sharedobjs.DynamicSymbolsLoader
+	loadedObjsPerProcCache loadedObjsPerProcessCache // cache of loaded shared objects per process
+	collisionChecksCache   collisionChecksCache      // cache of symbols collisions
+	symbolsBlacklistMap    map[string]bool           // will delete symbols NOT in this map
+	symbolsWhitelistMap    map[string]bool           // will delete symbols IN this map
+	returnedErrorsMap      map[string]bool           // keep track of logged/debugged errors
 }
 
 func initSOCollisionsEventGenerator(
 	soLoader sharedobjs.DynamicSymbolsLoader,
 	symbolsBlackList []string,
-	symbolsWhiteList []string) *SymbolsCollisionArgsGenerator {
-	lruCallback := simplelru.EvictCallback(func(key interface{}, value interface{}) {})
-	processLoadedObjectsLRU, _ := simplelru.NewLRU(1024, lruCallback)
-	objectCollisionsLRU, _ := simplelru.NewLRU(1024, lruCallback)
+	symbolsWhiteList []string,
+) *SymbolsCollisionArgsGenerator {
+
+	noCallback := simplelru.EvictCallback(func(key interface{}, value interface{}) {})
+	loadedObsPerProcessLRU, _ := simplelru.NewLRU(1024, noCallback)
+	collisionChecksLRU, _ := simplelru.NewLRU(1024, noCallback)
+
 	symbolsBlackListMap := make(map[string]bool)
 	for _, sym := range symbolsBlackList {
 		symbolsBlackListMap[sym] = true
 	}
+
 	symbolsWhiteListMap := make(map[string]bool)
 	for _, sym := range symbolsWhiteList {
 		symbolsWhiteListMap[sym] = true
 	}
+
 	return &SymbolsCollisionArgsGenerator{
-		soLoader:          soLoader,
-		processesSOsCache: processesLoadedObjectsCache{processLoadedObjectsLRU},
-		collisionsCache:   sharedObjectsCollisionsCache{objectCollisionsLRU},
-		symbolsBlackList:  symbolsBlackListMap,
-		symbolsWhiteList:  symbolsWhiteListMap,
-		returnedErrors:    make(map[string]bool),
+		soLoader:               soLoader,
+		loadedObjsPerProcCache: loadedObjsPerProcessCache{loadedObsPerProcessLRU},
+		collisionChecksCache:   collisionChecksCache{collisionChecksLRU},
+		symbolsBlacklistMap:    symbolsBlackListMap,
+		symbolsWhitelistMap:    symbolsWhiteListMap,
+		returnedErrorsMap:      make(map[string]bool),
 	}
 }
 
-func (soColGen *SymbolsCollisionArgsGenerator) deriveArgs(event trace.Event) ([][]interface{}, []error) {
+// deriveArgs calls the appropriate derivation handler depending on the event type.
+func (gen *SymbolsCollisionArgsGenerator) deriveArgs(event trace.Event) ([][]interface{}, []error) {
 	switch events.ID(event.EventID) {
 	case events.SharedObjectLoaded:
-		return soColGen.handleSOLoaded(event)
+		return gen.handleShObjLoaded(event) // manages symbol collisions caches and generate events
 	case events.SchedProcessExec:
-		return soColGen.handleExec(event)
-	default:
-		return nil, []error{fmt.Errorf("received unexpected event - \"%s\"", event.EventName)}
+		return gen.handleExec(event) // evicts saved data (loaded shared objects) for the process
 	}
+
+	return nil, []error{fmt.Errorf("received unexpected event - \"%s\"", event.EventName)}
 }
 
-// handleSOLoaded check when a shared object is loaded into a process if some of its exported symbols collide with
-// previously loaded shared object.
-// An event will be created for each SO it has collisions with.
-// The main efficiency features it uses is caching examined SOs symbols and collision check results.
-// The hope is that after few processes are executed, all major libraries in the system will be cached already
-// and most libraries combinations collisions check results will be cached too.
-func (soColGen *SymbolsCollisionArgsGenerator) handleSOLoaded(event trace.Event) ([][]interface{}, []error) {
-	loadingObjectInfo, err := getSharedObjectInfo(event)
+// handleShObjLoaded handles the shared object loaded event (from mmap).
+func (gen *SymbolsCollisionArgsGenerator) handleShObjLoaded(event trace.Event) (
+	[][]interface{}, []error,
+) {
+	// When a shared object is loaded into a process virtual memory address space, check if some of
+	// the loaded shared object exported symbols collide with symbols from previously loaded shared
+	// objects of the same process.
+
+	loadingObjectInfo, err := getSharedObjectInfo(event) // info about shared object being loaded
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	processLoadedObjects, ok := soColGen.processesSOsCache.GetProcessLoadedObjects(event.HostProcessID)
+	// pick loaded shared objects of the process
+	loadedShObjsInfo, ok := gen.loadedObjsPerProcCache.GetLoadedObjsPerProcess(event.HostProcessID)
 	if !ok {
-		processLoadedObjects = []sharedobjs.ObjInfo{}
+		loadedShObjsInfo = []sharedobjs.ObjInfo{}
 	}
-	newProcessLoadedObjects := append(processLoadedObjects, loadingObjectInfo)
-	soColGen.processesSOsCache.SetProcessLoadedObjects(event.HostProcessID, newProcessLoadedObjects)
 
-	// Exported symbols will be updated if needed in the findSOCollisions method
-	loadingObject := loadingSOInstance{ObjInfo: loadingObjectInfo}
+	// new list including object being loaded, add new list to shared objects cache per process
+	newLoadedObjs := append(loadedShObjsInfo, loadingObjectInfo)
+	gen.loadedObjsPerProcCache.SetProcessLoadedObjects(event.HostProcessID, newLoadedObjs)
 
-	var collisionEventsArgs [][]interface{}
+	loadingObject := &loadingSharedObj{
+		ObjInfo: loadingObjectInfo,
+		// exportedSymbols: will be updated by findShObjsCollisions
+	}
+
+	var collisionEventsArgs [][]interface{} // multiple derived events
 	var errs []error
-	for _, lsoInfo := range processLoadedObjects {
-		collisions, err := soColGen.findSOCollisions(&loadingObject, lsoInfo)
+
+	for _, loadedShObjInfo := range loadedShObjsInfo {
+		collisions, err := gen.findShObjsCollisions(loadingObject, loadedShObjInfo)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
 		if len(collisions) > 0 {
-			collisionEventsArgs = append(collisionEventsArgs, []interface{}{loadingObjectInfo.Path, lsoInfo.Path, collisions})
+			// An event will be created for each shared object it has collisions with. The main
+			// efficiency features it uses:
+			//
+			// - caching examined, and per process, shared object symbols.
+			// - collision check results caching between existing shared objects.
+			//
+			// The hope is that, after few processes are executed, all major libraries in the system
+			// are cached and most libraries combinations results are cached too.
+			collisionEventsArgs = append(collisionEventsArgs,
+				[]interface{}{
+					loadingObjectInfo.Path, // loaded path (string)
+					loadedShObjInfo.Path,   // collision path (string)
+					collisions,             // symbols (string)
+				},
+			)
 		}
 	}
 
 	return collisionEventsArgs, errs
 }
 
-// handleExec delete saved process loaded objects in case of execve, because entire memory is overwritten in this case
-func (soColGen *SymbolsCollisionArgsGenerator) handleExec(event trace.Event) ([][]interface{}, []error) {
-	soColGen.processesSOsCache.SetProcessLoadedObjects(event.HostProcessID, []sharedobjs.ObjInfo{})
-	return nil, nil
-}
-
-// findSOCollisions check for collisions between new SO loaded to existing one in the most efficient way possible.
-// It updates the given SO if symbols are missing.
-func (soColGen *SymbolsCollisionArgsGenerator) findSOCollisions(so *loadingSOInstance, loadedSO sharedobjs.ObjInfo) ([]string, error) {
+// findShObjsCollisions checks for symbols collisions between new shared object, being loaded into
+// the virtual memory address space of a process, AND an existing already loaded shared object of
+// the same process. It tries to do optimize efficiency by caching collision results, to be used in
+// a near future. It also updates the given shared object if symbols are missing.
+func (gen *SymbolsCollisionArgsGenerator) findShObjsCollisions(
+	loadingShObj *loadingSharedObj, loadedShObjInfo sharedobjs.ObjInfo,
+) (
+	[]string, error,
+) {
 	var err error
-	collisions, ok := soColGen.collisionsCache.GetCollision(so.Id, loadedSO.Id)
+
+	// ObjId contains: Inode, Device and Ctime. Collisions are unique until a sh object file changes.
+	collisions, ok := gen.collisionChecksCache.GetShObjsCollisions(loadingShObj.Id, loadedShObjInfo.Id)
+
 	if !ok {
-		if so.ExportedSymbols == nil {
-			so.ExportedSymbols, err = soColGen.soLoader.GetExportedSymbols(so.ObjInfo)
-			if err != nil {
-				// TODO: rate limit frequent errors for overloaded envs
-				_, ok := soColGen.returnedErrors[err.Error()]
-				if !ok {
-					soColGen.returnedErrors[err.Error()] = true
-					logger.Warn("symbols_loaded", "object loaded", so.ObjInfo, "error", err.Error())
-				} else {
-					logger.Debug("symbols_loaded", "object loaded", so.ObjInfo, "error", err.Error())
-				}
-				return nil, nil
-			}
-			so.FilterSymbols(soColGen.symbolsBlackList)
-			so.FilterOutSymbols(soColGen.symbolsWhiteList)
-			if err != nil {
-				return nil, err
-			}
-		}
-		lsoSyms, err := soColGen.soLoader.GetExportedSymbols(loadedSO)
+		// get exported symbols from the shared object BEING loaded
+		loadingShObj.exportedSymbols, err = gen.soLoader.GetExportedSymbols(loadingShObj.ObjInfo)
 		if err != nil {
 			// TODO: rate limit frequent errors for overloaded envs
-			_, ok := soColGen.returnedErrors[err.Error()]
+			_, ok := gen.returnedErrorsMap[err.Error()]
 			if !ok {
-				soColGen.returnedErrors[err.Error()] = true
-				logger.Warn("symbols_loaded", "object loaded", loadedSO, "error", err.Error())
+				gen.returnedErrorsMap[err.Error()] = true
+				logger.Warn("symbols_loaded", "object loaded", loadingShObj.ObjInfo, "error", err.Error())
 			} else {
-				logger.Debug("symbols_loaded", "object loaded", loadedSO, "error", err.Error())
+				logger.Debug("symbols_loaded", "object loaded", loadingShObj.ObjInfo, "error", err.Error())
+			}
+			return nil, err
+		}
+		loadingShObj.FilterSymbols(gen.symbolsBlacklistMap)    // del symbols NOT in blacklist
+		loadingShObj.FilterOutSymbols(gen.symbolsWhitelistMap) // del symbols IN the white list
+
+		// get exported symbols from the shared object ALREADY loaded
+		loadedExportedSyms, err := gen.soLoader.GetExportedSymbols(loadedShObjInfo)
+		if err != nil {
+			// TODO: rate limit frequent errors for overloaded envs
+			_, ok := gen.returnedErrorsMap[err.Error()]
+			if !ok {
+				gen.returnedErrorsMap[err.Error()] = true
+				logger.Warn("symbols_loaded", "object loaded", loadedShObjInfo, "error", err.Error())
+			} else {
+				logger.Debug("symbols_loaded", "object loaded", loadedShObjInfo, "error", err.Error())
 			}
 			return nil, nil
 		}
-		lso := loadingSOInstance{ObjInfo: loadedSO, ExportedSymbols: lsoSyms}
-		lso.FilterSymbols(soColGen.symbolsBlackList)
-		lso.FilterOutSymbols(soColGen.symbolsWhiteList)
-		collisions = so.GetCollisions(lso)
-		soColGen.collisionsCache.AddCollisions(so.Id, loadedSO.Id, collisions)
+
+		// create a loadingSharedObj from the already loaded shared object (to get collisions)
+		loadedShObj := loadingSharedObj{ObjInfo: loadedShObjInfo, exportedSymbols: loadedExportedSyms}
+		loadedShObj.FilterSymbols(gen.symbolsBlacklistMap)    // del symbols NOT in blacklist
+		loadedShObj.FilterOutSymbols(gen.symbolsWhitelistMap) // del symbols IN the white list
+
+		collisions = loadingShObj.GetCollisions(loadedShObj)
+
+		// cache collision results
+		gen.collisionChecksCache.AddCollisions(loadingShObj.Id, loadedShObjInfo.Id, collisions)
 	}
-	return collisions, nil
+
+	return collisions, nil // cached or just calculated
 }
 
-// processesLoadedObjectsCache is a cache for shared objects loaded to a process
-type processesLoadedObjectsCache struct {
+// handleExec handles the execve() system call event.
+func (gen *SymbolsCollisionArgsGenerator) handleExec(event trace.Event) (
+	[][]interface{}, []error,
+) {
+	// Delete (set to empty) a process saved data (loaded shared objects information) for the
+	// process if it calls execve(). This is needed because all the virtual memory address space of
+	// such process will vanish and the saved data will be useless.
+	gen.loadedObjsPerProcCache.SetProcessLoadedObjects(event.HostProcessID, []sharedobjs.ObjInfo{})
+
+	return nil, nil
+}
+
+//
+// Already loaded shared objects, per process, cache -----------------------------------------------
+//
+
+type loadedObjsPerProcessCache struct {
 	cache *simplelru.LRU
 }
 
-// GetProcessLoadedObjects get the shared SOs loaded to the process, and if the process existed in the cache.
-func (pcache *processesLoadedObjectsCache) GetProcessLoadedObjects(pid int) ([]sharedobjs.ObjInfo, bool) {
-	var loadedObjects []sharedobjs.ObjInfo
-	loadedObjectsIface, ok := pcache.cache.Get(pid)
+// GetLoadedObjsPerProcess returns the shared objects already loaded in a given process vm space.
+func (procLoadedObjsCache *loadedObjsPerProcessCache) GetLoadedObjsPerProcess(
+	pid int,
+) (
+	[]sharedobjs.ObjInfo, bool,
+) {
+	var loadedObjs []sharedobjs.ObjInfo
+
+	loadedObjsIface, ok := procLoadedObjsCache.cache.Get(pid) // loaded objs per process (ObjInfo)
 	if ok {
-		loadedObjects = loadedObjectsIface.([]sharedobjs.ObjInfo)
-		return loadedObjects, true
+		loadedObjs = loadedObjsIface.([]sharedobjs.ObjInfo)
+		return loadedObjs, true // true if process existed in the cache
 	}
+
 	return nil, false
 }
 
-func (pcache *processesLoadedObjectsCache) SetProcessLoadedObjects(pid int, loadedObjects []sharedobjs.ObjInfo) {
-	pcache.cache.Add(pid, loadedObjects)
+// SetProcessLoadedObjects sets the shared objects loaded in one process vm address space.
+func (procLoadedObjsCache *loadedObjsPerProcessCache) SetProcessLoadedObjects(
+	pid int, loadedObjects []sharedobjs.ObjInfo,
+) {
+	procLoadedObjsCache.cache.Add(pid, loadedObjects)
 }
 
-// collisionsKey is the key for the sharedObjectsCollisionsCache cache.
-// The order is meaningful, so when using it all options should be checked.
+//
+// Shared Object Pairs collisions checks cache -----------------------------------------------------
+//
+
 type collisionsKey struct {
-	obj1 sharedobjs.ObjID
+	obj1 sharedobjs.ObjID // order is meaningful, compare obj1 to obj2 and obj2 to obj1
 	obj2 sharedobjs.ObjID
 }
 
-// sharedObjectsCollisionsCache is a cache for collision checks which were performed already
-type sharedObjectsCollisionsCache struct {
+type collisionChecksCache struct {
 	cache *simplelru.LRU
 }
 
-// AddCollisions add the collisions between 2 shared objects to the cache.
-// It will override previous cached collision if there is one, and create new one if not.
-func (socCache sharedObjectsCollisionsCache) AddCollisions(obj1 sharedobjs.ObjID,
+// AddCollisions adds collisions between 2 shared objects to the cache.
+func (socCache collisionChecksCache) AddCollisions(
+	obj1 sharedobjs.ObjID,
 	obj2 sharedobjs.ObjID,
-	collisions []string) {
-	key, _, ok := socCache.getObjCollisions(obj1, obj2)
+	collisions []string,
+) {
+	key, _, ok := socCache.getObjCollisionsAndCollisionKey(obj1, obj2)
 	if !ok {
+		// creates a new collision if it does not exist yet
 		key = collisionsKey{obj1: obj1, obj2: obj2}
 	}
+	// overrides previously cached collisions
 	socCache.setObjCollisions(key, collisions)
 }
 
-// GetCollision return the symbols collided between 2 shared objects from the cache if there are any.
-// Return bool indication if the collision existed in the cache.
-func (socCache sharedObjectsCollisionsCache) GetCollision(obj1 sharedobjs.ObjID,
-	obj2 sharedobjs.ObjID) ([]string, bool) {
-	_, collisions, ok := socCache.getObjCollisions(obj1, obj2)
+// GetShObjsCollisions returns the collisions between 2 shared objects from the cache.
+func (socCache collisionChecksCache) GetShObjsCollisions(
+	obj1 sharedobjs.ObjID,
+	obj2 sharedobjs.ObjID,
+) (
+	[]string, bool,
+) {
+	_, collisions, ok := socCache.getObjCollisionsAndCollisionKey(obj1, obj2)
 	if ok {
 		return collisions, true
 	}
-	return nil, false
+
+	return nil, false // no collisions found
 }
 
-// Get from the cache the collisions check result of the object with other shared objects.
-// Return the key with which the collision was cached (if it was), the collisions and if
-// there was a cached collision at all.
-func (socCache sharedObjectsCollisionsCache) getObjCollisions(obj1 sharedobjs.ObjID,
-	obj2 sharedobjs.ObjID) (
-	collisionsKey, []string, bool) {
+// getObjCollisionsAndCollisionKey gets the collisions between 2 shared objects, and the cache key.
+func (socCache collisionChecksCache) getObjCollisionsAndCollisionKey(
+	obj1 sharedobjs.ObjID,
+	obj2 sharedobjs.ObjID,
+) (
+	collisionsKey, []string, bool,
+) {
 	key := collisionsKey{
-		obj1: obj1,
+		obj1: obj1, // compare obj1 to obj2
 		obj2: obj2,
 	}
 	collisionsIface, ok := socCache.cache.Get(key)
 	if !ok {
-		key = collisionsKey{
+		key = collisionsKey{ // try comparing obj2 to obj1
 			obj1: obj2,
 			obj2: obj1,
 		}
@@ -236,64 +334,77 @@ func (socCache sharedObjectsCollisionsCache) getObjCollisions(obj1 sharedobjs.Ob
 		collisions := collisionsIface.([]string)
 		return key, collisions, true
 	}
-	return collisionsKey{}, nil, false
+
+	return collisionsKey{}, nil, false // no collisions found
 }
 
-func (socCache sharedObjectsCollisionsCache) setObjCollisions(key collisionsKey,
-	collisions []string) {
+// setObjCollisions sets the collisions between 2 shared objects in the cache.
+func (socCache collisionChecksCache) setObjCollisions(key collisionsKey, collisions []string) {
 	socCache.cache.Add(key, collisions)
 }
 
-// loadingSOInstance is the whole relevant information collected on a loaded SO
-type loadingSOInstance struct {
+//
+// Info about a shared object being loaded in a process virtual memory address space ---------------
+//
+
+type loadingSharedObj struct { // extends ObjInfo
 	sharedobjs.ObjInfo
-	ExportedSymbols map[string]bool
+	exportedSymbols map[string]bool
 }
 
-func (so *loadingSOInstance) ContainsSymbol(sym string) bool {
-	_, ok := so.ExportedSymbols[sym]
+// ContainsSymbol returns true if the shared object being loaded contains the given symbol.
+func (so *loadingSharedObj) ContainsSymbol(sym string) bool {
+	_, ok := so.exportedSymbols[sym]
 	return ok
 }
 
-func (so *loadingSOInstance) GetSymbols() []string {
-	symbols := make([]string, len(so.ExportedSymbols))
+// GetSymbols returns the list of exported symbols of the shared object being loaded.
+func (so *loadingSharedObj) GetSymbols() []string {
+	symbols := make([]string, len(so.exportedSymbols))
+
 	i := 0
-	for sym := range so.ExportedSymbols {
+	for sym := range so.exportedSymbols {
 		symbols[i] = sym
 		i += 1
 	}
+
 	return symbols
 }
 
-func (so *loadingSOInstance) GetCollisions(obj loadingSOInstance) []string {
+// GetCollisions returns the list of symbols which collide with the given shared object.
+func (so *loadingSharedObj) GetCollisions(obj loadingSharedObj) []string {
 	var collidedSymbols []string
+
 	for _, sym := range so.GetSymbols() {
 		if obj.ContainsSymbol(sym) {
 			collidedSymbols = append(collidedSymbols, sym)
 		}
 	}
+
 	return collidedSymbols
 }
 
-// FilterSymbols remove all exported symbols which are not in the filter map
-func (so *loadingSOInstance) FilterSymbols(filterSymbols map[string]bool) {
+// FilterSymbols removes all exported symbols which ARE NOT in the filter map.
+func (so *loadingSharedObj) FilterSymbols(filterSymbols map[string]bool) {
 	if len(filterSymbols) == 0 {
 		return
 	}
+
 	filteredSymbols := make(map[string]bool)
 	for filterSym := range filterSymbols {
-		if so.ExportedSymbols[filterSym] {
+		if so.exportedSymbols[filterSym] {
 			filteredSymbols[filterSym] = true
 		}
 	}
-	so.ExportedSymbols = filteredSymbols
+
+	so.exportedSymbols = filteredSymbols
 }
 
-// FilterOutSymbols remove all exported symbols which are in the filter map
-func (so *loadingSOInstance) FilterOutSymbols(filterSymbols map[string]bool) {
-	for exSymbol := range so.ExportedSymbols {
+// FilterOutSymbols removes all exported symbols which ARE in the filter map.
+func (so *loadingSharedObj) FilterOutSymbols(filterSymbols map[string]bool) {
+	for exSymbol := range so.exportedSymbols {
 		if filterSymbols[exSymbol] {
-			delete(so.ExportedSymbols, exSymbol)
+			delete(so.exportedSymbols, exSymbol)
 		}
 	}
 }

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -1,8 +1,13 @@
 package derive
 
 import (
-	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/filterscope"
 
 	"github.com/aquasecurity/tracee/pkg/utils/sharedobjs"
 	"github.com/stretchr/testify/assert"
@@ -10,7 +15,7 @@ import (
 )
 
 type testSO struct {
-	so                 loadingSOInstance
+	so                 loadingSharedObj
 	expectedCollisions []string
 }
 
@@ -18,27 +23,30 @@ func getSymbolsCollisionTestCases() []struct {
 	name      string
 	blackList []string
 	whiteList []string
-	loadingSO loadingSOInstance
+	loadingSO loadingSharedObj
 	loadedSOs []testSO
 } {
 	return []struct {
 		name      string
 		blackList []string
 		whiteList []string
-		loadingSO loadingSOInstance
+		loadingSO loadingSharedObj
 		loadedSOs []testSO
 	}{
 		{
 			name: "One loaded SO which collides",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true},
+				exportedSymbols: map[string]bool{"open": true},
 			},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"open": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"open": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
@@ -46,15 +54,18 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "One loaded SO which doesn't collide",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true},
+				exportedSymbols: map[string]bool{"open": true},
 			},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"write": true},
 					},
 					expectedCollisions: []string{},
 				},
@@ -62,15 +73,18 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "One loaded SO which collides partly",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true, "ioctl": true},
+				exportedSymbols: map[string]bool{"open": true, "ioctl": true},
 			},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"open": true, "write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"open": true, "write": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
@@ -78,22 +92,28 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "Multiple loaded SO which collides",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true},
+				exportedSymbols: map[string]bool{"open": true},
 			},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"open": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"open": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 3}, Path: "3.so"},
-						ExportedSymbols: map[string]bool{"open": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 3},
+							Path: "3.so",
+						},
+						exportedSymbols: map[string]bool{"open": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
@@ -101,22 +121,28 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "Multiple loaded SO which doesn't collide",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true},
+				exportedSymbols: map[string]bool{"open": true},
 			},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"write": true},
 					},
 					expectedCollisions: []string{},
 				},
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 3}, Path: "3.so"},
-						ExportedSymbols: map[string]bool{"ioctl": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 3},
+							Path: "3.so",
+						},
+						exportedSymbols: map[string]bool{"ioctl": true},
 					},
 					expectedCollisions: []string{},
 				},
@@ -124,29 +150,38 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "Multiple loaded SO which partly collide",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true, "ioctl": true},
+				exportedSymbols: map[string]bool{"open": true, "ioctl": true},
 			},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"write": true},
 					},
 					expectedCollisions: []string{},
 				},
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 3}, Path: "3.so"},
-						ExportedSymbols: map[string]bool{"open": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 3},
+							Path: "3.so",
+						},
+						exportedSymbols: map[string]bool{"open": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 4}, Path: "4.so"},
-						ExportedSymbols: map[string]bool{"ioctl": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 4},
+							Path: "4.so",
+						},
+						exportedSymbols: map[string]bool{"ioctl": true},
 					},
 					expectedCollisions: []string{"ioctl"},
 				},
@@ -154,16 +189,19 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "Collision which is partly filtered in",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true, "write": true},
+				exportedSymbols: map[string]bool{"open": true, "write": true},
 			},
 			blackList: []string{"open"},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"open": true, "write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"open": true, "write": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
@@ -171,16 +209,19 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "Collision which is partly filtered out",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true, "write": true},
+				exportedSymbols: map[string]bool{"open": true, "write": true},
 			},
 			whiteList: []string{"write"},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"open": true, "write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"open": true, "write": true},
 					},
 					expectedCollisions: []string{"open"},
 				},
@@ -188,16 +229,19 @@ func getSymbolsCollisionTestCases() []struct {
 		},
 		{
 			name: "Collision which is filtered out",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true, "write": true},
+				exportedSymbols: map[string]bool{"open": true, "write": true},
 			},
 			whiteList: []string{"open", "write"},
 			loadedSOs: []testSO{
 				{
-					so: loadingSOInstance{
-						ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-						ExportedSymbols: map[string]bool{"open": true, "write": true},
+					so: loadingSharedObj{
+						ObjInfo: sharedobjs.ObjInfo{
+							Id:   sharedobjs.ObjID{Inode: 2},
+							Path: "2.so",
+						},
+						exportedSymbols: map[string]bool{"open": true, "write": true},
 					},
 					expectedCollisions: []string{},
 				},
@@ -209,43 +253,43 @@ func getSymbolsCollisionTestCases() []struct {
 func TestSymbolsCollisionArgsGenerator_FindSOCollision(t *testing.T) {
 	testCases := []struct {
 		name            string
-		loadingSO       loadingSOInstance
-		loadedSO        loadingSOInstance
+		loadingSO       loadingSharedObj
+		loadedSO        loadingSharedObj
 		expectedResults []string
 	}{
 		{
 			name: "One symbol which collides",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true},
+				exportedSymbols: map[string]bool{"open": true},
 			},
-			loadedSO: loadingSOInstance{
+			loadedSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-				ExportedSymbols: map[string]bool{"open": true},
+				exportedSymbols: map[string]bool{"open": true},
 			},
 			expectedResults: []string{"open"},
 		},
 		{
 			name: "One symbols which doesn't collide",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"write": true},
+				exportedSymbols: map[string]bool{"write": true},
 			},
-			loadedSO: loadingSOInstance{
+			loadedSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-				ExportedSymbols: map[string]bool{"ioctl": true},
+				exportedSymbols: map[string]bool{"ioctl": true},
 			},
 			expectedResults: nil,
 		},
 		{
 			name: "Multiple symbols which part of them collide",
-			loadingSO: loadingSOInstance{
+			loadingSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 1}, Path: "1.so"},
-				ExportedSymbols: map[string]bool{"open": true, "write": true},
+				exportedSymbols: map[string]bool{"open": true, "write": true},
 			},
-			loadedSO: loadingSOInstance{
+			loadedSO: loadingSharedObj{
 				ObjInfo:         sharedobjs.ObjInfo{Id: sharedobjs.ObjID{Inode: 2}, Path: "2.so"},
-				ExportedSymbols: map[string]bool{"open": true, "ioctl": true},
+				exportedSymbols: map[string]bool{"open": true, "ioctl": true},
 			},
 			expectedResults: []string{"open"},
 		},
@@ -304,11 +348,28 @@ func TestSymbolsCollisionArgsGenerator_FindSOCollision(t *testing.T) {
 			for _, testCase := range testCases {
 				t.Run(testCase.name, func(t *testing.T) {
 					mockLoader := initLoaderMock(false)
-					gen := initSOCollisionsEventGenerator(mockLoader, filterTestCase.blackList, filterTestCase.whiteList)
-					mockLoader.addSOSymbols(testSOInstance{info: testCase.loadingSO.ObjInfo, syms: testCase.loadingSO.GetSymbols()})
-					mockLoader.addSOSymbols(testSOInstance{info: testCase.loadedSO.ObjInfo, syms: testCase.loadedSO.GetSymbols()})
+					gen := initSOCollisionsEventGenerator(
+						mockLoader,
+						filterTestCase.blackList,
+						filterTestCase.whiteList,
+					)
+					mockLoader.addSOSymbols(
+						testSOInstance{
+							info: testCase.loadingSO.ObjInfo,
+							syms: testCase.loadingSO.GetSymbols(),
+						},
+					)
+					mockLoader.addSOSymbols(
+						testSOInstance{
+							info: testCase.loadedSO.ObjInfo,
+							syms: testCase.loadedSO.GetSymbols(),
+						},
+					)
 					gen.soLoader = mockLoader
-					collisions, err := gen.findSOCollisions(&testCase.loadingSO, testCase.loadedSO.ObjInfo)
+					collisions, err := gen.findShObjsCollisions(
+						&testCase.loadingSO,
+						testCase.loadedSO.ObjInfo,
+					)
 					require.NoError(t, err)
 					for _, collision := range collisions {
 						if len(filterTestCase.blackList) > 0 {
@@ -316,7 +377,11 @@ func TestSymbolsCollisionArgsGenerator_FindSOCollision(t *testing.T) {
 						}
 						assert.NotContains(t, filterTestCase.whiteList, collision)
 					}
-					expectedResults := copyListFiltered(testCase.expectedResults, filterTestCase.blackList, filterTestCase.whiteList)
+					expectedResults := copyListFiltered(
+						testCase.expectedResults,
+						filterTestCase.blackList,
+						filterTestCase.whiteList,
+					)
 					assert.ElementsMatch(t, expectedResults, collisions)
 				})
 			}
@@ -331,18 +396,31 @@ func TestSymbolsCollisionArgsGenerator_deriveArgs(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mockLoader := initLoaderMock(false)
-			gen := initSOCollisionsEventGenerator(mockLoader, testCase.blackList, testCase.whiteList)
-			mockLoader.addSOSymbols(testSOInstance{info: testCase.loadingSO.ObjInfo, syms: testCase.loadingSO.GetSymbols()})
+			gen := initSOCollisionsEventGenerator(
+				mockLoader,
+				testCase.blackList,
+				testCase.whiteList,
+			)
+			mockLoader.addSOSymbols(
+				testSOInstance{
+					info: testCase.loadingSO.ObjInfo,
+					syms: testCase.loadingSO.GetSymbols(),
+				},
+			)
 
 			// Init cache for test
 			loadedSOs := make([]sharedobjs.ObjInfo, len(testCase.loadedSOs))
 			for i, lso := range testCase.loadedSOs {
-				mockLoader.addSOSymbols(testSOInstance{info: lso.so.ObjInfo, syms: lso.so.GetSymbols()})
+				mockLoader.addSOSymbols(
+					testSOInstance{info: lso.so.ObjInfo, syms: lso.so.GetSymbols()},
+				)
 				loadedSOs[i] = lso.so.ObjInfo
 			}
-			gen.processesSOsCache.SetProcessLoadedObjects(pid, loadedSOs)
+			gen.loadedObjsPerProcCache.SetProcessLoadedObjects(pid, loadedSOs)
 
-			colEventsArgs, errs := gen.deriveArgs(generateSOLoadedEvent(pid, testCase.loadingSO.ObjInfo))
+			colEventsArgs, errs := gen.deriveArgs(
+				generateSOLoadedEvent(pid, testCase.loadingSO.ObjInfo),
+			)
 			require.Empty(t, errs)
 			for _, lso := range testCase.loadedSOs {
 				if len(lso.expectedCollisions) > 0 {
@@ -376,12 +454,45 @@ func TestSymbolsCollision(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			mockLoader := initLoaderMock(false)
-			deriveFunc := SymbolsCollision(mockLoader, testCase.blackList, testCase.whiteList)
-			mockLoader.addSOSymbols(testSOInstance{info: testCase.loadingSO.ObjInfo, syms: testCase.loadingSO.GetSymbols()})
+
+			// Prepare mocked filters for the existing test cases
+
+			filterName := "symbols_collision.args.symbols"
+			eventsNameToID := map[string]events.ID{"symbols_collision": events.SymbolsCollision}
+
+			fScope := filterscope.NewFilterScope()
+			fScope.EventsToTrace = map[events.ID]string{events.SymbolsCollision: "symbols_collision"}
+
+			if len(testCase.blackList) > 0 {
+				operAndValsBlack := fmt.Sprintf("!=%s", strings.Join(testCase.blackList, ","))
+				err := fScope.ArgFilter.Parse(filterName, operAndValsBlack, eventsNameToID)
+				require.NoError(t, err)
+			}
+			if len(testCase.whiteList) > 0 {
+				operAndValsWhite := fmt.Sprintf("=%s", strings.Join(testCase.whiteList, ","))
+				err := fScope.ArgFilter.Parse(filterName, operAndValsWhite, eventsNameToID)
+				require.NoError(t, err)
+			}
+
+			fScopes := filterscope.NewFilterScopes()
+			err := fScopes.Set(0, fScope)
+			require.NoError(t, err)
+
+			// Pick derive function from mocked tests
+			deriveFunc := SymbolsCollision(mockLoader, fScopes)
+
+			mockLoader.addSOSymbols(
+				testSOInstance{
+					info: testCase.loadingSO.ObjInfo,
+					syms: testCase.loadingSO.GetSymbols(),
+				},
+			)
 
 			// Parse loading events to initialize cache
 			for _, lso := range testCase.loadedSOs {
-				mockLoader.addSOSymbols(testSOInstance{info: lso.so.ObjInfo, syms: lso.so.GetSymbols()})
+				mockLoader.addSOSymbols(
+					testSOInstance{info: lso.so.ObjInfo, syms: lso.so.GetSymbols()},
+				)
 				_, errs := deriveFunc(generateSOLoadedEvent(pid, lso.so.ObjInfo))
 				require.Empty(t, errs)
 			}

--- a/pkg/utils/sharedobjs/container_symbols_loader.go
+++ b/pkg/utils/sharedobjs/container_symbols_loader.go
@@ -9,10 +9,10 @@ import (
 // This object operation requires the CAP_DAC_OVERRIDE to access files across the system.
 type ContainersSymbolsLoader struct {
 	hostLoader   DynamicSymbolsLoader
-	pathResolver *containers.PathResolver
+	pathResolver *containers.ContainerPathResolver
 }
 
-func InitContainersSymbolsLoader(pathResolver *containers.PathResolver, cacheSize int) *ContainersSymbolsLoader {
+func InitContainersSymbolsLoader(pathResolver *containers.ContainerPathResolver, cacheSize int) *ContainersSymbolsLoader {
 	return &ContainersSymbolsLoader{
 		hostLoader:   InitHostSymbolsLoader(cacheSize),
 		pathResolver: pathResolver,
@@ -21,7 +21,7 @@ func InitContainersSymbolsLoader(pathResolver *containers.PathResolver, cacheSiz
 
 func (cLoader *ContainersSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	var err error
-	soInfo.Path, err = cLoader.pathResolver.ResolveAbsolutePath(soInfo.Path, soInfo.MountNS)
+	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (cLoader *ContainersSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[s
 
 func (cLoader *ContainersSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	var err error
-	soInfo.Path, err = cLoader.pathResolver.ResolveAbsolutePath(soInfo.Path, soInfo.MountNS)
+	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (cLoader *ContainersSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[
 
 func (cLoader *ContainersSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	var err error
-	soInfo.Path, err = cLoader.pathResolver.ResolveAbsolutePath(soInfo.Path, soInfo.MountNS)
+	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
commit edd80f47 (HEAD -> symbols_coll_refactor, rafaeldtinoco/symbols_coll_refactor, main)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sun Feb 19 14:25:27 2023

    symbols_collision: refactor and comment extension
    
    1. containers/path_resolver: return a pointer
    
    2. ebpf/tracee:
       - cleanup derivation table init function
       - move symbols_collision initialization to the correct place
    
    3. events/symbols_loaded:
       - extend init function with code from derivation table init
       - adjust formatting for readability
    
    4. events/symbols_collision:
       - extend init function with code from derivation table init
       - adjust formatting for readability
       - add comments to explain the logic
       - rename variables for meaning clarity
    
    5. events/symbols_collision_test:
       - adjust test to reflect the new init function

commit 0fa6ca53
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Sun Feb 19 14:24:25 2023

    cmd/flags/filter: nit spelling fix

commit cad2076b
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Feb 17 13:41:00 2023

    containers: rename PathResolver to ContainerPathResolver

commit 344f1006
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Thu Feb 16 22:11:18 2023

    tracee: adjust singleton class by adding comments

commit c931a3e8
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Thu Feb 16 22:14:13 2023

    tracee: advance bucketscache initialization
    
    This is needed for further changes.