### PR TITLE
k8s: remove flag everythingIsAnEvent from helm

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -30,14 +30,6 @@ spec:
         - name: tracee
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.everythingIsAnEvent }}
-          command: ["/tracee/tracee"]
-          args:
-            - --output
-            - json
-            - --filter
-            - event={{ .Values.events }}
-          {{- end }}
           {{- if .Values.postee.enabled }}
           args:
             - --webhook={{ .Values.postee.webhook }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -60,11 +60,6 @@ postee:
   enabled: false
   webhook: http://tracee-postee:8082
 
-# This flags enable the new tracee experience. It is a single binary, where every rule is
-# part of the events pipeline.
-everythingIsAnEvent: false
-events: anti_debugging,aslr_inspection,cgroup_notify_on_release,cgroup_release_agent,core_pattern_modification,default_loader_mod,disk_mount,docker_abuse,dynamic_code_loading,fileless_execution,hidden_file_created,illegitimate_shell,k8s_api_connection,k8s_cert_theft,kernel_module_loading,ld_preload,process_vm_write_inject,proc_fops_hooking,proc_kcore_read,proc_mem_access,proc_mem_code_injection,ptrace_code_injection,rcd_modification,sched_debug_recon,scheduled_task_mod,stdio_over_socket,sudoers_modification,syscall_hooking,system_request_key_mod
-
 signatures:
   # config defines Common Expression Language (CEL) signatures that are loaded
   # by Tracee-Rules from the --rules-dir directory. If the config object is not


### PR DESCRIPTION
This flag was used for users who wanted to try the new experience when it was beta, but the new experience will now be the default option.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR removes the helm flag `everythingIsAnEvent` which was used to enable the new experience while it was beta. With the next release this experience will be the default option. 

This is part of https://github.com/aquasecurity/tracee/issues/2355

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
# have a k8s cluster

helm repo add aqua https://aquasecurity.github.io/helm-charts/
helm dependency update ./deploy/helm/tracee
helm install tracee ./deploy/helm/tracee \
        --namespace tracee-system --create-namespace \
        --set hostPID=true

```

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
