### PR TITLE
builder: add goimports to tracee-make docker imgs

### DIFF
--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -24,7 +24,9 @@ RUN apk --no-cache update && \
     apk --no-cache add libelf-static && \
     apk --no-cache add zlib-static && \
     curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.48.0/opa_linux_amd64_static && \
-    chmod 755 /usr/bin/opa
+    chmod 755 /usr/bin/opa && \
+    GOROOT=/usr/lib/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest && \
+    sudo cp $HOME/go/bin/goimports-reviser /usr/bin/
 
 # extra tools for testing things
 

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -71,7 +71,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     curl -L -o /tmp/golang.tar.xz https://go.dev/dl/go1.19.5.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /tmp/golang.tar.xz && \
     update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 1 && \
-    update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1
+    update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1 && \
+    GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest && \
+    sudo cp $HOME/go/bin/goimports-reviser /usr/bin/
 
 USER tracee
 ENV HOME /home/tracee


### PR DESCRIPTION
### 1. Explain what the PR does

builder: add goimports to tracee-make docker imgs

### 2. Explain how to test it

`make -f builder/Makefile.tracee-make ubuntu-prepare`
`make -f builder/Makefile.tracee-make ubuntu-shell`
`make check-fmt`
`make fix-fmt`

### 3. Other comments

Complement of:

- #2815
