### PR TITLE
Add webhook printer

### DIFF
--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -1032,7 +1032,7 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
 			},
-			expectedError: errors.New("flags.validateForwardFlag: forward flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("flags.validateURL: forward flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:    "empty forward flag",
@@ -1040,7 +1040,7 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
 			},
-			expectedError: errors.New("flags.validateForwardFlag: forward flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("flags.validateURL: forward flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:    "invalid forward url",
@@ -1048,7 +1048,7 @@ func TestPrepareOutput(t *testing.T) {
 			expectedOutput: flags.OutputConfig{
 				LogFile: os.Stderr,
 			},
-			expectedError: errors.New("flags.validateForwardFlag: invalid uri for forward output \"lalala\". Use '--output help' for more info"),
+			expectedError: errors.New("flags.validateURL: invalid uri for forward output \"lalala\". Use '--output help' for more info"),
 		},
 		{
 			testName:    "forward",
@@ -1057,6 +1057,42 @@ func TestPrepareOutput(t *testing.T) {
 				LogFile: os.Stderr,
 				PrinterConfigs: []printer.Config{
 					{Kind: "forward", OutPath: "tcp://localhost:1234"},
+				},
+				TraceeConfig: &tracee.OutputConfig{},
+			},
+		},
+		// webhook
+		{
+			testName:    "empty webhook flag",
+			outputSlice: []string{"webhook"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateURL: webhook flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "empty webhook flag",
+			outputSlice: []string{"webhook:"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateURL: webhook flag can't be empty, use '--output help' for more info"),
+		},
+		{
+			testName:    "invalid webhook url",
+			outputSlice: []string{"webhook:lalala"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+			},
+			expectedError: errors.New("flags.validateURL: invalid uri for webhook output \"lalala\". Use '--output help' for more info"),
+		},
+		{
+			testName:    "webhook",
+			outputSlice: []string{"webhook:http://localhost:8080"},
+			expectedOutput: flags.OutputConfig{
+				LogFile: os.Stderr,
+				PrinterConfigs: []printer.Config{
+					{Kind: "webhook", OutPath: "http://localhost:8080"},
 				},
 				TraceeConfig: &tracee.OutputConfig{},
 			},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR adds a webhook printer. The webhook is used to send events to postee or falcosidekiq so users can configure alerting or actions on top of it. 

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

Start a simple http server and point the webhook to it. An example of this feature working with postee:

<img width="1278" alt="Screenshot 2023-03-01 at 08 59 56" src="https://user-images.githubusercontent.com/34032/222133567-477fb57d-f36e-49e1-a4ee-59aa1ea6ef8f.png">


<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

For now the printer is not implementing `template`, it only supports `json`. Templating is coming on a different PR. 