### PR TITLE
workflow: snapshot labels for jenkins are too long

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Release Snapshot X64 (Default)
     runs-on:
       [
-        "github-self-hosted_ami-0f66f3ab4856ffc3f_${{ github.event.number }}-${{ github.run_id }}_snapshotx64",
+        "github-self-hosted_ami-0f66f3ab4856ffc3f_${{ github.event.number }}-${{ github.run_id }}",
       ]
     steps:
       - name: Checkout Code
@@ -62,7 +62,7 @@ jobs:
     # only runs after x64 released (x64 is still the "default" arch)
     runs-on:
       [
-        "github-self-hosted_ami-0226a47b9804ee055_${{ github.event.number }}-${{ github.run_id }}_snapshotarm64",
+        "github-self-hosted_ami-0226a47b9804ee055_${{ github.event.number }}-${{ github.run_id }}",
       ]
     steps:
       - name: Checkout Code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Release X64 (Default)
     runs-on:
       [
-        "github-self-hosted_ami-0f66f3ab4856ffc3f_${{ github.event.number }}-${{ github.run_id }}_releasex64",
+        "github-self-hosted_ami-0f66f3ab4856ffc3f_${{ github.event.number }}-${{ github.run_id }}",
       ]
     permissions:
       contents: write
@@ -43,7 +43,7 @@ jobs:
       - release
     runs-on:
       [
-        "github-self-hosted_ami-0226a47b9804ee055_${{ github.event.number }}-${{ github.run_id }}_releasearm64",
+        "github-self-hosted_ami-0226a47b9804ee055_${{ github.event.number }}-${{ github.run_id }}",
       ]
     permissions:
       contents: write


### PR DESCRIPTION
- remove the extra tag from the AMI names because of jenkins limits