### PR TITLE
types: add event metadata

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -44,6 +44,15 @@ type Event struct {
 	StackAddresses      []uint64     `json:"stackAddresses"`
 	ContextFlags        ContextFlags `json:"contextFlags"`
 	Args                []Argument   `json:"args"` //Arguments are ordered according their appearance in the original event
+	Metadata            *Metadata    `json:"metadata,omitempty"`
+}
+
+// Metadata is a struct that holds metadata about an event
+type Metadata struct {
+	Version     string
+	Description string
+	Tags        []string
+	Properties  map[string]interface{}
 }
 
 // ContextFlags are flags representing event context


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR adds support to Metadata to `trace.Event`. At first this will be used to add `SignatureMetadata` when a signature event is created from a detection. Instead of adding `SignatureMetadata` directly, we have a more generic approach allowing for future use by events that are not signatures (eg: derivations, ebpf)

The `Metadata` field is a pointer and marked as `omitempty` so we only print it if there are metadata. 

This PR is part of https://github.com/aquasecurity/tracee/issues/2355

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

Test the PR using this change to add signature metadata to signature events https://github.com/aquasecurity/tracee/pull/2753

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

The [first implementation](https://github.com/aquasecurity/tracee/pull/2744) was using a more dynamic approach, but after discussion we decide to have a structure for the specific fields  `Version`, `Description`, `Tags`, `Properties`. This is based on `SignatureMetadata`, but different because we don't need name, nor id, as events already have name and id of themselves. 

<!--
Links? References? Anything pointing to more context about the change.
-->
