### PR TITLE
workflow: update AMI IDs for 30GB images

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Release Snapshot X64 (Default)
     runs-on:
       [
-        "github-self-hosted_ami-0b445cffc9303efcc_${{ github.event.number }}-${{ github.run_id }}",
+        "github-self-hosted_ami-0f2475a5a0c2160fe_${{ github.event.number }}-${{ github.run_id }}",
       ]
     steps:
       - name: Checkout Code
@@ -62,7 +62,7 @@ jobs:
     # only runs after x64 released (x64 is still the "default" arch)
     runs-on:
       [
-        "github-self-hosted_ami-0aa5b93153349d9ec_${{ github.event.number }}-${{ github.run_id }}",
+        "github-self-hosted_ami-0ba464e9b7e49c0c1_${{ github.event.number }}-${{ github.run_id }}",
       ]
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Release X64 (Default)
     runs-on:
       [
-        "github-self-hosted_ami-0b445cffc9303efcc_${{ github.event.number }}-${{ github.run_id }}",
+        "github-self-hosted_ami-0f2475a5a0c2160fe_${{ github.event.number }}-${{ github.run_id }}",
       ]
     permissions:
       contents: write
@@ -40,7 +40,7 @@ jobs:
       - release
     runs-on:
       [
-        "github-self-hosted_ami-0aa5b93153349d9ec_${{ github.event.number }}-${{ github.run_id }}",
+        "github-self-hosted_ami-0ba464e9b7e49c0c1_${{ github.event.number }}-${{ github.run_id }}",
       ]
     permissions:
       contents: write


### PR DESCRIPTION
- Jenkins currently does not accept 60GB images.

- By the time BTFHUB is activated (back) the 60GB images will probably be needed because of the current size of the BTFHUB repo.

[actions skip]