### PR TITLE
capabilities: drop capabilities by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,6 @@ require (
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.64 // indirect
 )
 
+replace github.com/aquasecurity/tracee/types => ./types
+
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0

--- a/pkg/cmd/flags/capabilities.go
+++ b/pkg/cmd/flags/capabilities.go
@@ -26,17 +26,18 @@ Available capabilities:
 
 func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) {
 	capsConfig := tracee.CapabilitiesConfig{
-		BypassCaps: true, // bypass capabilities by default
+		BypassCaps: false, // DO NOT bypass capabilities by default
 	}
 
 	for _, slice := range capsSlice {
 		if strings.Contains(slice, "bypass=") {
 			b := strings.TrimPrefix(slice, "bypass=")
-			if b == "0" || b == "false" {
-				capsConfig.BypassCaps = false
-			} else if b != "1" && b != "true" {
+			if b == "1" || b == "true" {
+				capsConfig.BypassCaps = true
+			} else if b != "0" && b != "false" {
 				return capsConfig, fmt.Errorf("bypass should either be true or false")
 			}
+
 		}
 		if strings.HasPrefix(slice, "add=") {
 			suffix := strings.TrimPrefix(slice, "add=")


### PR DESCRIPTION
Fixes: #2397

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR changes the default behavior from NOT dropping capabilities by default to dropping. 

### 2. Explain how to test it

Make sure you have `/proc/sys/kernel/perf_event_paranoid` set to 0.

Then run tracee with multiple events and capture options and, at the end, chose to add or drop capabilities at will:

```
sudo rm -rf /tmp/tracee/out/pcap && sudo tracee-ebpf --pprof --metrics --log debug --install-path /tmp/tracee --output option:parse-arguments --capabilities bypass=false --output format:json --trace event=net_packet_dns_request --capture network --capture pcap:single,process,command,container --capture pcap-options:filtered --capture pcap-snaplen:max --capabilities bypass=false --capabilities add=cap_lease --capabilities drop=cap_sys_admin
```

Note: If you drop cap_bpf, for example, tracee won't be able to work (as it tries to use cap_bpf by default in newer kernels, instead of cap_sys_admin). Now, if you drop cap_bpf but add cap_sys_admin, then it will work <- This might be a good test to play with.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
