### PR TITLE
Add multiple printers

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -67,14 +67,14 @@ func main() {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
 
-			flags.PrintAndExitIfHelp(c)
+			flags.PrintAndExitIfHelp(c, false)
 
 			if c.Bool("list") {
 				cmd.PrintEventList(false) // list events
 				return nil
 			}
 
-			runner, err := urfave.GetTraceeRunner(c, version)
+			runner, err := urfave.GetTraceeRunner(c, version, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -70,7 +70,7 @@ func main() {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
 
-			flags.PrintAndExitIfHelp(c)
+			flags.PrintAndExitIfHelp(c, true)
 
 			// Rego command line flags
 
@@ -97,7 +97,7 @@ func main() {
 				return nil
 			}
 
-			runner, err := urfave.GetTraceeRunner(c, version)
+			runner, err := urfave.GetTraceeRunner(c, version, true)
 			if err != nil {
 				return err
 			}
@@ -146,7 +146,7 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:    "output",
 				Aliases: []string{"o"},
-				Value:   cli.NewStringSlice("format:table"),
+				Value:   cli.NewStringSlice("table"),
 				Usage:   "control how and where output is printed. run '--output help' for more info.",
 			},
 			&cli.StringSliceFlag{

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -561,7 +561,7 @@ func TestPrepareCapture(t *testing.T) {
 	})
 }
 
-func TestPrepareOutput(t *testing.T) {
+func TestTraceeEbpfPrepareOutput(t *testing.T) {
 	testCases := []struct {
 		testName       string
 		outputSlice    []string
@@ -728,7 +728,7 @@ func TestPrepareOutput(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			output, err := flags.PrepareOutput(testcase.outputSlice)
+			output, err := flags.TraceeEbpfPrepareOutput(testcase.outputSlice)
 			if err != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"github.com/aquasecurity/tracee/pkg/filters"
@@ -561,7 +562,7 @@ func TestPrepareCapture(t *testing.T) {
 	})
 }
 
-func TestTraceeEbpfPrepareOutput(t *testing.T) {
+func TestPrepareTraceeEbpfOutput(t *testing.T) {
 	testCases := []struct {
 		testName       string
 		outputSlice    []string
@@ -736,6 +737,488 @@ func TestTraceeEbpfPrepareOutput(t *testing.T) {
 				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
 			}
 		})
+	}
+}
+
+func TestPrepareOutput(t *testing.T) {
+	testCases := []struct {
+		testName       string
+		outputSlice    []string
+		expectedOutput flags.OutputConfig
+		expectedError  error
+	}{
+		// validations
+		{
+			testName:    "invalid output flag",
+			outputSlice: []string{"foo"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("invalid output flag: foo, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty option flag",
+			outputSlice: []string{"option"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.parseOption: option flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty option flag 2",
+			outputSlice: []string{"option:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.parseOption: option flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid option value",
+			outputSlice: []string{"option:foo"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.setOption: invalid output option: foo, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty file for format",
+			outputSlice: []string{"json:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.parseFormat: format flag can't be empty, use '--output help' for more info"),
+		},
+		// formats
+		{
+			testName:    "default format",
+			outputSlice: []string{},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table to stdout",
+			outputSlice: []string{"table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table to /tmp/table",
+			outputSlice: []string{"table:/tmp/table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "/tmp/table"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "table to stdout, and to /tmp/table",
+			outputSlice: []string{"table", "table:/tmp/table"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+					{Kind: "table", OutPath: "/tmp/table"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "json to stdout",
+			outputSlice: []string{"json"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "json to /tmp/json, and json to /tmp/json2",
+			outputSlice: []string{"json:/tmp/json", "json:/tmp/json2"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "/tmp/json"},
+					{Kind: "json", OutPath: "/tmp/json2"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gob to stdout",
+			outputSlice: []string{"gob"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gob", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gob to stdout",
+			outputSlice: []string{"gob"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gob", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gob to /tmp/gob1,/tmp/gob2",
+			outputSlice: []string{"gob:/tmp/gob1,/tmp/gob2"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gob", OutPath: "/tmp/gob1"},
+					{Kind: "gob", OutPath: "/tmp/gob2"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "table-verbose to stdout",
+			outputSlice: []string{"table-verbose"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table-verbose", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gotemplate to stdout",
+			outputSlice: []string{"gotemplate=template.tmpl"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gotemplate=template.tmpl", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "gotemplate to multiple files",
+			outputSlice: []string{"gotemplate=template.tmpl:/tmp/gotemplate1,/tmp/gotemplate2"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate1"},
+					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate2"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName: "multiple formats",
+			outputSlice: []string{
+				"table",
+				"json:/tmp/json,/tmp/json2",
+				"gob:/tmp/gob1",
+				"gotemplate=template.tmpl:/tmp/gotemplate1",
+			},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+					{Kind: "json", OutPath: "/tmp/json"},
+					{Kind: "json", OutPath: "/tmp/json2"},
+					{Kind: "gob", OutPath: "/tmp/gob1"},
+					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate1"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "two formats for stdout",
+			outputSlice: []string{"table", "json"},
+			expectedOutput: flags.OutputConfig{
+				LogFile:      os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+			expectedError: errors.New("flags.parseFormat: cannot use the same path for multiple outputs: stdout, use '--output help' for more info"),
+		},
+		{
+			testName:    "format for the same file twice",
+			outputSlice: []string{"table:/tmp/test,/tmp/test"},
+			expectedOutput: flags.OutputConfig{
+				LogFile:      os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+			expectedError: errors.New("flags.parseFormat: cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+		},
+		{
+			testName:    "two differents formats for the same file",
+			outputSlice: []string{"table:/tmp/test", "json:/tmp/test"},
+			expectedOutput: flags.OutputConfig{
+				LogFile:      os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+			expectedError: errors.New("flags.parseFormat: cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+		},
+		{
+			testName:    "none",
+			outputSlice: []string{"none"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "ignore", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		{
+			testName:    "invalid value for none format",
+			outputSlice: []string{"none:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("none output does not support path. Use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid value for none format 2",
+			outputSlice: []string{"none:/tmp/test"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("none output does not support path. Use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid value for log-file",
+			outputSlice: []string{"log-file"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateLogfile: log-file flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid value for log-file 2",
+			outputSlice: []string{"log-file:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateLogfile: log-file flag can't be empty, use '--output help' for more info"),
+		},
+		// forward
+		{
+			testName:    "empty forward flag",
+			outputSlice: []string{"forward"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateForwardFlag: forward flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty forward flag",
+			outputSlice: []string{"forward:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateForwardFlag: forward flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid forward url",
+			outputSlice: []string{"forward:lalala"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateForwardFlag: invalid uri for forward output \"lalala\". Use '--output help' for more info"),
+		},
+		{
+			testName:    "forward",
+			outputSlice: []string{"forward:tcp://localhost:1234"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "forward", OutPath: "tcp://localhost:1234"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		// options
+		{
+			testName:    "option stack-addresses",
+			outputSlice: []string{"option:stack-addresses"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					StackAddresses: true,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option exec-env",
+			outputSlice: []string{"option:exec-env"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ExecEnv:        true,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option relative-time",
+			outputSlice: []string{"json", "option:relative-time"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout", RelativeTS: true},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					RelativeTime: true,
+				},
+			},
+		},
+		{
+			testName:    "option exec-hash",
+			outputSlice: []string{"option:exec-hash"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ExecHash:       true,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option parse-arguments",
+			outputSlice: []string{"json", "option:parse-arguments"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout"},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+				},
+			},
+		},
+		{
+			testName:    "option parse-arguments-fds",
+			outputSlice: []string{"json", "option:parse-arguments-fds"},
+			expectedOutput: flags.OutputConfig{
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout"},
+				},
+				LogFile: os.Stderr,
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
+				},
+			},
+		},
+		{
+			testName:    "option sort-events",
+			outputSlice: []string{"option:sort-events"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					ParseArguments: true,
+					EventsSorting:  true,
+				},
+			},
+		},
+		{
+			testName: "all options",
+			outputSlice: []string{
+				"json",
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+			},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "json", OutPath: "stdout", RelativeTS: true},
+				},
+				TraceeConfig: &tracee.OutputConfig{
+					StackAddresses:    true,
+					ExecEnv:           true,
+					RelativeTime:      true,
+					ExecHash:          true,
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
+					EventsSorting:     true,
+				},
+			},
+		},
+	}
+	for _, testcase := range testCases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			output, err := flags.PrepareOutput(testcase.outputSlice)
+			if err != nil {
+				assert.Equal(t, testcase.expectedError, err)
+			} else {
+				assert.Equal(t, testcase.expectedOutput.LogFile, output.LogFile)
+				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
+
+				assertPrinterConfigs(t, testcase.expectedOutput.PrinterConfigs, output.PrinterConfigs)
+
+			}
+		})
+	}
+}
+
+func assertPrinterConfigs(t *testing.T, expected []printer.Config, actual []printer.Config) {
+	// use a map to compare because the order of the printers is not guaranteed
+	printersMap := make(map[string]printer.Config)
+
+	for _, p := range expected {
+		printersMap[p.OutPath] = p
+	}
+
+	for _, p := range actual {
+		expectedPrinter, ok := printersMap[p.OutPath]
+		assert.True(t, ok)
+
+		assert.Equal(t, expectedPrinter.Kind, p.Kind)
+		assert.Equal(t, expectedPrinter.OutPath, p.OutPath)
+		assert.Equal(t, expectedPrinter.RelativeTS, p.RelativeTS)
+		assert.Equal(t, expectedPrinter.ContainerMode, p.ContainerMode)
 	}
 }
 

--- a/pkg/cmd/flags/help.go
+++ b/pkg/cmd/flags/help.go
@@ -51,7 +51,7 @@ func getHelpString(key string) string {
 	case "filter":
 		return filterHelp()
 	case "output":
-		return outputHelp()
+		return traceeEbpfOutputHelp()
 	case "capabilities":
 		return capabilitiesHelp()
 	case "rego":

--- a/pkg/cmd/flags/help.go
+++ b/pkg/cmd/flags/help.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func PrintAndExitIfHelp(ctx *cli.Context) {
+func PrintAndExitIfHelp(ctx *cli.Context, newBinary bool) {
 	keys := []string{
 		"crs",
 		"cache",
@@ -21,7 +21,7 @@ func PrintAndExitIfHelp(ctx *cli.Context) {
 
 	for _, k := range keys {
 		if checkIsHelp(ctx, k) {
-			fmt.Print(getHelpString(k))
+			fmt.Print(getHelpString(k, newBinary))
 			os.Exit(0)
 		}
 	}
@@ -40,7 +40,7 @@ func checkIsHelp(ctx *cli.Context, k string) bool {
 	return v == "help"
 }
 
-func getHelpString(key string) string {
+func getHelpString(key string, newBinary bool) string {
 	switch key {
 	case "crs":
 		return containersHelp()
@@ -51,6 +51,9 @@ func getHelpString(key string) string {
 	case "filter":
 		return filterHelp()
 	case "output":
+		if newBinary {
+			return outputHelp()
+		}
 		return traceeEbpfOutputHelp()
 	case "capabilities":
 		return capabilitiesHelp()

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -1,0 +1,279 @@
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/cmd/printer"
+	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+func outputHelp() string {
+	return `Control how and where output is printed.
+Format options:
+table[:/path/to/file,...]                          output events in table format (default). The default path to file is stdout.
+table-verbose[:/path/to/file,...]                  output events in table format with extra fields per event. The default path to file is stdout.
+json[:/path/to/file,...]                           output events in json format. The default path to file is stdout.
+gob[:/path/to/file,...]                            output events in gob format. The default path to file is stdout.
+gotemplate=/path/to/template[:/path/to/file,...]   output events formatted using a given gotemplate file. The default path to file is stdout.
+none                                               ignore stream of events output, usually used with --capture
+
+Fluent Forward options:
+forward:url                                        send events in json format using the Forward protocol to a Fluent receiver
+
+Log options:
+log-file:/path/to/file                             write the logs to a specified file. create/trim the file if exists (default: stderr)
+
+Other options:
+option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
+                                                   augment output according to given options (default: none)
+  stack-addresses                                  include stack memory addresses for each event
+  exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
+  relative-time                                    use relative timestamp instead of wall timestamp for events
+  exec-hash                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
+  parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
+  parse-arguments-fds                              enable parse-arguments and enrich fd with its file path translation. This can cause pipeline slowdowns.
+  sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
+
+Examples:
+  --output json                                                  | output as json to stdout
+  --output json:/my/out                                          | output as json to /my/out
+  --output gotemplate=/path/to/my.tmpl                           | output as the provided go template to stdout
+  --output gob:/my/out --output log-file:/my/log                 | output gob to /my/out and logs to /my/log
+  --output json --output gob:/my/out                             | output as json to stdout and as gob to /my/out
+  --output json:/my/out1,/my/out2                                | output as json to both /my/out and /my/out2
+  --output none                                                  | ignore events output
+  --output table --output option:stack-addresses                 | output as table with stack addresses
+  --output forward:tcp://user:pass@127.0.0.1:24224?tag=tracee    | output via the Forward protocol to 127.0.0.1 on port 24224 with the tag 'tracee' using TCP
+
+Use this flag multiple times to choose multiple output options
+`
+}
+
+type OutputConfig struct {
+	TraceeConfig   *tracee.OutputConfig
+	PrinterConfigs []printer.Config
+	LogFile        *os.File
+}
+
+func PrepareOutput(outputSlice []string) (OutputConfig, error) {
+	outConfig := OutputConfig{}
+	traceeConfig := &tracee.OutputConfig{}
+
+	var logPath string
+
+	//outpath:format
+	printerMap := make(map[string]string)
+
+	for _, o := range outputSlice {
+		outputParts := strings.SplitN(o, ":", 2)
+
+		if strings.HasPrefix(outputParts[0], "gotemplate=") {
+			err := parseFormat(outputParts, printerMap)
+			if err != nil {
+				return outConfig, err
+			}
+			continue
+		}
+
+		switch outputParts[0] {
+		case "none":
+			if len(outputParts) > 1 {
+				return outConfig, errors.New("none output does not support path. Use '--output help' for more info")
+			}
+			printerMap["stdout"] = "ignore"
+		case "table", "table-verbose", "json", "gob":
+			err := parseFormat(outputParts, printerMap)
+			if err != nil {
+				return outConfig, err
+			}
+		case "forward":
+			// Validate the forward configuration details which are as follows:
+			// --output forward:[protocol://user:pass@]host:port[?k=v#f]
+			// Only host and port are required.
+			err := validateForwardFlag(outputParts)
+			if err != nil {
+				return outConfig, err
+			}
+
+			printerMap[outputParts[1]] = "forward"
+		case "log-file":
+			err := validateLogfile(outputParts)
+			if err != nil {
+				return outConfig, err
+			}
+			logPath = outputParts[1]
+		case "option":
+			err := parseOption(outputParts, traceeConfig)
+			if err != nil {
+				return outConfig, err
+			}
+		default:
+			return outConfig, fmt.Errorf("invalid output flag: %s, use '--output help' for more info", outputParts[0])
+		}
+	}
+
+	// default
+	if len(printerMap) == 0 {
+		printerMap["stdout"] = "table"
+	}
+
+	printerConfigs, err := getPrinterConfigs(printerMap, traceeConfig)
+	if err != nil {
+		return outConfig, err
+	}
+
+	if logPath == "" {
+		outConfig.LogFile = os.Stderr
+	} else {
+		file, err := createFile(logPath)
+		if err != nil {
+			return outConfig, err
+		}
+
+		outConfig.LogFile = file
+	}
+
+	outConfig.TraceeConfig = traceeConfig
+	outConfig.PrinterConfigs = printerConfigs
+
+	return outConfig, nil
+}
+
+// setOption sets the given option in the given config
+func setOption(config *tracee.OutputConfig, option string) error {
+	switch option {
+	case "stack-addresses":
+		config.StackAddresses = true
+	case "exec-env":
+		config.ExecEnv = true
+	case "relative-time":
+		config.RelativeTime = true
+	case "exec-hash":
+		config.ExecHash = true
+	case "parse-arguments":
+		config.ParseArguments = true
+	case "parse-arguments-fds":
+		config.ParseArgumentsFDs = true
+		config.ParseArguments = true // no point in parsing file descriptor args only
+	case "sort-events":
+		config.EventsSorting = true
+	default:
+		return logger.NewErrorf("invalid output option: %s, use '--output help' for more info", option)
+	}
+
+	return nil
+}
+
+// getPrinterConfigs returns a slice of printer.Configs based on the given printerMap
+func getPrinterConfigs(printerMap map[string]string, traceeConfig *tracee.OutputConfig) ([]printer.Config, error) {
+	printerConfigs := make([]printer.Config, 0, len(printerMap))
+
+	for outPath, printerKind := range printerMap {
+		if printerKind == "table" {
+			setOption(traceeConfig, "parse-arguments")
+		}
+
+		outFile := os.Stdout
+		var err error
+
+		if outPath != "stdout" && printerKind != "forward" {
+			outFile, err = createFile(outPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		printerConfigs = append(printerConfigs, printer.Config{
+			Kind:       printerKind,
+			OutPath:    outPath,
+			OutFile:    outFile,
+			RelativeTS: traceeConfig.RelativeTime,
+		})
+	}
+
+	return printerConfigs, nil
+}
+
+// parseFormat parses the given format and sets it in the given printerMap
+func parseFormat(outputParts []string, printerMap map[string]string) error {
+	// if not file was passed, we use stdout
+	if len(outputParts) == 1 {
+		outputParts = append(outputParts, "stdout")
+	}
+
+	for _, outPath := range strings.Split(outputParts[1], ",") {
+
+		if outPath == "" {
+			return logger.NewErrorf("format flag can't be empty, use '--output help' for more info")
+		}
+
+		if _, ok := printerMap[outPath]; ok {
+			return logger.NewErrorf("cannot use the same path for multiple outputs: %s, use '--output help' for more info", outPath)
+		}
+		printerMap[outPath] = outputParts[0]
+	}
+
+	return nil
+}
+
+// parseOption parses the given option and sets it in the given config
+func parseOption(outputParts []string, traceeConfig *tracee.OutputConfig) error {
+	if len(outputParts) == 1 || outputParts[1] == "" {
+		return logger.NewErrorf("option flag can't be empty, use '--output help' for more info")
+	}
+
+	for _, option := range strings.Split(outputParts[1], ",") {
+		err := setOption(traceeConfig, option)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateLogfile validates the given logfile
+func validateLogfile(outputParts []string) error {
+	if len(outputParts) == 1 || outputParts[1] == "" {
+		return logger.NewErrorf("log-file flag can't be empty, use '--output help' for more info")
+	}
+
+	return nil
+}
+
+// creates *os.File for the given path
+func createFile(path string) (*os.File, error) {
+	fileInfo, err := os.Stat(path)
+	if err == nil && fileInfo.IsDir() {
+		return nil, logger.NewErrorf("cannot use a path of existing directory %s", path)
+	}
+
+	dir := filepath.Dir(path)
+	os.MkdirAll(dir, 0755)
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, logger.NewErrorf("failed to create output path: %v", err)
+	}
+
+	return file, nil
+}
+
+func validateForwardFlag(outputParts []string) error {
+	if len(outputParts) == 1 || outputParts[1] == "" {
+		return logger.NewErrorf("forward flag can't be empty, use '--output help' for more info")
+	}
+	// Now parse our URL using the standard library and report any errors from basic parsing.
+	_, err := url.ParseRequestURI(outputParts[1])
+
+	if err != nil {
+		return logger.NewErrorf("invalid uri for forward output %q. Use '--output help' for more info", outputParts[1])
+	}
+
+	return nil
+}

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -1,9 +1,7 @@
 package flags
 
 import (
-	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
@@ -14,12 +12,11 @@ import (
 func traceeEbpfOutputHelp() string {
 	return `Control how and where output is printed.
 Possible options:
-[format:]table                                     output events in table format
+[format:]table                                     output events in table format (default)
 [format:]table-verbose                             output events in table format with extra fields per event
 [format:]json                                      output events in json format
 [format:]gob                                       output events in gob format
 [format:]gotemplate=/path/to/template              output events formatted using a given gotemplate file
-forward:url                                        send events in json format using the Forward protocol to a Fluent receiver
 out-file:/path/to/file                             write the output to a specified file. create/trim the file if exists (default: stdout)
 log-file:/path/to/file                             write the logs to a specified file. create/trim the file if exists (default: stderr)
 none                                               ignore stream of events output, usually used with --capture
@@ -33,50 +30,24 @@ option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-ev
   parse-arguments-fds                              enable parse-arguments and enrich fd with its file path translation. This can cause pipeline slowdowns.
   sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
 Examples:
-  --output json                                                    | output as json
-  --output gotemplate=/path/to/my.tmpl                             | output as the provided go template
-  --output out-file:/my/out --output log-file:/my/log              | output to /my/out and logs to /my/log
-  --output forward:tcp://user:pass@127.0.0.1:24224?tag=tracee      | output via the Forward protocol to 127.0.0.1 on port 24224 with the tag 'tracee' using TCP
-  --output none                                                    | ignore events output
+  --output json                                            | output as json to stdout
+  --output gotemplate=/path/to/my.tmpl                     | output as the provided go template
+  --output out-file:/my/out --output log-file:/my/log      | output to /my/out and logs to /my/log
+  --output none                                            | ignore events output
 Use this flag multiple times to choose multiple output options
 `
-}
-
-type OutputConfig struct {
-	TraceeConfig  *tracee.OutputConfig
-	PrinterConfig printer.Config
-	LogFile       *os.File
 }
 
 func TraceeEbpfPrepareOutput(outputSlice []string) (OutputConfig, error) {
 	outConfig := OutputConfig{}
 	traceeConfig := &tracee.OutputConfig{}
-	printerConfig := printer.Config{}
 
 	var outPath string
 	var logPath string
+
 	printerKind := "table"
 
 	for _, o := range outputSlice {
-		// Forward uses the net/url library to handle a full url including protocol, etc. so must cope with embedded colon characters
-		if strings.HasPrefix(o, "forward:") {
-			// Validate the forward configuration details which are as follows:
-			// --output forward:[protocol://user:pass@]host:port[?k=v#f]
-			// Only host and port are required.
-
-			forwardURL, err := parseForwardFlag(o)
-			if err != nil {
-				return outConfig, err
-			}
-
-			printerKind = "forward"
-			// Deliberately lightweight to just pass the URL into the printer config.
-			// We handle the specific configuration and other checks as part of the Init() call there.
-			printerConfig.ForwardURL = forwardURL
-
-			continue
-		}
-
 		outputParts := strings.SplitN(o, ":", 2)
 		numParts := len(outputParts)
 		if numParts == 1 && outputParts[0] != "none" {
@@ -97,47 +68,43 @@ func TraceeEbpfPrepareOutput(outputSlice []string) (OutputConfig, error) {
 		case "log-file":
 			logPath = outputParts[1]
 		case "option":
-			switch outputParts[1] {
-			case "stack-addresses":
-				traceeConfig.StackAddresses = true
-			case "exec-env":
-				traceeConfig.ExecEnv = true
-			case "relative-time":
-				traceeConfig.RelativeTime = true
-				printerConfig.RelativeTS = true
-			case "exec-hash":
-				traceeConfig.ExecHash = true
-			case "parse-arguments":
-				traceeConfig.ParseArguments = true
-			case "parse-arguments-fds":
-				traceeConfig.ParseArgumentsFDs = true
-				traceeConfig.ParseArguments = true // no point in parsing file descriptor args only
-			case "sort-events":
-				traceeConfig.EventsSorting = true
-			default:
-				return outConfig, logger.NewErrorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
+			err := setOption(traceeConfig, outputParts[1])
+			if err != nil {
+				return outConfig, err
 			}
 		default:
 			return outConfig, logger.NewErrorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
 		}
 	}
 
+	printerConfigs := make([]printer.Config, 0)
+
 	if printerKind == "table" {
-		traceeConfig.ParseArguments = true
+		setOption(traceeConfig, "parse-arguments")
 	}
 
-	printerConfig.Kind = printerKind
-
 	if outPath == "" {
-		printerConfig.OutFile = os.Stdout
+		stdoutConfig := printer.Config{
+			Kind:       printerKind,
+			OutFile:    os.Stdout,
+			RelativeTS: traceeConfig.RelativeTime,
+		}
+
+		printerConfigs = append(printerConfigs, stdoutConfig)
 	} else {
 		file, err := createFile(outPath)
 		if err != nil {
 			return outConfig, err
 		}
 
-		printerConfig.OutPath = outPath
-		printerConfig.OutFile = file
+		printerConfig := printer.Config{
+			Kind:       printerKind,
+			OutPath:    outPath,
+			OutFile:    file,
+			RelativeTS: traceeConfig.RelativeTime,
+		}
+
+		printerConfigs = append(printerConfigs, printerConfig)
 	}
 
 	if logPath == "" {
@@ -152,7 +119,7 @@ func TraceeEbpfPrepareOutput(outputSlice []string) (OutputConfig, error) {
 	}
 
 	outConfig.TraceeConfig = traceeConfig
-	outConfig.PrinterConfig = printerConfig
+	outConfig.PrinterConfigs = printerConfigs
 
 	return outConfig, nil
 }
@@ -167,35 +134,4 @@ func validateFormat(printerKind string) error {
 	}
 
 	return nil
-}
-
-func createFile(path string) (*os.File, error) {
-	fileInfo, err := os.Stat(path)
-	if err == nil && fileInfo.IsDir() {
-		return nil, logger.NewErrorf("cannot use a path of existing directory %s", path)
-	}
-
-	dir := filepath.Dir(path)
-	os.MkdirAll(dir, 0755)
-	file, err := os.Create(path)
-	if err != nil {
-		return nil, logger.NewErrorf("failed to create output path: %v", err)
-	}
-
-	return file, nil
-}
-
-func parseForwardFlag(o string) (*url.URL, error) {
-	// Split out just the config
-	forwardConfigParts := strings.SplitN(o, ":", 2)
-	if len(forwardConfigParts) != 2 {
-		return nil, logger.NewErrorf("invalid configuration for forward output: %q. Use '--output help' for more info", o)
-	}
-	// Now parse our URL using the standard library and report any errors from basic parsing.
-	forwardURL, err := url.Parse(forwardConfigParts[1])
-	if err != nil {
-		return nil, logger.NewErrorf("invalid configuration for forward output (%s): %v. Use '--output help' for more info", forwardConfigParts[1], err)
-	}
-
-	return forwardURL, nil
 }

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
-func outputHelp() string {
+func traceeEbpfOutputHelp() string {
 	return `Control how and where output is printed.
 Possible options:
 [format:]table                                     output events in table format
@@ -48,7 +48,7 @@ type OutputConfig struct {
 	LogFile       *os.File
 }
 
-func PrepareOutput(outputSlice []string) (OutputConfig, error) {
+func TraceeEbpfPrepareOutput(outputSlice []string) (OutputConfig, error) {
 	outConfig := OutputConfig{}
 	traceeConfig := &tracee.OutputConfig{}
 	printerConfig := printer.Config{}

--- a/pkg/cmd/printer/broadcast.go
+++ b/pkg/cmd/printer/broadcast.go
@@ -1,0 +1,58 @@
+package printer
+
+import (
+	"context"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+// Broadcast is a printer that broadcasts events to multiple printers
+type Broadcast struct {
+	eventsChan []chan trace.Event
+}
+
+// NewBroadcast creates a new Broadcast printer
+func NewBroadcast(ctx context.Context, printers []EventPrinter) *Broadcast {
+	eventsChan := make([]chan trace.Event, 0, len(printers))
+
+	for _, printer := range printers {
+		// we use a buffered channel to avoid blocking the event channel,
+		// we match the size of ChanEvents buffer
+		eventChan := make(chan trace.Event, 1000)
+		eventsChan = append(eventsChan, eventChan)
+
+		go startPrinter(ctx, eventChan, printer)
+	}
+
+	return &Broadcast{eventsChan: eventsChan}
+}
+
+// Print broadcasts the event to all printers
+func (b *Broadcast) Print(event trace.Event) {
+	for _, c := range b.eventsChan {
+		// we use select to avoid blocking the print loop if one of the printers is slow
+		// in case the event can't be sent because the buffered channel is full, we drop it
+		// and log an warning
+		select {
+		case c <- event:
+		default:
+			// TODO: add metrics about not printed events
+			logger.Info("dropping event due to slow printer", "event", event)
+		}
+	}
+}
+
+func startPrinter(ctx context.Context, c chan trace.Event, p EventPrinter) {
+	// Print the preamble and start event channel reception
+	p.Preamble()
+
+	for {
+		select {
+		case event := <-c:
+			p.Print(event)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -66,7 +66,7 @@ func TestTraceeEbpfPrepareOutputPrinterConfig(t *testing.T) {
 			if err != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {
-				assert.Equal(t, testcase.expectedPrinter, outputConfig.PrinterConfig)
+				assert.Equal(t, testcase.expectedPrinter, outputConfig.PrinterConfigs[0])
 			}
 		})
 	}

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPrepareOutputPrinterConfig(t *testing.T) {
+func TestTraceeEbpfPrepareOutputPrinterConfig(t *testing.T) {
 
 	testCases := []struct {
 		testName        string
@@ -62,7 +62,7 @@ func TestPrepareOutputPrinterConfig(t *testing.T) {
 	}
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
-			outputConfig, err := flags.PrepareOutput(testcase.outputSlice)
+			outputConfig, err := flags.TraceeEbpfPrepareOutput(testcase.outputSlice)
 			if err != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -13,9 +13,9 @@ import (
 )
 
 type Runner struct {
-	TraceeConfig  tracee.Config
-	PrinterConfig printer.Config
-	Server        *server.Server
+	TraceeConfig tracee.Config
+	Printers     []printer.EventPrinter
+	Server       *server.Server
 }
 
 func (r Runner) Run(ctx context.Context) error {
@@ -39,19 +39,14 @@ func (r Runner) Run(ctx context.Context) error {
 		go r.Server.Start()
 	}
 
-	// Configure the events printer
-
-	printer, err := printer.New(r.PrinterConfig)
-	if err != nil {
-		return logger.ErrorFunc(err)
-	}
-
 	// Print statistics at the end
 
 	defer func() {
-		stats := t.Stats()
-		printer.Epilogue(*stats)
-		printer.Close()
+		for _, p := range r.Printers {
+			stats := t.Stats()
+			p.Epilogue(*stats)
+			p.Close()
+		}
 	}()
 
 	// Initialize tracee
@@ -61,14 +56,14 @@ func (r Runner) Run(ctx context.Context) error {
 		return logger.NewErrorf("error initializing Tracee: %v", err)
 	}
 
-	// Print the preamble and start event channel reception
+	broadcast := printer.NewBroadcast(ctx, r.Printers)
 
+	// Start event channel reception
 	go func() {
-		printer.Preamble()
 		for {
 			select {
 			case event := <-r.TraceeConfig.ChanEvents:
-				printer.Print(event)
+				broadcast.Print(event)
 			case <-ctx.Done():
 				return
 			}
@@ -149,23 +144,4 @@ func getPad(padChar string, padLength int) (pad string) {
 		pad += padChar
 	}
 	return
-}
-
-func GetContainerMode(cfg tracee.Config) printer.ContainerMode {
-	containerMode := printer.ContainerModeDisabled
-
-	for filterScope := range cfg.FilterScopes.Map() {
-		if filterScope.ContainerFilterEnabled() {
-			// enable printer container print mode if container filters are set
-			containerMode = printer.ContainerModeEnabled
-			if cfg.ContainersEnrich {
-				// further enable container enrich print mode if container enrichment is enabled
-				containerMode = printer.ContainerModeEnriched
-			}
-
-			break
-		}
-	}
-
-	return containerMode
 }

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
+	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -13,7 +14,7 @@ import (
 	cli "github.com/urfave/cli/v2"
 )
 
-func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
+func GetTraceeRunner(c *cli.Context, version string, newBinary bool) (cmd.Runner, error) {
 	var runner cmd.Runner
 
 	// Initialize a tracee config structure
@@ -25,10 +26,19 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Output command line flags
 
-	output, err := flags.TraceeEbpfPrepareOutput(c.StringSlice("output"))
+	var err error
+	var output flags.OutputConfig
+
+	if newBinary {
+		output, err = flags.PrepareOutput(c.StringSlice("output"))
+	} else {
+		output, err = flags.TraceeEbpfPrepareOutput(c.StringSlice("output"))
+	}
+
 	if err != nil {
 		return runner, err
 	}
+	cfg.Output = output.TraceeConfig
 
 	// Log command line flags
 
@@ -98,10 +108,18 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 	cfg.FilterScopes = filterScopes
 
 	// Container information printer flag
+	containerMode := getContainerMode(cfg)
+	printers := make([]printer.EventPrinter, 0, len(output.PrinterConfigs))
+	for _, pConfig := range output.PrinterConfigs {
+		pConfig.ContainerMode = containerMode
 
-	printerConfig := output.PrinterConfig
-	printerConfig.ContainerMode = cmd.GetContainerMode(cfg)
-	cfg.Output = output.TraceeConfig
+		p, err := printer.New(pConfig)
+		if err != nil {
+			return runner, err
+		}
+
+		printers = append(printers, p)
+	}
 
 	// Check kernel lockdown
 
@@ -156,7 +174,26 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	runner.Server = httpServer
 	runner.TraceeConfig = cfg
-	runner.PrinterConfig = printerConfig
+	runner.Printers = printers
 
 	return runner, nil
+}
+
+func getContainerMode(cfg tracee.Config) printer.ContainerMode {
+	containerMode := printer.ContainerModeDisabled
+
+	for filterScope := range cfg.FilterScopes.Map() {
+		if filterScope.ContainerFilterEnabled() {
+			// enable printer container print mode if container filters are set
+			containerMode = printer.ContainerModeEnabled
+			if cfg.ContainersEnrich {
+				// further enable container enrich print mode if container enrichment is enabled
+				containerMode = printer.ContainerModeEnriched
+			}
+
+			break
+		}
+	}
+
+	return containerMode
 }

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -25,7 +25,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Output command line flags
 
-	output, err := flags.PrepareOutput(c.StringSlice("output"))
+	output, err := flags.TraceeEbpfPrepareOutput(c.StringSlice("output"))
 	if err != nil {
 		return runner, err
 	}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR add support for multiple printers to new `tracee` binary. The old binary `tracee-ebpf` maintain the previous syntax, and the change is only implemented for the new binary, for such I have first created a commit where I rename the previous `output` flag in order to simplify the deletion once we deprecate and remove `tracee-ebpf`. 

The new syntax was discussed on a previous PR https://github.com/aquasecurity/tracee/pull/2709
This PR is part of https://github.com/aquasecurity/tracee/issues/2355
Close https://github.com/aquasecurity/tracee/issues/2231

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

Please check the help commands:
```
tracee-ebpf --output help
tracee --output help
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

Multiple printers will be the base of the webhook implementation for the new binary, where webhooks will be a printer like stdout, etc. 
