### PR TITLE
libbpfgo: set libbpfgo callbacks

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -6,10 +6,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
 	"github.com/aquasecurity/tracee/pkg/cmd/urfave"
 	"github.com/aquasecurity/tracee/pkg/logger"
 
@@ -31,27 +31,7 @@ func init() {
 		)
 	}
 
-	// Set libbpfgo logging callbacks
-	libbpfgo.SetLoggerCbs(libbpfgo.Callbacks{
-		Log: func(libLevel int, msg string, keyValues ...interface{}) {
-			lvl := logger.ErrorLevel
-
-			switch libLevel {
-			case libbpfgo.LibbpfWarnLevel:
-				lvl = logger.WarnLevel
-			case libbpfgo.LibbpfInfoLevel:
-				lvl = logger.InfoLevel
-			case libbpfgo.LibbpfDebugLevel:
-				lvl = logger.DebugLevel
-			}
-
-			logger.Log(lvl, false, msg, keyValues...)
-		},
-		LogFilters: []func(libLevel int, msg string) bool{
-			libbpfgo.LogFilterLevel,
-			libbpfgo.LogFilterOutput,
-		},
-	})
+	initialize.SetLibbpfgoCallbacks()
 }
 
 var version string

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -6,10 +6,10 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
 	"github.com/aquasecurity/tracee/pkg/cmd/urfave"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -35,27 +35,7 @@ func init() {
 		)
 	}
 
-	// Set libbpfgo logging callbacks
-	libbpfgo.SetLoggerCbs(libbpfgo.Callbacks{
-		Log: func(libLevel int, msg string, keyValues ...interface{}) {
-			lvl := logger.ErrorLevel
-
-			switch libLevel {
-			case libbpfgo.LibbpfWarnLevel:
-				lvl = logger.WarnLevel
-			case libbpfgo.LibbpfInfoLevel:
-				lvl = logger.InfoLevel
-			case libbpfgo.LibbpfDebugLevel:
-				lvl = logger.DebugLevel
-			}
-
-			logger.Log(lvl, false, msg, keyValues...)
-		},
-		LogFilters: []func(libLevel int, msg string) bool{
-			libbpfgo.LogFilterLevel,
-			libbpfgo.LogFilterOutput,
-		},
-	})
+	initialize.SetLibbpfgoCallbacks()
 }
 
 var version string

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/IBM/fluent-forward-go v0.2.1
 	github.com/Masterminds/sprig/v3 v3.2.2
-	github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2
+	github.com/aquasecurity/libbpfgo v0.4.6-libbpf-1.1.0
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1
 	github.com/aquasecurity/tracee/types v0.0.0-20230221114307-1825fd3fbad7
 	github.com/containerd/containerd v1.6.18

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed h1:u
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220418222510-f25a4f6275ed/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2 h1:26nRGlFZuVx2Rlx3mCjb20oc0T1fmjWPkaFtFD9tvNw=
 github.com/aquasecurity/libbpfgo v0.4.5-libbpf-1.0.1.0.20230220155652-8f83f25d0ee2/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
+github.com/aquasecurity/libbpfgo v0.4.6-libbpf-1.1.0 h1:b4RQasaC8u+zvCFJO6z4e+XoDJ3XEwxcMSdrbT1GFnk=
+github.com/aquasecurity/libbpfgo v0.4.6-libbpf-1.1.0/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1 h1:pQQ/vb0z2dw3fFkvD4XDw6XGM82EjPfS93Cav77wjIo=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230109115933-5ede01b209e1/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/aquasecurity/tracee/types v0.0.0-20230215201818-c508a5339e07 h1:6XkjmyQTMOpRQACGuBmKWBUjAqfmWsV7Qr1OznXQqJU=

