### PR TITLE
tests: disable cache for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -752,6 +752,7 @@ test-integration: \
 			" \
 		-v \
 		-p 1 \
+		-count=1 \
 		./tests/integration/... \
 
 .PHONY: test-signatures


### PR DESCRIPTION
### 1. Explain what the PR does

Disabling the cache allows us to run the cache multiple times and detect non-deterministic anomalies.

### 2. Explain how to test it

### 3. Other comments

Run `sudo make test-integration` more than one time and see that it no longer caches.