### PR TITLE
errfmt: introduce new package for error formatting

### DIFF
--- a/pkg/bucketscache/bucketscache.go
+++ b/pkg/bucketscache/bucketscache.go
@@ -3,7 +3,7 @@ package bucketscache
 import (
 	"sync"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 type BucketsCache struct {
@@ -69,5 +69,5 @@ func (c *BucketsCache) addBucketItem(key uint32, value uint32, force bool) {
 }
 
 func NoSuchItem(key uint32, index int) error {
-	return logger.NewErrorf("no such item in cache at key: %d, index: %d", key, index)
+	return errfmt.Errorf("no such item in cache at key: %d, index: %d", key, index)
 }

--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -9,8 +9,8 @@ package bufferdecoder
 import (
 	"encoding/binary"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 type EbpfDecoder struct {
@@ -43,7 +43,7 @@ func (decoder *EbpfDecoder) ReadAmountBytes() int {
 func (decoder *EbpfDecoder) DecodeContext(ctx *Context) error {
 	offset := decoder.cursor
 	if uint32(len(decoder.buffer[offset:])) < ctx.GetSizeBytes() {
-		return logger.NewErrorf("context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), ctx.GetSizeBytes())
+		return errfmt.Errorf("context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), ctx.GetSizeBytes())
 	}
 
 	// event_context start
@@ -84,7 +84,7 @@ func (decoder *EbpfDecoder) DecodeUint8(msg *uint8) error {
 	readAmount := 1
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = decoder.buffer[decoder.cursor]
 	decoder.cursor += readAmount
@@ -96,7 +96,7 @@ func (decoder *EbpfDecoder) DecodeInt8(msg *int8) error {
 	readAmount := 1
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int8(decoder.buffer[offset])
 	decoder.cursor += readAmount
@@ -108,7 +108,7 @@ func (decoder *EbpfDecoder) DecodeUint16(msg *uint16) error {
 	readAmount := 2
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.LittleEndian.Uint16(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -120,7 +120,7 @@ func (decoder *EbpfDecoder) DecodeUint16BigEndian(msg *uint16) error {
 	readAmount := 2
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.BigEndian.Uint16(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -132,7 +132,7 @@ func (decoder *EbpfDecoder) DecodeInt16(msg *int16) error {
 	readAmount := 2
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int16(binary.LittleEndian.Uint16(decoder.buffer[offset : offset+readAmount]))
 	decoder.cursor += readAmount
@@ -144,7 +144,7 @@ func (decoder *EbpfDecoder) DecodeUint32(msg *uint32) error {
 	readAmount := 4
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -156,7 +156,7 @@ func (decoder *EbpfDecoder) DecodeUint32BigEndian(msg *uint32) error {
 	readAmount := 4
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.BigEndian.Uint32(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -168,7 +168,7 @@ func (decoder *EbpfDecoder) DecodeInt32(msg *int32) error {
 	readAmount := 4
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int32(binary.LittleEndian.Uint32(decoder.buffer[offset : offset+readAmount]))
 	decoder.cursor += readAmount
@@ -180,7 +180,7 @@ func (decoder *EbpfDecoder) DecodeUint64(msg *uint64) error {
 	readAmount := 8
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+readAmount])
 	decoder.cursor += readAmount
@@ -192,7 +192,7 @@ func (decoder *EbpfDecoder) DecodeInt64(msg *int64) error {
 	readAmount := 8
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < readAmount {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = int64(binary.LittleEndian.Uint64(decoder.buffer[decoder.cursor : decoder.cursor+readAmount]))
 	decoder.cursor += readAmount
@@ -203,7 +203,7 @@ func (decoder *EbpfDecoder) DecodeInt64(msg *int64) error {
 func (decoder *EbpfDecoder) DecodeBool(msg *bool) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < 1 {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = (decoder.buffer[offset] != 0)
 	decoder.cursor += 1
@@ -215,7 +215,7 @@ func (decoder *EbpfDecoder) DecodeBytes(msg []byte, size uint32) error {
 	offset := decoder.cursor
 	castedSize := int(size)
 	if len(decoder.buffer[offset:]) < castedSize {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	_ = copy(msg[:], decoder.buffer[offset:offset+castedSize])
 	decoder.cursor += castedSize
@@ -226,7 +226,7 @@ func (decoder *EbpfDecoder) DecodeBytes(msg []byte, size uint32) error {
 func (decoder *EbpfDecoder) DecodeIntArray(msg []int32, size uint32) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(size*4) {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	for i := 0; i < int(size); i++ {
 		msg[i] = int32(binary.LittleEndian.Uint32(decoder.buffer[decoder.cursor : decoder.cursor+4]))
@@ -240,13 +240,13 @@ func (decoder *EbpfDecoder) DecodeUint64Array(msg *[]uint64) error {
 	var arrLen uint8
 	err := decoder.DecodeUint8(&arrLen)
 	if err != nil {
-		return logger.NewErrorf("error reading ulong array number of elements: %v", err)
+		return errfmt.Errorf("error reading ulong array number of elements: %v", err)
 	}
 	for i := 0; i < int(arrLen); i++ {
 		var element uint64
 		err := decoder.DecodeUint64(&element)
 		if err != nil {
-			return logger.NewErrorf("can't read element %d uint64 from buffer: %s", i, err)
+			return errfmt.Errorf("can't read element %d uint64 from buffer: %s", i, err)
 		}
 		*msg = append(*msg, element)
 	}
@@ -257,7 +257,7 @@ func (decoder *EbpfDecoder) DecodeUint64Array(msg *[]uint64) error {
 func (decoder *EbpfDecoder) DecodeSlimCred(slimCred *SlimCred) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < 80 {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	slimCred.Uid = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
 	slimCred.Gid = binary.LittleEndian.Uint32(decoder.buffer[offset+4 : offset+8])
@@ -282,7 +282,7 @@ func (decoder *EbpfDecoder) DecodeSlimCred(slimCred *SlimCred) error {
 func (decoder *EbpfDecoder) DecodeChunkMeta(chunkMeta *ChunkMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(chunkMeta.GetSizeBytes()) {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	chunkMeta.BinType = BinType(decoder.buffer[offset])
 	chunkMeta.CgroupID = binary.LittleEndian.Uint64(decoder.buffer[offset+1 : offset+9])
@@ -297,7 +297,7 @@ func (decoder *EbpfDecoder) DecodeChunkMeta(chunkMeta *ChunkMeta) error {
 func (decoder *EbpfDecoder) DecodeVfsWriteMeta(vfsWriteMeta *VfsWriteMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(vfsWriteMeta.GetSizeBytes()) {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	vfsWriteMeta.DevID = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
 	vfsWriteMeta.Inode = binary.LittleEndian.Uint64(decoder.buffer[offset+4 : offset+12])
@@ -311,7 +311,7 @@ func (decoder *EbpfDecoder) DecodeVfsWriteMeta(vfsWriteMeta *VfsWriteMeta) error
 func (decoder *EbpfDecoder) DecodeKernelModuleMeta(kernelModuleMeta *KernelModuleMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(kernelModuleMeta.GetSizeBytes()) {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	kernelModuleMeta.DevID = binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4])
 	kernelModuleMeta.Inode = binary.LittleEndian.Uint64(decoder.buffer[offset+4 : offset+12])
@@ -325,7 +325,7 @@ func (decoder *EbpfDecoder) DecodeKernelModuleMeta(kernelModuleMeta *KernelModul
 func (decoder *EbpfDecoder) DecodeMprotectWriteMeta(mprotectWriteMeta *MprotectWriteMeta) error {
 	offset := decoder.cursor
 	if len(decoder.buffer[offset:]) < int(mprotectWriteMeta.GetSizeBytes()) {
-		return logger.NewErrorf("can't read context from buffer: buffer too short")
+		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	mprotectWriteMeta.Ts = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+8])
 	decoder.cursor += int(mprotectWriteMeta.GetSizeBytes())

--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -61,10 +61,10 @@ func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.A
 
 	err = ebpfMsgDecoder.DecodeUint8(&argIdx)
 	if err != nil {
-		return 0, arg, logger.NewErrorf("error reading arg index: %v", err)
+		return 0, arg, errfmt.Errorf("error reading arg index: %v", err)
 	}
 	if int(argIdx) >= len(params) {
-		return 0, arg, logger.NewErrorf("invalid arg index %d", argIdx)
+		return 0, arg, errfmt.Errorf("invalid arg index %d", argIdx)
 	}
 	arg.ArgMeta = params[argIdx]
 	argType := GetParamType(arg.Type)
@@ -116,12 +116,12 @@ func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.A
 		var arrLen uint8
 		err = ebpfMsgDecoder.DecodeUint8(&arrLen)
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading string array number of elements: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading string array number of elements: %v", err)
 		}
 		for i := 0; i < int(arrLen); i++ {
 			s, err := readStringFromBuff(ebpfMsgDecoder)
 			if err != nil {
-				return uint(argIdx), arg, logger.NewErrorf("error reading string element: %v", err)
+				return uint(argIdx), arg, errfmt.Errorf("error reading string element: %v", err)
 			}
 			ss = append(ss, s)
 		}
@@ -133,15 +133,15 @@ func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.A
 
 		err = ebpfMsgDecoder.DecodeUint32(&arrLen)
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading args array length: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading args array length: %v", err)
 		}
 		err = ebpfMsgDecoder.DecodeUint32(&argNum)
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading args number: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading args number: %v", err)
 		}
 		resBytes, err := ReadByteSliceFromBuff(ebpfMsgDecoder, int(arrLen))
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading args array: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading args array: %v", err)
 		}
 		ss = strings.Split(string(resBytes), "\x00")
 		if ss[len(ss)-1] == "" {
@@ -155,25 +155,25 @@ func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.A
 		var size uint32
 		err = ebpfMsgDecoder.DecodeUint32(&size)
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading byte array size: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading byte array size: %v", err)
 		}
 		// error if byte buffer is too big (and not a network event)
 		if size > 4096 && (id < events.NetPacketBase || id > events.MaxNetID) {
-			return uint(argIdx), arg, logger.NewErrorf("byte array size too big: %d", size)
+			return uint(argIdx), arg, errfmt.Errorf("byte array size too big: %d", size)
 		}
 		res, err = ReadByteSliceFromBuff(ebpfMsgDecoder, int(size))
 	case intArr2T:
 		var intArray [2]int32
 		err = ebpfMsgDecoder.DecodeIntArray(intArray[:], 2)
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading int elements: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading int elements: %v", err)
 		}
 		res = intArray
 	case uint64ArrT:
 		ulongArray := make([]uint64, 0)
 		err := ebpfMsgDecoder.DecodeUint64Array(&ulongArray)
 		if err != nil {
-			return uint(argIdx), arg, logger.NewErrorf("error reading ulong elements: %v", err)
+			return uint(argIdx), arg, errfmt.Errorf("error reading ulong elements: %v", err)
 		}
 		res = ulongArray
 	case timespecT:
@@ -181,17 +181,17 @@ func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.A
 		var nsec int64
 		err = ebpfMsgDecoder.DecodeInt64(&sec)
 		if err != nil {
-			return uint(argIdx), arg, logger.ErrorFunc(err)
+			return uint(argIdx), arg, errfmt.WrapError(err)
 		}
 		err = ebpfMsgDecoder.DecodeInt64(&nsec)
 		res = float64(sec) + (float64(nsec) / float64(1000000000))
 
 	default:
 		// if we don't recognize the arg type, we can't parse the rest of the buffer
-		return uint(argIdx), arg, logger.NewErrorf("error unknown arg type %v", argType)
+		return uint(argIdx), arg, errfmt.Errorf("error unknown arg type %v", argType)
 	}
 	if err != nil {
-		return uint(argIdx), arg, logger.ErrorFunc(err)
+		return uint(argIdx), arg, errfmt.WrapError(err)
 	}
 	arg.Value = res
 	return uint(argIdx), arg, nil
@@ -252,7 +252,7 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 	var family int16
 	err := ebpfMsgDecoder.DecodeInt16(&family)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	socketDomainArg, err := helpers.ParseSocketDomainArgument(uint64(family))
 	if err != nil {
@@ -271,7 +271,7 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 		var sunPathBuf [108]byte
 		err := ebpfMsgDecoder.DecodeBytes(sunPathBuf[:], 108)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_un: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_un: %v", err)
 		}
 		trimmedPath := bytes.TrimLeft(sunPathBuf[:], "\000")
 		sunPath := ""
@@ -280,7 +280,7 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 			sunPath, err = readStringVarFromBuff(pathDecoder, 108)
 		}
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_un: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_un: %v", err)
 		}
 		res["sun_path"] = sunPath
 	case 2: // AF_INET
@@ -299,18 +299,18 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 		var port uint16
 		err = ebpfMsgDecoder.DecodeUint16BigEndian(&port)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in: %v", err)
 		}
 		res["sin_port"] = strconv.Itoa(int(port))
 		var addr uint32
 		err = ebpfMsgDecoder.DecodeUint32BigEndian(&addr)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in: %v", err)
 		}
 		res["sin_addr"] = PrintUint32IP(addr)
 		_, err := ReadByteSliceFromBuff(ebpfMsgDecoder, 8)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in: %v", err)
 		}
 	case 10: // AF_INET6
 		/*
@@ -329,25 +329,25 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 		var port uint16
 		err = ebpfMsgDecoder.DecodeUint16BigEndian(&port)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in6: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in6: %v", err)
 		}
 		res["sin6_port"] = strconv.Itoa(int(port))
 
 		var flowinfo uint32
 		err = ebpfMsgDecoder.DecodeUint32BigEndian(&flowinfo)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in6: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in6: %v", err)
 		}
 		res["sin6_flowinfo"] = strconv.Itoa(int(flowinfo))
 		addr, err := ReadByteSliceFromBuff(ebpfMsgDecoder, 16)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in6: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in6: %v", err)
 		}
 		res["sin6_addr"] = Print16BytesSliceIP(addr)
 		var scopeid uint32
 		err = ebpfMsgDecoder.DecodeUint32BigEndian(&scopeid)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing sockaddr_in6: %v", err)
+			return nil, errfmt.Errorf("error parsing sockaddr_in6: %v", err)
 		}
 		res["sin6_scopeid"] = strconv.Itoa(int(scopeid))
 	}
@@ -359,10 +359,10 @@ func readStringFromBuff(ebpfMsgDecoder *EbpfDecoder) (string, error) {
 	var size uint32
 	err = ebpfMsgDecoder.DecodeUint32(&size)
 	if err != nil {
-		return "", logger.NewErrorf("error reading string size: %v", err)
+		return "", errfmt.Errorf("error reading string size: %v", err)
 	}
 	if size > 4096 {
-		return "", logger.NewErrorf("string size too big: %d", size)
+		return "", errfmt.Errorf("string size too big: %d", size)
 	}
 	res, err := ReadByteSliceFromBuff(ebpfMsgDecoder, int(size-1)) //last byte is string terminating null
 	defer func() {
@@ -370,7 +370,7 @@ func readStringFromBuff(ebpfMsgDecoder *EbpfDecoder) (string, error) {
 		ebpfMsgDecoder.DecodeInt8(&dummy) // discard last byte which is string terminating null
 	}()
 	if err != nil {
-		return "", logger.NewErrorf("error reading string arg: %v", err)
+		return "", errfmt.Errorf("error reading string arg: %v", err)
 	}
 	return string(res), nil
 }
@@ -383,13 +383,13 @@ func readStringVarFromBuff(decoder *EbpfDecoder, max int) (string, error) {
 	res := make([]byte, max)
 	err = decoder.DecodeInt8(&char)
 	if err != nil {
-		return "", logger.NewErrorf("error reading null terminated string: %v", err)
+		return "", errfmt.Errorf("error reading null terminated string: %v", err)
 	}
 	for count := 1; char != 0 && count < max; count++ {
 		res = append(res, byte(char))
 		err = decoder.DecodeInt8(&char)
 		if err != nil {
-			return "", logger.NewErrorf("error reading null terminated string: %v", err)
+			return "", errfmt.Errorf("error reading null terminated string: %v", err)
 		}
 	}
 	res = bytes.TrimLeft(res[:], "\000")
@@ -401,7 +401,7 @@ func ReadByteSliceFromBuff(ebpfMsgDecoder *EbpfDecoder, len int) ([]byte, error)
 	res := make([]byte, len)
 	err = ebpfMsgDecoder.DecodeBytes(res[:], uint32(len))
 	if err != nil {
-		return nil, logger.NewErrorf("error reading byte array: %v", err)
+		return nil, errfmt.Errorf("error reading byte array: %v", err)
 	}
 	return res, nil
 }

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/mount"
 )
 
@@ -63,7 +63,7 @@ func NewCgroups() (*Cgroups, error) {
 	// discover the default cgroup being used
 	defaultVersion, err := GetCgroupDefaultVersion()
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	// only start cgroupv1 if it is the OS default (orelse it isn't needed)
@@ -71,7 +71,7 @@ func NewCgroups() (*Cgroups, error) {
 		cgroupv1, err = NewCgroup(CgroupVersion1)
 		if err != nil {
 			if _, ok := err.(*VersionNotSupported); !ok {
-				return nil, logger.ErrorFunc(err)
+				return nil, errfmt.WrapError(err)
 			}
 		}
 	}
@@ -80,7 +80,7 @@ func NewCgroups() (*Cgroups, error) {
 	cgroupv2, err = NewCgroup(CgroupVersion2)
 	if err != nil {
 		if _, ok := err.(*VersionNotSupported); !ok {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 	}
 
@@ -103,7 +103,7 @@ func NewCgroups() (*Cgroups, error) {
 		// discover default cgroup controller hierarchy id for cgroupv1
 		hid, err = GetCgroupControllerHierarchy(CgroupDefaultController)
 		if err != nil {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 
 	case CgroupVersion2:
@@ -127,7 +127,7 @@ func (cs *Cgroups) Destroy() error {
 	if cs.cgroupv1 != nil {
 		err := cs.cgroupv1.destroy()
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 	if cs.cgroupv2 != nil {
@@ -194,7 +194,7 @@ func (c *CgroupV1) init() error {
 	// 0. check if cgroup type is supported
 	supported, err := mount.IsFileSystemSupported(CgroupVersion1.String())
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	if !supported {
 		return &VersionNotSupported{}
@@ -208,7 +208,7 @@ func (c *CgroupV1) init() error {
 		sysFsCgroup, // where to check for already mounted cgroupfs
 	)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	// 2. discover where cgroup is mounted
@@ -245,7 +245,7 @@ func (c *CgroupV2) init() error {
 	// 0. check if cgroup type is supported
 	supported, err := mount.IsFileSystemSupported(CgroupVersion2.String())
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	if !supported {
 		return &VersionNotSupported{}
@@ -259,7 +259,7 @@ func (c *CgroupV2) init() error {
 		sysFsCgroup, // where to check for already mounted cgroupfs
 	)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	// 2. discover where cgroup is mounted
@@ -385,7 +385,7 @@ func GetCgroupControllerHierarchy(subsys string) (int, error) {
 func GetCgroupPath(rootDir string, cgroupId uint64, subPath string) (string, error) {
 	entries, err := os.ReadDir(rootDir)
 	if err != nil {
-		return "", logger.ErrorFunc(err)
+		return "", errfmt.WrapError(err)
 	}
 
 	for _, entry := range entries {

--- a/pkg/cmd/flags/cache.go
+++ b/pkg/cmd/flags/cache.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
-	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func cacheHelp() string {
@@ -34,7 +34,7 @@ func PrepareCache(cacheSlice []string) (queue.CacheConfig, error) {
 	for _, o := range cacheSlice {
 		cacheParts := strings.SplitN(o, "=", 2)
 		if len(cacheParts) != 2 {
-			return cache, logger.NewErrorf("unrecognized cache option format: %s", o)
+			return cache, errfmt.Errorf("unrecognized cache option format: %s", o)
 		}
 		key := cacheParts[0]
 		value := cacheParts[1]
@@ -45,19 +45,19 @@ func PrepareCache(cacheSlice []string) (queue.CacheConfig, error) {
 			case "mem":
 				cacheTypeMem = true
 			default:
-				return nil, logger.NewErrorf("unrecognized cache-mem option: %s (valid options are: none,mem)", o)
+				return nil, errfmt.Errorf("unrecognized cache-mem option: %s (valid options are: none,mem)", o)
 			}
 		case "mem-cache-size":
 			if !cacheTypeMem {
-				return nil, logger.NewErrorf("you need to specify cache-type=mem before setting mem-cache-size")
+				return nil, errfmt.Errorf("you need to specify cache-type=mem before setting mem-cache-size")
 			}
 			eventsCacheMemSizeMb, err = strconv.Atoi(value)
 			if err != nil {
-				return nil, logger.NewErrorf("could not parse mem-cache-size value: %v", err)
+				return nil, errfmt.Errorf("could not parse mem-cache-size value: %v", err)
 			}
 
 		default:
-			return nil, logger.NewErrorf("unrecognized cache option format: %s", o)
+			return nil, errfmt.Errorf("unrecognized cache option format: %s", o)
 		}
 	}
 	if cacheTypeMem {

--- a/pkg/cmd/flags/capabilities.go
+++ b/pkg/cmd/flags/capabilities.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 func capabilitiesHelp() string {
@@ -35,7 +35,7 @@ func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) 
 			if b == "0" || b == "false" {
 				capsConfig.BypassCaps = false
 			} else if b != "1" && b != "true" {
-				return capsConfig, logger.NewErrorf("bypass should either be true or false")
+				return capsConfig, errfmt.Errorf("bypass should either be true or false")
 			}
 		}
 		if strings.HasPrefix(slice, "add=") {
@@ -65,7 +65,7 @@ func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) 
 	for _, a := range capsConfig.AddCaps {
 		for _, d := range capsConfig.DropCaps {
 			if a == d {
-				return capsConfig, logger.NewErrorf("cant add and drop %v at the same time", a)
+				return capsConfig, errfmt.Errorf("cant add and drop %v at the same time", a)
 			}
 		}
 	}

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 func captureHelp() string {
@@ -94,7 +94,7 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 			capture.FileWrite = true
 			pathPrefix := strings.TrimSuffix(strings.TrimPrefix(cap, "write="), "*")
 			if len(pathPrefix) == 0 {
-				return tracee.CaptureConfig{}, logger.NewErrorf("capture write filter cannot be empty")
+				return tracee.CaptureConfig{}, errfmt.Errorf("capture write filter cannot be empty")
 			}
 			filterFileWrite = append(filterFileWrite, pathPrefix)
 		} else if cap == "exec" {
@@ -155,10 +155,10 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 				context = strings.TrimSuffix(context, "b")
 				amount, err = strconv.ParseUint(context, 10, 64)
 			} else {
-				return tracee.CaptureConfig{}, logger.NewErrorf("could not parse pcap snaplen: missing b or kb ?")
+				return tracee.CaptureConfig{}, errfmt.Errorf("could not parse pcap snaplen: missing b or kb ?")
 			}
 			if err != nil {
-				return tracee.CaptureConfig{}, logger.NewErrorf("could not parse pcap snaplen: %v", err)
+				return tracee.CaptureConfig{}, errfmt.Errorf("could not parse pcap snaplen: %v", err)
 			}
 			if amount >= (1 << 16) {
 				amount = (1 << 16) - 1
@@ -169,10 +169,10 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 		} else if strings.HasPrefix(cap, "dir:") {
 			outDir = strings.TrimPrefix(cap, "dir:")
 			if len(outDir) == 0 {
-				return tracee.CaptureConfig{}, logger.NewErrorf("capture output dir cannot be empty")
+				return tracee.CaptureConfig{}, errfmt.Errorf("capture output dir cannot be empty")
 			}
 		} else {
-			return tracee.CaptureConfig{}, logger.NewErrorf("invalid capture option specified, use '--capture help' for more info")
+			return tracee.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--capture help' for more info")
 		}
 	}
 	capture.FilterFileWrite = filterFileWrite

--- a/pkg/cmd/flags/containers.go
+++ b/pkg/cmd/flags/containers.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/containers/runtime"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -57,19 +58,19 @@ func PrepareContainers(containerFlags []string) (runtime.Sockets, error) {
 	for _, flag := range containerFlags {
 		parts := strings.Split(flag, ":")
 		if len(parts) != 2 {
-			return sockets, logger.NewErrorf("failed to parse container flags (must be of format {runtime}:{socket path})")
+			return sockets, errfmt.Errorf("failed to parse container flags (must be of format {runtime}:{socket path})")
 		}
 		containerRuntime := parts[0]
 
 		if !contains(supportedRuntimes, containerRuntime) {
-			return sockets, logger.NewErrorf("provided unsupported container runtime (see --crs help for supported runtimes)")
+			return sockets, errfmt.Errorf("provided unsupported container runtime (see --crs help for supported runtimes)")
 		}
 
 		socket := parts[1]
 		err := sockets.Register(runtime.FromString(containerRuntime), socket)
 
 		if err != nil {
-			return sockets, logger.NewErrorf("failed to register runtime socket, %s", err.Error())
+			return sockets, errfmt.Errorf("failed to register runtime socket, %s", err.Error())
 		}
 	}
 

--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/filterscope"
@@ -582,7 +583,7 @@ func (filter *cliFilter) Parse(operatorAndValues string) error {
 
 	if operatorString == "!" {
 		if len(operatorAndValues) < 3 {
-			return logger.NewErrorf("invalid operator and/or values given to filter: %s", operatorAndValues)
+			return errfmt.Errorf("invalid operator and/or values given to filter: %s", operatorAndValues)
 		}
 		operatorString = operatorAndValues[0:2]
 		valuesString = operatorAndValues[2:]
@@ -597,7 +598,7 @@ func (filter *cliFilter) Parse(operatorAndValues string) error {
 		case "!=":
 			filter.NotEqual = append(filter.NotEqual, values[i])
 		default:
-			return logger.NewErrorf("invalid filter operator: %s", operatorString)
+			return errfmt.Errorf("invalid filter operator: %s", operatorString)
 		}
 	}
 

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -6,6 +6,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -29,7 +30,7 @@ Examples:
 }
 
 func InvalidLogOption(opt string) error {
-	return logger.NewErrorf("invalid log option: %s, use '--log help' for more info", opt)
+	return errfmt.Errorf("invalid log option: %s, use '--log help' for more info", opt)
 }
 
 func PrepareLogger(logOptions []string, w io.Writer) (*logger.LoggerConfig, error) {

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 func outputHelp() string {
@@ -173,7 +173,7 @@ func setOption(config *tracee.OutputConfig, option string) error {
 	case "sort-events":
 		config.EventsSorting = true
 	default:
-		return logger.NewErrorf("invalid output option: %s, use '--output help' for more info", option)
+		return errfmt.Errorf("invalid output option: %s, use '--output help' for more info", option)
 	}
 
 	return nil
@@ -219,11 +219,11 @@ func parseFormat(outputParts []string, printerMap map[string]string) error {
 	for _, outPath := range strings.Split(outputParts[1], ",") {
 
 		if outPath == "" {
-			return logger.NewErrorf("format flag can't be empty, use '--output help' for more info")
+			return errfmt.Errorf("format flag can't be empty, use '--output help' for more info")
 		}
 
 		if _, ok := printerMap[outPath]; ok {
-			return logger.NewErrorf("cannot use the same path for multiple outputs: %s, use '--output help' for more info", outPath)
+			return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use '--output help' for more info", outPath)
 		}
 		printerMap[outPath] = outputParts[0]
 	}
@@ -234,7 +234,7 @@ func parseFormat(outputParts []string, printerMap map[string]string) error {
 // parseOption parses the given option and sets it in the given config
 func parseOption(outputParts []string, traceeConfig *tracee.OutputConfig) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
-		return logger.NewErrorf("option flag can't be empty, use '--output help' for more info")
+		return errfmt.Errorf("option flag can't be empty, use '--output help' for more info")
 	}
 
 	for _, option := range strings.Split(outputParts[1], ",") {
@@ -250,7 +250,7 @@ func parseOption(outputParts []string, traceeConfig *tracee.OutputConfig) error 
 // validateLogfile validates the given logfile
 func validateLogfile(outputParts []string) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
-		return logger.NewErrorf("log-file flag can't be empty, use '--output help' for more info")
+		return errfmt.Errorf("log-file flag can't be empty, use '--output help' for more info")
 	}
 
 	return nil
@@ -260,14 +260,14 @@ func validateLogfile(outputParts []string) error {
 func createFile(path string) (*os.File, error) {
 	fileInfo, err := os.Stat(path)
 	if err == nil && fileInfo.IsDir() {
-		return nil, logger.NewErrorf("cannot use a path of existing directory %s", path)
+		return nil, errfmt.Errorf("cannot use a path of existing directory %s", path)
 	}
 
 	dir := filepath.Dir(path)
 	os.MkdirAll(dir, 0755)
 	file, err := os.Create(path)
 	if err != nil {
-		return nil, logger.NewErrorf("failed to create output path: %v", err)
+		return nil, errfmt.Errorf("failed to create output path: %v", err)
 	}
 
 	return file, nil
@@ -277,13 +277,13 @@ func createFile(path string) (*os.File, error) {
 // --output [webhook|forward]:[protocol://user:pass@]host:port[?k=v#f]
 func validateURL(outputParts []string, flag string) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
-		return logger.NewErrorf("%s flag can't be empty, use '--output help' for more info", flag)
+		return errfmt.Errorf("%s flag can't be empty, use '--output help' for more info", flag)
 	}
 	// Now parse our URL using the standard library and report any errors from basic parsing.
 	_, err := url.ParseRequestURI(outputParts[1])
 
 	if err != nil {
-		return logger.NewErrorf("invalid uri for %s output %q. Use '--output help' for more info", flag, outputParts[1])
+		return errfmt.Errorf("invalid uri for %s output %q. Use '--output help' for more info", flag, outputParts[1])
 	}
 
 	return nil

--- a/pkg/cmd/flags/rego.go
+++ b/pkg/cmd/flags/rego.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/open-policy-agent/opa/compile"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/signatures/rego"
 )
 
@@ -40,7 +40,7 @@ func PrepareRego(regoSlice []string) (rego.Config, error) {
 		case "aio":
 			c.AIO = true
 		default:
-			return rego.Config{}, logger.NewErrorf("invalid rego option specified, use '--rego help' for more info")
+			return rego.Config{}, errfmt.Errorf("invalid rego option specified, use '--rego help' for more info")
 		}
 	}
 

--- a/pkg/cmd/flags/server/server.go
+++ b/pkg/cmd/flags/server/server.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/server"
 )
 
@@ -19,7 +19,7 @@ const (
 
 func PrepareServer(listenAddr string, metrics, healthz, pprof bool) (*server.Server, error) {
 	if len(listenAddr) == 0 {
-		return nil, logger.NewErrorf("listen address cannot be empty")
+		return nil, errfmt.Errorf("listen address cannot be empty")
 	}
 
 	if metrics || healthz || pprof {

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 func traceeEbpfOutputHelp() string {
@@ -73,7 +73,7 @@ func TraceeEbpfPrepareOutput(outputSlice []string) (OutputConfig, error) {
 				return outConfig, err
 			}
 		default:
-			return outConfig, logger.NewErrorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
+			return outConfig, errfmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
 		}
 	}
 
@@ -130,7 +130,7 @@ func validateFormat(printerKind string) error {
 		printerKind != "json" &&
 		printerKind != "gob" &&
 		!strings.HasPrefix(printerKind, "gotemplate=") {
-		return logger.NewErrorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
+		return errfmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
 	}
 
 	return nil

--- a/pkg/cmd/initialize/kernelconfig.go
+++ b/pkg/cmd/initialize/kernelconfig.go
@@ -3,6 +3,7 @@ package initialize
 import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -21,7 +22,7 @@ func KernelConfig() (*helpers.KernelConfig, error) {
 	kernelConfig.AddNeeded(helpers.CONFIG_BPF_EVENTS, helpers.BUILTIN)
 	missing := kernelConfig.CheckMissing() // do fail if we found os-release file and it is not enough
 	if len(missing) > 0 {
-		return nil, logger.NewErrorf("missing kernel configuration options: %s", missing)
+		return nil, errfmt.Errorf("missing kernel configuration options: %s", missing)
 	}
 	return kernelConfig, nil
 }

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/server"
@@ -23,7 +24,7 @@ func (r Runner) Run(ctx context.Context) error {
 
 	t, err := tracee.New(r.TraceeConfig)
 	if err != nil {
-		return logger.NewErrorf("error creating Tracee: %v", err)
+		return errfmt.Errorf("error creating Tracee: %v", err)
 	}
 
 	// Decide if HTTP server should be started
@@ -53,7 +54,7 @@ func (r Runner) Run(ctx context.Context) error {
 
 	err = t.Init()
 	if err != nil {
-		return logger.NewErrorf("error initializing Tracee: %v", err)
+		return errfmt.Errorf("error initializing Tracee: %v", err)
 	}
 
 	broadcast := printer.NewBroadcast(ctx, r.Printers)

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -129,7 +130,7 @@ func GetTraceeRunner(c *cli.Context, version string, newBinary bool) (cmd.Runner
 		logger.Debug("OSInfo", "lockdown", err)
 	}
 	if err == nil && lockdown == helpers.CONFIDENTIALITY {
-		return runner, logger.NewErrorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs")
+		return runner, errfmt.Errorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs")
 
 	}
 
@@ -157,7 +158,7 @@ func GetTraceeRunner(c *cli.Context, version string, newBinary bool) (cmd.Runner
 	traceeInstallPath := c.String("install-path")
 	err = initialize.BpfObject(&cfg, kernelConfig, OSInfo, traceeInstallPath, version)
 	if err != nil {
-		return runner, logger.NewErrorf("failed preparing BPF object: %v", err)
+		return runner, errfmt.Errorf("failed preparing BPF object: %v", err)
 	}
 
 	cfg.ChanEvents = make(chan trace.Event, 1000)

--- a/pkg/containers/runtime/crio.go
+++ b/pkg/containers/runtime/crio.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 type crioEnricher struct {
@@ -19,7 +19,7 @@ func CrioEnricher(socket string) (ContainerEnricher, error) {
 	unixSocket := "unix://" + strings.TrimPrefix(socket, "unix://")
 	conn, err := grpc.Dial(unixSocket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	client := cri.NewRuntimeServiceClient(conn)
 
@@ -39,7 +39,7 @@ func (e *crioEnricher) Get(containerId string, ctx context.Context) (ContainerMe
 		Verbose:     true,
 	})
 	if err != nil {
-		return metadata, logger.ErrorFunc(err)
+		return metadata, errfmt.WrapError(err)
 	}
 
 	//if in k8s we can extract pod info from labels

--- a/pkg/containers/runtime/docker.go
+++ b/pkg/containers/runtime/docker.go
@@ -6,7 +6,7 @@ import (
 
 	docker "github.com/docker/docker/client"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 type dockerEnricher struct {
@@ -17,7 +17,7 @@ func DockerEnricher(socket string) (ContainerEnricher, error) {
 	unixSocket := "unix://" + strings.TrimPrefix(socket, "unix://")
 	cli, err := docker.NewClientWithOpts(docker.WithHost(unixSocket), docker.WithAPIVersionNegotiation())
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	enricher := &dockerEnricher{}
@@ -32,7 +32,7 @@ func (e *dockerEnricher) Get(containerId string, ctx context.Context) (Container
 	}
 	resp, err := e.client.ContainerInspect(ctx, containerId)
 	if err != nil {
-		return metadata, logger.ErrorFunc(err)
+		return metadata, errfmt.WrapError(err)
 	}
 	container := (*resp.ContainerJSONBase)
 	metadata.Name = container.Name

--- a/pkg/containers/runtime/sockets.go
+++ b/pkg/containers/runtime/sockets.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"os"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // Sockets represent existing container runtime connections
@@ -19,7 +19,7 @@ func (s *Sockets) Register(runtime RuntimeId, socket string) error {
 
 	_, err := os.Stat(socket)
 	if err != nil {
-		return logger.NewErrorf("failed to register runtime socket %v", err)
+		return errfmt.Errorf("failed to register runtime socket %v", err)
 	}
 	s.sockets[runtime] = socket
 	return nil

--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 type Counter struct {
@@ -25,7 +25,7 @@ func (c *Counter) Increment(amount ...uint64) error {
 
 	sum, err := sumUint64(amount...)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	return c.incAtomic(sum)
@@ -38,7 +38,7 @@ func (c *Counter) Decrement(amount ...uint64) error {
 
 	sum, err := sumUint64(amount...)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	return c.decAtomic(sum)
@@ -88,9 +88,9 @@ func sumUint64(values ...uint64) (uint64, error) {
 }
 
 func errorCounterWrapAround() error {
-	return logger.NewErrorf("counter: wrap around")
+	return errfmt.Errorf("counter: wrap around")
 }
 
 func errorCounterSumWrapAround() error {
-	return logger.NewErrorf("counter sum: wrap around")
+	return errfmt.Errorf("counter sum: wrap around")
 }

--- a/pkg/ebpf/bpf_log.go
+++ b/pkg/ebpf/bpf_log.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -139,7 +140,7 @@ func (b BPFLog) Size() int {
 
 func (b *BPFLog) Decode(rawBuffer []byte) error {
 	if len(rawBuffer) < b.Size() {
-		return logger.NewErrorf("can't decode log raw data - buffer of %d should have at least %d bytes", len(rawBuffer), b.Size())
+		return errfmt.Errorf("can't decode log raw data - buffer of %d should have at least %d bytes", len(rawBuffer), b.Size())
 	}
 
 	b.id = BPFLogType(binary.LittleEndian.Uint32(rawBuffer[0:4]))
@@ -167,7 +168,7 @@ func (t *Tracee) processBPFLogs() {
 
 			bpfLog := BPFLog{}
 			if err := bpfLog.Decode(rawData); err != nil {
-				t.handleError(logger.NewErrorf("consume BPFLogsChannel: decode - %v", err))
+				t.handleError(errfmt.Errorf("consume BPFLogsChannel: decode - %v", err))
 				continue
 			}
 			// This logger timestamp in no way reflects the bpf log original time

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -1,8 +1,8 @@
 package ebpf
 
 import (
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -13,12 +13,12 @@ func FindingToEvent(f detect.Finding) (*trace.Event, error) {
 	s, ok := f.Event.Payload.(trace.Event)
 
 	if !ok {
-		return nil, logger.NewErrorf("error converting finding to event: %s", f.SigMetadata.ID)
+		return nil, errfmt.Errorf("error converting finding to event: %s", f.SigMetadata.ID)
 	}
 
 	eventID, found := events.Definitions.GetID(f.SigMetadata.EventName)
 	if !found {
-		return nil, logger.NewErrorf("error finding event not found: %s", f.SigMetadata.EventName)
+		return nil, errfmt.Errorf("error finding event not found: %s", f.SigMetadata.EventName)
 	}
 
 	return newEvent(int(eventID), f, s), nil

--- a/pkg/ebpf/initialization/kconfig.go
+++ b/pkg/ebpf/initialization/kconfig.go
@@ -3,6 +3,7 @@ package initialization
 import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -22,7 +23,7 @@ func LoadKconfigValues(kc *helpers.KernelConfig) (map[helpers.KernelConfigOption
 	var err error
 	for key, keyString := range kconfigUsed {
 		if err = kc.AddCustomKernelConfig(key, keyString); err != nil {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 	}
 

--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -6,8 +6,8 @@ import (
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 var maxKsymNameLen = 64 // Most match the constant in the bpf code
@@ -31,7 +31,7 @@ func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helper
 		address := value.Address
 		err := bpfKsymsMap.Update(unsafe.Pointer(&key[0]), unsafe.Pointer(&address))
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 	return nil
@@ -58,12 +58,12 @@ func (t *Tracee) NewKernelSymbols() error {
 
 	kernelSymbols, err = helpers.NewLazyKernelSymbolsMap()
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	if !ValidateKsymbolsTable(kernelSymbols) {
 		// debug.PrintStack()
-		return logger.NewErrorf("invalid ksymbol table")
+		return errfmt.Errorf("invalid ksymbol table")
 	}
 	t.kernelSymbols = kernelSymbols
 
@@ -80,7 +80,7 @@ func (t *Tracee) UpdateBPFKsymbolsMap() error {
 
 	bpfKsymsMap, err = t.bpfModule.GetMap("ksymbols_map")
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	// get required symbols by chosen events
@@ -102,7 +102,7 @@ func (t *Tracee) UpdateBPFKsymbolsMap() error {
 func (t *Tracee) UpdateKallsyms() error {
 	err := t.UpdateKernelSymbols()
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	return t.UpdateBPFKsymbolsMap()

--- a/pkg/ebpf/probes/common.go
+++ b/pkg/ebpf/probes/common.go
@@ -3,7 +3,7 @@ package probes
 import (
 	bpf "github.com/aquasecurity/libbpfgo"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // enableDisableAutoload enables or disables an eBPF program autoload setting
@@ -11,12 +11,12 @@ func enableDisableAutoload(module *bpf.Module, programName string, autoload bool
 	var err error
 
 	if module == nil || programName == "" {
-		return logger.NewErrorf("incorrect arguments (program: %s)", programName)
+		return errfmt.Errorf("incorrect arguments (program: %s)", programName)
 	}
 
 	prog, err := module.GetProgram(programName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	return prog.SetAutoload(autoload)

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -3,7 +3,7 @@ package probes
 import (
 	bpf "github.com/aquasecurity/libbpfgo"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 //
@@ -167,7 +167,7 @@ func (p *probes) GetProbeType(handle Handle) string {
 // Attach attaches given handle's program to its hook
 func (p *probes) Attach(handle Handle, args ...interface{}) error {
 	if _, ok := p.probes[handle]; !ok {
-		return logger.NewErrorf("probe handle (%d) does not exist", handle)
+		return errfmt.Errorf("probe handle (%d) does not exist", handle)
 	}
 
 	return p.probes[handle].attach(p.module, args...)
@@ -176,7 +176,7 @@ func (p *probes) Attach(handle Handle, args ...interface{}) error {
 // Detach detaches given handle's program from its hook
 func (p *probes) Detach(handle Handle, args ...interface{}) error {
 	if _, ok := p.probes[handle]; !ok {
-		return logger.NewErrorf("probe handle (%d) does not exist", handle)
+		return errfmt.Errorf("probe handle (%d) does not exist", handle)
 	}
 
 	return p.probes[handle].detach(args...)
@@ -187,7 +187,7 @@ func (p *probes) DetachAll() error {
 	for _, pr := range p.probes {
 		err := pr.detach()
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 

--- a/pkg/ebpf/probes/trace.go
+++ b/pkg/ebpf/probes/trace.go
@@ -5,7 +5,7 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 //
@@ -39,12 +39,12 @@ func (p *traceProbe) attach(module *bpf.Module, args ...interface{}) error {
 	}
 
 	if module == nil {
-		return logger.NewErrorf("incorrect arguments for event: %s", p.eventName)
+		return errfmt.Errorf("incorrect arguments for event: %s", p.eventName)
 	}
 
 	prog, err := module.GetProgram(p.programName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	switch p.probeType {
@@ -63,7 +63,7 @@ func (p *traceProbe) attach(module *bpf.Module, args ...interface{}) error {
 	}
 
 	if err != nil {
-		return logger.NewErrorf("failed to attach event: %s (%v)", p.eventName, err)
+		return errfmt.Errorf("failed to attach event: %s (%v)", p.eventName, err)
 	}
 
 	p.bpfLink = link
@@ -81,7 +81,7 @@ func (p *traceProbe) detach(args ...interface{}) error {
 
 	err = p.bpfLink.Destroy()
 	if err != nil {
-		return logger.NewErrorf("failed to detach event: %s (%v)", p.eventName, err)
+		return errfmt.Errorf("failed to detach event: %s (%v)", p.eventName, err)
 	}
 
 	p.bpfLink = nil // NOTE: needed so a new call to bpf_link__destroy() works

--- a/pkg/ebpf/write_capture.go
+++ b/pkg/ebpf/write_capture.go
@@ -7,6 +7,7 @@ import (
 	"path"
 
 	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
@@ -41,12 +42,12 @@ func (t *Tracee) processFileWrites() {
 			}
 
 			if meta.Size <= 0 {
-				t.handleError(logger.NewErrorf("invalid chunk size: %d", meta.Size))
+				t.handleError(errfmt.Errorf("invalid chunk size: %d", meta.Size))
 				continue
 			}
 
 			if ebpfMsgDecoder.BuffLen() < int(meta.Size) {
-				t.handleError(logger.NewErrorf("chunk too large: %d", meta.Size))
+				t.handleError(errfmt.Errorf("chunk too large: %d", meta.Size))
 				continue
 			}
 
@@ -103,7 +104,7 @@ func (t *Tracee) processFileWrites() {
 					filename = fmt.Sprintf("%s.pid-%d", filename, kernelModuleMeta.Pid)
 				}
 			} else {
-				t.handleError(logger.NewErrorf("unknown binary type: %d", meta.BinType))
+				t.handleError(errfmt.Errorf("unknown binary type: %d", meta.BinType))
 				continue
 			}
 

--- a/pkg/errfmt/errfmt.go
+++ b/pkg/errfmt/errfmt.go
@@ -1,0 +1,47 @@
+package errfmt
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// funcName returns the name of the function that called it based on the
+// skip value. 0 is the current function, 1 is the caller of the current
+// function, etc.
+func funcName(skip int) string {
+	pc, _, _, _ := runtime.Caller(skip + 1)
+	funcName := runtime.FuncForPC(pc).Name()
+	index := strings.LastIndex(funcName, "/") + 1
+
+	return funcName[index:]
+}
+
+// prefixFunc prefixes a given string with the name of the function that
+// called it based on the skip value.
+func prefixFunc(msg string, skip int) error {
+	fName := funcName(skip + 1)
+
+	return fmt.Errorf("%v: %v", fName, msg)
+}
+
+// Errorf returns an error prefixed by the current (caller) function name
+// and formatted with the given arguments.
+func Errorf(format string, a ...interface{}) error {
+	sentence := fmt.Sprintf(format, a...)
+	if sentence == "" {
+		return nil
+	}
+
+	return prefixFunc(sentence, 1)
+}
+
+// WrapError returns the given error prefixed by the current (caller) function
+// name.
+func WrapError(e error) error {
+	if e == nil {
+		return nil
+	}
+
+	return prefixFunc(e.Error(), 1)
+}

--- a/pkg/errfmt/errfmt_test.go
+++ b/pkg/errfmt/errfmt_test.go
@@ -1,0 +1,78 @@
+package errfmt
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		args   []interface{}
+		want   error
+	}{
+		{
+			name:   "empty format string",
+			format: "",
+			args:   []interface{}{},
+			want:   nil,
+		},
+		{
+			name:   "non-empty format string",
+			format: "an error occurred",
+			args:   []interface{}{},
+			want:   fmt.Errorf("errfmt.TestErrorf.func1: an error occurred"),
+		},
+		{
+			name:   "format string with arguments",
+			format: "an error occurred, %d",
+			args:   []interface{}{42},
+			want:   fmt.Errorf("errfmt.TestErrorf.func1: an error occurred, 42"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Errorf(tt.format, tt.args...)
+			if tt.want == nil {
+				assert.Equal(t, tt.want, got)
+				return
+			}
+			assert.Equal(t, tt.want.Error(), got.Error(), "got: %v, want: %v", got.Error(), tt.want.Error())
+		})
+	}
+}
+
+func TestWrapError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: nil,
+		},
+		{
+			name: "non-nil error",
+			err:  errors.New("an error occurred"),
+			want: fmt.Errorf("errfmt.TestWrapError.func1: an error occurred"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WrapError(tt.err)
+			if tt.want == nil {
+				assert.Equal(t, tt.want, got)
+				return
+			}
+			assert.Equal(t, tt.want.Error(), got.Error(), "got: %v, want: %v", got.Error(), tt.want.Error())
+		})
+	}
+}

--- a/pkg/events/derive/container_create.go
+++ b/pkg/events/derive/container_create.go
@@ -3,9 +3,9 @@ package derive
 import (
 	"github.com/aquasecurity/tracee/pkg/cgroup"
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -19,11 +19,11 @@ func deriveContainerCreateArgs(containers *containers.Containers) func(event tra
 	return func(event trace.Event) ([]interface{}, error) {
 		// if cgroup_id is from non default hid (v1 case), the cgroup info query will fail, so we skip
 		if check, err := isCgroupEventInHid(&event, containers); !check {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 		cgroupId, err := parse.ArgVal[uint64](&event, "cgroup_id")
 		if err != nil {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 		if info := containers.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
 			args := []interface{}{
@@ -52,7 +52,7 @@ func isCgroupEventInHid(event *trace.Event, containers *containers.Containers) (
 	}
 	hierarchyID, err := parse.ArgVal[uint32](event, "hierarchy_id")
 	if err != nil {
-		return false, logger.ErrorFunc(err)
+		return false, errfmt.WrapError(err)
 	}
 	return containers.GetDefaultCgroupHierarchyID() == int(hierarchyID), nil
 }

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -2,9 +2,9 @@ package derive
 
 import (
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -18,11 +18,11 @@ func deriveContainerRemoveArgs(containers *containers.Containers) deriveArgsFunc
 	return func(event trace.Event) ([]interface{}, error) {
 		// if cgroup_id is from non default hid (v1 case), the cgroup info query will fail, so we skip
 		if check, err := isCgroupEventInHid(&event, containers); !check {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 		cgroupId, err := parse.ArgVal[uint64](&event, "cgroup_id")
 		if err != nil {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 		if info := containers.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
 			return []interface{}{info.Runtime.String(), info.Container.ContainerId}, nil

--- a/pkg/events/derive/detect_hooked_syscall.go
+++ b/pkg/events/derive/detect_hooked_syscall.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -20,11 +20,11 @@ func deriveDetectHookedSyscallArgs(kernelSymbols helpers.KernelSymbolTable) deri
 	return func(event trace.Event) ([]interface{}, error) {
 		syscallAddresses, err := parse.ArgVal[[]uint64](&event, "syscalls_addresses")
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing syscalls_numbers arg: %v", err)
+			return nil, errfmt.Errorf("error parsing syscalls_numbers arg: %v", err)
 		}
 		hookedSyscall, err := analyzeHookedAddresses(syscallAddresses, kernelSymbols)
 		if err != nil {
-			return nil, logger.NewErrorf("error parsing analyzing hooked syscalls addresses arg: %v", err)
+			return nil, errfmt.Errorf("error parsing analyzing hooked syscalls addresses arg: %v", err)
 		}
 		return []interface{}{hookedSyscall}, nil
 	}
@@ -39,7 +39,7 @@ func analyzeHookedAddresses(addresses []uint64, kernelSymbols helpers.KernelSymb
 		}
 		syscallsToCheck := events.SyscallsToCheck()
 		if idx > len(syscallsToCheck) {
-			return nil, logger.NewErrorf("syscall inedx out of the syscalls to check list")
+			return nil, errfmt.Errorf("syscall inedx out of the syscalls to check list")
 		}
 		hookingFunction := utils.ParseSymbol(syscallAddress, kernelSymbols)
 		syscallNumber := syscallsToCheck[idx]

--- a/pkg/events/derive/hooked_seq_ops.go
+++ b/pkg/events/derive/hooked_seq_ops.go
@@ -3,9 +3,9 @@ package derive
 import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -36,7 +36,7 @@ func deriveHookedSeqOpsArgs(kernelSymbols helpers.KernelSymbolTable) deriveArgsF
 	return func(event trace.Event) ([]interface{}, error) {
 		seqOpsArr, err := parse.ArgVal[[]uint64](&event, "net_seq_ops")
 		if err != nil || len(seqOpsArr) < 1 {
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 		hookedSeqOps := make(map[string]trace.HookedSymbolData, 0)
 		for i, addr := range seqOpsArr {

--- a/pkg/events/derive/net_packet_dns.go
+++ b/pkg/events/derive/net_packet_dns.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"github.com/google/gopacket/layers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -23,7 +24,7 @@ func deriveDNS() deriveArgsFunction {
 func deriveDNSEvents(event trace.Event) ([]interface{}, error) {
 	net, dns, err := eventToProtoDNS(&event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	if dns == nil {
 		return nil, nil // connection related packets
@@ -56,13 +57,13 @@ func deriveDNSRequest() deriveArgsFunction {
 func deriveDNSRequestEvents(event trace.Event) ([]interface{}, error) {
 	net, dns, err := eventToProtoDNS(&event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	if dns == nil {
 		return nil, nil // connection related packets
 	}
 	if net == nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	// discover if it is a request or response
@@ -105,13 +106,13 @@ func deriveDNSResponse() deriveArgsFunction {
 func deriveDNSResponseEvents(event trace.Event) ([]interface{}, error) {
 	net, dns, err := eventToProtoDNS(&event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	if dns == nil {
 		return nil, nil // connection related packets
 	}
 	if net == nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	// discover if it is a request or response
@@ -157,7 +158,7 @@ func eventToProtoDNS(event *trace.Event) (*netPair, *trace.ProtoDNS, error) {
 
 	layer7, err := parseUntilLayer7(event, &DnsNetPair)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 
 	switch l7 := layer7.(type) {

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -107,7 +107,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 	} else if event.ReturnValue&familyIpv6 == familyIpv6 {
 		layerType = layers.LayerTypeIPv6
 	} else {
-		return nil, logger.NewErrorf("base layer type not supported: %d", event.ReturnValue)
+		return nil, errfmt.Errorf("base layer type not supported: %d", event.ReturnValue)
 	}
 
 	// parse packet with gopacket
@@ -135,7 +135,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 		pair.dstIP = v.DstIP
 		pair.length = uint32(v.Length)
 	default:
-		return nil, logger.NewErrorf("layer 3 not supported: %v", layer3)
+		return nil, errfmt.Errorf("layer 3 not supported: %v", layer3)
 	}
 
 	// transport layer
@@ -152,7 +152,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 		pair.dstPort = uint16(v.DstPort)
 		pair.proto = IPPROTO_UDP
 	default:
-		return nil, logger.NewErrorf("layer 4 not supported: %v", layer4)
+		return nil, errfmt.Errorf("layer 4 not supported: %v", layer4)
 	}
 
 	// check partial packet decoding

--- a/pkg/events/derive/net_packet_http.go
+++ b/pkg/events/derive/net_packet_http.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"net/http"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -27,7 +27,7 @@ func deriveHTTP() deriveArgsFunction {
 func deriveHTTPEvents(event trace.Event) ([]interface{}, error) {
 	net, http, err := eventToProtoHTTP(&event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	if http == nil {
 		return nil, nil // connection related packets
@@ -60,13 +60,13 @@ func deriveHTTPRequest() deriveArgsFunction {
 func deriveHTTPRequestEvents(event trace.Event) ([]interface{}, error) {
 	net, http, err := eventToProtoHTTPRequest(&event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	if http == nil {
 		return nil, nil // not a request
 	}
 	if net == nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	meta := convertNetPairToPktMeta(net)
@@ -92,13 +92,13 @@ func deriveHTTPResponse() deriveArgsFunction {
 func deriveHTTPResponseEvents(event trace.Event) ([]interface{}, error) {
 	net, http, err := eventToProtoHTTPResponse(&event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	if http == nil {
 		return nil, nil // // not a response
 	}
 	if net == nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	meta := convertNetPairToPktMeta(net)
@@ -114,7 +114,7 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 	layer7, err := parseUntilLayer7(event, &httpNetPair)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 	if layer7 == nil {
 		return nil, nil, nil
@@ -133,7 +133,7 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 			httpReq, err = http.ReadRequest(reader)
 			if err != nil {
-				return nil, nil, logger.ErrorFunc(err)
+				return nil, nil, errfmt.WrapError(err)
 			}
 
 			copyHTTPReqToProtoHTTP(httpReq, &protoHttp)
@@ -142,13 +142,13 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 			httpRes, err = http.ReadResponse(reader, nil)
 			if err != nil {
-				return nil, nil, logger.ErrorFunc(err)
+				return nil, nil, errfmt.WrapError(err)
 			}
 
 			copyHTTPResToProtoHTTP(httpRes, &protoHttp)
 
 		} else {
-			return &httpNetPair, nil, logger.NewErrorf("unspecified direction for HTTP packet")
+			return &httpNetPair, nil, errfmt.Errorf("unspecified direction for HTTP packet")
 		}
 
 		return &httpNetPair, &protoHttp, nil
@@ -162,7 +162,7 @@ func eventToProtoHTTPRequest(event *trace.Event) (*netPair, *trace.ProtoHTTPRequ
 
 	layer7, err := parseUntilLayer7(event, &httpNetPair)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 	if layer7 == nil {
 		return nil, nil, nil
@@ -179,7 +179,7 @@ func eventToProtoHTTPRequest(event *trace.Event) (*netPair, *trace.ProtoHTTPRequ
 
 		httpReq, err := http.ReadRequest(reader)
 		if err != nil {
-			return nil, nil, logger.ErrorFunc(err)
+			return nil, nil, errfmt.WrapError(err)
 		}
 
 		var httpRequest trace.ProtoHTTPRequest
@@ -197,7 +197,7 @@ func eventToProtoHTTPResponse(event *trace.Event) (*netPair, *trace.ProtoHTTPRes
 
 	layer7, err := parseUntilLayer7(event, &httpNetPair)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 	if layer7 == nil {
 		return nil, nil, nil
@@ -214,7 +214,7 @@ func eventToProtoHTTPResponse(event *trace.Event) (*netPair, *trace.ProtoHTTPRes
 
 		httpRes, err := http.ReadResponse(reader, nil)
 		if err != nil {
-			return nil, nil, logger.ErrorFunc(err)
+			return nil, nil, errfmt.WrapError(err)
 		}
 
 		var httpResponse trace.ProtoHTTPResponse

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/golang-lru/simplelru"
 	"golang.org/x/exp/maps"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/filterscope"
@@ -102,7 +103,7 @@ func (gen *SymbolsCollisionArgsGenerator) deriveArgs(event trace.Event) ([][]int
 		return gen.handleExec(event) // evicts saved data (loaded shared objects) for the process
 	}
 
-	return nil, []error{logger.NewErrorf("received unexpected event - \"%s\"", event.EventName)}
+	return nil, []error{errfmt.Errorf("received unexpected event - \"%s\"", event.EventName)}
 }
 
 // handleShObjLoaded handles the shared object loaded event (from mmap).
@@ -190,7 +191,7 @@ func (gen *SymbolsCollisionArgsGenerator) findShObjsCollisions(
 			} else {
 				logger.Debug("symbols_loaded", "object loaded", loadingShObj.ObjInfo, "error", err.Error())
 			}
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 		loadingShObj.FilterSymbols(gen.symbolsBlacklistMap)    // del symbols NOT in blacklist
 		loadingShObj.FilterOutSymbols(gen.symbolsWhitelistMap) // del symbols IN the white list
@@ -206,7 +207,7 @@ func (gen *SymbolsCollisionArgsGenerator) findShObjsCollisions(
 			} else {
 				logger.Debug("symbols_loaded", "object loaded", loadedShObjInfo, "error", err.Error())
 			}
-			return nil, logger.ErrorFunc(err)
+			return nil, errfmt.WrapError(err)
 		}
 
 		// create a loadingSharedObj from the already loaded shared object (to get collisions)

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -6,6 +6,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/filters"
@@ -107,7 +108,7 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(
 
 	loadingObjectInfo, err := getSharedObjectInfo(event)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 
 	if symbsLoadedGen.isWhitelist(loadingObjectInfo.Path) {
@@ -183,19 +184,19 @@ func getSharedObjectInfo(event trace.Event) (sharedobjs.ObjInfo, error) {
 
 	loadedObjectInode, err := parse.ArgVal[uint64](&event, "inode")
 	if err != nil {
-		return objInfo, logger.ErrorFunc(err)
+		return objInfo, errfmt.WrapError(err)
 	}
 	loadedObjectDevice, err := parse.ArgVal[uint32](&event, "dev")
 	if err != nil {
-		return objInfo, logger.ErrorFunc(err)
+		return objInfo, errfmt.WrapError(err)
 	}
 	loadedObjectCtime, err := parse.ArgVal[uint64](&event, "ctime")
 	if err != nil {
-		return objInfo, logger.ErrorFunc(err)
+		return objInfo, errfmt.WrapError(err)
 	}
 	loadedObjectPath, err := parse.ArgVal[string](&event, "pathname")
 	if err != nil {
-		return objInfo, logger.ErrorFunc(err)
+		return objInfo, errfmt.WrapError(err)
 	}
 
 	objInfo = sharedobjs.ObjInfo{

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -4,8 +4,8 @@ import (
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
 	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events/trigger"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -119,11 +119,11 @@ type eventDefinitions struct {
 // Add adds an event to definitions
 func (e *eventDefinitions) Add(eventId ID, evt Event) error {
 	if _, ok := e.events[eventId]; ok {
-		return logger.NewErrorf("error event id already exist: %v", eventId)
+		return errfmt.Errorf("error event id already exist: %v", eventId)
 	}
 
 	if _, ok := e.GetID(evt.Name); ok {
-		return logger.NewErrorf("error event name already exist: %v", evt.Name)
+		return errfmt.Errorf("error event name already exist: %v", evt.Name)
 	}
 
 	e.events[eventId] = evt

--- a/pkg/events/parse/params.go
+++ b/pkg/events/parse/params.go
@@ -1,7 +1,7 @@
 package parse
 
 import (
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -11,10 +11,10 @@ func ArgVal[T any](event *trace.Event, argName string) (T, error) {
 			val, ok := arg.Value.(T)
 			if !ok {
 				zeroVal := *new(T)
-				return zeroVal, logger.NewErrorf("argument %s is not of type %T", argName, zeroVal)
+				return zeroVal, errfmt.Errorf("argument %s is not of type %T", argName, zeroVal)
 			}
 			return val, nil
 		}
 	}
-	return *new(T), logger.NewErrorf("argument %s not found", argName)
+	return *new(T), errfmt.Errorf("argument %s not found", argName)
 }

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -9,7 +9,7 @@ import (
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/helpers"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -282,7 +282,7 @@ func ParseArgsFDs(event *trace.Event, fdArgPathMap *bpf.BPFMap) error {
 			}
 			bs, err := fdArgPathMap.GetValue(unsafe.Pointer(fdArgTask))
 			if err != nil {
-				return logger.ErrorFunc(err)
+				return errfmt.WrapError(err)
 			}
 
 			fpath := string(bytes.Trim(bs, "\x00"))
@@ -323,7 +323,7 @@ func parseBpfAttachHelperUsage(helperArg int32) (string, error) {
 	case 2:
 		return "unknown", nil
 	default:
-		return "", logger.NewErrorf("unknown value got from bpf_attach event for helper usage arg")
+		return "", errfmt.Errorf("unknown value got from bpf_attach event for helper usage arg")
 	}
 }
 
@@ -340,6 +340,6 @@ func parseBpfAttachPerfType(perfType int32) (string, error) {
 	case 4:
 		return "uretprobe", nil
 	default:
-		return "", logger.NewErrorf("unknown perf_type got from bpf_attach event")
+		return "", errfmt.Errorf("unknown perf_type got from bpf_attach event")
 	}
 }

--- a/pkg/events/sorting/cpu_queue.go
+++ b/pkg/events/sorting/cpu_queue.go
@@ -1,7 +1,7 @@
 package sorting
 
 import (
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -34,7 +34,7 @@ func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *trace.Event) error {
 			}
 			if insertLocation.next == insertLocation {
 				if err != nil {
-					err = logger.NewErrorf("encountered node with self reference at next: %v", err)
+					err = errfmt.Errorf("encountered node with self reference at next: %v", err)
 				}
 			}
 			insertLocation = insertLocation.next
@@ -43,7 +43,7 @@ func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *trace.Event) error {
 	} else {
 		cq.put(newNode)
 	}
-	return logger.ErrorFunc(err)
+	return errfmt.WrapError(err)
 }
 
 // insertAfter insert new event to the queue after another node

--- a/pkg/events/sorting/pool.go
+++ b/pkg/events/sorting/pool.go
@@ -3,7 +3,7 @@ package sorting
 import (
 	"sync"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -31,7 +31,7 @@ func (p *eventsPool) Alloc(event *trace.Event) (*eventNode, error) {
 	if node != nil {
 		if node.isAllocated {
 			p.poolMutex.Unlock()
-			return &eventNode{event: event, isAllocated: true}, logger.NewErrorf("bug: alocated node in pool")
+			return &eventNode{event: event, isAllocated: true}, errfmt.Errorf("bug: alocated node in pool")
 		}
 		p.head = node.previous
 		node.event = event
@@ -56,7 +56,7 @@ func (p *eventsPool) Free(node *eventNode) error {
 	defer p.poolMutex.Unlock()
 	// Prevent malicious use of free
 	if p.allocationsCount == 0 {
-		return logger.NewErrorf("bug: free called when no allocated node exist")
+		return errfmt.Errorf("bug: free called when no allocated node exist")
 	}
 
 	node.isAllocated = false

--- a/pkg/events/sorting/queue.go
+++ b/pkg/events/sorting/queue.go
@@ -3,7 +3,7 @@ package sorting
 import (
 	"sync"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -31,7 +31,7 @@ func (eq *eventsQueue) Put(newEvent *trace.Event) error {
 	eq.mutex.Lock()
 	defer eq.mutex.Unlock()
 	eq.put(newNode)
-	return logger.ErrorFunc(err)
+	return errfmt.WrapError(err)
 }
 
 // Get remove the node at the head of the queue and return it
@@ -42,23 +42,23 @@ func (eq *eventsQueue) Get() (*trace.Event, error) {
 	defer eq.mutex.Unlock()
 	if eq.head == nil {
 		if eq.tail != nil {
-			return nil, logger.NewErrorf("bug: TAIL without a HEAD")
+			return nil, errfmt.Errorf("bug: TAIL without a HEAD")
 		}
 		return nil, nil
 	}
 	headNode := eq.head
 	if headNode == eq.tail {
 		if headNode.next != nil || headNode.previous != nil {
-			return nil, logger.NewErrorf("bug: last existing node still conneced")
+			return nil, errfmt.Errorf("bug: last existing node still conneced")
 		}
 		eq.tail = nil
 		eq.head = nil
 	} else {
 		if headNode.previous == nil {
-			return nil, logger.NewErrorf("bug: not TAIL lacking previous")
+			return nil, errfmt.Errorf("bug: not TAIL lacking previous")
 		}
 		if headNode.next != nil {
-			return nil, logger.NewErrorf("bug: HEAD has next")
+			return nil, errfmt.Errorf("bug: HEAD has next")
 		}
 		headNode.previous.next = nil
 		eq.head = headNode.previous
@@ -69,7 +69,7 @@ func (eq *eventsQueue) Get() (*trace.Event, error) {
 	err := eq.pool.Free(headNode)
 	if err != nil {
 		eq.pool.Reset()
-		return extractedEvent, logger.NewErrorf("error in queue's node freeing - %v", err)
+		return extractedEvent, errfmt.Errorf("error in queue's node freeing - %v", err)
 	}
 	return extractedEvent, nil
 }

--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -105,6 +105,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils/environment"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -131,7 +132,7 @@ type EventsChronologicalSorter struct {
 func InitEventSorter() (*EventsChronologicalSorter, error) {
 	cpusAmount, err := environment.GetCPUAmount()
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	newSorter := EventsChronologicalSorter{
 		cpuEventsQueues:                  make([]cpuEventsQueue, cpusAmount),
@@ -255,7 +256,7 @@ func (sorter *EventsChronologicalSorter) getMostDelayingEventCPUQueue() (*cpuEve
 		}
 	}
 	if mostDelayingEventQueue == nil {
-		return nil, 0, logger.NewErrorf("no queue with events found")
+		return nil, 0, errfmt.Errorf("no queue with events found")
 	}
 	return mostDelayingEventQueue, mostDelayingEventQueueHeadTimestamp, nil
 }
@@ -278,7 +279,7 @@ func (sorter *EventsChronologicalSorter) getUpdatedMostDelayedLastCPUEventTimest
 		cq.IsUpdated = false // Mark that the values of the queue were checked from previous time
 	}
 	if !foundUpdatedQueue {
-		return 0, logger.NewErrorf("no valid CPU events queue was updated since last interval")
+		return 0, errfmt.Errorf("no valid CPU events queue was updated since last interval")
 	}
 	return newMostDelayedEventTimestamp, nil
 }
@@ -295,7 +296,7 @@ func (sorter *EventsChronologicalSorter) getMostRecentEventTimestamp() (int, err
 		}
 	}
 	if mostRecentEventTimestamp == 0 {
-		return 0, logger.NewErrorf("all CPU queques are empty")
+		return 0, errfmt.Errorf("all CPU queques are empty")
 	}
 	return mostRecentEventTimestamp, nil
 }

--- a/pkg/events/trigger/context.go
+++ b/pkg/events/trigger/context.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 
 	"github.com/aquasecurity/tracee/pkg/counter"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -57,7 +57,7 @@ func (store *context) Get(id uint64) (trace.Event, bool) {
 func (store *context) Apply(event trace.Event) (trace.Event, error) {
 	contextID, err := parse.ArgVal[uint64](&event, ContextArgName)
 	if err != nil {
-		return trace.Event{}, logger.NewErrorf("error parsing caller_context_id arg: %v", err)
+		return trace.Event{}, errfmt.Errorf("error parsing caller_context_id arg: %v", err)
 	}
 	invoking, ok := store.Get(contextID)
 	if !ok {
@@ -76,7 +76,7 @@ func (store *context) Apply(event trace.Event) (trace.Event, error) {
 	invoking.MatchedScopes = event.MatchedScopes
 	copied := copy(invoking.Args, event.Args)
 	if copied != len(event.Args) {
-		return trace.Event{}, logger.NewErrorf("failed to apply event's args")
+		return trace.Event{}, errfmt.Errorf("failed to apply event's args")
 	}
 	invoking.ArgsNum = event.ArgsNum
 

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -111,7 +111,7 @@ func (filter *ArgFilter) Parse(filterName string, operatorAndValues string, even
 		return NewStringFilter()
 	})
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	filter.Enable()
@@ -136,7 +136,7 @@ func (filter *ArgFilter) parseFilter(id events.ID, argName string, operatorAndVa
 	argFilter := filter.filters[id][argName]
 	err := argFilter.Parse(operatorAndValues)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	// store the arg filter again

--- a/pkg/filters/context.go
+++ b/pkg/filters/context.go
@@ -3,8 +3,8 @@ package filters
 import (
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -101,7 +101,7 @@ func (filter *ContextFilter) Parse(filterName string, operatorAndValues string) 
 
 	err := eventFilter.Parse(eventField, operatorAndValues)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	filter.Enable()
@@ -254,7 +254,7 @@ func (f *eventCtxFilter) Parse(field string, operatorAndValues string) error {
 func (f *eventCtxFilter) addContainer(filter Filter, operatorAndValues string) error {
 	err := filter.Parse(operatorAndValues)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	f.containerFilter.add(true, Equal)
 	f.containerFilter.Enable()

--- a/pkg/filters/int.go
+++ b/pkg/filters/int.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/exp/constraints"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 const (
@@ -176,7 +176,7 @@ func (filter *IntFilter[T]) Parse(operatorAndValues string) error {
 		}
 		err = filter.add(valInt, operator)
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 

--- a/pkg/filters/processtree.go
+++ b/pkg/filters/processtree.go
@@ -11,7 +11,7 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
@@ -57,7 +57,7 @@ func (filter *ProcessTreeFilter) Parse(operatorAndValues string) error {
 	} else if strings.HasPrefix(operatorAndValues, "!=") {
 		valuesString = operatorAndValues[2:]
 		if len(valuesString) == 0 {
-			return logger.NewErrorf("no value passed with operator in process tree filter")
+			return errfmt.Errorf("no value passed with operator in process tree filter")
 		}
 		equalityOperator = false
 	} else {
@@ -68,7 +68,7 @@ func (filter *ProcessTreeFilter) Parse(operatorAndValues string) error {
 	for _, value := range values {
 		pid, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
-			return logger.NewErrorf("invalid PID given to filter: %s", valuesString)
+			return errfmt.Errorf("invalid PID given to filter: %s", valuesString)
 		}
 		filter.PIDs[uint32(pid)] = equalityOperator
 	}
@@ -85,18 +85,18 @@ func (filter *ProcessTreeFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID 
 
 	processTreeBPFMap, err := bpfModule.GetMap(filter.mapName)
 	if err != nil {
-		return logger.NewErrorf("could not find bpf process_tree_map: %v", err)
+		return errfmt.Errorf("could not find bpf process_tree_map: %v", err)
 	}
 
 	procDir, err := os.Open("/proc")
 	if err != nil {
-		return logger.NewErrorf("could not open proc dir: %v", err)
+		return errfmt.Errorf("could not open proc dir: %v", err)
 	}
 	defer procDir.Close()
 
 	entries, err := procDir.Readdirnames(-1)
 	if err != nil {
-		return logger.NewErrorf("could not read proc dir: %v", err)
+		return errfmt.Errorf("could not read proc dir: %v", err)
 	}
 
 	updateBPF := func(shouldBeTraced bool, pid uint64) {

--- a/pkg/filters/retval.go
+++ b/pkg/filters/retval.go
@@ -3,8 +3,8 @@ package filters
 import (
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 type RetFilter struct {
@@ -74,7 +74,7 @@ func (filter *RetFilter) Parse(filterName string, operatorAndValues string, even
 	// Treat operatorAndValues as an int filter to avoid code duplication
 	err := intFilter.Parse(operatorAndValues)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	filter.filters[id] = intFilter

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -7,8 +7,8 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/filters/sets"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
@@ -115,7 +115,7 @@ func (f *StringFilter) Parse(operatorAndValues string) error {
 	for _, val := range values {
 		err := f.add(val, stringToOperator(operatorString))
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 
@@ -243,7 +243,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID ui
 
 	bpfMap, err := bpfModule.GetMap(filter.mapName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	filterVal := make([]byte, 16)
@@ -267,7 +267,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID ui
 		binary.LittleEndian.PutUint64(filterVal[0:8], equalInScopes)
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		if err = bpfMap.Update(unsafe.Pointer(&byteStr[0]), unsafe.Pointer(&filterVal[0])); err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 
@@ -290,7 +290,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, filterScopeID ui
 		binary.LittleEndian.PutUint64(filterVal[0:8], equalInScopes)
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		if err = bpfMap.Update(unsafe.Pointer(&byteStr[0]), unsafe.Pointer(&filterVal[0])); err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 

--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -12,7 +12,7 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
@@ -200,7 +200,7 @@ func (filter *UIntFilter[T]) Parse(operatorAndValues string) error {
 		}
 		err = filter.add(valInt, operator)
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 
@@ -240,7 +240,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, filterScopeID u
 	// 4. pid_ns_filter     u64, eq_t
 	equalityFilterMap, err := bpfModule.GetMap(filter.mapName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	var keyPointer unsafe.Pointer
@@ -270,7 +270,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, filterScopeID u
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		err = equalityFilterMap.Update(unsafe.Pointer(keyPointer), unsafe.Pointer(&filterVal[0]))
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 
@@ -298,7 +298,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, filterScopeID u
 		binary.LittleEndian.PutUint64(filterVal[8:16], equalitySetInScopes)
 		err = equalityFilterMap.Update(unsafe.Pointer(keyPointer), unsafe.Pointer(&filterVal[0]))
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -568,28 +568,3 @@ func GetLevel() Level {
 func HasDebugLevel() bool {
 	return pkgLogger.cfg.Level == DebugLevel
 }
-
-// ErrorFuncName displays a given error prefixed by the current (caller) fn name
-// and a given string in a given format (just like fmt.Sprintf)
-func NewErrorf(format string, a ...interface{}) error {
-	sentence := fmt.Sprintf(format, a...)
-
-	pc, _, _, _ := runtime.Caller(1)
-	funcName := runtime.FuncForPC(pc).Name()
-	index := strings.LastIndex(funcName, "/") + 1
-
-	return fmt.Errorf("%v: %v", funcName[index:], sentence)
-}
-
-// ErrorFunc displays a given error prefixed by the current (caller) fn name
-func ErrorFunc(e error) error {
-	if e != nil {
-		pc, _, _, _ := runtime.Caller(1)
-		funcName := runtime.FuncForPC(pc).Name()
-		index := strings.LastIndex(funcName, "/") + 1
-
-		return fmt.Errorf("%v: %v", funcName[index:], e)
-	}
-
-	return nil
-}

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/aquasecurity/tracee/pkg/counter"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // When updating this struct, please make sure to update the relevant exporting functions
@@ -29,7 +29,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.EventCount.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -39,7 +39,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.EventsFiltered.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -49,7 +49,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.NetCapCount.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -59,7 +59,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.LostEvCount.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -69,7 +69,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.LostWrCount.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -79,7 +79,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.LostNtCapCount.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -89,7 +89,7 @@ func (stats *Stats) RegisterPrometheus() error {
 	}, func() float64 { return float64(stats.BPFLogsCount.Read()) }))
 
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 
 	err = prometheus.Register(prometheus.NewCounterFunc(prometheus.CounterOpts{
@@ -98,5 +98,5 @@ func (stats *Stats) RegisterPrometheus() error {
 		Help:      "errors accumulated by tracee-ebpf",
 	}, func() float64 { return float64(stats.ErrorCount.Read()) }))
 
-	return logger.ErrorFunc(err)
+	return errfmt.WrapError(err)
 }

--- a/pkg/pcaps/common.go
+++ b/pkg/pcaps/common.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -83,7 +84,7 @@ func getPcapFileName(event *trace.Event, pcapType PcapType) (string, error) {
 	// create needed dirs
 	err = mkdirForPcapType(outputDirectory, contID, pcapType)
 	if err != nil {
-		return "", logger.ErrorFunc(err)
+		return "", errfmt.WrapError(err)
 	}
 
 	// return filename in format according to pcap type
@@ -158,7 +159,7 @@ func mkdirForPcapType(o *os.File, c string, t PcapType) error {
 		e = utils.MkdirAtExist(o, pcapCommDir+c, os.ModePerm)
 	}
 
-	return logger.ErrorFunc(e)
+	return errfmt.WrapError(e)
 }
 
 // getPcapFileAndWriter returns a file descriptor and and its associated pcap
@@ -170,7 +171,7 @@ func getPcapFileAndWriter(event *trace.Event, t PcapType) (
 ) {
 	pcapFilePath, err := getPcapFileName(event, t)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 	file, err := utils.OpenAt(
 		outputDirectory,
@@ -179,7 +180,7 @@ func getPcapFileAndWriter(event *trace.Event, t PcapType) (
 		0644,
 	)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 
 	logger.Debug("pcap file (re)opened", "filename", pcapFilePath)
@@ -190,11 +191,11 @@ func getPcapFileAndWriter(event *trace.Event, t PcapType) (
 		pcapgo.DefaultNgWriterOptions,
 	)
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 	err = writer.Flush()
 	if err != nil {
-		return nil, nil, logger.ErrorFunc(err)
+		return nil, nil, errfmt.WrapError(err)
 	}
 
 	return file, writer, nil

--- a/pkg/pcaps/pcap.go
+++ b/pkg/pcaps/pcap.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcapgo"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -74,7 +74,7 @@ func NewPcap(e *trace.Event, t PcapType) (*Pcap, error) {
 
 	p.pcapFile, p.pcapWriter, err = getPcapFileAndWriter(e, t)
 
-	return p, logger.ErrorFunc(err)
+	return p, errfmt.WrapError(err)
 }
 
 func (p *Pcap) write(event *trace.Event, payload []byte) error {

--- a/pkg/pcaps/pcaps.go
+++ b/pkg/pcaps/pcaps.go
@@ -3,6 +3,7 @@ package pcaps
 import (
 	"os"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -57,7 +58,7 @@ func New(simple Config, output *os.File) (*Pcaps, error) {
 			logger.Debug("pcap enabled: " + t.String())
 			caches[t], err = newPcapCache(t)
 			if err != nil {
-				return nil, logger.ErrorFunc(err)
+				return nil, errfmt.WrapError(err)
 			}
 		} else {
 			// remove keys that were not requested
@@ -73,17 +74,17 @@ func (p *Pcaps) Write(event *trace.Event, payload []byte) error {
 
 	// sanity check
 	if events.ID(event.EventID) != events.NetPacketCapture {
-		return logger.NewErrorf("wrong event type given to pcap")
+		return errfmt.Errorf("wrong event type given to pcap")
 	}
 
 	for k := range p.pcapCaches {
 		item, err := p.pcapCaches[k].get(event)
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 		err = item.write(event, payload)
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 
@@ -96,7 +97,7 @@ func (p *Pcaps) Destroy() error {
 	for k := range p.pcapCaches {
 		err := p.pcapCaches[k].destroy()
 		if err != nil {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 

--- a/pkg/utils/environment/amount_cpus.go
+++ b/pkg/utils/environment/amount_cpus.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 const possibleCPUsFilePath = "/sys/devices/system/cpu/possible"
@@ -18,7 +18,7 @@ func GetCPUAmount() (int, error) {
 			return cpusAmount, nil
 		}
 	}
-	return 0, logger.ErrorFunc(err)
+	return 0, errfmt.WrapError(err)
 }
 
 const singleValue = 1
@@ -37,25 +37,25 @@ func parsePossibleCPUAmountFromCPUFileFormat(cpuFileContent string) (int, error)
 	var usedSize, groupSize int
 	bitmapsRegions := strings.Split(cpuFileContent, ",")
 	if len(bitmapsRegions) > 1 {
-		return 0, logger.NewErrorf("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
+		return 0, errfmt.Errorf("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
 	}
 	cpusAmount := 0
 	n, _ := fmt.Sscanf(bitmapsRegions[0], "%d-%d:%d/%d", &rangeStart, &rangeEnd, &usedSize, &groupSize)
 	switch n {
 	case singleValue:
 		if rangeStart != 0 {
-			return 0, logger.NewErrorf("possible cpus must start from the index 0, so single CPU index value must be 0")
+			return 0, errfmt.Errorf("possible cpus must start from the index 0, so single CPU index value must be 0")
 		}
 		cpusAmount = 1
 	case rangeValues:
 		if rangeStart != 0 {
-			return 0, logger.NewErrorf("possible cpus should be following indexes range starting with 0")
+			return 0, errfmt.Errorf("possible cpus should be following indexes range starting with 0")
 		}
 		cpusAmount = rangeEnd - rangeStart + 1
 	case rangeValuesWithGroups:
-		return 0, logger.NewErrorf("possible cpus should be following indexes, but received groups format")
+		return 0, errfmt.Errorf("possible cpus should be following indexes, but received groups format")
 	default:
-		return 0, logger.NewErrorf("unkown possible cpu file format")
+		return 0, errfmt.Errorf("unkown possible cpu file format")
 	}
 	return cpusAmount, nil
 }

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -8,14 +8,14 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // OpenExistingDir open a directory with given path, and return the os.File of it.
 func OpenExistingDir(path string) (*os.File, error) {
 	outDirFD, err := unix.Open(path, unix.O_DIRECTORY|unix.O_PATH, 0)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return os.NewFile(uintptr(outDirFD), path), nil
 }
@@ -24,7 +24,7 @@ func OpenExistingDir(path string) (*os.File, error) {
 func OpenAt(dir *os.File, relativePath string, flags int, perm fs.FileMode) (*os.File, error) {
 	pidFileFD, err := unix.Openat(int(dir.Fd()), relativePath, flags, uint32(perm))
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return os.NewFile(uintptr(pidFileFD), path.Join(dir.Name(), relativePath)), nil
 }
@@ -40,7 +40,7 @@ func MkdirAtExist(dir *os.File, relativePath string, perm fs.FileMode) error {
 	if err != nil {
 		// Seems that os.ErrExist doesn't catch the error (at least on Manjaro distro)
 		if err != os.ErrExist && err.Error() != "file exists" {
-			return logger.ErrorFunc(err)
+			return errfmt.WrapError(err)
 		}
 	}
 	return nil
@@ -55,7 +55,7 @@ func CreateAt(dir *os.File, relativePath string) (*os.File, error) {
 func Dup(file *os.File) (*os.File, error) {
 	newFD, err := unix.Dup(int(file.Fd()))
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return os.NewFile(uintptr(newFD), file.Name()), nil
 }
@@ -69,24 +69,24 @@ func RenameAt(olddir *os.File, oldpath string, newdir *os.File, newpath string) 
 func CopyRegularFileByPath(src, dst string) error {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	if !sourceFileStat.Mode().IsRegular() {
-		return logger.NewErrorf("%s is not a regular file", src)
+		return errfmt.Errorf("%s is not a regular file", src)
 	}
 	source, err := os.Open(src)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	defer source.Close()
 	destination, err := os.Create(dst)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	defer destination.Close()
 	_, err = io.Copy(destination, source)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	return nil
 }
@@ -95,24 +95,24 @@ func CopyRegularFileByPath(src, dst string) error {
 func CopyRegularFileByRelativePath(srcName string, dstDir *os.File, dstName string) error {
 	sourceFileStat, err := os.Stat(srcName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	if !sourceFileStat.Mode().IsRegular() {
-		return logger.NewErrorf("%s is not a regular file", srcName)
+		return errfmt.Errorf("%s is not a regular file", srcName)
 	}
 	source, err := os.Open(srcName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	defer source.Close()
 	destination, err := CreateAt(dstDir, dstName)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	defer destination.Close()
 	_, err = io.Copy(destination, source)
 	if err != nil {
-		return logger.ErrorFunc(err)
+		return errfmt.WrapError(err)
 	}
 	return nil
 }
@@ -121,7 +121,7 @@ func CopyRegularFileByRelativePath(srcName string, dstDir *os.File, dstName stri
 func IsDirEmpty(pathname string) (bool, error) {
 	dir, err := os.Open(pathname)
 	if err != nil {
-		return false, logger.ErrorFunc(err)
+		return false, errfmt.WrapError(err)
 	}
 	defer dir.Close()
 
@@ -130,5 +130,5 @@ func IsDirEmpty(pathname string) (bool, error) {
 		return true, nil
 	}
 
-	return false, logger.ErrorFunc(err)
+	return false, errfmt.WrapError(err)
 }

--- a/pkg/utils/proc/exe.go
+++ b/pkg/utils/proc/exe.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // GetProcNS returns the namespace ID of a given namespace and process.
@@ -13,7 +13,7 @@ import (
 func GetProcBinary(pid uint) (string, error) {
 	binPath, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
 	if err != nil {
-		return "", logger.NewErrorf("could not read exe file: %v", err)
+		return "", errfmt.Errorf("could not read exe file: %v", err)
 	}
 	return binPath, nil
 }
@@ -23,12 +23,12 @@ func GetProcBinary(pid uint) (string, error) {
 func GetAllBinaryProcs() (map[string][]uint32, error) {
 	procDir, err := os.Open("/proc")
 	if err != nil {
-		return nil, logger.NewErrorf("could not open procfs dir: %v", err)
+		return nil, errfmt.Errorf("could not open procfs dir: %v", err)
 	}
 	defer procDir.Close()
 	procs, err := procDir.Readdirnames(-1)
 	if err != nil {
-		return nil, logger.NewErrorf("could not open procfs dir: %v", err)
+		return nil, errfmt.Errorf("could not open procfs dir: %v", err)
 
 	}
 	binProcs := map[string][]uint32{}

--- a/pkg/utils/sharedobjs/container_symbols_loader.go
+++ b/pkg/utils/sharedobjs/container_symbols_loader.go
@@ -2,7 +2,7 @@ package sharedobjs
 
 import (
 	"github.com/aquasecurity/tracee/pkg/containers"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // ContainersSymbolsLoader is a decorator for SO loaders that resolves containers-relative paths to
@@ -24,7 +24,7 @@ func (cLoader *ContainersSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[s
 	var err error
 	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return cLoader.hostLoader.GetDynamicSymbols(soInfo)
 }
@@ -33,7 +33,7 @@ func (cLoader *ContainersSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[
 	var err error
 	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return cLoader.hostLoader.GetExportedSymbols(soInfo)
 }
@@ -42,7 +42,7 @@ func (cLoader *ContainersSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[
 	var err error
 	soInfo.Path, err = cLoader.pathResolver.GetHostAbsPath(soInfo.Path, soInfo.MountNS)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return cLoader.hostLoader.GetImportedSymbols(soInfo)
 }

--- a/pkg/utils/sharedobjs/host_symbols_loader.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/golang-lru/simplelru"
 
 	"github.com/aquasecurity/tracee/pkg/capabilities"
-	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 // HostSymbolsLoader is responsible for efficient reading of shared object's symbols.
@@ -32,7 +32,7 @@ func InitHostSymbolsLoader(cacheSize int) *HostSymbolsLoader {
 func (soLoader *HostSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	dynSyms := copyMap(syms.Imported)
 	for expSym := range syms.Exported {
@@ -46,7 +46,7 @@ func (soLoader *HostSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string
 func (soLoader *HostSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return copyMap(syms.Exported), nil
 }
@@ -56,7 +56,7 @@ func (soLoader *HostSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[strin
 func (soLoader *HostSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return copyMap(syms.Imported), nil
 }
@@ -68,7 +68,7 @@ func (soLoader *HostSymbolsLoader) loadSOSymbols(soInfo ObjInfo) (*dynamicSymbol
 	}
 	syms, err := soLoader.loadingFunc(soInfo.Path)
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	soLoader.soCache.Add(soInfo, syms)
 	return syms, nil
@@ -110,13 +110,13 @@ func loadSharedObjectDynamicSymbols(path string) (*dynamicSymbols, error) {
 		return e
 	})
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	defer loadedObject.Close()
 
 	dynamicSymbols, err := loadedObject.DynamicSymbols()
 	if err != nil {
-		return nil, logger.ErrorFunc(err)
+		return nil, errfmt.WrapError(err)
 	}
 	return parseDynamicSymbols(dynamicSymbols), nil
 }


### PR DESCRIPTION
### 1. Explain what the PR does

commit 69d1a2ac61418a0e336ca077f68688634173c2b3

    errfmt: refactor to use pkg/errfmt

commit 52d176ce8f17888cbf3cf02ab95e91bc72a9e4f8

    errfmt: introduce new package for error formatting
    
    This commit introduces a new error-formatting package, moving and
    re-factoring existing error-formatting code from the logger package
    into it.

Fixes: #2783

- #2783

### 2. Explain how to test it

### 3. Other comments
