### PR TITLE
ebpf: align execve enter and exit timestamps

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -440,6 +440,7 @@ int syscall__execve(void *ctx)
     if (!p.task_info->syscall_traced)
         return -1;
     syscall_data_t *sys = &p.task_info->syscall_data;
+    p.event->context.ts = sys->ts;
 
     if (!should_submit(SYSCALL_EXECVE, &(p.event->context)))
         return 0;
@@ -463,6 +464,7 @@ int syscall__execveat(void *ctx)
     if (!p.task_info->syscall_traced)
         return -1;
     syscall_data_t *sys = &p.task_info->syscall_data;
+    p.event->context.ts = sys->ts;
 
     if (!should_submit(SYSCALL_EXECVEAT, &(p.event->context)))
         return 0;


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

For almost all of the syscalls, we submit an event at sys_exit hook point. Execve, however, is a special case since we can't use the provided pointers at exit time as they are invalid. For this reason, we currently have two hookpoints for execve syscall - one at syscall entry, and the other one at syscall exit. The latter is called only when execve fails and returns an error.

Align the timestamp used by a failed execve call to the timestamp used by the syscall entry hook.

### 2. Explain how to test it

Simply start tracee with only execve event and watch for some failed execve call:
`./dist/tracee -f e=execve`
The timestamp should now be aligned.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
