### PR TITLE
sets: default set can't have network events v419

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -6141,8 +6141,114 @@ var Definitions = eventDefinitions{
 				{Type: "void*", Name: "symbol_address"},
 			},
 		},
+		PrintMemDump: {
+			ID32Bit: sys32undefined,
+			Name:    "print_mem_dump",
+			Sets:    []string{},
+			Params: []trace.ArgMeta{
+				{Type: "bytes", Name: "bytes"},
+				{Type: "void*", Name: "address"},
+				{Type: "u64", Name: "length"},
+				{Type: "u64", Name: "caller_context_id"},
+				{Type: "char*", Name: "arch"},
+				{Type: "char*", Name: "symbol_name"},
+				{Type: "char*", Name: "symbol_owner"},
+			},
+			Probes: []probeDependency{
+				{Handle: probes.PrintMemDump, Required: true},
+			},
+			Dependencies: dependencies{
+				Events: []eventDependency{
+					{EventID: DoInitModule},
+				},
+				KSymbols: &[]kSymbolDependency{},
+			},
+		},
+		VfsRead: {
+			ID32Bit: sys32undefined,
+			Name:    "vfs_read",
+			Probes: []probeDependency{
+				{Handle: probes.VfsRead, Required: true},
+				{Handle: probes.VfsReadRet, Required: true},
+			},
+			Sets: []string{},
+			Params: []trace.ArgMeta{
+				{Type: "const char*", Name: "pathname"},
+				{Type: "dev_t", Name: "dev"},
+				{Type: "unsigned long", Name: "inode"},
+				{Type: "size_t", Name: "count"},
+				{Type: "off_t", Name: "pos"},
+			},
+		},
+		VfsReadv: {
+			ID32Bit: sys32undefined,
+			Name:    "vfs_readv",
+			Probes: []probeDependency{
+				{Handle: probes.VfsReadV, Required: true},
+				{Handle: probes.VfsReadVRet, Required: true},
+			},
+			Sets: []string{},
+			Params: []trace.ArgMeta{
+				{Type: "const char*", Name: "pathname"},
+				{Type: "dev_t", Name: "dev"},
+				{Type: "unsigned long", Name: "inode"},
+				{Type: "unsigned long", Name: "vlen"},
+				{Type: "off_t", Name: "pos"},
+			},
+		},
+		VfsUtimes: {
+			ID32Bit: sys32undefined,
+			Name:    "vfs_utimes",
+			Probes: []probeDependency{
+				{Handle: probes.VfsUtimes, Required: false},    // this probe exits in kernels >= 5.9
+				{Handle: probes.UtimesCommon, Required: false}, // this probe exits in kernels < 5.9
+			},
+			Sets: []string{},
+			Params: []trace.ArgMeta{
+				{Type: "const char*", Name: "pathname"},
+				{Type: "dev_t", Name: "dev"},
+				{Type: "unsigned long", Name: "inode"},
+				{Type: "u64", Name: "atime"},
+				{Type: "u64", Name: "mtime"},
+			},
+		},
+		DoTruncate: {
+			ID32Bit: sys32undefined,
+			Name:    "do_truncate",
+			Probes: []probeDependency{
+				{Handle: probes.DoTruncate, Required: true},
+			},
+			Sets: []string{},
+			Params: []trace.ArgMeta{
+				{Type: "const char*", Name: "pathname"},
+				{Type: "unsigned long", Name: "inode"},
+				{Type: "dev_t", Name: "dev"},
+				{Type: "u64", Name: "length"},
+			},
+		},
+		FileModification: {
+			ID32Bit: sys32undefined,
+			Name:    "file_modification",
+			DocPath: "kprobes/file_modification.md",
+			Sets:    []string{},
+			Params: []trace.ArgMeta{
+				{Type: "const char*", Name: "file_path"},
+				{Type: "dev_t", Name: "dev"},
+				{Type: "unsigned long", Name: "inode"},
+				{Type: "unsigned long", Name: "old_ctime"},
+				{Type: "unsigned long", Name: "new_ctime"},
+			},
+			Probes: []probeDependency{
+				{Handle: probes.FdInstall, Required: true},
+				{Handle: probes.FilpClose, Required: true},
+				{Handle: probes.FileUpdateTime, Required: true},
+				{Handle: probes.FileUpdateTimeRet, Required: true},
+				{Handle: probes.FileModified, Required: false},    // not required because doesn't ...
+				{Handle: probes.FileModifiedRet, Required: false}, // ... exist in kernels < 5.3
+			},
+		},
 		//
-		// Network Protocol Event Types
+		// Network Protocol Event Types (add new events above here)
 		//
 		NetPacketBase: {
 			ID32Bit:  sys32undefined,
@@ -6468,111 +6574,6 @@ var Definitions = eventDefinitions{
 				},
 			},
 		},
