### PR TITLE
workflow: fix: github login action not working

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,11 +48,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
       - name: Lint
@@ -86,11 +81,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
       - name: Build Signatures
@@ -112,11 +102,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
       - name: Build Tracee Benchmark Tool
@@ -148,11 +133,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
       - name: Run Unit Tests
@@ -171,11 +151,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Install Dependencies
         uses: ./.github/actions/build-dependencies
       - name: Run Integration Tests
@@ -221,11 +196,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -259,11 +229,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -298,11 +263,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -336,11 +296,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -378,11 +333,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -416,11 +366,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -455,11 +400,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -493,11 +433,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -534,11 +469,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -572,11 +502,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -611,11 +536,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -649,11 +569,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -690,11 +605,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -728,11 +638,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -767,11 +672,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -805,11 +705,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -846,11 +741,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -884,11 +774,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -923,11 +808,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -961,11 +841,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode
@@ -1002,11 +877,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Login to docker.io registry
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: AWS Environment
         run: |
           dmidecode


### PR DESCRIPTION
Looks like github login actions does not work when using "pull_request" event. Remove it from pr.yaml. Seems like we're not blocked by docker hub limits currently. Will have to find a way to overcome that in the "on: pull_request" workflow.
