### PR TITLE
tracee: make it the default binary

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -7,72 +7,29 @@
 # variables
 
 TRACEE_TMP="/tmp/tracee"
-TRACEE_PIPE="${TRACEE_TMP}/pipe"
 TRACEE_OUT="${TRACEE_TMP}/out"
+TRACEE_SRC=${TRACEE_SRC:="/tracee/src"}
+TRACEE_EXE=${TRACEE_EXE:="/tracee/tracee"}
 
-TRACEE_EBPF_SRC=${TRACEE_EBPF_SRC:="/tracee/src"}
-TRACEE_EBPF_EXE=${TRACEE_EBPF_EXE:="/tracee/tracee-ebpf"}
-TRACEE_RULES_EXE=${TRACEE_RULES_EXE:="/tracee/tracee-rules"}
-TRACEE_RULES=${TRACEE_RULES:="/tracee/signatures"}
 LIBBPFGO_OSRELEASE_FILE=${LIBBPFGO_OSRELEASE_FILE:=""}
-
-TRACEE_EBPF_ONLY=${TRACEE_EBPF_ONLY:=0} # used by both container images
 
 EBPF_PROBE_TIMEOUT=${EBPF_PROBE_TIMEOUT:=3} # 3 seconds for ebpf co-re probe
 
 # functions
 
 run_tracee() {
-    if [ ${TRACEE_EBPF_ONLY} -eq 1 ]; then
-        run_tracee_ebpf $@
-    else
-        run_tracee_rules $@
-    fi
-}
-
-probe_tracee_ebpf() {
-    # check if non CO-RE obj is needed (tracee-ebpf ret code is 2)
-
-    TRACEE_RET=0
-    if [ ${probed_cap} -ne 1 ]; then
-        probed_cap=1
-
-        echo "INFO: probing tracee-ebpf capabilities..."
-        timeout --preserve-status ${EBPF_PROBE_TIMEOUT} \
-            ${TRACEE_EBPF_EXE} --metrics --output=none \
-            --filter comm="nothing" 2>&1 > /dev/null 2>&1
-        TRACEE_RET=$?
-    fi
-}
-
-run_tracee_ebpf() {
-    ${TRACEE_EBPF_EXE} $@
-    TRACEE_RET=$?
-}
-
-run_tracee_rules() {
-
     probe_tracee_ebpf
-    if [ ${TRACEE_RET} -eq 2 ]; then
+    if [ "${TRACEE_RET}" -eq 2 ]; then
         return
     fi
 
     mkdir -p ${TRACEE_OUT}
-    rm -f ${TRACEE_PIPE}
-    mkfifo ${TRACEE_PIPE}
 
-    # start tracee-ebpf
+    # start tracee
 
-    events=$($TRACEE_RULES_EXE --list-events --rules-dir $TRACEE_RULES)
-    if [ -z $events ]; then
-        echo "ERROR: cannot list events via '$TRACEE_RULES_EXE --list-events --rules-dir $TRACEE_RULES'"
-        exit 1
-    fi
-
-    echo "INFO: starting tracee-ebpf..."
-    ${TRACEE_EBPF_EXE} \
+    echo "INFO: starting tracee..."
+    ${TRACEE_EXE} \
         --metrics \
-        --output=format:gob \
         --output=option:parse-arguments \
         --cache cache-type=mem \
         --cache mem-cache-size=512 \
@@ -80,81 +37,35 @@ run_tracee_rules() {
         --capabilities bypass=${CAPABILITIES_BYPASS:="0"}\
         --capabilities add=${CAPABILITIES_ADD:=""}\
         --capabilities drop=${CAPABILITIES_DROP:=""}\
-        --filter event=${events} \
-        --output=out-file:${TRACEE_PIPE} &
-    tracee_ebpf_pid=$!
-
-    # start tracee-rules
-
-    allcaps=""
-    if [[ ${CAPABILITIES_BYPASS:="0"} == "1" ]]; then
-        allcaps="--allcaps"
-    fi
-
-    echo "INFO: starting tracee-rules..."
-    $TRACEE_RULES_EXE \
-        --metrics --input-tracee=file:${TRACEE_PIPE} \
-        --input-tracee=format:gob \
-        --rules-dir $TRACEE_RULES \
-        $allcaps \
         $@
+    #tracee_pid=$!
+
     TRACEE_RET=$?
+}
+
+probe_tracee_ebpf() {
+    # check if non CO-RE obj is needed (tracee-ebpf ret code is 2)
+
+    TRACEE_RET=0
+    if [ "${probed_cap}" -ne 1 ]; then
+        probed_cap=1
+
+        echo "INFO: probing tracee-ebpf capabilities..."
+        timeout --preserve-status "${EBPF_PROBE_TIMEOUT}" \
+            "${TRACEE_EBPF_EXE}" --metrics --output=none \
+            --filter comm="nothing" 2>&1 > /dev/null 2>&1
+        TRACEE_RET=$?
+    fi
 }
 
 # startup
 
 probed_cap=0
 
-if [ ! -x ${TRACEE_EBPF_EXE} ]; then
-    echo "ERROR: cannot execute ${TRACEE_EBPF_EXE}"
+if [ ! -x "${TRACEE_EXE}" ]; then
+    echo "ERROR: cannot execute ${TRACEE_EXE}"
     exit 1
 fi
-
-if [ ! -x ${TRACEE_RULES_EXE} ]; then
-    echo "ERROR: cannot execute ${TRACEE_EBPF_EXE}"
-    exit 1
-fi
-
-# docker 1st argument might be "trace" only (so tracee-ebpf is executed)
-if [ "${1}" == "trace" ]; then
-    TRACEE_EBPF_ONLY=1
-    shift
-elif [ "${1}" == "custom-rules" ]; then
-    TRACEE_RULES="/custom-rules"
-    if [ ! -d "$TRACEE_RULES" ]; then
-        echo "ERROR:"
-        echo "ERROR: "$TRACEE_RULES" doesn't exist"
-        echo "ERROR: Mount a volume for it:"
-        echo "ERROR:     host: /your/custom/rules/dir"
-        echo "ERROR:     guest: /custom-rules"
-        echo "ERROR:"
-        exit 1
-    fi
-    shift
-fi
-
-for arg in ${@}; do
-    case ${arg} in
-    "-h" | "--help")
-        if [ ${TRACEE_EBPF_ONLY} -eq 1 ]; then
-            ${TRACEE_EBPF_EXE} --help
-        else
-            ${TRACEE_RULES_EXE} --help
-        fi
-
-        exit $?
-        ;;
-    "-l" | "--list")
-        if [ ${TRACEE_EBPF_ONLY} -eq 1 ]; then
-            ${TRACEE_EBPF_EXE} --list
-        else
-            ${TRACEE_RULES_EXE} --list
-        fi
-
-        exit $?
-        ;;
-    esac
-done
 
 if [ "${LIBBPFGO_OSRELEASE_FILE}" == "" ]; then
     echo "ERROR:"
