### PR TITLE
Fix make error when output for xargs is empty

### DIFF
--- a/builder/Makefile.tracee-container
+++ b/builder/Makefile.tracee-container
@@ -105,7 +105,7 @@ build-tracee: \
 	$(CMD_DOCKER) images \
 		--filter "label=AS=tracee-make" \
 		--format "{{.ID}}" \
-		| xargs $(CMD_DOCKER) rmi
+		| xargs -r $(CMD_DOCKER) rmi
 
 .PHONY: build-tracee-full
 build-tracee-full: \
@@ -122,7 +122,7 @@ build-tracee-full: \
 	$(CMD_DOCKER) images \
 		--filter "label=AS=tracee-make" \
 		--format "{{.ID}}" \
-		| xargs $(CMD_DOCKER) rmi
+		| xargs -r $(CMD_DOCKER) rmi
 
 #
 # run tracee and tracee-full


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix make error when output for xargs is empty

### 2. Explain how to test it

Run `BTFHUB=0 make -f builder/Makefile.tracee-container build-tracee` on a system without any docker images.

### 3. Other comments

The next command should return an empty result:
```bash
	$(CMD_DOCKER) images \
		--filter "label=AS=tracee-make" \
		--format "{{.ID}}"
```

<!--
Links? References? Anything pointing to more context about the change.
-->
