### PR TITLE
ebpf: remove params_type_map and use events_map instead

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -348,20 +348,20 @@ static __always_inline int events_perf_submit(program_data_t *p, u32 id, long re
 
 #define DEC_ARG(n, enc_arg) ((enc_arg >> (8 * n)) & 0xFF)
 
-static __always_inline int save_args_to_submit_buf(event_data_t *event, u64 types, args_t *args)
+static __always_inline int save_args_to_submit_buf(event_data_t *event, args_t *args)
 {
     unsigned int i;
     unsigned int rc = 0;
     unsigned int arg_num = 0;
     short family = 0;
 
-    if (types == 0)
+    if (event->param_types == 0)
         return 0;
 
 #pragma unroll
     for (i = 0; i < 6; i++) {
         int size = 0;
-        u8 type = DEC_ARG(i, types);
+        u8 type = DEC_ARG(i, event->param_types);
         u8 index = i;
         switch (type) {
             case NONE_T:

--- a/pkg/ebpf/c/common/probes.h
+++ b/pkg/ebpf/c/common/probes.h
@@ -25,7 +25,7 @@
         return save_args(&args, id);                                                               \
     }
 
-#define TRACE_RET_FUNC(name, id, types, ret)                                                       \
+#define TRACE_RET_FUNC(name, id, ret)                                                              \
     int trace_ret_##name(void *ctx)                                                                \
     {                                                                                              \
         args_t args = {};                                                                          \
@@ -37,10 +37,10 @@
         if (!init_program_data(&p, ctx))                                                           \
             return 0;                                                                              \
                                                                                                    \
-        if (!should_submit(id, &(p.event->context)))                                               \
+        if (!should_submit(id, p.event))                                                           \
             return 0;                                                                              \
                                                                                                    \
-        save_args_to_submit_buf(p->event, types, &args);                                           \
+        save_args_to_submit_buf(p.event, &args);                                                   \
                                                                                                    \
         return events_perf_submit(&p, id, ret);                                                    \
     }

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -85,10 +85,9 @@ BPF_HASH(uts_ns_filter, string_filter_t, eq_t, 256);               // filter eve
 BPF_HASH(comm_filter, string_filter_t, eq_t, 256);                 // filter events by command name
 BPF_HASH(cgroup_id_filter, u32, eq_t, 256);                        // filter events by cgroup id
 BPF_HASH(binary_filter, binary_t, eq_t, 256);                      // filter events by binary path and mount namespace
-BPF_HASH(events_map, u32, u64, MAX_EVENT_ID);                      // map to persist event configuration data (currently submit policies)
+BPF_HASH(events_map, u32, event_config_t, MAX_EVENT_ID);           // map to persist event configuration data
 BPF_HASH(bin_args_map, u64, bin_args_t, 256);                      // persist args for send_bin funtion
 BPF_HASH(sys_32_to_64_map, u32, u32, 1024);                        // map 32bit to 64bit syscalls
-BPF_HASH(params_types_map, u32, u64, 1024);                        // encoded parameters types for event
 BPF_HASH(process_tree_map, u32, eq_t, 10240);                      // filter events by the ancestry of the traced process
 BPF_LRU_HASH(proc_info_map, u32, proc_info_t, 10240);              // holds data for every process
 BPF_LRU_HASH(task_info_map, u32, task_info_t, 10240);              // holds data for every task

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -312,6 +312,11 @@ typedef struct config_entry {
     u64 pid_min;
 } config_entry_t;
 
+typedef struct event_config {
+    u64 submit_for_policies;
+    u64 param_types;
+} event_config_t;
+
 enum capture_options_e
 {
     NET_CAP_OPT_FILTERED = (1 << 0), // pcap should obey event filters
@@ -327,6 +332,7 @@ typedef struct event_data {
     char args[ARGS_BUF_SIZE];
     u32 buf_off;
     struct task_struct *task;
+    u64 param_types;
 } event_data_t;
 
 #define MAX_EVENT_SIZE sizeof(event_context_t) + ARGS_BUF_SIZE


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The recently introduced events_map should carry all the configuration data required for the event. Currently it has only one value specifying for which scopes the event should be submitted. However, we can also use it to store the encoded event's parameter types which is currently being done using the params_type_map. This has two advantages - First, it removes the params_type_map which reduces memory footprint and complexity. Second, it saves an extra map lookup in the params_type_map, which is located in syscalls submit hotpath.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
