### PR TITLE
types: matchedScopes -> matchedPolicies

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -37,7 +37,7 @@ type Event struct {
 	PodSandbox          bool         `json:"podSandbox"`
 	EventID             int          `json:"eventId,string"`
 	EventName           string       `json:"eventName"`
-	MatchedScopes       uint64       `json:"matchedScopes"`
+	MatchedPolicies     uint64       `json:"matchedPolicies"`
 	ArgsNum             int          `json:"argsNum"`
 	ReturnValue         int          `json:"returnValue"`
 	Syscall             string       `json:"syscall"`


### PR DESCRIPTION
### 1. Explain what the PR does

This a prior step demanded by #2845.

Rename Event matchedScopes to matchedPolicies to be more consistent with the rest of the codebase.

This field will be replaced by matchedPoliciesNames in future PRs, but for now we just rename it to avoid confusion.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
