### PR TITLE
printer: block instead of drop events for broadcast

### DIFF
--- a/pkg/cmd/printer/broadcast.go
+++ b/pkg/cmd/printer/broadcast.go
@@ -3,7 +3,6 @@ package printer
 import (
 	"context"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -31,15 +30,8 @@ func NewBroadcast(ctx context.Context, printers []EventPrinter) *Broadcast {
 // Print broadcasts the event to all printers
 func (b *Broadcast) Print(event trace.Event) {
 	for _, c := range b.eventsChan {
-		// we use select to avoid blocking the print loop if one of the printers is slow
-		// in case the event can't be sent because the buffered channel is full, we drop it
-		// and log an warning
-		select {
-		case c <- event:
-		default:
-			// TODO: add metrics about not printed events
-			logger.Info("dropping event due to slow printer", "event", event)
-		}
+		// we are blocking here if the printer is not consuming events fast enough
+		c <- event
 	}
 }
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR is changing the printer broadcast to block instead of drop events. The use of nonblocking here is dropping a lot of events, we could use a timeout to give some or increase the size of the buffer, but this needs to be investigated deeper. 

The previous solution was a blocking one, based on the fact that tracee core is ready to hold events, with a buffer 10 times bigger than the buffers for the printers -> https://github.com/aquasecurity/tracee/blob/main/pkg/ebpf/events_pipeline.go#L102

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

we will test it on the e2e to validate it fixes the flaky tests created

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

I will create a issue to investigate it further, but considering we have a release this week, blocking is the best solution