### PR TITLE
Add signature event metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1
-	github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07
+	github.com/aquasecurity/tracee/types v0.0.0-20230221114307-1825fd3fbad7
 	github.com/containerd/containerd v1.6.18
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,10 @@ github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1 h1
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07 h1:6XkjmyQTMOpRQACGuBmKWBUjAqfmWsV7Qr1OznXQqJU=
 github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07/go.mod h1:pXXAxJZ+H1Ro0lsHA14pX6Rc7GkNBxeJMwWIUAPJ3eA=
+github.com/aquasecurity/tracee/types v0.0.0-20230221043114-1785c0ddeab6 h1:+kDxoW7nNLQ69aBNDrIdgbPZ5ooDGa7xpZX5lJqZH3A=
+github.com/aquasecurity/tracee/types v0.0.0-20230221043114-1785c0ddeab6/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
+github.com/aquasecurity/tracee/types v0.0.0-20230221114307-1825fd3fbad7 h1:NDyIRyseynh50ZuqGgjwCYvF0iLqKSiUt5y2dagTmDk=
+github.com/aquasecurity/tracee/types v0.0.0-20230221114307-1825fd3fbad7/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/ebpf/finding_test.go
+++ b/pkg/ebpf/finding_test.go
@@ -1,0 +1,112 @@
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindingToEvent(t *testing.T) {
+	expected := &trace.Event{
+		EventID:             int(events.StartSignatureID),
+		EventName:           "fake_signature_event",
+		ProcessorID:         1,
+		ProcessID:           2,
+		CgroupID:            3,
+		ThreadID:            4,
+		ParentProcessID:     5,
+		HostProcessID:       6,
+		HostThreadID:        7,
+		HostParentProcessID: 8,
+		UserID:              9,
+		MountNS:             10,
+		PIDNS:               11,
+		ProcessName:         "process",
+		HostName:            "host",
+		ContainerID:         "containerID",
+		ContainerImage:      "image",
+		ContainerName:       "container",
+		PodName:             "pod",
+		PodNamespace:        "namespace",
+		PodUID:              "uid",
+		ReturnValue:         0,
+		MatchedScopes:       1,
+		ArgsNum:             0,
+		Metadata: &trace.Metadata{
+			Version:     "1",
+			Description: "description",
+			Tags:        []string{"tag1", "tag2"},
+			Properties: map[string]interface{}{
+				"prop1":         "value1",
+				"prop2":         1,
+				"signatureID":   "fake_signature_id",
+				"signatureName": "fake_signature_event",
+			},
+		},
+	}
+
+	finding := createFakeEventAndFinding()
+	got, err := FindingToEvent(finding)
+
+	assert.NoError(t, err)
+	assert.Equal(t, got, expected)
+}
+
+func createFakeEventAndFinding() detect.Finding {
+	eventName := "fake_signature_event"
+	event := events.NewEventDefinition(eventName, []string{"signatures"}, []events.ID{events.Ptrace})
+
+	events.Definitions.Add(events.StartSignatureID, event)
+
+	return detect.Finding{
+		SigMetadata: detect.SignatureMetadata{
+			ID:          "fake_signature_id",
+			Name:        eventName,
+			EventName:   eventName,
+			Version:     "1",
+			Description: "description",
+			Tags:        []string{"tag1", "tag2"},
+			Properties: map[string]interface{}{
+				"prop1": "value1",
+				"prop2": 1,
+			},
+		},
+		Data: map[string]interface{}{
+			"arg1": "value1",
+			"arg2": 1,
+		},
+		Event: protocol.Event{
+			Headers: protocol.EventHeaders{},
+			Payload: trace.Event{
+				EventID:             int(events.Ptrace),
+				EventName:           "ptrace",
+				ProcessorID:         1,
+				ProcessID:           2,
+				CgroupID:            3,
+				ThreadID:            4,
+				ParentProcessID:     5,
+				HostProcessID:       6,
+				HostThreadID:        7,
+				HostParentProcessID: 8,
+				UserID:              9,
+				MountNS:             10,
+				PIDNS:               11,
+				ProcessName:         "process",
+				HostName:            "host",
+				ContainerID:         "containerID",
+				ContainerImage:      "image",
+				ContainerName:       "container",
+				PodName:             "pod",
+				PodNamespace:        "namespace",
+				PodUID:              "uid",
+				ReturnValue:         0,
+				MatchedScopes:       1,
+				ArgsNum:             0,
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR uses the new [Metadata](https://github.com/aquasecurity/tracee/pull/2752) field from `trace.Event` to add the Signature Metadata from the detection into the signature event. Because `SignatureMetadata` contains a few specific fields that don't fit on the `trace.Event` metadata, we are adding them as properties (`SignatureID`, and `SignatureName`)

We add extra signature metadata information, because it is used by internal services, though once we finish the new architecture where sigantures raise events, instead of findings we will remove it. https://github.com/aquasecurity/tracee/issues/2541

```json
{"timestamp":1676925283242804700,"threadStartTime":1676925283242676500,"processorId":4,"processId":1514163,"cgroupId":700736,"threadId":1514163,"parentProcessId":1514161,"hostProcessId":1514163,"hostThreadId":1514163,"hostParentProcessId":1514161,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","hostName":"josedonizetti-x","containerId":"","containerImage":"","containerName":"","podName":"","podNamespace":"","podUID":"","podSandbox":false,"eventId":"6018","eventName":"Anti-Debugging detected","matchedScopes":1,"argsNum":4,"returnValue":0,"syscall":"","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"args":[{"name":"request","type":"string","value":"PTRACE_TRACEME"},{"name":"pid","type":"pid_t","value":0},{"name":"addr","type":"void*","value":"0x0"},{"name":"data","type":"void*","value":"0x0"}], "metadata":{"Version":"1","Description":"A process used anti-debugging techniques to block a debugger. Malware use anti-debugging to stay invisible and inhibit analysis of their behavior.","Tags":null,"Properties":{"Category":"defense-evasion","Kubernetes_Technique":"","Severity":1,"Technique":"Debugger Evasion","external_id":"T1622","id":"attack-pattern--e4dc8c01-417f-458d-9ee0-bb0617c1b391","signatureID":"TRC-102","signatureName":"Anti-Debugging detected"}}}
```

This PR is part of https://github.com/aquasecurity/tracee/issues/2355
<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
# pull the pr
make clean && make
trace --trace event=execve,anti_debugging
```

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments
