### PR TITLE
types: add SignatureContext type for init

### DIFF
--- a/types/detect/detect.go
+++ b/types/detect/detect.go
@@ -1,7 +1,9 @@
 // Package detect includes the "API" of the rule-engine and includes public facing types that consumers of the rule engine should work with
 package detect
 
-import "github.com/aquasecurity/tracee/types/protocol"
+import (
+	"github.com/aquasecurity/tracee/types/protocol"
+)
 
 // Signature is the basic unit of business logic for the rule-engine
 type Signature interface {
@@ -10,13 +12,18 @@ type Signature interface {
 	//GetSelectedEvents allows the signature to declare which events it subscribes to
 	GetSelectedEvents() ([]SignatureEventSelector, error)
 	//Init allows the signature to initialize its internal state
-	Init(cb SignatureHandler) error
+	Init(ctx SignatureContext) error
 	//Close cleans the signature after Init operation
 	Close()
 	//OnEvent allows the signature to process events passed by the Engine. this is the business logic of the signature
 	OnEvent(event protocol.Event) error
 	//OnSignal allows the signature to handle lifecycle events of the signature
 	OnSignal(signal Signal) error
+}
+
+type SignatureContext struct {
+	Callback SignatureHandler
+	Logger   Logger
 }
 
 // SignatureMetadata represents information about the signature
@@ -51,4 +58,12 @@ type Finding struct {
 	Data        map[string]interface{}
 	Event       protocol.Event //Event is the causal event of the Finding
 	SigMetadata SignatureMetadata
+}
+
+// Logger interface to inject in signatures
+type Logger interface {
+	Debugw(format string, v ...interface{})
+	Infow(format string, v ...interface{})
+	Warnw(format string, v ...interface{})
+	Errorw(format string, v ...interface{})
 }


### PR DESCRIPTION
Add a Context type for signatures in order to have a centralized struct for adding context injections to signatures.
This change is included with the addition of a logger to the context.

Required for #2864