--- a/pkg/cmd/initialize/callbacks.go
+++ b/pkg/cmd/initialize/callbacks.go
@@ -1,0 +1,80 @@
+package initialize
+
+import (
+	"regexp"
+
+	"github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+var (
+	// triggered by: libbpf/src/nlattr.c->libbpf_nla_dump_errormsg()
+	// "libbpf: Kernel error message: %s\n"
+	// 1. %s = "Exclusivity flag on"
+	libbpfgoKernelExclusivityFlagOnRegexp = regexp.MustCompile(`libbpf:.*Kernel error message:.*Exclusivity flag on`)
+
+	// triggered by: libbpf/src/libbpf.c->bpf_program__attach_kprobe_opts()
+	// "libbpf: prog '%s': failed to create %s '%s+0x%zx' perf event: %s\n"
+	// 1. %s = trace_check_map_func_compatibility | trace_utimes_common
+	// 2. %s = kretprobe or kprobe
+	// 3. %s = check_map_func_compatibility (function name)
+	// 4. %x = offset (ignored in this check)
+	// 5. %s = No such file or directory
+	libbpfgoKprobePerfEventRegexp = regexp.MustCompile(`libbpf:.*prog '(?:trace_check_map_func_compatibility|trace_utimes_common)'.*failed to create kprobe.*perf event: No such file or directory`)
+
+	// triggered by: libbpf/src/libbpf.c->bpf_program__attach_fd()
+	// "libbpf: prog '%s': failed to attach to %s: %s\n"
+	// 1. %s = cgroup_skb_ingress or cgroup_skb_egress
+	// 2. %s = cgroup
+	// 3. %s = Invalid argument
+	libbpfgoAttachCgroupregexp = regexp.MustCompile(`libbpf:.*prog 'cgroup_skb_ingress|cgroup_skb_egress'.*failed to attach to cgroup.*Invalid argument`)
+)
+
+// SetLibbpfgoCallbacks sets libbpfgo logger callbacks
+func SetLibbpfgoCallbacks() {
+	libbpfgo.SetLoggerCbs(libbpfgo.Callbacks{
+		Log: func(libLevel int, msg string) {
+			lvl := logger.ErrorLevel
+
+			switch libLevel {
+			case libbpfgo.LibbpfWarnLevel:
+				lvl = logger.WarnLevel
+			case libbpfgo.LibbpfInfoLevel:
+				lvl = logger.InfoLevel
+			case libbpfgo.LibbpfDebugLevel:
+				lvl = logger.DebugLevel
+			}
+
+			logger.Log(lvl, false, msg)
+		},
+		LogFilters: []func(libLevel int, msg string) bool{
+			// Ignore libbpf outputs that are not relevant to tracee
+			func(libLevel int, msg string) bool {
+				if libLevel != libbpfgo.LibbpfWarnLevel {
+					return true
+				}
+
+				// BUG: https:/github.com/aquasecurity/tracee/issues/1676
+				if libbpfgoKernelExclusivityFlagOnRegexp.MatchString(msg) {
+					return true
+				}
+
+				// BUGS: https://github.com/aquasecurity/tracee/issues/2446
+				//       https://github.com/aquasecurity/tracee/issues/2754
+				if libbpfgoKprobePerfEventRegexp.MatchString(msg) {
+					return true
+				}
+
+				// AttachCgroupLegacy() will first try AttachCgroup() and it might fail. This
+				// is not an error and is the best way of probing for eBPF cgroup attachment
+				// link existence.
+				if libbpfgoAttachCgroupregexp.MatchString(msg) {
+					return true
+				}
+
+				// output is not filtered
+				return false
+			},
+		},
+	})
+}

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -16,6 +16,8 @@ import (
 
 // load tracee into memory with args
 func startTracee(t *testing.T, config tracee.Config, output *tracee.OutputConfig, capture *tracee.CaptureConfig, ctx context.Context) *tracee.Tracee {
+	initialize.SetLibbpfgoCallbacks()
+
 	kernelConfig, err := initialize.KernelConfig()
 	require.NoError(t, err)
 


### PR DESCRIPTION
### 1. Explain what the PR does

commit 0a83bf085508b3a58abad01723ae77d9fe506816

    libbpfgo: set libbpfgo callbacks
    
    This brings to Tracee the libbpfgo filtering logic that was removed from
    libbpfgo.
    
     - https://github.com/aquasecurity/libbpfgo/pull/294
    
    This also changes libbpfgoKprobePerfEventRegexp to match:
    'trace_utimes_common' progs.

commit 29b5090afa69e9abffbc8832df654159186172fb

    bump libbpfgo to v0.4.6


### 2. Explain how to test it

Compile and run, the libbpf output should remain as silent as ever.

### 3. Other comments

Fixes: #2756 #2754

Context:

- https://github.com/aquasecurity/libbpfgo/pull/284#issuecomment-1437170456

#### Related:

- #2756
- #2754