### PR TITLE
tracee: add signature metadata to events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,3 +101,5 @@ require (
 )
 
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0
+
+replace github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07 => ./types

--- a/pkg/ebpf/finding_test.go
+++ b/pkg/ebpf/finding_test.go
@@ -1,0 +1,112 @@
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindingToEvent(t *testing.T) {
+	expected := &trace.Event{
+		EventID:             int(events.StartRulesID),
+		EventName:           "fake_signature_event",
+		ProcessorID:         1,
+		ProcessID:           2,
+		CgroupID:            3,
+		ThreadID:            4,
+		ParentProcessID:     5,
+		HostProcessID:       6,
+		HostThreadID:        7,
+		HostParentProcessID: 8,
+		UserID:              9,
+		MountNS:             10,
+		PIDNS:               11,
+		ProcessName:         "process",
+		HostName:            "host",
+		ContainerID:         "containerID",
+		ContainerImage:      "image",
+		ContainerName:       "container",
+		PodName:             "pod",
+		PodNamespace:        "namespace",
+		PodUID:              "uid",
+		ReturnValue:         0,
+		MatchedScopes:       1,
+		ArgsNum:             0,
+		Metadata: trace.Metadata{
+			"SignatureID":          "fake_signature_id",
+			"SignatureName":        "fake_signature_event",
+			"SignatureDescription": "description",
+			"SignatureVersion":     "1",
+			"SignatureTags":        []trace.Value{"tag1", "tag2"},
+			"SignatureProperties": map[string]interface{}{
+				"prop1": "value1",
+				"prop2": 1,
+			},
+		},
+	}
+
+	finding := createFakeEventAndFinding()
+	got, err := FindingToEvent(finding)
+
+	assert.NoError(t, err)
+	assert.Equal(t, got, expected)
+}
+
+func createFakeEventAndFinding() detect.Finding {
+	eventName := "fake_signature_event"
+	event := events.NewEventDefinition(eventName, []string{"signatures"}, []events.ID{events.Ptrace})
+
+	events.Definitions.Add(events.StartRulesID, event)
+
+	return detect.Finding{
+		SigMetadata: detect.SignatureMetadata{
+			ID:          "fake_signature_id",
+			Name:        eventName,
+			EventName:   eventName,
+			Version:     "1",
+			Description: "description",
+			Tags:        []string{"tag1", "tag2"},
+			Properties: map[string]interface{}{
+				"prop1": "value1",
+				"prop2": 1,
+			},
+		},
+		Data: map[string]interface{}{
+			"arg1": "value1",
+			"arg2": 1,
+		},
+		Event: protocol.Event{
+			Headers: protocol.EventHeaders{},
+			Payload: trace.Event{
+				EventID:             int(events.Ptrace),
+				EventName:           "ptrace",
+				ProcessorID:         1,
+				ProcessID:           2,
+				CgroupID:            3,
+				ThreadID:            4,
+				ParentProcessID:     5,
+				HostProcessID:       6,
+				HostThreadID:        7,
+				HostParentProcessID: 8,
+				UserID:              9,
+				MountNS:             10,
+				PIDNS:               11,
+				ProcessName:         "process",
+				HostName:            "host",
+				ContainerID:         "containerID",
+				ContainerImage:      "image",
+				ContainerName:       "container",
+				PodName:             "pod",
+				PodNamespace:        "namespace",
+				PodUID:              "uid",
+				ReturnValue:         0,
+				MatchedScopes:       1,
+				ArgsNum:             0,
+			},
+		},
+	}
+}

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -44,7 +44,12 @@ type Event struct {
 	StackAddresses      []uint64     `json:"stackAddresses"`
 	ContextFlags        ContextFlags `json:"contextFlags"`
 	Args                []Argument   `json:"args"` //Arguments are ordered according their appearance in the original event
+	Metadata            Metadata     `json:"metadata,omitempty"`
 }
+
+type Value interface{}
+
+type Metadata map[string]Value
 
 // ContextFlags are flags representing event context
 type ContextFlags struct {
@@ -93,7 +98,7 @@ func (e Event) ToProtocol() protocol.Event {
 // Argument holds the information for one argument
 type Argument struct {
 	ArgMeta
-	Value interface{} `json:"value"`
+	Value Value `json:"value"`
 }
 
 // ArgMeta describes an argument


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR adds support to Metadata to `trace.Event`. At first this will be used to add `SignatureMetadata` when a signature event is created from a detection. Instead of adding `SignatureMetadata` directly, we have a more generic approach allowing for future use by events that are not signatures (eg: derivations, ebpf)

The `Metadata` field is marked as `omitempty` so we only print it if there is metadata, below an example of a signaure event, and a ebpf event. 

signature event, example:
```
{"timestamp":1676897645064612171,"threadStartTime":1676897645064527338,"processorId":5,"processId":1120432,"cgroupId":695068,"threadId":1120432,"parentProcessId":1120430,"hostProcessId":1120432,"hostThreadId":1120432,"hostParentProcessId":1120430,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","hostName":"josedonizetti-x","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","podSandbox":false,"eventId":"6018","eventName":"Anti-Debugging detected","matchedScopes":1,"argsNum":4,"returnValue":0,"syscall":"","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"args":[{"name":"request","type":"string","value":"PTRACE_TRACEME"},{"name":"pid","type":"pid_t","value":0},{"name":"addr","type":"void*","value":"0x0"},{"name":"data","type":"void*","value":"0x0"}],"metadata":{"SignatureDescription":"A process used anti-debugging techniques to block a debugger. Malware use anti-debugging to stay invisible and inhibit analysis of their behavior.","SignatureID":"TRC-102","SignatureName":"Anti-Debugging detected","SignatureProperties":{"Category":"defense-evasion","Kubernetes_Technique":"","Severity":1,"Technique":"Debugger Evasion","external_id":"T1622","id":"attack-pattern--e4dc8c01-417f-458d-9ee0-bb0617c1b391"},"SignatureTags":[],"SignatureVersion":"1"}}
```

ebpf event, example:
```
{"timestamp":1676897716479720220,"threadStartTime":1676897716479580710,"processorId":6,"processId":670474,"cgroupId":624894,"threadId":670474,"parentProcessId":813,"hostProcessId":1121318,"hostThreadId":1121318,"hostParentProcessId":320717,"userId":0,"mountNamespace":4026533146,"pidNamespace":4026533150,"processName":"dockerd","hostName":"minikube","containerId":"3a62920213e94143b47f7cdf0ee2dcf5754535608193b9e30de441e85eeb661e","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","podSandbox":false,"eventId":"59","eventName":"execve","matchedScopes":1,"argsNum":2,"returnValue":0,"syscall":"execve","stackAddresses":null,"contextFlags":{"containerStarted":true,"isCompat":false},"args":[{"name":"pathname","type":"const char*","value":"/usr/bin/runc"},{"name":"argv","type":"const char*const*","value":["runc","--version"]},{"name":"envp","type":"const char*const*","value":null}]}
```

### 2. Explain how to test it

```
# pull pr
make
./tracee ..
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

This PR is marked as a draft to validate the idea, if you agree, I will extract another PR from this one to update types. 