### PR TITLE
k8s: fix templates to use unified binary

### DIFF
--- a/deploy/helm/tracee/templates/NOTES.txt
+++ b/deploy/helm/tracee/templates/NOTES.txt
@@ -4,13 +4,7 @@ By default, threat detections are printed to the standard output of each pod:
 
 $ kubectl logs -f daemonset/{{ include "tracee.fullname" . }} -n {{ .Release.Namespace }}
 
-*** Detection ***
-Time: 2022-06-08T13:59:01Z
-Signature ID: TRC-9
-Signature: New Executable Was Dropped During Runtime
-Data: map[file path:/bin/apache]
-Command: cp
-Hostname: attacker
+{"timestamp":1677676197900822209,"threadStartTime":1677676197713685267,"processorId":0,"processId":441,"cgroupId":7408,"threadId":441,"parentProcessId":431,"hostProcessId":4741,"hostThreadId":4741,"hostParentProcessId":4729,"userId":0,"mountNamespace":4026532733,"pidNamespace":4026532734,"processName":"dpkg","hostName":"app-75ff449bcd-","containerId":"ae95a93ce0c2f1b824ac4b205e4d1a3c8f724d663626c1ad23576efec64318de","containerImage":"docker.io/library/ubuntu:latest","containerName":"app","podName":"app-75ff449bcd-hfwnz","podNamespace":"default","podUID":"0f7ad251-39da-44f7-af28-34a0e971be3e","podSandbox":false,"eventId":"6029","eventName":"New executable dropped","matchedScopes":1,"argsNum":1,"returnValue":32768,"syscall":"","stackAddresses":null,"contextFlags":{"containerStarted":true,"isCompat":false},"args":[{"name":"path","type":"const char *","value":"/usr/bin/strace.dpkg-new"}],"metadata":{"Version":"1","Description":"An Executable file was dropped in the system during runtime. Container images are usually built with all binaries needed inside. A dropped binary may indicate that an adversary infiltrated your container.","Tags":null,"Properties":{"Category":"defense-evasion","Kubernetes_Technique":"","Severity":2,"Technique":"Masquerading","external_id":"T1036","id":"attack-pattern--42e8de7b-37b2-4258-905a-6897815e58e0","signatureID":"TRC-1022","signatureName":"New executable dropped"}}}
 
 {{- if .Values.postee.enabled }}
 

--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -30,11 +30,11 @@ spec:
         - name: tracee
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.postee.enabled }}
           args:
-            - --webhook={{ .Values.postee.webhook }}
-            - --webhook-template=./templates/rawjson.tmpl
-            - --webhook-content-type=application/json
+            - --filter set=signatures
+            - --output json
+          {{- if .Values.postee.enabled }}
+            - --output webhook:{{ .Values.postee.webhook }}
           {{- end }}
           env:
             - name: LIBBPFGO_OSRELEASE_FILE

--- a/deploy/kubernetes/kustomize/base/tracee.yaml
+++ b/deploy/kubernetes/kustomize/base/tracee.yaml
@@ -21,6 +21,9 @@ spec:
       - name: tracee
         image: docker.io/aquasec/tracee:0.11.1
         imagePullPolicy: IfNotPresent
+        args:
+          - --filter set=signatures
+          - --output json
         env:
           - name: LIBBPFGO_OSRELEASE_FILE
             value: /etc/os-release-host

--- a/deploy/kubernetes/kustomize/falcosidekick/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/falcosidekick/kustomization.yaml
@@ -9,9 +9,6 @@ patchesJson6902:
     name: tracee
   patch: |-
     - op: add
-      path: /spec/template/spec/containers/0/args
-      value: 
-        - --webhook http://tracee-webhook:2801 
-        - --webhook-template ./templates/falcosidekick.tmpl 
-        - --webhook-content-type application/json
+      path: /spec/template/spec/containers/0/args/2
+      value: --output webhook:http://tracee-webhook:2801
 

--- a/deploy/kubernetes/kustomize/postee/kustomization.yaml
+++ b/deploy/kubernetes/kustomize/postee/kustomization.yaml
@@ -9,9 +9,5 @@ patchesJson6902:
     name: tracee
   patch: |-
     - op: add
-      path: /spec/template/spec/containers/0/args
-      value: 
-        - --webhook=http://postee-svc:8082
-        - --webhook-template=./templates/rawjson.tmpl
-        - --webhook-content-type=application/json
-
+      path: /spec/template/spec/containers/0/args/2
+      value: --output webhook:http://postee-svc:8082

--- a/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
+++ b/deploy/kubernetes/tracee-falcosidekick/tracee.yaml
@@ -18,9 +18,9 @@ spec:
     spec:
       containers:
       - args:
-        - --webhook http://tracee-webhook:2801
-        - --webhook-template ./templates/falcosidekick.tmpl
-        - --webhook-content-type application/json
+        - --filter set=signatures
+        - --output json
+        - --output webhook:http://tracee-webhook:2801
         env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host

--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -18,9 +18,9 @@ spec:
     spec:
       containers:
       - args:
-        - --webhook=http://postee-svc:8082
-        - --webhook-template=./templates/rawjson.tmpl
-        - --webhook-content-type=application/json
+        - --filter set=signatures
+        - --output json
+        - --output webhook:http://postee-svc:8082
         env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -17,7 +17,10 @@ spec:
       name: tracee
     spec:
       containers:
-      - env:
+      - args:
+        - --filter set=signatures
+        - --output json
+        env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host
         image: docker.io/aquasec/tracee:0.11.1


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR updates the kubernetes templates to use the new release, with the unified binary. 

This is part of https://github.com/aquasecurity/tracee/issues/2355
<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
# have a k8s cluster
# checkout this PR

# install tracee 
kubectl apply -f deploy/kubernetes/tracee/tracee.yaml 

# the pod will crash because the docker image is not with all the latest changes

kubectl edit ds/tracee # this opens an yaml, update the image: with `josedonizetti/tracee:0.12.0`

kubectl logs -f ds/tracee

```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

Depends on https://github.com/aquasecurity/tracee/pull/2782

Tracee base, Tracee with Postee are working, but Tracee with Falcosidekiq is not, this is expected, because it depends on templates on the printer, a PR to fix it is on the way.