-		PrintMemDump: {
-			ID32Bit: sys32undefined,
-			Name:    "print_mem_dump",
-			Sets:    []string{},
-			Params: []trace.ArgMeta{
-				{Type: "bytes", Name: "bytes"},
-				{Type: "void*", Name: "address"},
-				{Type: "u64", Name: "length"},
-				{Type: "u64", Name: "caller_context_id"},
-				{Type: "char*", Name: "arch"},
-				{Type: "char*", Name: "symbol_name"},
-				{Type: "char*", Name: "symbol_owner"},
-			},
-			Probes: []probeDependency{
-				{Handle: probes.PrintMemDump, Required: true},
-			},
-			Dependencies: dependencies{
-				Events: []eventDependency{
-					{EventID: DoInitModule},
-				},
-				KSymbols: &[]kSymbolDependency{},
-			},
-		},
-		VfsRead: {
-			ID32Bit: sys32undefined,
-			Name:    "vfs_read",
-			Probes: []probeDependency{
-				{Handle: probes.VfsRead, Required: true},
-				{Handle: probes.VfsReadRet, Required: true},
-			},
-			Sets: []string{},
-			Params: []trace.ArgMeta{
-				{Type: "const char*", Name: "pathname"},
-				{Type: "dev_t", Name: "dev"},
-				{Type: "unsigned long", Name: "inode"},
-				{Type: "size_t", Name: "count"},
-				{Type: "off_t", Name: "pos"},
-			},
-		},
-		VfsReadv: {
-			ID32Bit: sys32undefined,
-			Name:    "vfs_readv",
-			Probes: []probeDependency{
-				{Handle: probes.VfsReadV, Required: true},
-				{Handle: probes.VfsReadVRet, Required: true},
-			},
-			Sets: []string{},
-			Params: []trace.ArgMeta{
-				{Type: "const char*", Name: "pathname"},
-				{Type: "dev_t", Name: "dev"},
-				{Type: "unsigned long", Name: "inode"},
-				{Type: "unsigned long", Name: "vlen"},
-				{Type: "off_t", Name: "pos"},
-			},
-		},
-		VfsUtimes: {
-			ID32Bit: sys32undefined,
-			Name:    "vfs_utimes",
-			Probes: []probeDependency{
-				{Handle: probes.VfsUtimes, Required: false},    // this probe exits in kernels >= 5.9
-				{Handle: probes.UtimesCommon, Required: false}, // this probe exits in kernels < 5.9
-			},
-			Sets: []string{},
-			Params: []trace.ArgMeta{
-				{Type: "const char*", Name: "pathname"},
-				{Type: "dev_t", Name: "dev"},
-				{Type: "unsigned long", Name: "inode"},
-				{Type: "u64", Name: "atime"},
-				{Type: "u64", Name: "mtime"},
-			},
-		},
-		DoTruncate: {
-			ID32Bit: sys32undefined,
-			Name:    "do_truncate",
-			Probes: []probeDependency{
-				{Handle: probes.DoTruncate, Required: true},
-			},
-			Sets: []string{},
-			Params: []trace.ArgMeta{
-				{Type: "const char*", Name: "pathname"},
-				{Type: "unsigned long", Name: "inode"},
-				{Type: "dev_t", Name: "dev"},
-				{Type: "u64", Name: "length"},
-			},
-		},
-		FileModification: {
-			ID32Bit: sys32undefined,
-			Name:    "file_modification",
-			DocPath: "kprobes/file_modification.md",
-			Sets:    []string{},
-			Params: []trace.ArgMeta{
-				{Type: "const char*", Name: "file_path"},
-				{Type: "dev_t", Name: "dev"},
-				{Type: "unsigned long", Name: "inode"},
-				{Type: "unsigned long", Name: "old_ctime"},
-				{Type: "unsigned long", Name: "new_ctime"},
-			},
-			Probes: []probeDependency{
-				{Handle: probes.FdInstall, Required: true},
-				{Handle: probes.FilpClose, Required: true},
-				{Handle: probes.FileUpdateTime, Required: true},
-				{Handle: probes.FileUpdateTimeRet, Required: true},
-				{Handle: probes.FileModified, Required: false},    // not required because doesn't ...
-				{Handle: probes.FileModifiedRet, Required: false}, // ... exist in kernels < 5.3
-			},
-		},
+		// NOTE: add new events before the network events (keep them at the end)
 	},
 }


### PR DESCRIPTION
## Description

Commit 0601f099 added network events to the default set but, since the default set is used for all versions, this broke v419 runs, as that version does not support network events.

commit a8a0d377 (HEAD -> v419-fix, rafaeldtinoco/v419-fix)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Mar 1 01:59:53 2023

    filter: mitigate v4.19 lack of network events
    
    The default event set includes some net_packet events, but they're
    not supported in vanilla v4.19 kernels. This patch mitigates this
    issue by adding all the network related events to an exclusion list
    during the filter events preparation phase.
    
    Fixes: #2771
    
    Note: This mitigation should be removed as soon as tracee has the
          feature probe mechanism in place.

commit e2d52ad5
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Mar 1 02:30:42 2023

    libbpfgo error callbacks: mitigate v4.19 map xattr
    
    Fixes: #1602

commit 03edd7be
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Mar 1 01:58:30 2023

    chore: events: keep network related events at the end