### PR TITLE
errors: improve error output

### DIFF
--- a/cmd/tracee-rules/input_test.go
+++ b/cmd/tracee-rules/input_test.go
@@ -86,7 +86,7 @@ func TestParseTraceeInputOptions(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			opt, err := parseTraceeInputOptions(testcase.optionStringSlice)
-			assert.Equal(t, testcase.expectedError, err)
+			assert.ErrorContains(t, err, testcase.expectedError.Error())
 			assert.Equal(t, testcase.expectedResultOptions, opt)
 		})
 	}

--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -215,7 +215,7 @@ HostName: foobar.local
 
 			switch {
 			case tc.expectedError != "":
-				assert.EqualError(t, actualError, tc.expectedError, tc.name)
+				assert.ErrorContains(t, actualError, tc.expectedError, tc.name)
 			default:
 				assert.NoError(t, actualError, tc.name)
 			}

--- a/pkg/bucketscache/bucketscache.go
+++ b/pkg/bucketscache/bucketscache.go
@@ -1,8 +1,9 @@
 package bucketscache
 
 import (
-	"fmt"
 	"sync"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 type BucketsCache struct {
@@ -68,5 +69,5 @@ func (c *BucketsCache) addBucketItem(key uint32, value uint32, force bool) {
 }
 
 func NoSuchItem(key uint32, index int) error {
-	return fmt.Errorf("no such item in cache at key: %d, index: %d", key, index)
+	return logger.NewErrorf("no such item in cache at key: %d, index: %d", key, index)
 }

--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -8,9 +8,9 @@ package bufferdecoder
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 type EbpfDecoder struct {
@@ -43,7 +43,7 @@ func (decoder *EbpfDecoder) ReadAmountBytes() int {
 func (decoder *EbpfDecoder) DecodeContext(ctx *Context) error {
 	offset := decoder.cursor
 	if uint32(len(decoder.buffer[offset:])) < ctx.GetSizeBytes() {
-		return fmt.Errorf("context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), ctx.GetSizeBytes())
+		return logger.NewErrorf("context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), ctx.GetSizeBytes())
 	}
 
 	// event_context start
@@ -84,7 +84,7 @@ func (decoder *EbpfDecoder) DecodeUint8(msg *uint8) error {
 	readAmount := 1
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = decoder.buffer[decoder.cursor]
 	decoder.cursor += readAmount
@@ -96,7 +96,7 @@ func (decoder *EbpfDecoder) DecodeInt8(msg *int8) error {
 	readAmount := 1
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int8(decoder.buffer[offset])
 	decoder.cursor += readAmount
@@ -108,7 +108,7 @@ func (decoder *EbpfDecoder) DecodeUint16(msg *uint16) error {
 	readAmount := 2
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.LittleEndian.Uint16(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -120,7 +120,7 @@ func (decoder *EbpfDecoder) DecodeUint16BigEndian(msg *uint16) error {
 	readAmount := 2
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.BigEndian.Uint16(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -132,7 +132,7 @@ func (decoder *EbpfDecoder) DecodeInt16(msg *int16) error {
 	readAmount := 2
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int16(binary.LittleEndian.Uint16(decoder.buffer[offset : offset+readAmount]))
 	decoder.cursor += readAmount
@@ -144,7 +144,7 @@ func (decoder *EbpfDecoder) DecodeUint32(msg *uint32) error {
 	readAmount := 4
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -156,7 +156,7 @@ func (decoder *EbpfDecoder) DecodeUint32BigEndian(msg *uint32) error {
 	readAmount := 4
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.BigEndian.Uint32(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -168,7 +168,7 @@ func (decoder *EbpfDecoder) DecodeInt32(msg *int32) error {
 	readAmount := 4
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int32(binary.LittleEndian.Uint32(decoder.buffer[offset : offset+readAmount]))
 	decoder.cursor += readAmount
@@ -180,7 +180,7 @@ func (decoder *EbpfDecoder) DecodeUint64(msg *uint64) error {
 	readAmount := 8
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -192,7 +192,7 @@ func (decoder *EbpfDecoder) DecodeInt64(msg *int64) error {
 	readAmount := 8
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int64(binary.LittleEndian.Uint64(decoder.buffer[decoder.cursor : decoder.cursor+readAmount]))
 	decoder.cursor += readAmount
@@ -203,7 +203,7 @@ func (decoder *EbpfDecoder) DecodeInt64(msg *int64) error {
 func (decoder *EbpfDecoder) DecodeBool(msg *bool) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < 1 {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	*msg = (decoder.buffer[offset] != 0)
 	decoder.cursor += 1
@@ -215,7 +215,7 @@ func (decoder *EbpfDecoder) DecodeBytes(msg []byte, size uint32) error {
 	offset := decoder.cursor
 	castedSize := int(size)
 	if len(decoder.buffer[offset:]) < castedSize {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	_ = copy(msg[:], decoder.buffer[offset:offset+castedSize])
 	decoder.cursor += castedSize
@@ -226,7 +226,7 @@ func (decoder *EbpfDecoder) DecodeBytes(msg []byte, size uint32) error {
 func (decoder *EbpfDecoder) DecodeIntArray(msg []int32, size uint32) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(size*4) {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	for i := 0; i < int(size); i++ {
 		msg[i] = int32(binary.LittleEndian.Uint32(decoder.buffer[decoder.cursor : decoder.cursor+4]))
@@ -240,13 +240,13 @@ func (decoder *EbpfDecoder) DecodeUint64Array(msg *[]uint64) error {
 	var arrLen uint8
 	err := decoder.DecodeUint8(&arrLen)
 	if err != nil {
-		return fmt.Errorf("error reading ulong array number of elements: %v", err)
+		return logger.NewErrorf("error reading ulong array number of elements: %v", err)
 	}
 	for i := 0; i < int(arrLen); i++ {
 		var element uint64
 		err := decoder.DecodeUint64(&element)
 		if err != nil {
-			return fmt.Errorf("can't read element %d uint64 from buffer: %s", i, err)
+			return logger.NewErrorf("can't read element %d uint64 from buffer: %s", i, err)
 		}
 		*msg = append(*msg, element)
 	}
@@ -257,7 +257,7 @@ func (decoder *EbpfDecoder) DecodeUint64Array(msg *[]uint64) error {
 func (decoder *EbpfDecoder) DecodeSlimCred(slimCred *SlimCred) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < 80 {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	slimCred.Uid = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
 	slimCred.Gid = binary.LittleEndian.Uint32(decoder.buffer[offset+4 : offset+8])
@@ -282,7 +282,7 @@ func (decoder *EbpfDecoder) DecodeSlimCred(slimCred *SlimCred) error {
 func (decoder *EbpfDecoder) DecodeChunkMeta(chunkMeta *ChunkMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(chunkMeta.GetSizeBytes()) {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	chunkMeta.BinType = BinType(decoder.buffer[offset])
 	chunkMeta.CgroupID = binary.LittleEndian.Uint64(decoder.buffer[offset+1 : offset+9])
@@ -297,7 +297,7 @@ func (decoder *EbpfDecoder) DecodeChunkMeta(chunkMeta *ChunkMeta) error {
 func (decoder *EbpfDecoder) DecodeVfsWriteMeta(vfsWriteMeta *VfsWriteMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(vfsWriteMeta.GetSizeBytes()) {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	vfsWriteMeta.DevID = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
 	vfsWriteMeta.Inode = binary.LittleEndian.Uint64(decoder.buffer[offset+4 : offset+12])
@@ -311,7 +311,7 @@ func (decoder *EbpfDecoder) DecodeVfsWriteMeta(vfsWriteMeta *VfsWriteMeta) error
 func (decoder *EbpfDecoder) DecodeKernelModuleMeta(kernelModuleMeta *KernelModuleMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(kernelModuleMeta.GetSizeBytes()) {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	kernelModuleMeta.DevID = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
 	kernelModuleMeta.Inode = binary.LittleEndian.Uint64(decoder.buffer[offset+4 : offset+12])
@@ -325,7 +325,7 @@ func (decoder *EbpfDecoder) DecodeKernelModuleMeta(kernelModuleMeta *KernelModul
 func (decoder *EbpfDecoder) DecodeMprotectWriteMeta(mprotectWriteMeta *MprotectWriteMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(mprotectWriteMeta.GetSizeBytes()) {
-		return fmt.Errorf("can't read context from buffer: buffer too short")
+		return logger.NewErrorf("can't read context from buffer: buffer too short")
 	}
 	mprotectWriteMeta.Ts = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+8])
 	decoder.cursor += int(mprotectWriteMeta.GetSizeBytes())

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -166,8 +166,11 @@ func TestReadArgFromBuff(t *testing.T) {
 	for _, tc := range testCases {
 		decoder := New(tc.input)
 		_, actual, err := ReadArgFromBuff(0, decoder, tc.params)
-		assert.Equal(t, tc.expectedError, err, tc.name)
-		assert.Equal(t, tc.expectedArg, actual.Value, tc.name)
+
+		if tc.expectedError != nil {
+			assert.ErrorContains(t, err, tc.expectedError.Error())
+		}
+		assert.Equal(t, tc.expectedArg, actual.Value)
 
 		if tc.name == "unknown" {
 			continue

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -45,7 +45,7 @@ func Initialize(bypass bool) error {
 		err = caps.initialize(bypass)
 	})
 
-	return err
+	return logger.ErrorFunc(err)
 }
 
 // GetInstance returns current "caps" instance. It initializes capabilities if
@@ -78,7 +78,7 @@ func (c *Capabilities) initialize(bypass bool) error {
 
 	err := c.getProc()
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	for c := range c.all {
@@ -87,7 +87,7 @@ func (c *Capabilities) initialize(bypass bool) error {
 
 	err = c.setProc()
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// The base for required capabilities (ring1) depends on the following:
@@ -140,7 +140,7 @@ func (c *Capabilities) Privileged(cb func() error) error {
 
 		err = c.apply(Privileged) // ring0 as effective for callback exec
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -149,7 +149,7 @@ func (c *Capabilities) Privileged(cb func() error) error {
 	if !c.bypass {
 		err = c.apply(Unprivileged) // back to ring3
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -166,7 +166,7 @@ func (c *Capabilities) Required(cb func() error) error {
 
 		err = c.apply(Required) // ring1 as effective
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -175,7 +175,7 @@ func (c *Capabilities) Required(cb func() error) error {
 	if !c.bypass {
 		err = c.apply(Unprivileged) // back to ring3
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -196,15 +196,15 @@ func (c *Capabilities) Requested(cb func() error, values ...cap.Value) error {
 
 		err = c.set(Requested, values...)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 		err = c.apply(Requested) // ring2 as effective
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 		err = c.unset(Requested, values...) // clean requested (for next calls)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -216,7 +216,7 @@ func (c *Capabilities) Requested(cb func() error, values ...cap.Value) error {
 	if !c.bypass {
 		err = c.apply(Unprivileged)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -239,7 +239,7 @@ func (c *Capabilities) Require(values ...cap.Value) error {
 	err = c.set(Required, values...) // populate ring1 (Required)
 	c.lock.Unlock()
 
-	return err
+	return logger.ErrorFunc(err)
 }
 
 // Unrequire is only called when command line "capabilities drop=X" is given.
@@ -257,7 +257,7 @@ func (c *Capabilities) Unrequire(values ...cap.Value) error {
 	err = c.unset(Required, values...) // unpopulate ring1 (Required)
 	c.lock.Unlock()
 
-	return err
+	return logger.ErrorFunc(err)
 }
 
 // Private Methods
@@ -303,7 +303,7 @@ func (c *Capabilities) apply(t ringType) error {
 
 	err = c.getProc()
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	logger.Debug("capabilities change")
@@ -314,7 +314,7 @@ func (c *Capabilities) apply(t ringType) error {
 		}
 		err = c.have.SetFlag(cap.Effective, v[t], k)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/mount"
 )
 
@@ -62,7 +63,7 @@ func NewCgroups() (*Cgroups, error) {
 	// discover the default cgroup being used
 	defaultVersion, err := GetCgroupDefaultVersion()
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	// only start cgroupv1 if it is the OS default (orelse it isn't needed)
@@ -70,7 +71,7 @@ func NewCgroups() (*Cgroups, error) {
 		cgroupv1, err = NewCgroup(CgroupVersion1)
 		if err != nil {
 			if _, ok := err.(*VersionNotSupported); !ok {
-				return nil, err
+				return nil, logger.ErrorFunc(err)
 			}
 		}
 	}
@@ -79,7 +80,7 @@ func NewCgroups() (*Cgroups, error) {
 	cgroupv2, err = NewCgroup(CgroupVersion2)
 	if err != nil {
 		if _, ok := err.(*VersionNotSupported); !ok {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 	}
 
@@ -102,7 +103,7 @@ func NewCgroups() (*Cgroups, error) {
 		// discover default cgroup controller hierarchy id for cgroupv1
 		hid, err = GetCgroupControllerHierarchy(CgroupDefaultController)
 		if err != nil {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 
 	case CgroupVersion2:
@@ -126,7 +127,7 @@ func (cs *Cgroups) Destroy() error {
 	if cs.cgroupv1 != nil {
 		err := cs.cgroupv1.destroy()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 	if cs.cgroupv2 != nil {
@@ -193,7 +194,7 @@ func (c *CgroupV1) init() error {
 	// 0. check if cgroup type is supported
 	supported, err := mount.IsFileSystemSupported(CgroupVersion1.String())
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	if !supported {
 		return &VersionNotSupported{}
@@ -207,7 +208,7 @@ func (c *CgroupV1) init() error {
 		sysFsCgroup, // where to check for already mounted cgroupfs
 	)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// 2. discover where cgroup is mounted
@@ -244,7 +245,7 @@ func (c *CgroupV2) init() error {
 	// 0. check if cgroup type is supported
 	supported, err := mount.IsFileSystemSupported(CgroupVersion2.String())
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	if !supported {
 		return &VersionNotSupported{}
@@ -258,7 +259,7 @@ func (c *CgroupV2) init() error {
 		sysFsCgroup, // where to check for already mounted cgroupfs
 	)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// 2. discover where cgroup is mounted
@@ -384,7 +385,7 @@ func GetCgroupControllerHierarchy(subsys string) (int, error) {
 func GetCgroupPath(rootDir string, cgroupId uint64, subPath string) (string, error) {
 	entries, err := os.ReadDir(rootDir)
 	if err != nil {
-		return "", err
+		return "", logger.ErrorFunc(err)
 	}
 
 	for _, entry := range entries {

--- a/pkg/cmd/flags/cache.go
+++ b/pkg/cmd/flags/cache.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/events/queue"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func cacheHelp() string {
@@ -34,7 +34,7 @@ func PrepareCache(cacheSlice []string) (queue.CacheConfig, error) {
 	for _, o := range cacheSlice {
 		cacheParts := strings.SplitN(o, "=", 2)
 		if len(cacheParts) != 2 {
-			return cache, fmt.Errorf("unrecognized cache option format: %s", o)
+			return cache, logger.NewErrorf("unrecognized cache option format: %s", o)
 		}
 		key := cacheParts[0]
 		value := cacheParts[1]
@@ -45,19 +45,19 @@ func PrepareCache(cacheSlice []string) (queue.CacheConfig, error) {
 			case "mem":
 				cacheTypeMem = true
 			default:
-				return nil, fmt.Errorf("unrecognized cache-mem option: %s (valid options are: none,mem)", o)
+				return nil, logger.NewErrorf("unrecognized cache-mem option: %s (valid options are: none,mem)", o)
 			}
 		case "mem-cache-size":
 			if !cacheTypeMem {
-				return nil, fmt.Errorf("you need to specify cache-type=mem before setting mem-cache-size")
+				return nil, logger.NewErrorf("you need to specify cache-type=mem before setting mem-cache-size")
 			}
 			eventsCacheMemSizeMb, err = strconv.Atoi(value)
 			if err != nil {
-				return nil, fmt.Errorf("could not parse mem-cache-size value: %v", err)
+				return nil, logger.NewErrorf("could not parse mem-cache-size value: %v", err)
 			}
 
 		default:
-			return nil, fmt.Errorf("unrecognized cache option format: %s", o)
+			return nil, logger.NewErrorf("unrecognized cache option format: %s", o)
 		}
 	}
 	if cacheTypeMem {

--- a/pkg/cmd/flags/capabilities.go
+++ b/pkg/cmd/flags/capabilities.go
@@ -1,11 +1,11 @@
 package flags
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func capabilitiesHelp() string {
@@ -35,7 +35,7 @@ func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) 
 			if b == "0" || b == "false" {
 				capsConfig.BypassCaps = false
 			} else if b != "1" && b != "true" {
-				return capsConfig, fmt.Errorf("bypass should either be true or false")
+				return capsConfig, logger.NewErrorf("bypass should either be true or false")
 			}
 		}
 		if strings.HasPrefix(slice, "add=") {
@@ -65,7 +65,7 @@ func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) 
 	for _, a := range capsConfig.AddCaps {
 		for _, d := range capsConfig.DropCaps {
 			if a == d {
-				return capsConfig, fmt.Errorf("cant add and drop %v at the same time", a)
+				return capsConfig, logger.NewErrorf("cant add and drop %v at the same time", a)
 			}
 		}
 	}

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -1,13 +1,13 @@
 package flags
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func captureHelp() string {
@@ -94,7 +94,7 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 			capture.FileWrite = true
 			pathPrefix := strings.TrimSuffix(strings.TrimPrefix(cap, "write="), "*")
 			if len(pathPrefix) == 0 {
-				return tracee.CaptureConfig{}, fmt.Errorf("capture write filter cannot be empty")
+				return tracee.CaptureConfig{}, logger.NewErrorf("capture write filter cannot be empty")
 			}
 			filterFileWrite = append(filterFileWrite, pathPrefix)
 		} else if cap == "exec" {
@@ -155,10 +155,10 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 				context = strings.TrimSuffix(context, "b")
 				amount, err = strconv.ParseUint(context, 10, 64)
 			} else {
-				return tracee.CaptureConfig{}, fmt.Errorf("could not parse pcap snaplen: missing b or kb ?")
+				return tracee.CaptureConfig{}, logger.NewErrorf("could not parse pcap snaplen: missing b or kb ?")
 			}
 			if err != nil {
-				return tracee.CaptureConfig{}, fmt.Errorf("could not parse pcap snaplen: %v", err)
+				return tracee.CaptureConfig{}, logger.NewErrorf("could not parse pcap snaplen: %v", err)
 			}
 			if amount >= (1 << 16) {
 				amount = (1 << 16) - 1
@@ -169,10 +169,10 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 		} else if strings.HasPrefix(cap, "dir:") {
 			outDir = strings.TrimPrefix(cap, "dir:")
 			if len(outDir) == 0 {
-				return tracee.CaptureConfig{}, fmt.Errorf("capture output dir cannot be empty")
+				return tracee.CaptureConfig{}, logger.NewErrorf("capture output dir cannot be empty")
 			}
 		} else {
-			return tracee.CaptureConfig{}, fmt.Errorf("invalid capture option specified, use '--capture help' for more info")
+			return tracee.CaptureConfig{}, logger.NewErrorf("invalid capture option specified, use '--capture help' for more info")
 		}
 	}
 	capture.FilterFileWrite = filterFileWrite

--- a/pkg/cmd/flags/containers.go
+++ b/pkg/cmd/flags/containers.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/containers/runtime"
@@ -58,19 +57,19 @@ func PrepareContainers(containerFlags []string) (runtime.Sockets, error) {
 	for _, flag := range containerFlags {
 		parts := strings.Split(flag, ":")
 		if len(parts) != 2 {
-			return sockets, fmt.Errorf("failed to parse container flags (must be of format {runtime}:{socket path})")
+			return sockets, logger.NewErrorf("failed to parse container flags (must be of format {runtime}:{socket path})")
 		}
 		containerRuntime := parts[0]
 
 		if !contains(supportedRuntimes, containerRuntime) {
-			return sockets, fmt.Errorf("provided unsupported container runtime (see --crs help for supported runtimes)")
+			return sockets, logger.NewErrorf("provided unsupported container runtime (see --crs help for supported runtimes)")
 		}
 
 		socket := parts[1]
 		err := sockets.Register(runtime.FromString(containerRuntime), socket)
 
 		if err != nil {
-			return sockets, fmt.Errorf("failed to register runtime socket, %s", err.Error())
+			return sockets, logger.NewErrorf("failed to register runtime socket, %s", err.Error())
 		}
 	}
 

--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -543,7 +543,7 @@ func (filter *cliFilter) Parse(operatorAndValues string) error {
 
 	if operatorString == "!" {
 		if len(operatorAndValues) < 3 {
-			return fmt.Errorf("invalid operator and/or values given to filter: %s", operatorAndValues)
+			return logger.NewErrorf("invalid operator and/or values given to filter: %s", operatorAndValues)
 		}
 		operatorString = operatorAndValues[0:2]
 		valuesString = operatorAndValues[2:]
@@ -558,7 +558,7 @@ func (filter *cliFilter) Parse(operatorAndValues string) error {
 		case "!=":
 			filter.NotEqual = append(filter.NotEqual, values[i])
 		default:
-			return fmt.Errorf("invalid filter operator: %s", operatorString)
+			return logger.NewErrorf("invalid filter operator: %s", operatorString)
 		}
 	}
 

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -545,7 +545,7 @@ func TestPrepareCapture(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, tc.expectedCapture, capture, tc.testName)
 				} else {
-					require.Equal(t, tc.expectedError, err, tc.testName)
+					assert.ErrorContains(t, err, tc.expectedError.Error(), tc.testName)
 					assert.Empty(t, capture, tc.testName)
 				}
 			})
@@ -730,7 +730,7 @@ func TestPrepareOutput(t *testing.T) {
 		t.Run(testcase.testName, func(t *testing.T) {
 			output, err := flags.PrepareOutput(testcase.outputSlice)
 			if err != nil {
-				assert.Equal(t, testcase.expectedError, err)
+				assert.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {
 				assert.Equal(t, testcase.expectedOutput.LogFile, output.LogFile)
 				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
@@ -784,7 +784,9 @@ func TestPrepareCache(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testName, func(t *testing.T) {
 			cache, err := flags.PrepareCache(testcase.cacheSlice)
-			assert.Equal(t, testcase.expectedError, err)
+			if testcase.expectedError != nil {
+				assert.ErrorContains(t, err, testcase.expectedError.Error())
+			}
 			assert.Equal(t, testcase.expectedCache, cache)
 		})
 	}
@@ -837,7 +839,7 @@ func TestPrepareRego(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, tc.expectedRego, rego, tc.testName)
 				} else {
-					require.Equal(t, tc.expectedError, err, tc.testName)
+					assert.ErrorContains(t, err, tc.expectedError.Error(), tc.testName)
 					assert.Empty(t, rego, tc.testName)
 				}
 			})

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -30,7 +29,7 @@ Examples:
 }
 
 func InvalidLogOption(opt string) error {
-	return fmt.Errorf("invalid log option: %s, use '--log help' for more info", opt)
+	return logger.NewErrorf("invalid log option: %s, use '--log help' for more info", opt)
 }
 
 func PrepareLogger(logOptions []string, w io.Writer) (*logger.LoggerConfig, error) {

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -9,6 +8,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func outputHelp() string {
@@ -115,10 +115,10 @@ func PrepareOutput(outputSlice []string) (OutputConfig, error) {
 			case "sort-events":
 				traceeConfig.EventsSorting = true
 			default:
-				return outConfig, fmt.Errorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
+				return outConfig, logger.NewErrorf("invalid output option: %s, use '--output help' for more info", outputParts[1])
 			}
 		default:
-			return outConfig, fmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
+			return outConfig, logger.NewErrorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
 		}
 	}
 
@@ -163,7 +163,7 @@ func validateFormat(printerKind string) error {
 		printerKind != "json" &&
 		printerKind != "gob" &&
 		!strings.HasPrefix(printerKind, "gotemplate=") {
-		return fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
+		return logger.NewErrorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
 	}
 
 	return nil
@@ -172,14 +172,14 @@ func validateFormat(printerKind string) error {
 func createFile(path string) (*os.File, error) {
 	fileInfo, err := os.Stat(path)
 	if err == nil && fileInfo.IsDir() {
-		return nil, fmt.Errorf("cannot use a path of existing directory %s", path)
+		return nil, logger.NewErrorf("cannot use a path of existing directory %s", path)
 	}
 
 	dir := filepath.Dir(path)
 	os.MkdirAll(dir, 0755)
 	file, err := os.Create(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create output path: %v", err)
+		return nil, logger.NewErrorf("failed to create output path: %v", err)
 	}
 
 	return file, nil
@@ -189,12 +189,12 @@ func parseForwardFlag(o string) (*url.URL, error) {
 	// Split out just the config
 	forwardConfigParts := strings.SplitN(o, ":", 2)
 	if len(forwardConfigParts) != 2 {
-		return nil, fmt.Errorf("invalid configuration for forward output: %q. Use '--output help' for more info", o)
+		return nil, logger.NewErrorf("invalid configuration for forward output: %q. Use '--output help' for more info", o)
 	}
 	// Now parse our URL using the standard library and report any errors from basic parsing.
 	forwardURL, err := url.Parse(forwardConfigParts[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid configuration for forward output (%s): %w. Use '--output help' for more info", forwardConfigParts[1], err)
+		return nil, logger.NewErrorf("invalid configuration for forward output (%s): %v. Use '--output help' for more info", forwardConfigParts[1], err)
 	}
 
 	return forwardURL, nil

--- a/pkg/cmd/flags/rego.go
+++ b/pkg/cmd/flags/rego.go
@@ -1,9 +1,9 @@
 package flags
 
 import (
-	"errors"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/signatures/rego"
 	"github.com/open-policy-agent/opa/compile"
 )
@@ -39,7 +39,7 @@ func PrepareRego(regoSlice []string) (rego.Config, error) {
 		case "aio":
 			c.AIO = true
 		default:
-			return rego.Config{}, errors.New("invalid rego option specified, use '--rego help' for more info")
+			return rego.Config{}, logger.NewErrorf("invalid rego option specified, use '--rego help' for more info")
 		}
 	}
 

--- a/pkg/cmd/flags/server/server.go
+++ b/pkg/cmd/flags/server/server.go
@@ -1,8 +1,7 @@
 package server
 
 import (
-	"errors"
-
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/server"
 )
 
@@ -20,7 +19,7 @@ const (
 
 func PrepareServer(listenAddr string, metrics, healthz, pprof bool) (*server.Server, error) {
 	if len(listenAddr) == 0 {
-		return nil, errors.New("listen address cannot be empty")
+		return nil, logger.NewErrorf("listen address cannot be empty")
 	}
 
 	if metrics || healthz || pprof {

--- a/pkg/cmd/initialize/kernelconfig.go
+++ b/pkg/cmd/initialize/kernelconfig.go
@@ -1,8 +1,6 @@
 package initialize
 
 import (
-	"fmt"
-
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
@@ -22,7 +20,7 @@ func KernelConfig() (*helpers.KernelConfig, error) {
 	kernelConfig.AddNeeded(helpers.CONFIG_BPF_EVENTS, helpers.BUILTIN)
 	missing := kernelConfig.CheckMissing() // do fail if we found os-release file and it is not enough
 	if len(missing) > 0 {
-		return nil, fmt.Errorf("missing kernel configuration options: %s", missing)
+		return nil, logger.NewErrorf("missing kernel configuration options: %s", missing)
 	}
 	return kernelConfig, nil
 }

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -64,7 +64,7 @@ func TestPrepareOutputPrinterConfig(t *testing.T) {
 		t.Run(testcase.testName, func(t *testing.T) {
 			outputConfig, err := flags.PrepareOutput(testcase.outputSlice)
 			if err != nil {
-				assert.Equal(t, testcase.expectedError, err)
+				assert.ErrorContains(t, err, testcase.expectedError.Error())
 			} else {
 				assert.Equal(t, testcase.expectedPrinter, outputConfig.PrinterConfig)
 			}

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -23,7 +23,7 @@ func (r Runner) Run(ctx context.Context) error {
 
 	t, err := tracee.New(r.TraceeConfig)
 	if err != nil {
-		return fmt.Errorf("error creating Tracee: %v", err)
+		return logger.NewErrorf("error creating Tracee: %v", err)
 	}
 
 	// Decide if HTTP server should be started
@@ -43,7 +43,7 @@ func (r Runner) Run(ctx context.Context) error {
 
 	printer, err := printer.New(r.PrinterConfig)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// Print statistics at the end
@@ -58,7 +58,7 @@ func (r Runner) Run(ctx context.Context) error {
 
 	err = t.Init()
 	if err != nil {
-		return fmt.Errorf("error initializing Tracee: %v", err)
+		return logger.NewErrorf("error initializing Tracee: %v", err)
 	}
 
 	// Print the preamble and start event channel reception

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -1,8 +1,6 @@
 package urfave
 
 import (
-	"fmt"
-
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/cmd"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
@@ -112,7 +110,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 		logger.Debug("osinfo", "lockdown", err)
 	}
 	if err == nil && lockdown == helpers.CONFIDENTIALITY {
-		return runner, fmt.Errorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs")
+		return runner, logger.NewErrorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs")
 
 	}
 
@@ -140,7 +138,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 	traceeInstallPath := c.String("install-path")
 	err = initialize.BpfObject(&cfg, kernelConfig, OSInfo, traceeInstallPath, version)
 	if err != nil {
-		return runner, fmt.Errorf("failed preparing BPF object: %w", err)
+		return runner, logger.NewErrorf("failed preparing BPF object: %v", err)
 	}
 
 	cfg.ChanEvents = make(chan trace.Event, 1000)

--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/bucketscache"
 	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 // ContainerPathResolver generates an accessible absolute path from the root mount namespace to a
@@ -33,7 +34,7 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 ) {
 	// path should be absolute, except, for example, memfd_create files
 	if mountNSAbsolutePath == "" || mountNSAbsolutePath[0] != '/' {
-		return "", fmt.Errorf("file path is not absolute in its container mount point")
+		return "", logger.NewErrorf("file path is not absolute in its container mount point")
 	}
 	// try to access the root fs via another process in the same mount namespace
 	// (since the current process might have already died)
@@ -44,10 +45,10 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 		err := capabilities.GetInstance().Required(func() error {
 			entries, err := fs.ReadDir(cPathRes.fs, strings.TrimPrefix(procRootPath, "/"))
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 			if len(entries) == 0 {
-				return fmt.Errorf("empty directory")
+				return logger.NewErrorf("empty directory")
 			}
 			return nil
 		})
@@ -55,5 +56,5 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 			return fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath), nil
 		}
 	}
-	return "", fmt.Errorf("has no access to container fs - no living task of mountns %d", mountNS)
+	return "", logger.NewErrorf("has no access to container fs - no living task of mountns %d", mountNS)
 }

--- a/pkg/containers/runtime/crio.go
+++ b/pkg/containers/runtime/crio.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	cri "github.com/kubernetes/cri-api/pkg/apis/runtime/v1alpha2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -17,7 +18,7 @@ func CrioEnricher(socket string) (ContainerEnricher, error) {
 	unixSocket := "unix://" + strings.TrimPrefix(socket, "unix://")
 	conn, err := grpc.Dial(unixSocket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	client := cri.NewRuntimeServiceClient(conn)
 
@@ -37,7 +38,7 @@ func (e *crioEnricher) Get(containerId string, ctx context.Context) (ContainerMe
 		Verbose:     true,
 	})
 	if err != nil {
-		return metadata, err
+		return metadata, logger.ErrorFunc(err)
 	}
 
 	//if in k8s we can extract pod info from labels

--- a/pkg/containers/runtime/docker.go
+++ b/pkg/containers/runtime/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	docker "github.com/docker/docker/client"
 )
 
@@ -15,7 +16,7 @@ func DockerEnricher(socket string) (ContainerEnricher, error) {
 	unixSocket := "unix://" + strings.TrimPrefix(socket, "unix://")
 	cli, err := docker.NewClientWithOpts(docker.WithHost(unixSocket), docker.WithAPIVersionNegotiation())
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	enricher := &dockerEnricher{}
@@ -30,7 +31,7 @@ func (e *dockerEnricher) Get(containerId string, ctx context.Context) (Container
 	}
 	resp, err := e.client.ContainerInspect(ctx, containerId)
 	if err != nil {
-		return metadata, err
+		return metadata, logger.ErrorFunc(err)
 	}
 	container := (*resp.ContainerJSONBase)
 	metadata.Name = container.Name

--- a/pkg/containers/runtime/sockets.go
+++ b/pkg/containers/runtime/sockets.go
@@ -1,8 +1,9 @@
 package runtime
 
 import (
-	"fmt"
 	"os"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 // Sockets represent existing container runtime connections
@@ -18,7 +19,7 @@ func (s *Sockets) Register(runtime RuntimeId, socket string) error {
 
 	_, err := os.Stat(socket)
 	if err != nil {
-		return fmt.Errorf("failed to register runtime socket %v", err)
+		return logger.NewErrorf("failed to register runtime socket %v", err)
 	}
 	s.sockets[runtime] = socket
 	return nil

--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"sync/atomic"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 type Counter struct {
@@ -23,7 +25,7 @@ func (c *Counter) Increment(amount ...uint64) error {
 
 	sum, err := sumUint64(amount...)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	return c.incAtomic(sum)
@@ -36,7 +38,7 @@ func (c *Counter) Decrement(amount ...uint64) error {
 
 	sum, err := sumUint64(amount...)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	return c.decAtomic(sum)
@@ -86,9 +88,9 @@ func sumUint64(values ...uint64) (uint64, error) {
 }
 
 func errorCounterWrapAround() error {
-	return fmt.Errorf("counter: wrap around")
+	return logger.NewErrorf("counter: wrap around")
 }
 
 func errorCounterSumWrapAround() error {
-	return fmt.Errorf("counter sum: wrap around")
+	return logger.NewErrorf("counter sum: wrap around")
 }

--- a/pkg/ebpf/bpf_log.go
+++ b/pkg/ebpf/bpf_log.go
@@ -139,7 +139,7 @@ func (b BPFLog) Size() int {
 
 func (b *BPFLog) Decode(rawBuffer []byte) error {
 	if len(rawBuffer) < b.Size() {
-		return fmt.Errorf("can't decode log raw data - buffer of %d should have at least %d bytes", len(rawBuffer), b.Size())
+		return logger.NewErrorf("can't decode log raw data - buffer of %d should have at least %d bytes", len(rawBuffer), b.Size())
 	}
 
 	b.id = BPFLogType(binary.LittleEndian.Uint32(rawBuffer[0:4]))
@@ -167,7 +167,7 @@ func (t *Tracee) processBPFLogs() {
 
 			bpfLog := BPFLog{}
 			if err := bpfLog.Decode(rawData); err != nil {
-				t.handleError(fmt.Errorf("consume BPFLogsChannel: decode - %v", err))
+				t.handleError(logger.NewErrorf("consume BPFLogsChannel: decode - %v", err))
 				continue
 			}
 			// This logger timestamp in no way reflects the bpf log original time

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -1,9 +1,8 @@
 package ebpf
 
 import (
-	"fmt"
-
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -14,12 +13,12 @@ func FindingToEvent(f detect.Finding) (*trace.Event, error) {
 	s, ok := f.Event.Payload.(trace.Event)
 
 	if !ok {
-		return nil, fmt.Errorf("error converting finding to event: %s", f.SigMetadata.ID)
+		return nil, logger.NewErrorf("error converting finding to event: %s", f.SigMetadata.ID)
 	}
 
 	eventID, found := events.Definitions.GetID(f.SigMetadata.EventName)
 	if !found {
-		return nil, fmt.Errorf("error finding event not found: %s", f.SigMetadata.EventName)
+		return nil, logger.NewErrorf("error finding event not found: %s", f.SigMetadata.EventName)
 	}
 
 	return newEvent(int(eventID), f, s), nil

--- a/pkg/ebpf/initialization/kconfig.go
+++ b/pkg/ebpf/initialization/kconfig.go
@@ -21,7 +21,7 @@ func LoadKconfigValues(kc *helpers.KernelConfig) (map[helpers.KernelConfigOption
 	var err error
 	for key, keyString := range kconfigUsed {
 		if err = kc.AddCustomKernelConfig(key, keyString); err != nil {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/ebpf/probes/common.go
+++ b/pkg/ebpf/probes/common.go
@@ -1,9 +1,8 @@
 package probes
 
 import (
-	"fmt"
-
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 // enableDisableAutoload enables or disables an eBPF program autoload setting
@@ -11,12 +10,12 @@ func enableDisableAutoload(module *bpf.Module, programName string, autoload bool
 	var err error
 
 	if module == nil || programName == "" {
-		return fmt.Errorf("incorrect arguments (program: %s)", programName)
+		return logger.NewErrorf("incorrect arguments (program: %s)", programName)
 	}
 
 	prog, err := module.GetProgram(programName)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	return prog.SetAutoload(autoload)

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -1,9 +1,8 @@
 package probes
 
 import (
-	"fmt"
-
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 //
@@ -132,7 +131,7 @@ func Init(module *bpf.Module, netEnabled bool) (Probes, error) {
 // Attach attaches given handle's program to its hook
 func (p *probes) Attach(handle Handle, args ...interface{}) error {
 	if _, ok := p.probes[handle]; !ok {
-		return fmt.Errorf("probe handle (%d) does not exist", handle)
+		return logger.NewErrorf("probe handle (%d) does not exist", handle)
 	}
 
 	return p.probes[handle].attach(p.module, args...)
@@ -141,7 +140,7 @@ func (p *probes) Attach(handle Handle, args ...interface{}) error {
 // Detach detaches given handle's program from its hook
 func (p *probes) Detach(handle Handle, args ...interface{}) error {
 	if _, ok := p.probes[handle]; !ok {
-		return fmt.Errorf("probe handle (%d) does not exist", handle)
+		return logger.NewErrorf("probe handle (%d) does not exist", handle)
 	}
 
 	return p.probes[handle].detach(args...)
@@ -152,7 +151,7 @@ func (p *probes) DetachAll() error {
 	for _, pr := range p.probes {
 		err := pr.detach()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/ebpf/probes/trace.go
+++ b/pkg/ebpf/probes/trace.go
@@ -1,10 +1,10 @@
 package probes
 
 import (
-	"fmt"
 	"strings"
 
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 //
@@ -38,12 +38,12 @@ func (p *traceProbe) attach(module *bpf.Module, args ...interface{}) error {
 	}
 
 	if module == nil {
-		return fmt.Errorf("incorrect arguments for event: %s", p.eventName)
+		return logger.NewErrorf("incorrect arguments for event: %s", p.eventName)
 	}
 
 	prog, err := module.GetProgram(p.programName)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	switch p.probeType {
@@ -62,7 +62,7 @@ func (p *traceProbe) attach(module *bpf.Module, args ...interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to attach event: %s (%v)", p.eventName, err)
+		return logger.NewErrorf("failed to attach event: %s (%v)", p.eventName, err)
 	}
 
 	p.bpfLink = link
@@ -80,7 +80,7 @@ func (p *traceProbe) detach(args ...interface{}) error {
 
 	err = p.bpfLink.Destroy()
 	if err != nil {
-		return fmt.Errorf("failed to detach event: %s (%v)", p.eventName, err)
+		return logger.NewErrorf("failed to detach event: %s (%v)", p.eventName, err)
 	}
 
 	p.bpfLink = nil // NOTE: needed so a new call to bpf_link__destroy() works

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -107,37 +106,37 @@ type InitValues struct {
 func (tc Config) Validate() error {
 	for filterScope := range tc.FilterScopes.Map() {
 		if filterScope == nil || filterScope.EventsToTrace == nil {
-			return fmt.Errorf("FilterScope or EventsToTrace is nil")
+			return logger.NewErrorf("FilterScope or EventsToTrace is nil")
 		}
 
 		for e := range filterScope.EventsToTrace {
 			_, exists := events.Definitions.GetSafe(e)
 			if !exists {
-				return fmt.Errorf("invalid event [%d] to trace in filter scope [%d]", e, filterScope.ID)
+				return logger.NewErrorf("invalid event [%d] to trace in filter scope [%d]", e, filterScope.ID)
 			}
 		}
 	}
 	if (tc.PerfBufferSize & (tc.PerfBufferSize - 1)) != 0 {
-		return fmt.Errorf("invalid perf buffer size - must be a power of 2")
+		return logger.NewErrorf("invalid perf buffer size - must be a power of 2")
 	}
 	if (tc.BlobPerfBufferSize & (tc.BlobPerfBufferSize - 1)) != 0 {
-		return fmt.Errorf("invalid perf buffer size - must be a power of 2")
+		return logger.NewErrorf("invalid perf buffer size - must be a power of 2")
 	}
 	if len(tc.Capture.FilterFileWrite) > 3 {
-		return fmt.Errorf("too many file-write filters given")
+		return logger.NewErrorf("too many file-write filters given")
 	}
 	for _, filter := range tc.Capture.FilterFileWrite {
 		if len(filter) > 50 {
-			return fmt.Errorf("the length of a path filter is limited to 50 characters: %s", filter)
+			return logger.NewErrorf("the length of a path filter is limited to 50 characters: %s", filter)
 		}
 	}
 
 	if tc.BPFObjBytes == nil {
-		return errors.New("nil bpf object in memory")
+		return logger.NewErrorf("nil bpf object in memory")
 	}
 
 	if tc.ChanEvents == nil {
-		return errors.New("nil events channel")
+		return logger.NewErrorf("nil events channel")
 	}
 
 	return nil
@@ -277,7 +276,7 @@ func (t *Tracee) handleEventsDependencies(eventId events.ID, submitMap uint64) {
 func New(cfg Config) (*Tracee, error) {
 	err := cfg.Validate()
 	if err != nil {
-		return nil, fmt.Errorf("validation error: %v", err)
+		return nil, logger.NewErrorf("validation error: %v", err)
 	}
 
 	// Create Tracee
@@ -291,7 +290,7 @@ func New(cfg Config) (*Tracee, error) {
 	// Initialize capabilities rings soon
 	err = capabilities.Initialize(t.config.Capabilities.BypassCaps)
 	if err != nil {
-		return t, err
+		return t, logger.ErrorFunc(err)
 	}
 	caps := capabilities.GetInstance()
 
@@ -324,7 +323,7 @@ func New(cfg Config) (*Tracee, error) {
 	for id := range t.events {
 		evt, ok := events.Definitions.GetSafe(id)
 		if !ok {
-			return t, fmt.Errorf("could not get event")
+			return t, logger.NewErrorf("could not get event")
 		}
 		for _, capArray := range evt.Dependencies.Capabilities {
 			caps.Require(capArray)
@@ -335,20 +334,20 @@ func New(cfg Config) (*Tracee, error) {
 
 	capsToAdd, err := capabilities.ReqByString(t.config.Capabilities.AddCaps...)
 	if err != nil {
-		return t, err
+		return t, logger.ErrorFunc(err)
 	}
 	err = caps.Require(capsToAdd...)
 	if err != nil {
-		return t, err
+		return t, logger.ErrorFunc(err)
 	}
 
 	capsToDrop, err := capabilities.ReqByString(t.config.Capabilities.DropCaps...)
 	if err != nil {
-		return t, err
+		return t, logger.ErrorFunc(err)
 	}
 	err = caps.Unrequire(capsToDrop...)
 	if err != nil {
-		return t, err
+		return t, logger.ErrorFunc(err)
 	}
 
 	// Register default event processors
@@ -369,7 +368,7 @@ func (t *Tracee) Init() error {
 
 	initReq, err := t.generateInitValues()
 	if err != nil {
-		return fmt.Errorf("failed to generate required init values: %s", err)
+		return logger.NewErrorf("failed to generate required init values: %s", err)
 	}
 
 	// Init kernel symbols map
@@ -377,7 +376,7 @@ func (t *Tracee) Init() error {
 	if initReq.kallsyms {
 		err = t.NewKernelSymbols()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -393,7 +392,7 @@ func (t *Tracee) Init() error {
 	var mntNSProcs map[int]int
 	err = capabilities.GetInstance().Requested(func() error {
 		mntNSProcs, err = proc.GetMountNSFirstProcesses()
-		return err
+		return logger.ErrorFunc(err)
 	},
 		cap.DAC_READ_SEARCH,
 		cap.SYS_PTRACE,
@@ -410,7 +409,7 @@ func (t *Tracee) Init() error {
 
 	t.cgroups, err = cgroup.NewCgroups()
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// Initialize containers enrichment logic
@@ -421,11 +420,11 @@ func (t *Tracee) Init() error {
 		"containers_map",
 	)
 	if err != nil {
-		return fmt.Errorf("error initializing containers: %w", err)
+		return logger.NewErrorf("error initializing containers: %v", err)
 	}
 
 	if err := t.containers.Populate(); err != nil {
-		return fmt.Errorf("error initializing containers: %w", err)
+		return logger.NewErrorf("error initializing containers: %v", err)
 	}
 
 	t.contPathResolver = containers.InitContainerPathResolver(&t.pidsInMntns)
@@ -435,7 +434,7 @@ func (t *Tracee) Init() error {
 
 	err = t.initDerivationTable()
 	if err != nil {
-		return fmt.Errorf("error initializing event derivation map: %w", err)
+		return logger.NewErrorf("error initializing event derivation map: %v", err)
 	}
 
 	// Initialize eBPF programs and maps
@@ -443,7 +442,7 @@ func (t *Tracee) Init() error {
 	err = t.initBPF()
 	if err != nil {
 		t.Close()
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// Initialize hashes for files
@@ -451,20 +450,20 @@ func (t *Tracee) Init() error {
 	t.fileHashes, err = lru.New(1024)
 	if err != nil {
 		t.Close()
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// Initialize capture directory
 
 	if err := os.MkdirAll(t.config.Capture.OutputPath, 0755); err != nil {
 		t.Close()
-		return fmt.Errorf("error creating output path: %w", err)
+		return logger.NewErrorf("error creating output path: %v", err)
 	}
 
 	t.outDir, err = utils.OpenExistingDir(t.config.Capture.OutputPath)
 	if err != nil {
 		t.Close()
-		return fmt.Errorf("error opening out directory: %w", err)
+		return logger.NewErrorf("error opening out directory: %v", err)
 	}
 
 	// Initialize network capture (all needed pcap files)
@@ -472,7 +471,7 @@ func (t *Tracee) Init() error {
 	t.netCapturePcap, err = pcaps.New(t.config.Capture.Net, t.outDir)
 	if err != nil {
 		t.Close()
-		return fmt.Errorf("error initializing network capture: %w", err)
+		return logger.NewErrorf("error initializing network capture: %v", err)
 	}
 
 	// Get reference to stack trace addresses map
@@ -480,7 +479,7 @@ func (t *Tracee) Init() error {
 	stackAddressesMap, err := t.bpfModule.GetMap("stack_addresses")
 	if err != nil {
 		t.Close()
-		return fmt.Errorf("error getting access to 'stack_addresses' eBPF Map %v", err)
+		return logger.NewErrorf("error getting access to 'stack_addresses' eBPF Map %v", err)
 	}
 	t.StackAddressesMap = stackAddressesMap
 
@@ -489,7 +488,7 @@ func (t *Tracee) Init() error {
 	fdArgPathMap, err := t.bpfModule.GetMap("fd_arg_path_map")
 	if err != nil {
 		t.Close()
-		return fmt.Errorf("error getting access to 'fd_arg_path_map' eBPF Map %v", err)
+		return logger.NewErrorf("error getting access to 'fd_arg_path_map' eBPF Map %v", err)
 	}
 	t.FDArgPathMap = fdArgPathMap
 
@@ -498,7 +497,7 @@ func (t *Tracee) Init() error {
 	if t.config.Output.EventsSorting {
 		t.eventsSorter, err = sorting.InitEventSorter()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -528,7 +527,7 @@ func (t *Tracee) generateInitValues() (InitValues, error) {
 	for evt := range t.events {
 		def, exists := events.Definitions.GetSafe(evt)
 		if !exists {
-			return initVals, fmt.Errorf("event with id %d doesn't exist", evt)
+			return initVals, logger.NewErrorf("event with id %d doesn't exist", evt)
 		}
 		if def.Dependencies.KSymbols != nil {
 			initVals.kallsyms = true
@@ -542,15 +541,15 @@ func (t *Tracee) generateInitValues() (InitValues, error) {
 func (t *Tracee) initTailCall(mapName string, mapIndexes []uint32, progName string) error {
 	bpfMap, err := t.bpfModule.GetMap(mapName)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	bpfProg, err := t.bpfModule.GetProgram(progName)
 	if err != nil {
-		return fmt.Errorf("could not get BPF program %s: %v", progName, err)
+		return logger.NewErrorf("could not get BPF program %s: %v", progName, err)
 	}
 	fd := bpfProg.FileDescriptor()
 	if fd < 0 {
-		return fmt.Errorf("could not get BPF program FD for %s: %v", progName, err)
+		return logger.NewErrorf("could not get BPF program FD for %s: %v", progName, err)
 	}
 
 	for _, index := range mapIndexes {
@@ -559,16 +558,16 @@ func (t *Tracee) initTailCall(mapName string, mapIndexes []uint32, progName stri
 		if def.Syscall {
 			err := t.probes.Attach(probes.SyscallEnter__Internal)
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 			err = t.probes.Attach(probes.SyscallExit__Internal)
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 		}
 		err := bpfMap.Update(unsafe.Pointer(&index), unsafe.Pointer(&fd))
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 	return nil
@@ -702,7 +701,7 @@ func (t *Tracee) initDerivationTable() error {
 // RegisterEventDerivation registers an event derivation handler for tracee to use in the event pipeline
 func (t *Tracee) RegisterEventDerivation(deriveFrom events.ID, deriveTo events.ID, deriveCondition func() bool, deriveLogic derive.DeriveFunction) error {
 	if t.eventDerivations == nil {
-		return fmt.Errorf("tracee not initialized yet")
+		return logger.NewErrorf("tracee not initialized yet")
 	}
 
 	return t.eventDerivations.Register(deriveFrom, deriveTo, deriveCondition, deriveLogic)
@@ -943,33 +942,33 @@ func (t *Tracee) populateBPFMaps() error {
 	// Prepare events map
 	eventsMap, err := t.bpfModule.GetMap("events_map")
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	for id, ecfg := range t.events {
 		submit := ecfg.submit
 		err := eventsMap.Update(unsafe.Pointer(&id), unsafe.Pointer(&submit))
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
 	// Prepare 32bit to 64bit syscall number mapping
 	sys32to64BPFMap, err := t.bpfModule.GetMap("sys_32_to_64_map") // u32, u32
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	for id, event := range events.Definitions.Events() {
 		ID32BitU32 := uint32(event.ID32Bit) // ID32Bit is int32
 		IDU32 := uint32(id)                 // ID is int32
 		if err := sys32to64BPFMap.Update(unsafe.Pointer(&ID32BitU32), unsafe.Pointer(&IDU32)); err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
 	if t.kernelSymbols != nil {
 		err = t.UpdateBPFKsymbolsMap()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -978,12 +977,12 @@ func (t *Tracee) populateBPFMaps() error {
 
 	bpfKConfigMap, err := t.bpfModule.GetMap("kconfig_map") // u32, u32
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	kconfigValues, err := initialization.LoadKconfigValues(t.config.KernelConfig)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	for key, value := range kconfigValues {
@@ -991,7 +990,7 @@ func (t *Tracee) populateBPFMaps() error {
 		valueU32 := uint32(value)
 		err = bpfKConfigMap.Update(unsafe.Pointer(&keyU32), unsafe.Pointer(&valueU32))
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -1001,7 +1000,7 @@ func (t *Tracee) populateBPFMaps() error {
 	if pcaps.PcapsEnabled(t.config.Capture.Net) {
 		bpfNetConfigMap, err := t.bpfModule.GetMap("netconfig_map")
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 
 		netConfigVal := make([]byte, 8) // u32 capture_options, u32 capture_length
@@ -1015,19 +1014,19 @@ func (t *Tracee) populateBPFMaps() error {
 			unsafe.Pointer(&cZero),
 			unsafe.Pointer(&netConfigVal[0]),
 		); err != nil {
-			return fmt.Errorf("error updating net config eBPF map: %v", err)
+			return logger.NewErrorf("error updating net config eBPF map: %v", err)
 		}
 	}
 
 	// Initialize config map
 	bpfConfigMap, err := t.bpfModule.GetMap("config_map")
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	configVal := t.computeConfigValues()
 	if err = bpfConfigMap.Update(unsafe.Pointer(&cZero), unsafe.Pointer(&configVal[0])); err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	for filterScope := range t.config.FilterScopes.Map() {
@@ -1045,7 +1044,7 @@ func (t *Tracee) populateBPFMaps() error {
 
 		for k, v := range errMap {
 			if v != nil {
-				return fmt.Errorf("error setting %v filter: %v", k, v)
+				return logger.NewErrorf("error setting %v filter: %v", k, v)
 			}
 		}
 	}
@@ -1053,19 +1052,19 @@ func (t *Tracee) populateBPFMaps() error {
 	// Populate containers map with existing containers
 	err = t.containers.PopulateBpfMap(t.bpfModule)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// Set filters given by the user to filter file write events
 	fileFilterMap, err := t.bpfModule.GetMap("file_filter") // u32, u32
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	for i := uint32(0); i < uint32(len(t.config.Capture.FilterFileWrite)); i++ {
 		FilterFileWriteBytes := []byte(t.config.Capture.FilterFileWrite[i])
 		if err = fileFilterMap.Update(unsafe.Pointer(&i), unsafe.Pointer(&FilterFileWriteBytes[0])); err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -1079,7 +1078,7 @@ func (t *Tracee) populateBPFMaps() error {
 	}
 	paramsTypesBPFMap, err := t.bpfModule.GetMap("params_types_map") // u32, u64
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	for e := range t.events {
 		eU32 := uint32(e) // e is int32
@@ -1089,7 +1088,7 @@ func (t *Tracee) populateBPFMaps() error {
 			paramsTypes = paramsTypes | (uint64(paramType) << (8 * n))
 		}
 		if err := paramsTypesBPFMap.Update(unsafe.Pointer(&eU32), unsafe.Pointer(&paramsTypes)); err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -1097,7 +1096,7 @@ func (t *Tracee) populateBPFMaps() error {
 	if ok {
 		syscallsToCheckMap, err := t.bpfModule.GetMap("syscalls_to_check_map")
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 		/* the syscallsToCheckMap store the syscall numbers that we are fetching from the syscall table, like that:
 		 * [syscall num #1][syscall num #2][syscall num #3]...
@@ -1107,7 +1106,7 @@ func (t *Tracee) populateBPFMaps() error {
 		for idx, val := range events.SyscallsToCheck() {
 			err = syscallsToCheckMap.Update(unsafe.Pointer(&(idx)), unsafe.Pointer(&val))
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 		}
 	}
@@ -1115,12 +1114,12 @@ func (t *Tracee) populateBPFMaps() error {
 	// Initialize tail call dependencies
 	tailCalls, err := t.GetTailCalls()
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	for _, tailCall := range tailCalls {
 		err := t.initTailCall(tailCall.MapName, tailCall.MapIndexes, tailCall.ProgName)
 		if err != nil {
-			return fmt.Errorf("failed to initialize tail call: %w", err)
+			return logger.NewErrorf("failed to initialize tail call: %v", err)
 		}
 	}
 
@@ -1202,11 +1201,11 @@ func (t *Tracee) attachProbes() error {
 		if event.Syscall {
 			err := t.probes.Attach(probes.SyscallEnter__Internal)
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 			err = t.probes.Attach(probes.SyscallExit__Internal)
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 		}
 
@@ -1214,7 +1213,7 @@ func (t *Tracee) attachProbes() error {
 		for _, dep := range event.Probes {
 			err = t.probes.Attach(dep.Handle, t.cgroups)
 			if err != nil && dep.Required {
-				return fmt.Errorf("failed to attach required probe: %v", err)
+				return logger.NewErrorf("failed to attach required probe: %v", err)
 			}
 		}
 	}
@@ -1240,35 +1239,35 @@ func (t *Tracee) initBPF() error {
 
 		t.bpfModule, err = bpf.NewModuleFromBufferArgs(newModuleArgs)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 
 		// Initialize probes
 
 		t.probes, err = probes.Init(t.bpfModule, t.netEnabled())
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 
 		// Load the eBPF object into kernel
 
 		err = t.bpfModule.BPFLoadObject()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 
 		// Populate eBPF maps with initial data
 
 		err = t.populateBPFMaps()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 
 		// Attach eBPF programs to selected event's probes
 
 		err = t.attachProbes()
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 
 		// Update all ProcessTreeFilters after probes are attached: reduce the
@@ -1277,7 +1276,7 @@ func (t *Tracee) initBPF() error {
 		for filterScope := range t.config.FilterScopes.Map() {
 			err = filterScope.ProcessTreeFilter.UpdateBPF(t.bpfModule, uint(filterScope.ID))
 			if err != nil {
-				return fmt.Errorf("error building process tree: %v", err)
+				return logger.NewErrorf("error building process tree: %v", err)
 			}
 		}
 
@@ -1286,7 +1285,7 @@ func (t *Tracee) initBPF() error {
 		t.eventsChannel = make(chan []byte, 1000)
 		t.lostEvChannel = make(chan uint64)
 		if t.config.PerfBufferSize < 1 {
-			return fmt.Errorf("invalid perf buffer size: %d", t.config.PerfBufferSize)
+			return logger.NewErrorf("invalid perf buffer size: %d", t.config.PerfBufferSize)
 		}
 		t.eventsPerfMap, err = t.bpfModule.InitPerfBuf(
 			"events",
@@ -1295,7 +1294,7 @@ func (t *Tracee) initBPF() error {
 			t.config.PerfBufferSize,
 		)
 		if err != nil {
-			return fmt.Errorf("error initializing events perf map: %v", err)
+			return logger.NewErrorf("error initializing events perf map: %v", err)
 		}
 
 		if t.config.BlobPerfBufferSize > 0 {
@@ -1308,7 +1307,7 @@ func (t *Tracee) initBPF() error {
 				t.config.BlobPerfBufferSize,
 			)
 			if err != nil {
-				return fmt.Errorf("error initializing file_writes perf map: %v", err)
+				return logger.NewErrorf("error initializing file_writes perf map: %v", err)
 			}
 		}
 
@@ -1322,7 +1321,7 @@ func (t *Tracee) initBPF() error {
 				t.config.PerfBufferSize,
 			)
 			if err != nil {
-				return fmt.Errorf("error initializing net capture perf map: %v", err)
+				return logger.NewErrorf("error initializing net capture perf map: %v", err)
 			}
 		}
 
@@ -1335,13 +1334,13 @@ func (t *Tracee) initBPF() error {
 			t.config.PerfBufferSize,
 		)
 		if err != nil {
-			return fmt.Errorf("error initializing logs perf map: %v", err)
+			return logger.NewErrorf("error initializing logs perf map: %v", err)
 		}
 
 		return nil
 	})
 
-	return err
+	return logger.ErrorFunc(err)
 }
 
 // Run starts the trace. it will run until ctx is cancelled
@@ -1372,7 +1371,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	err = t.writePid()
 	if err != nil {
 		// not able to write pid, abort
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// block until ctx is cancelled elsewhere
@@ -1392,7 +1391,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 		destinationFilePath := "written_files"
 		f, err := utils.OpenAt(t.outDir, destinationFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			return fmt.Errorf("error logging written files")
+			return logger.NewErrorf("error logging written files")
 		}
 		defer f.Close()
 		for fileName, filePath := range t.writtenFiles {
@@ -1408,7 +1407,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 				continue
 			}
 			if _, err := f.WriteString(fmt.Sprintf("%s %s\n", fileName, filePath)); err != nil {
-				return fmt.Errorf("error logging written files")
+				return logger.NewErrorf("error logging written files")
 			}
 		}
 	}
@@ -1424,7 +1423,7 @@ func (t *Tracee) Close() {
 			if t.probes != nil {
 				err := t.probes.DetachAll()
 				if err != nil {
-					return fmt.Errorf("failed to detach probes when closing tracee: %s", err)
+					return logger.NewErrorf("failed to detach probes when closing tracee: %s", err)
 				}
 			}
 			if t.bpfModule != nil {
@@ -1433,7 +1432,7 @@ func (t *Tracee) Close() {
 			if t.containers != nil {
 				err := t.containers.Close()
 				if err != nil {
-					return fmt.Errorf("failed to clean containers module when closing tracee: %s", err)
+					return logger.NewErrorf("failed to clean containers module when closing tracee: %s", err)
 				}
 			}
 			t.running = false
@@ -1457,7 +1456,7 @@ func (t *Tracee) Running() bool {
 func (t *Tracee) computeOutFileHash(fileName string) (string, error) {
 	f, err := utils.OpenAt(t.outDir, fileName, os.O_RDONLY, 0)
 	if err != nil {
-		return "", err
+		return "", logger.ErrorFunc(err)
 	}
 	defer f.Close()
 	return computeFileHash(f)
@@ -1466,7 +1465,7 @@ func (t *Tracee) computeOutFileHash(fileName string) (string, error) {
 func computeFileHashAtPath(fileName string) (string, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return "", err
+		return "", logger.ErrorFunc(err)
 	}
 	defer f.Close()
 	return computeFileHash(f)
@@ -1476,7 +1475,7 @@ func computeFileHash(file *os.File) (string, error) {
 	h := sha256.New()
 	_, err := io.Copy(h, file)
 	if err != nil {
-		return "", err
+		return "", logger.ErrorFunc(err)
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
@@ -1598,7 +1597,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 			for _, field := range lengthFilter.Equal() {
 				length, err = strconv.ParseUint(field, 10, 64)
 				if err != nil {
-					return err
+					return logger.ErrorFunc(err)
 				}
 				//lint:ignore SA4004 we only want the first argument
 				break
@@ -1610,7 +1609,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 			for _, field := range addressFilter.Equal() {
 				address, err := strconv.ParseUint(field, 16, 64)
 				if err != nil {
-					return err
+					return logger.ErrorFunc(err)
 				}
 				t.triggerMemDumpCall(address, length, uint64(eventHandle))
 			}
@@ -1630,11 +1629,11 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 					owner = symbolSlice[0]
 					name = symbolSlice[1]
 				} else {
-					return fmt.Errorf("invalid symbols provided %s - more than one ':' provided", field)
+					return logger.NewErrorf("invalid symbols provided %s - more than one ':' provided", field)
 				}
 				symbol, err := t.kernelSymbols.GetSymbolByName(owner, name)
 				if err != nil {
-					return err
+					return logger.ErrorFunc(err)
 				}
 				t.triggerMemDumpCall(symbol.Address, length, uint64(eventHandle))
 			}
@@ -1643,7 +1642,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 
 	for k, v := range errArgFilter {
 		if v != nil {
-			return fmt.Errorf("error setting %v filter: %v", k, v)
+			return logger.NewErrorf("error setting %v filter: %v", k, v)
 		}
 	}
 
@@ -1659,12 +1658,12 @@ func (t *Tracee) triggerMemDumpCall(address uint64, length uint64, eventHandle u
 func (t *Tracee) writePid() error {
 	pidFile, err := utils.OpenAt(t.outDir, "tracee.pid", syscall.O_WRONLY|syscall.O_CREAT, 0640)
 	if err != nil {
-		return fmt.Errorf("error creating readiness file: %w", err)
+		return logger.NewErrorf("error creating readiness file: %v", err)
 	}
 
 	_, err = pidFile.Write([]byte(strconv.Itoa(os.Getpid()) + "\n"))
 	if err != nil {
-		return fmt.Errorf("error writing to readiness file: %w", err)
+		return logger.NewErrorf("error writing to readiness file: %v", err)
 	}
 
 	return nil

--- a/pkg/ebpf/write_capture.go
+++ b/pkg/ebpf/write_capture.go
@@ -41,12 +41,12 @@ func (t *Tracee) processFileWrites() {
 			}
 
 			if meta.Size <= 0 {
-				t.handleError(fmt.Errorf("error in file writer: invalid chunk size: %d", meta.Size))
+				t.handleError(logger.NewErrorf("invalid chunk size: %d", meta.Size))
 				continue
 			}
 
 			if ebpfMsgDecoder.BuffLen() < int(meta.Size) {
-				t.handleError(fmt.Errorf("error in file writer: chunk too large: %d", meta.Size))
+				t.handleError(logger.NewErrorf("chunk too large: %d", meta.Size))
 				continue
 			}
 
@@ -103,7 +103,7 @@ func (t *Tracee) processFileWrites() {
 					filename = fmt.Sprintf("%s.pid-%d", filename, kernelModuleMeta.Pid)
 				}
 			} else {
-				t.handleError(fmt.Errorf("error in file writer: unknown binary type: %d", meta.BinType))
+				t.handleError(logger.NewErrorf("unknown binary type: %d", meta.BinType))
 				continue
 			}
 

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/containers"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -17,11 +18,11 @@ func deriveContainerRemoveArgs(containers *containers.Containers) deriveArgsFunc
 	return func(event trace.Event) ([]interface{}, error) {
 		// if cgroup_id is from non default hid (v1 case), the cgroup info query will fail, so we skip
 		if check, err := isCgroupEventInHid(&event, containers); !check {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 		cgroupId, err := parse.ArgVal[uint64](&event, "cgroup_id")
 		if err != nil {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 		if info := containers.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
 			return []interface{}{info.Runtime.String(), info.Container.ContainerId}, nil

--- a/pkg/events/derive/detect_hooked_syscall.go
+++ b/pkg/events/derive/detect_hooked_syscall.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -18,11 +19,11 @@ func deriveDetectHookedSyscallArgs(kernelSymbols helpers.KernelSymbolTable) deri
 	return func(event trace.Event) ([]interface{}, error) {
 		syscallAddresses, err := parse.ArgVal[[]uint64](&event, "syscalls_addresses")
 		if err != nil {
-			return nil, fmt.Errorf("error parsing syscalls_numbers arg: %v", err)
+			return nil, logger.NewErrorf("error parsing syscalls_numbers arg: %v", err)
 		}
 		hookedSyscall, err := analyzeHookedAddresses(syscallAddresses, kernelSymbols)
 		if err != nil {
-			return nil, fmt.Errorf("error parsing analyzing hooked syscalls addresses arg: %v", err)
+			return nil, logger.NewErrorf("error parsing analyzing hooked syscalls addresses arg: %v", err)
 		}
 		return []interface{}{hookedSyscall}, nil
 	}
@@ -37,7 +38,7 @@ func analyzeHookedAddresses(addresses []uint64, kernelSymbols helpers.KernelSymb
 		}
 		syscallsToCheck := events.SyscallsToCheck()
 		if idx > len(syscallsToCheck) {
-			return nil, fmt.Errorf("syscall inedx out of the syscalls to check list")
+			return nil, logger.NewErrorf("syscall inedx out of the syscalls to check list")
 		}
 		hookingFunction := utils.ParseSymbol(syscallAddress, kernelSymbols)
 		syscallNumber := syscallsToCheck[idx]

--- a/pkg/events/derive/hooked_seq_ops.go
+++ b/pkg/events/derive/hooked_seq_ops.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -34,7 +35,7 @@ func deriveHookedSeqOpsArgs(kernelSymbols helpers.KernelSymbolTable) deriveArgsF
 	return func(event trace.Event) ([]interface{}, error) {
 		seqOpsArr, err := parse.ArgVal[[]uint64](&event, "net_seq_ops")
 		if err != nil || len(seqOpsArr) < 1 {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 		hookedSeqOps := make(map[string]trace.HookedSymbolData, 0)
 		for i, addr := range seqOpsArr {

--- a/pkg/events/derive/net_packet_dns.go
+++ b/pkg/events/derive/net_packet_dns.go
@@ -23,7 +23,7 @@ func deriveDNS() deriveArgsFunction {
 func deriveDNSEvents(event trace.Event) ([]interface{}, error) {
 	net, dns, err := eventToProtoDNS(&event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	if dns == nil {
 		return nil, nil // connection related packets
@@ -56,13 +56,13 @@ func deriveDNSRequest() deriveArgsFunction {
 func deriveDNSRequestEvents(event trace.Event) ([]interface{}, error) {
 	net, dns, err := eventToProtoDNS(&event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	if dns == nil {
 		return nil, nil // connection related packets
 	}
 	if net == nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	// discover if it is a request or response
@@ -105,13 +105,13 @@ func deriveDNSResponse() deriveArgsFunction {
 func deriveDNSResponseEvents(event trace.Event) ([]interface{}, error) {
 	net, dns, err := eventToProtoDNS(&event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	if dns == nil {
 		return nil, nil // connection related packets
 	}
 	if net == nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	// discover if it is a request or response
@@ -157,7 +157,7 @@ func eventToProtoDNS(event *trace.Event) (*netPair, *trace.ProtoDNS, error) {
 
 	layer7, err := parseUntilLayer7(event, &DnsNetPair)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, logger.ErrorFunc(err)
 	}
 
 	switch l7 := layer7.(type) {

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -1,11 +1,11 @@
 package derive
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
@@ -106,7 +106,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 	} else if event.ReturnValue&familyIpv6 == familyIpv6 {
 		layerType = layers.LayerTypeIPv6
 	} else {
-		return nil, fmt.Errorf("base layer type not supported: %d", event.ReturnValue)
+		return nil, logger.NewErrorf("base layer type not supported: %d", event.ReturnValue)
 	}
 
 	// parse packet with gopacket
@@ -134,7 +134,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 		pair.dstIP = v.DstIP
 		pair.length = uint32(v.Length)
 	default:
-		return nil, fmt.Errorf("layer 3 not supported: %v", layer3)
+		return nil, logger.NewErrorf("layer 3 not supported: %v", layer3)
 	}
 
 	// transport layer
@@ -151,7 +151,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 		pair.dstPort = uint16(v.DstPort)
 		pair.proto = IPPROTO_UDP
 	default:
-		return nil, fmt.Errorf("layer 4 not supported: %v", layer4)
+		return nil, logger.NewErrorf("layer 4 not supported: %v", layer4)
 	}
 
 	// check partial packet decoding

--- a/pkg/events/derive/net_packet_http.go
+++ b/pkg/events/derive/net_packet_http.go
@@ -3,10 +3,10 @@ package derive
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"net/http"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -27,7 +27,7 @@ func deriveHTTP() deriveArgsFunction {
 func deriveHTTPEvents(event trace.Event) ([]interface{}, error) {
 	net, http, err := eventToProtoHTTP(&event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	if http == nil {
 		return nil, nil // connection related packets
@@ -60,13 +60,13 @@ func deriveHTTPRequest() deriveArgsFunction {
 func deriveHTTPRequestEvents(event trace.Event) ([]interface{}, error) {
 	net, http, err := eventToProtoHTTPRequest(&event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	if http == nil {
 		return nil, nil // not a request
 	}
 	if net == nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	meta := convertNetPairToPktMeta(net)
@@ -92,13 +92,13 @@ func deriveHTTPResponse() deriveArgsFunction {
 func deriveHTTPResponseEvents(event trace.Event) ([]interface{}, error) {
 	net, http, err := eventToProtoHTTPResponse(&event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	if http == nil {
 		return nil, nil // // not a response
 	}
 	if net == nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	meta := convertNetPairToPktMeta(net)
@@ -114,7 +114,7 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 	layer7, err := parseUntilLayer7(event, &httpNetPair)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, logger.ErrorFunc(err)
 	}
 	if layer7 == nil {
 		return nil, nil, nil
@@ -133,7 +133,7 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 			httpReq, err = http.ReadRequest(reader)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, logger.ErrorFunc(err)
 			}
 
 			copyHTTPReqToProtoHTTP(httpReq, &protoHttp)
@@ -142,13 +142,13 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 			httpRes, err = http.ReadResponse(reader, nil)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, logger.ErrorFunc(err)
 			}
 
 			copyHTTPResToProtoHTTP(httpRes, &protoHttp)
 
 		} else {
-			return &httpNetPair, nil, fmt.Errorf("unspecified direction for HTTP packet")
+			return &httpNetPair, nil, logger.NewErrorf("unspecified direction for HTTP packet")
 		}
 
 		return &httpNetPair, &protoHttp, nil
@@ -162,7 +162,7 @@ func eventToProtoHTTPRequest(event *trace.Event) (*netPair, *trace.ProtoHTTPRequ
 
 	layer7, err := parseUntilLayer7(event, &httpNetPair)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, logger.ErrorFunc(err)
 	}
 	if layer7 == nil {
 		return nil, nil, nil
@@ -179,7 +179,7 @@ func eventToProtoHTTPRequest(event *trace.Event) (*netPair, *trace.ProtoHTTPRequ
 
 		httpReq, err := http.ReadRequest(reader)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, logger.ErrorFunc(err)
 		}
 
 		var httpRequest trace.ProtoHTTPRequest
@@ -197,7 +197,7 @@ func eventToProtoHTTPResponse(event *trace.Event) (*netPair, *trace.ProtoHTTPRes
 
 	layer7, err := parseUntilLayer7(event, &httpNetPair)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, logger.ErrorFunc(err)
 	}
 	if layer7 == nil {
 		return nil, nil, nil
@@ -214,7 +214,7 @@ func eventToProtoHTTPResponse(event *trace.Event) (*netPair, *trace.ProtoHTTPRes
 
 		httpRes, err := http.ReadResponse(reader, nil)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, logger.ErrorFunc(err)
 		}
 
 		var httpResponse trace.ProtoHTTPResponse

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -1,8 +1,6 @@
 package derive
 
 import (
-	"fmt"
-
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/filterscope"
@@ -103,7 +101,7 @@ func (gen *SymbolsCollisionArgsGenerator) deriveArgs(event trace.Event) ([][]int
 		return gen.handleExec(event) // evicts saved data (loaded shared objects) for the process
 	}
 
-	return nil, []error{fmt.Errorf("received unexpected event - \"%s\"", event.EventName)}
+	return nil, []error{logger.NewErrorf("received unexpected event - \"%s\"", event.EventName)}
 }
 
 // handleShObjLoaded handles the shared object loaded event (from mmap).
@@ -191,7 +189,7 @@ func (gen *SymbolsCollisionArgsGenerator) findShObjsCollisions(
 			} else {
 				logger.Debug("symbols_loaded", "object loaded", loadingShObj.ObjInfo, "error", err.Error())
 			}
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 		loadingShObj.FilterSymbols(gen.symbolsBlacklistMap)    // del symbols NOT in blacklist
 		loadingShObj.FilterOutSymbols(gen.symbolsWhitelistMap) // del symbols IN the white list
@@ -207,7 +205,7 @@ func (gen *SymbolsCollisionArgsGenerator) findShObjsCollisions(
 			} else {
 				logger.Debug("symbols_loaded", "object loaded", loadedShObjInfo, "error", err.Error())
 			}
-			return nil, nil
+			return nil, logger.ErrorFunc(err)
 		}
 
 		// create a loadingSharedObj from the already loaded shared object (to get collisions)

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -106,7 +106,7 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(
 
 	loadingObjectInfo, err := getSharedObjectInfo(event)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 
 	if symbsLoadedGen.isWhitelist(loadingObjectInfo.Path) {
@@ -182,19 +182,19 @@ func getSharedObjectInfo(event trace.Event) (sharedobjs.ObjInfo, error) {
 
 	loadedObjectInode, err := parse.ArgVal[uint64](&event, "inode")
 	if err != nil {
-		return objInfo, err
+		return objInfo, logger.ErrorFunc(err)
 	}
 	loadedObjectDevice, err := parse.ArgVal[uint32](&event, "dev")
 	if err != nil {
-		return objInfo, err
+		return objInfo, logger.ErrorFunc(err)
 	}
 	loadedObjectCtime, err := parse.ArgVal[uint64](&event, "ctime")
 	if err != nil {
-		return objInfo, err
+		return objInfo, logger.ErrorFunc(err)
 	}
 	loadedObjectPath, err := parse.ArgVal[string](&event, "pathname")
 	if err != nil {
-		return objInfo, err
+		return objInfo, logger.ErrorFunc(err)
 	}
 
 	objInfo = sharedobjs.ObjInfo{

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,10 +1,9 @@
 package events
 
 import (
-	"fmt"
-
 	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
 	"github.com/aquasecurity/tracee/pkg/events/trigger"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
@@ -119,11 +118,11 @@ type eventDefinitions struct {
 // Add adds an event to definitions
 func (e *eventDefinitions) Add(eventId ID, evt Event) error {
 	if _, ok := e.events[eventId]; ok {
-		return fmt.Errorf("error event id already exist: %v", eventId)
+		return logger.NewErrorf("error event id already exist: %v", eventId)
 	}
 
 	if _, ok := e.GetID(evt.Name); ok {
-		return fmt.Errorf("error event name already exist: %v", evt.Name)
+		return logger.NewErrorf("error event name already exist: %v", evt.Name)
 	}
 
 	e.events[eventId] = evt

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -80,7 +80,7 @@ func TestAdd(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := Definitions.Add(test.evt.ID32Bit, test.evt)
 			if err != nil {
-				assert.Equal(t, test.err, err.Error())
+				assert.ErrorContains(t, err, test.err)
 				return
 			}
 

--- a/pkg/events/parse/params.go
+++ b/pkg/events/parse/params.go
@@ -1,8 +1,7 @@
 package parse
 
 import (
-	"fmt"
-
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -12,10 +11,10 @@ func ArgVal[T any](event *trace.Event, argName string) (T, error) {
 			val, ok := arg.Value.(T)
 			if !ok {
 				zeroVal := *new(T)
-				return zeroVal, fmt.Errorf("argument %s is not of type %T", argName, zeroVal)
+				return zeroVal, logger.NewErrorf("argument %s is not of type %T", argName, zeroVal)
 			}
 			return val, nil
 		}
 	}
-	return *new(T), fmt.Errorf("argument %s not found", argName)
+	return *new(T), logger.NewErrorf("argument %s not found", argName)
 }

--- a/pkg/events/parse/params_test.go
+++ b/pkg/events/parse/params_test.go
@@ -56,7 +56,7 @@ func TestArgVal(t *testing.T) {
 				val, err := ArgVal[int32](&e, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
-					assert.Equal(t, tt.errorMessage, err.Error())
+					assert.Contains(t, err.Error(), tt.errorMessage)
 				} else {
 					assert.NoError(t, err)
 					assert.Equal(t, tt.expectedValue, val)
@@ -113,7 +113,7 @@ func TestArgVal(t *testing.T) {
 				val, err := ArgVal[string](&e, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
-					assert.Equal(t, tt.errorMessage, err.Error())
+					assert.Contains(t, err.Error(), tt.errorMessage)
 				} else {
 					assert.NoError(t, err)
 					assert.Equal(t, tt.expectedValue, val)
@@ -170,7 +170,7 @@ func TestArgVal(t *testing.T) {
 				val, err := ArgVal[uint64](&e, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
-					assert.Equal(t, tt.errorMessage, err.Error())
+					assert.Contains(t, err.Error(), tt.errorMessage)
 				} else {
 					assert.NoError(t, err)
 					assert.Equal(t, tt.expectedValue, val)
@@ -227,7 +227,7 @@ func TestArgVal(t *testing.T) {
 				val, err := ArgVal[uint32](&e, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
-					assert.Equal(t, tt.errorMessage, err.Error())
+					assert.Contains(t, err.Error(), tt.errorMessage)
 				} else {
 					assert.NoError(t, err)
 					assert.Equal(t, tt.expectedValue, val)
@@ -284,7 +284,7 @@ func TestArgVal(t *testing.T) {
 				val, err := ArgVal[[]string](&e, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
-					assert.Equal(t, tt.errorMessage, err.Error())
+					assert.Contains(t, err.Error(), tt.errorMessage)
 				} else {
 					assert.NoError(t, err)
 					assert.Equal(t, tt.expectedValue, val)
@@ -341,7 +341,7 @@ func TestArgVal(t *testing.T) {
 				val, err := ArgVal[[]uint64](&e, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
-					assert.Equal(t, tt.errorMessage, err.Error())
+					assert.Contains(t, err.Error(), tt.errorMessage)
 				} else {
 					assert.NoError(t, err)
 					assert.Equal(t, tt.expectedValue, val)

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -8,6 +8,7 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/helpers"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -280,7 +281,7 @@ func ParseArgsFDs(event *trace.Event, fdArgPathMap *bpf.BPFMap) error {
 			}
 			bs, err := fdArgPathMap.GetValue(unsafe.Pointer(fdArgTask))
 			if err != nil {
-				return err
+				return logger.ErrorFunc(err)
 			}
 
 			fpath := string(bytes.Trim(bs, "\x00"))
@@ -321,7 +322,7 @@ func parseBpfAttachHelperUsage(helperArg int32) (string, error) {
 	case 2:
 		return "unknown", nil
 	default:
-		return "", fmt.Errorf("unknown value got from bpf_attach event for helper usage arg")
+		return "", logger.NewErrorf("unknown value got from bpf_attach event for helper usage arg")
 	}
 }
 
@@ -338,6 +339,6 @@ func parseBpfAttachPerfType(perfType int32) (string, error) {
 	case 4:
 		return "uretprobe", nil
 	default:
-		return "", fmt.Errorf("unknown perf_type got from bpf_attach event")
+		return "", logger.NewErrorf("unknown perf_type got from bpf_attach event")
 	}
 }

--- a/pkg/events/sorting/cpu_queue.go
+++ b/pkg/events/sorting/cpu_queue.go
@@ -1,8 +1,7 @@
 package sorting
 
 import (
-	"fmt"
-
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -35,7 +34,7 @@ func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *trace.Event) error {
 			}
 			if insertLocation.next == insertLocation {
 				if err != nil {
-					err = fmt.Errorf("encountered node with self reference at next: %w", err)
+					err = logger.NewErrorf("encountered node with self reference at next: %v", err)
 				}
 			}
 			insertLocation = insertLocation.next
@@ -44,7 +43,7 @@ func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *trace.Event) error {
 	} else {
 		cq.put(newNode)
 	}
-	return err
+	return logger.ErrorFunc(err)
 }
 
 // insertAfter insert new event to the queue after another node

--- a/pkg/events/sorting/pool.go
+++ b/pkg/events/sorting/pool.go
@@ -1,9 +1,9 @@
 package sorting
 
 import (
-	"fmt"
 	"sync"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -31,7 +31,7 @@ func (p *eventsPool) Alloc(event *trace.Event) (*eventNode, error) {
 	if node != nil {
 		if node.isAllocated {
 			p.poolMutex.Unlock()
-			return &eventNode{event: event, isAllocated: true}, fmt.Errorf("BUG: alocated node in pool")
+			return &eventNode{event: event, isAllocated: true}, logger.NewErrorf("BUG: alocated node in pool")
 		}
 		p.head = node.previous
 		node.event = event
@@ -56,7 +56,7 @@ func (p *eventsPool) Free(node *eventNode) error {
 	defer p.poolMutex.Unlock()
 	// Prevent malicious use of free
 	if p.allocationsCount == 0 {
-		return fmt.Errorf("BUG: free called when no allocated node exist")
+		return logger.NewErrorf("BUG: free called when no allocated node exist")
 	}
 
 	node.isAllocated = false

--- a/pkg/events/sorting/queue.go
+++ b/pkg/events/sorting/queue.go
@@ -1,9 +1,9 @@
 package sorting
 
 import (
-	"fmt"
 	"sync"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -31,7 +31,7 @@ func (eq *eventsQueue) Put(newEvent *trace.Event) error {
 	eq.mutex.Lock()
 	defer eq.mutex.Unlock()
 	eq.put(newNode)
-	return err
+	return logger.ErrorFunc(err)
 }
 
 // Get remove the node at the head of the queue and return it
@@ -42,23 +42,23 @@ func (eq *eventsQueue) Get() (*trace.Event, error) {
 	defer eq.mutex.Unlock()
 	if eq.head == nil {
 		if eq.tail != nil {
-			return nil, fmt.Errorf("BUG: TAIL without a HEAD")
+			return nil, logger.NewErrorf("BUG: TAIL without a HEAD")
 		}
 		return nil, nil
 	}
 	headNode := eq.head
 	if headNode == eq.tail {
 		if headNode.next != nil || headNode.previous != nil {
-			return nil, fmt.Errorf("BUG: last existing node still conneced")
+			return nil, logger.NewErrorf("BUG: last existing node still conneced")
 		}
 		eq.tail = nil
 		eq.head = nil
 	} else {
 		if headNode.previous == nil {
-			return nil, fmt.Errorf("BUG: not TAIL lacking previous")
+			return nil, logger.NewErrorf("BUG: not TAIL lacking previous")
 		}
 		if headNode.next != nil {
-			return nil, fmt.Errorf("BUG: HEAD has next")
+			return nil, logger.NewErrorf("BUG: HEAD has next")
 		}
 		headNode.previous.next = nil
 		eq.head = headNode.previous
@@ -69,7 +69,7 @@ func (eq *eventsQueue) Get() (*trace.Event, error) {
 	err := eq.pool.Free(headNode)
 	if err != nil {
 		eq.pool.Reset()
-		return extractedEvent, fmt.Errorf("error in queue's node freeing - %v", err)
+		return extractedEvent, logger.NewErrorf("error in queue's node freeing - %v", err)
 	}
 	return extractedEvent, nil
 }

--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -101,7 +101,6 @@ package sorting
 
 import (
 	gocontext "context"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -132,7 +131,7 @@ type EventsChronologicalSorter struct {
 func InitEventSorter() (*EventsChronologicalSorter, error) {
 	cpusAmount, err := environment.GetCPUAmount()
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	newSorter := EventsChronologicalSorter{
 		cpuEventsQueues:                  make([]cpuEventsQueue, cpusAmount),
@@ -256,7 +255,7 @@ func (sorter *EventsChronologicalSorter) getMostDelayingEventCPUQueue() (*cpuEve
 		}
 	}
 	if mostDelayingEventQueue == nil {
-		return nil, 0, fmt.Errorf("no queue with events found")
+		return nil, 0, logger.NewErrorf("no queue with events found")
 	}
 	return mostDelayingEventQueue, mostDelayingEventQueueHeadTimestamp, nil
 }
@@ -279,7 +278,7 @@ func (sorter *EventsChronologicalSorter) getUpdatedMostDelayedLastCPUEventTimest
 		cq.IsUpdated = false // Mark that the values of the queue were checked from previous time
 	}
 	if !foundUpdatedQueue {
-		return 0, fmt.Errorf("no valid CPU events queue was updated since last interval")
+		return 0, logger.NewErrorf("no valid CPU events queue was updated since last interval")
 	}
 	return newMostDelayedEventTimestamp, nil
 }
@@ -296,7 +295,7 @@ func (sorter *EventsChronologicalSorter) getMostRecentEventTimestamp() (int, err
 		}
 	}
 	if mostRecentEventTimestamp == 0 {
-		return 0, fmt.Errorf("all CPU queques are empty")
+		return 0, logger.NewErrorf("all CPU queques are empty")
 	}
 	return mostRecentEventTimestamp, nil
 }

--- a/pkg/events/trigger/context.go
+++ b/pkg/events/trigger/context.go
@@ -1,12 +1,11 @@
 package trigger
 
 import (
-	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/aquasecurity/tracee/pkg/counter"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -58,7 +57,7 @@ func (store *context) Get(id uint64) (trace.Event, bool) {
 func (store *context) Apply(event trace.Event) (trace.Event, error) {
 	contextID, err := parse.ArgVal[uint64](&event, ContextArgName)
 	if err != nil {
-		return trace.Event{}, fmt.Errorf("error parsing caller_context_id arg: %v", err)
+		return trace.Event{}, logger.NewErrorf("error parsing caller_context_id arg: %v", err)
 	}
 	invoking, ok := store.Get(contextID)
 	if !ok {
@@ -77,7 +76,7 @@ func (store *context) Apply(event trace.Event) (trace.Event, error) {
 	invoking.MatchedScopes = event.MatchedScopes
 	copied := copy(invoking.Args, event.Args)
 	if copied != len(event.Args) {
-		return trace.Event{}, errors.New("failed to apply event's args")
+		return trace.Event{}, logger.NewErrorf("failed to apply event's args")
 	}
 	invoking.ArgsNum = event.ArgsNum
 

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -110,7 +111,7 @@ func (filter *ArgFilter) Parse(filterName string, operatorAndValues string, even
 		return NewStringFilter()
 	})
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	filter.Enable()
@@ -135,7 +136,7 @@ func (filter *ArgFilter) parseFilter(id events.ID, argName string, operatorAndVa
 	argFilter := filter.filters[id][argName]
 	err := argFilter.Parse(operatorAndValues)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	// store the arg filter again

--- a/pkg/filters/context.go
+++ b/pkg/filters/context.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -100,7 +101,7 @@ func (filter *ContextFilter) Parse(filterName string, operatorAndValues string) 
 
 	err := eventFilter.Parse(eventField, operatorAndValues)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	filter.Enable()
@@ -253,7 +254,7 @@ func (f *eventCtxFilter) Parse(field string, operatorAndValues string) error {
 func (f *eventCtxFilter) addContainer(filter Filter, operatorAndValues string) error {
 	err := filter.Parse(operatorAndValues)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 	f.containerFilter.add(true, Equal)
 	f.containerFilter.Enable()

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -314,7 +314,7 @@ func TestStringFilter(t *testing.T) {
 			for _, expr := range tc.expressions {
 				err := filter.Parse(expr)
 				if tc.expectedErr != nil {
-					assert.Equal(t, tc.expectedErr, err)
+					assert.ErrorContains(t, err, tc.expectedErr.Error())
 				}
 			}
 			if tc.expectedErr == nil {

--- a/pkg/filters/int.go
+++ b/pkg/filters/int.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"golang.org/x/exp/constraints"
 )
 
@@ -174,7 +175,7 @@ func (filter *IntFilter[T]) Parse(operatorAndValues string) error {
 		}
 		err = filter.add(valInt, operator)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/filters/processtree.go
+++ b/pkg/filters/processtree.go
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
@@ -55,7 +56,7 @@ func (filter *ProcessTreeFilter) Parse(operatorAndValues string) error {
 	} else if strings.HasPrefix(operatorAndValues, "!=") {
 		valuesString = operatorAndValues[2:]
 		if len(valuesString) == 0 {
-			return fmt.Errorf("no value passed with operator in process tree filter")
+			return logger.NewErrorf("no value passed with operator in process tree filter")
 		}
 		equalityOperator = false
 	} else {
@@ -66,7 +67,7 @@ func (filter *ProcessTreeFilter) Parse(operatorAndValues string) error {
 	for _, value := range values {
 		pid, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
-			return fmt.Errorf("invalid PID given to filter: %s", valuesString)
+			return logger.NewErrorf("invalid PID given to filter: %s", valuesString)
 		}
 		filter.PIDs[uint32(pid)] = equalityOperator
 	}
@@ -83,18 +84,18 @@ func (filter *ProcessTreeFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID 
 
 	processTreeBPFMap, err := bpfModule.GetMap(filter.mapName)
 	if err != nil {
-		return fmt.Errorf("could not find bpf process_tree_map: %v", err)
+		return logger.NewErrorf("could not find bpf process_tree_map: %v", err)
 	}
 
 	procDir, err := os.Open("/proc")
 	if err != nil {
-		return fmt.Errorf("could not open proc dir: %v", err)
+		return logger.NewErrorf("could not open proc dir: %v", err)
 	}
 	defer procDir.Close()
 
 	entries, err := procDir.Readdirnames(-1)
 	if err != nil {
-		return fmt.Errorf("could not read proc dir: %v", err)
+		return logger.NewErrorf("could not read proc dir: %v", err)
 	}
 
 	updateBPF := func(shouldBeTraced bool, pid uint64) {

--- a/pkg/filters/retval.go
+++ b/pkg/filters/retval.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 type RetFilter struct {
@@ -73,7 +74,7 @@ func (filter *RetFilter) Parse(filterName string, operatorAndValues string, even
 	// Treat operatorAndValues as an int filter to avoid code duplication
 	err := intFilter.Parse(operatorAndValues)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	filter.filters[id] = intFilter

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -7,6 +7,7 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/tracee/pkg/filters/sets"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
@@ -113,7 +114,7 @@ func (f *StringFilter) Parse(operatorAndValues string) error {
 	for _, val := range values {
 		err := f.add(val, stringToOperator(operatorString))
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -241,7 +242,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID ui
 
 	bpfMap, err := bpfModule.GetMap(filter.mapName)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	filterVal := make([]byte, 16)
@@ -265,7 +266,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID ui
 		binary.LittleEndian.PutUint64(filterVal[0:8], equalInScopes)
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		if err = bpfMap.Update(unsafe.Pointer(&byteStr[0]), unsafe.Pointer(&filterVal[0])); err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -288,7 +289,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID ui
 		binary.LittleEndian.PutUint64(filterVal[0:8], equalInScopes)
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		if err = bpfMap.Update(unsafe.Pointer(&byteStr[0]), unsafe.Pointer(&filterVal[0])); err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"golang.org/x/exp/constraints"
 )
@@ -197,7 +198,7 @@ func (filter *UIntFilter[T]) Parse(operatorAndValues string) error {
 		}
 		err = filter.add(valInt, operator)
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -237,7 +238,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, filterScopeID u
 	// 4. pid_ns_filter     u64, eq_t
 	equalityFilterMap, err := bpfModule.GetMap(filter.mapName)
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	var keyPointer unsafe.Pointer
@@ -267,7 +268,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, filterScopeID u
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		err = equalityFilterMap.Update(unsafe.Pointer(keyPointer), unsafe.Pointer(&filterVal[0]))
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -295,7 +296,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, filterScopeID u
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		err = equalityFilterMap.Update(unsafe.Pointer(keyPointer), unsafe.Pointer(&filterVal[0]))
 		if err != nil {
-			return err
+			return logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -568,3 +568,28 @@ func GetLevel() Level {
 func HasDebugLevel() bool {
 	return pkgLogger.cfg.Level == DebugLevel
 }
+
+// ErrorFuncName displays a given error prefixed by the current (caller) fn name
+// and a given string in a given format (just like fmt.Sprintf)
+func NewErrorf(format string, a ...interface{}) error {
+	sentence := fmt.Sprintf(format, a...)
+
+	pc, _, _, _ := runtime.Caller(1)
+	funcName := runtime.FuncForPC(pc).Name()
+	index := strings.LastIndex(funcName, "/") + 1
+
+	return fmt.Errorf("%v: %v", funcName[index:], sentence)
+}
+
+// ErrorFunc displays a given error prefixed by the current (caller) fn name
+func ErrorFunc(e error) error {
+	if e != nil {
+		pc, _, _, _ := runtime.Caller(1)
+		funcName := runtime.FuncForPC(pc).Name()
+		index := strings.LastIndex(funcName, "/") + 1
+
+		return fmt.Errorf("%v: %v", funcName[index:], e)
+	}
+
+	return nil
+}

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"github.com/aquasecurity/tracee/pkg/counter"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -27,7 +28,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.EventCount.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -37,7 +38,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.EventsFiltered.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -47,7 +48,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.NetCapCount.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -57,7 +58,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.LostEvCount.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -67,7 +68,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.LostWrCount.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -77,7 +78,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.LostNtCapCount.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -87,7 +88,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.BPFLogsCount.Read()) }))
 
 	if err != nil {
-		return err
+		return logger.ErrorFunc(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -96,5 +97,5 @@ func (stats *Stats) RegisterPrometheus() error {
 		Help:      "errors accumulated by tracee-ebpf",
 	}, func() float64 { return float64(stats.ErrorCount.Read()) }))
 
-	return err
+	return logger.ErrorFunc(err)
 }

--- a/pkg/pcaps/cache.go
+++ b/pkg/pcaps/cache.go
@@ -1,10 +1,7 @@
 package pcaps
 
 import (
-	"fmt"
-
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 	lru "github.com/hashicorp/golang-lru"
 )
@@ -35,7 +32,7 @@ func newPcapCache(itemType PcapType) (*PcapCache, error) {
 	return &PcapCache{
 		itemCache: cache,
 		itemType:  itemType,
-	}, utils.ErrorFuncName(err)
+	}, logger.ErrorFunc(err)
 }
 
 func (p *PcapCache) get(event *trace.Event) (*Pcap, error) {
@@ -48,7 +45,7 @@ func (p *PcapCache) get(event *trace.Event) (*Pcap, error) {
 		// create an item and return it
 		new, err := NewPcap(event, p.itemType)
 		if err != nil {
-			return nil, utils.ErrorFuncName(err)
+			return nil, logger.ErrorFunc(err)
 		}
 		p.itemCache.Add(getItemIndexFromEvent(event, p.itemType), new)
 		item = new
@@ -56,7 +53,7 @@ func (p *PcapCache) get(event *trace.Event) (*Pcap, error) {
 		// return the cached item
 		item, ok = i.(*Pcap)
 		if !ok {
-			return nil, fmt.Errorf("unexpected item type in pcap cache")
+			return nil, logger.NewErrorf("unexpected item type in pcap cache")
 		}
 	}
 
@@ -70,7 +67,7 @@ func (p *PcapCache) destroy() error {
 		case *Pcap:
 			key.close()
 		default:
-			return fmt.Errorf("wrong key type in pcap cache")
+			return logger.NewErrorf("wrong key type in pcap cache")
 		}
 	}
 	p.itemCache.Purge()

--- a/pkg/pcaps/common.go
+++ b/pkg/pcaps/common.go
@@ -82,7 +82,7 @@ func getPcapFileName(event *trace.Event, pcapType PcapType) (string, error) {
 	// create needed dirs
 	err = mkdirForPcapType(outputDirectory, contID, pcapType)
 	if err != nil {
-		return "", utils.ErrorFuncName(err)
+		return "", logger.ErrorFunc(err)
 	}
 
 	// return filename in format according to pcap type
@@ -157,7 +157,7 @@ func mkdirForPcapType(o *os.File, c string, t PcapType) error {
 		e = utils.MkdirAtExist(o, pcapCommDir+c, os.ModePerm)
 	}
 
-	return utils.ErrorFuncName(e)
+	return logger.ErrorFunc(e)
 }
 
 // getPcapFileAndWriter returns a file descriptor and and its associated pcap
@@ -169,7 +169,7 @@ func getPcapFileAndWriter(event *trace.Event, t PcapType) (
 ) {
 	pcapFilePath, err := getPcapFileName(event, t)
 	if err != nil {
-		return nil, nil, utils.ErrorFuncName(err)
+		return nil, nil, logger.ErrorFunc(err)
 	}
 	file, err := utils.OpenAt(
 		outputDirectory,
@@ -178,7 +178,7 @@ func getPcapFileAndWriter(event *trace.Event, t PcapType) (
 		0644,
 	)
 	if err != nil {
-		return nil, nil, utils.ErrorFuncName(err)
+		return nil, nil, logger.ErrorFunc(err)
 	}
 
 	logger.Debug("pcap file (re)opened", "filename", pcapFilePath)
@@ -189,11 +189,11 @@ func getPcapFileAndWriter(event *trace.Event, t PcapType) (
 		pcapgo.DefaultNgWriterOptions,
 	)
 	if err != nil {
-		return nil, nil, utils.ErrorFuncName(err)
+		return nil, nil, logger.ErrorFunc(err)
 	}
 	err = writer.Flush()
 	if err != nil {
-		return nil, nil, utils.ErrorFuncName(err)
+		return nil, nil, logger.ErrorFunc(err)
 	}
 
 	return file, writer, nil

--- a/pkg/pcaps/pcap.go
+++ b/pkg/pcaps/pcap.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/aquasecurity/tracee/pkg/utils"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcapgo"
@@ -73,7 +73,7 @@ func NewPcap(e *trace.Event, t PcapType) (*Pcap, error) {
 
 	p.pcapFile, p.pcapWriter, err = getPcapFileAndWriter(e, t)
 
-	return p, utils.ErrorFuncName(err)
+	return p, logger.ErrorFunc(err)
 }
 
 func (p *Pcap) write(event *trace.Event, payload []byte) error {

--- a/pkg/pcaps/pcaps.go
+++ b/pkg/pcaps/pcaps.go
@@ -1,12 +1,10 @@
 package pcaps
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -59,7 +57,7 @@ func New(simple Config, output *os.File) (*Pcaps, error) {
 			logger.Debug("pcap enabled: " + t.String())
 			caches[t], err = newPcapCache(t)
 			if err != nil {
-				return nil, utils.ErrorFuncName(err)
+				return nil, logger.ErrorFunc(err)
 			}
 		} else {
 			// remove keys that were not requested
@@ -75,17 +73,17 @@ func (p *Pcaps) Write(event *trace.Event, payload []byte) error {
 
 	// sanity check
 	if events.ID(event.EventID) != events.NetPacketCapture {
-		return fmt.Errorf("wrong event type given to pcap")
+		return logger.NewErrorf("wrong event type given to pcap")
 	}
 
 	for k := range p.pcapCaches {
 		item, err := p.pcapCaches[k].get(event)
 		if err != nil {
-			return utils.ErrorFuncName(err)
+			return logger.ErrorFunc(err)
 		}
 		err = item.write(event, payload)
 		if err != nil {
-			return utils.ErrorFuncName(err)
+			return logger.ErrorFunc(err)
 		}
 	}
 
@@ -98,7 +96,7 @@ func (p *Pcaps) Destroy() error {
 	for k := range p.pcapCaches {
 		err := p.pcapCaches[k].destroy()
 		if err != nil {
-			return utils.ErrorFuncName(err)
+			return logger.ErrorFunc(err)
 		}
 	}
 

--- a/pkg/utils/environment/amount_cpus.go
+++ b/pkg/utils/environment/amount_cpus.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 const possibleCPUsFilePath = "/sys/devices/system/cpu/possible"
@@ -16,7 +18,7 @@ func GetCPUAmount() (int, error) {
 			return cpusAmount, nil
 		}
 	}
-	return 0, err
+	return 0, logger.ErrorFunc(err)
 }
 
 const singleValue = 1
@@ -35,25 +37,25 @@ func parsePossibleCPUAmountFromCPUFileFormat(cpuFileContent string) (int, error)
 	var usedSize, groupSize int
 	bitmapsRegions := strings.Split(cpuFileContent, ",")
 	if len(bitmapsRegions) > 1 {
-		return 0, fmt.Errorf("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
+		return 0, logger.NewErrorf("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
 	}
 	cpusAmount := 0
 	n, _ := fmt.Sscanf(bitmapsRegions[0], "%d-%d:%d/%d", &rangeStart, &rangeEnd, &usedSize, &groupSize)
 	switch n {
 	case singleValue:
 		if rangeStart != 0 {
-			return 0, fmt.Errorf("possible cpus must start from the index 0, so single CPU index value must be 0")
+			return 0, logger.NewErrorf("possible cpus must start from the index 0, so single CPU index value must be 0")
 		}
 		cpusAmount = 1
 	case rangeValues:
 		if rangeStart != 0 {
-			return 0, fmt.Errorf("possible cpus should be following indexes range starting with 0")
+			return 0, logger.NewErrorf("possible cpus should be following indexes range starting with 0")
 		}
 		cpusAmount = rangeEnd - rangeStart + 1
 	case rangeValuesWithGroups:
-		return 0, fmt.Errorf("possible cpus should be following indexes, but received groups format")
+		return 0, logger.NewErrorf("possible cpus should be following indexes, but received groups format")
 	default:
-		return 0, fmt.Errorf("unkown possible cpu file format")
+		return 0, logger.NewErrorf("unkown possible cpu file format")
 	}
 	return cpusAmount, nil
 }

--- a/pkg/utils/proc/exe.go
+++ b/pkg/utils/proc/exe.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 // GetProcNS returns the namespace ID of a given namespace and process.
@@ -11,7 +13,7 @@ import (
 func GetProcBinary(pid uint) (string, error) {
 	binPath, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
 	if err != nil {
-		return "", fmt.Errorf("could not read exe file: %v", err)
+		return "", logger.NewErrorf("could not read exe file: %v", err)
 	}
 	return binPath, nil
 }
@@ -21,12 +23,12 @@ func GetProcBinary(pid uint) (string, error) {
 func GetAllBinaryProcs() (map[string][]uint32, error) {
 	procDir, err := os.Open("/proc")
 	if err != nil {
-		return nil, fmt.Errorf("could not open procfs dir: %v", err)
+		return nil, logger.NewErrorf("could not open procfs dir: %v", err)
 	}
 	defer procDir.Close()
 	procs, err := procDir.Readdirnames(-1)
 	if err != nil {
-		return nil, fmt.Errorf("could not open procfs dir: %v", err)
+		return nil, logger.NewErrorf("could not open procfs dir: %v", err)
 
 	}
 	binProcs := map[string][]uint32{}

--- a/pkg/utils/proc/ns.go
+++ b/pkg/utils/proc/ns.go
@@ -15,13 +15,13 @@ import (
 func GetMountNSFirstProcesses() (map[int]int, error) {
 	procDir, err := os.Open("/proc")
 	if err != nil {
-		return nil, fmt.Errorf("could not open proc dir: %v", err)
+		return nil, logger.NewErrorf("could not open proc dir: %v", err)
 	}
 	defer procDir.Close()
 
 	entries, err := procDir.Readdirnames(-1)
 	if err != nil {
-		return nil, fmt.Errorf("could not read proc dir: %v", err)
+		return nil, logger.NewErrorf("could not read proc dir: %v", err)
 	}
 
 	type pidTimestamp struct {
@@ -68,7 +68,7 @@ func GetMountNSFirstProcesses() (map[int]int, error) {
 func GetProcessStartTime(pid uint) (int, error) {
 	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
-		return 0, err
+		return 0, logger.ErrorFunc(err)
 	}
 	// see https://man7.org/linux/man-pages/man5/proc.5.html for how to read /proc/pid/stat
 	startTimeOffset := 22 // Offset start at 1
@@ -76,16 +76,16 @@ func GetProcessStartTime(pid uint) (int, error) {
 	// We want to remove the comm from the string, because it can contain a space which will change the offsets after split
 	splitByComm := bytes.SplitN(stat, []byte{')', ' '}, 2)
 	if len(splitByComm) != 2 {
-		return 0, fmt.Errorf("error in parsing /proc/<pid>/stat format - comm name is not surounded by parentheses as expected")
+		return 0, logger.NewErrorf("error in parsing /proc/<pid>/stat format - comm name is not surounded by parentheses as expected")
 	}
 	newStartTimeOffset := startTimeOffset - commOffset
 	splitStat := bytes.SplitN(splitByComm[1], []byte{' '}, newStartTimeOffset+1)
 	if len(splitStat) != newStartTimeOffset+1 {
-		return 0, fmt.Errorf("error in parsing /proc/<pid>/stat format - only %d values found inside", len(splitStat))
+		return 0, logger.NewErrorf("error in parsing /proc/<pid>/stat format - only %d values found inside", len(splitStat))
 	}
 	startTime, err := strconv.Atoi(string(splitStat[newStartTimeOffset-1]))
 	if err != nil {
-		return 0, err
+		return 0, logger.ErrorFunc(err)
 	}
 
 	return startTime, nil
@@ -109,24 +109,24 @@ type ProcNS struct {
 func GetAllProcNS(pid uint) (*ProcNS, error) {
 	nsDir, err := os.Open(fmt.Sprintf("/proc/%d/ns", pid))
 	if err != nil {
-		return nil, fmt.Errorf("could not open ns dir: %v", err)
+		return nil, logger.NewErrorf("could not open ns dir: %v", err)
 	}
 	defer nsDir.Close()
 
 	entries, err := nsDir.Readdirnames(-1)
 	if err != nil {
-		return nil, fmt.Errorf("could not read ns dir: %v", err)
+		return nil, logger.NewErrorf("could not read ns dir: %v", err)
 	}
 
 	var procNS ProcNS
 	for _, entry := range entries {
 		nsLink, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", pid, entry))
 		if err != nil {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 		ns, err := extractNSFromLink(nsLink)
 		if err != nil {
-			return nil, err
+			return nil, logger.ErrorFunc(err)
 		}
 		switch entry {
 		case "cgroup":
@@ -150,7 +150,7 @@ func GetAllProcNS(pid uint) (*ProcNS, error) {
 		case "uts":
 			procNS.Uts = ns
 		default:
-			return nil, fmt.Errorf("encountered unexpected namespace file - %s", entry)
+			return nil, logger.NewErrorf("encountered unexpected namespace file - %s", entry)
 		}
 	}
 	return &procNS, nil
@@ -161,11 +161,11 @@ func GetAllProcNS(pid uint) (*ProcNS, error) {
 func GetProcNS(pid uint, nsName string) (int, error) {
 	nsLink, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/%s", pid, nsName))
 	if err != nil {
-		return 0, fmt.Errorf("could not read ns file: %v", err)
+		return 0, logger.NewErrorf("could not read ns file: %v", err)
 	}
 	ns, err := extractNSFromLink(nsLink)
 	if err != nil {
-		return 0, fmt.Errorf("could not extract ns id: %v", err)
+		return 0, logger.NewErrorf("could not extract ns id: %v", err)
 	}
 	return ns, nil
 }
@@ -173,12 +173,12 @@ func GetProcNS(pid uint, nsName string) (int, error) {
 func extractNSFromLink(link string) (int, error) {
 	nsLinkSplitted := strings.SplitN(link, ":[", 2)
 	if len(nsLinkSplitted) != 2 {
-		return 0, fmt.Errorf("link format is not supported")
+		return 0, logger.NewErrorf("link format is not supported")
 	}
 	nsString := strings.TrimSuffix(nsLinkSplitted[1], "]")
 	ns, err := strconv.Atoi(nsString)
 	if err != nil {
-		return 0, err
+		return 0, logger.ErrorFunc(err)
 	}
 	return ns, nil
 }

--- a/pkg/utils/sharedobjs/container_symbols_loader.go
+++ b/pkg/utils/sharedobjs/container_symbols_loader.go
@@ -2,6 +2,7 @@ package sharedobjs
 
 import (
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 // ContainersSymbolsLoader is a decorator for SO loaders that resolves containers-relative paths to
@@ -23,7 +24,7 @@ func (cLoader *ContainersSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[s
 	var err error
 	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	return cLoader.hostLoader.GetDynamicSymbols(soInfo)
 }
@@ -32,7 +33,7 @@ func (cLoader *ContainersSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[
 	var err error
 	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	return cLoader.hostLoader.GetExportedSymbols(soInfo)
 }
@@ -41,7 +42,7 @@ func (cLoader *ContainersSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[
 	var err error
 	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	return cLoader.hostLoader.GetImportedSymbols(soInfo)
 }

--- a/pkg/utils/sharedobjs/host_symbols_loader.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader.go
@@ -4,6 +4,7 @@ import (
 	"debug/elf"
 
 	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/hashicorp/golang-lru/simplelru"
 )
 
@@ -30,7 +31,7 @@ func InitHostSymbolsLoader(cacheSize int) *HostSymbolsLoader {
 func (soLoader *HostSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	dynSyms := copyMap(syms.Imported)
 	for expSym := range syms.Exported {
@@ -44,7 +45,7 @@ func (soLoader *HostSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string
 func (soLoader *HostSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	return copyMap(syms.Exported), nil
 }
@@ -54,7 +55,7 @@ func (soLoader *HostSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[strin
 func (soLoader *HostSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	return copyMap(syms.Imported), nil
 }
@@ -66,7 +67,7 @@ func (soLoader *HostSymbolsLoader) loadSOSymbols(soInfo ObjInfo) (*dynamicSymbol
 	}
 	syms, err := soLoader.loadingFunc(soInfo.Path)
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	soLoader.soCache.Add(soInfo, syms)
 	return syms, nil
@@ -108,13 +109,13 @@ func loadSharedObjectDynamicSymbols(path string) (*dynamicSymbols, error) {
 		return e
 	})
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	defer loadedObject.Close()
 
 	dynamicSymbols, err := loadedObject.DynamicSymbols()
 	if err != nil {
-		return nil, err
+		return nil, logger.ErrorFunc(err)
 	}
 	return parseDynamicSymbols(dynamicSymbols), nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-	"runtime"
 	"strings"
 
 	"github.com/aquasecurity/libbpfgo/helpers"
@@ -17,20 +15,6 @@ func ParseSymbol(address uint64, table helpers.KernelSymbolTable) *helpers.Kerne
 	hookingFunction.Owner = strings.TrimPrefix(hookingFunction.Owner, "[")
 	hookingFunction.Owner = strings.TrimSuffix(hookingFunction.Owner, "]")
 	return hookingFunction
-}
-
-// ErrorFuncName displays a given error prefixed by the current (caller) fn name
-func ErrorFuncName(e error) error {
-
-	if e != nil {
-		pc, _, _, _ := runtime.Caller(1)
-		funcName := runtime.FuncForPC(pc).Name()
-		index := strings.LastIndex(funcName, "/") + 1
-
-		return fmt.Errorf("%v: %v", funcName[index:], e)
-	}
-
-	return nil
 }
 
 func HasBit(n uint64, offset uint) bool {


### PR DESCRIPTION
### 1. Explain what the PR does

errors: improve error output

It is very common to receive errors such as:

  "operation failed"

due to error being propagated to upper layers without context. If the error is related to a syscall, for example, it might be very generic and impossible to know its origins.

The logger package has solved that by putting context frames in both logger and debug messages, but it is not enough when tracee is being exited due to an error.

This patch:

- provides context for all existing errors.
- move error context functions to logger package.

By doing this change, it was possible to understand better all errors coming from dropping privileges, for example. Without it, it was very time consuming to understand what error was coming from which part of the code.