@@ -184,13 +95,13 @@ fi
 
 # main
 
-if [ -d "${TRACEE_EBPF_SRC}" ]; then
+if [ -d "${TRACEE_SRC}" ]; then
     # full container image
 
     # run first, may find cached eBPF non CO-RE obj in /tmp/tracee
     run_tracee $@
 
-    if [ ${TRACEE_RET} -eq 2 ]; then
+    if [ "${TRACEE_RET}" -eq 2 ]; then
         # if ret code is 2, compile non CO-RE obj, run again
 
         if [ ! -d "/lib/modules/$(uname -r)" ]; then
@@ -206,7 +117,7 @@ if [ -d "${TRACEE_EBPF_SRC}" ]; then
             exit 1
         fi
 
-        cd ${TRACEE_EBPF_SRC}
+        cd "${TRACEE_SRC}"
         make clean
         make install-bpf-nocore
         # force nocore ebpf object
@@ -222,11 +133,11 @@ fi
 
 run_tracee $@
 
-if [ ${TRACEE_RET} -eq 2 ] && [ ! -d "${TRACEE_EBPF_SRC}" ]; then
+if [ "${TRACEE_RET}" -eq 2 ] && [ ! -d "${TRACEE_SRC}" ]; then
     echo "INFO:"
     echo "INFO: You should try the FULL tracee container image, it supports"
     echo "INFO: building, based on your host environment, needed eBPF objects"
-    echo "INFO: so tracee-ebpf may work."
+    echo "INFO: so tracee may work."
     echo "INFO:"
 fi
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR changes docker image entrypoint to use the new tracee binary. It removes the use of the older binaries `tracee-ebpf` and `tracee-rules`.

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
make -f builder/Makefile.tracee-container build-tracee
docker run  --name tracee --rm -it  --pid=host --cgroupns=host --privileged  -v /etc/os-release:/etc/os-release-host:ro      -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host  tracee:latest

# test different options
docker run  --name tracee --rm -it  --pid=host --cgroupns=host --privileged  -v /etc/os-release:/etc/os-release-host:ro      -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host  tracee:latest --output json

docker run  --name tracee --rm -it  --pid=host --cgroupns=host --privileged  -v /etc/os-release:/etc/os-release-host:ro      -e LIBBPFGO_OSRELEASE_FILE=/etc/os-release-host  tracee:latest --filter set=signatures
```

Do the same for the full image. 

This is part of https://github.com/aquasecurity/tracee/issues/2355
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
