### PR TITLE
Feature/improve symbols loaded performance

### DIFF
--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -95,7 +95,7 @@ func initSymbolsLoadedEventGenerator(
 		}
 	}
 
-	cacheLRU, _ := lru.New(1024)
+	cacheLRU, _ := lru.New(10240)
 
 	return &symbolsLoadedEventGenerator{
 		soLoader:            soLoader,

--- a/pkg/utils/sharedobjs/host_symbols_loader.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader.go
@@ -4,6 +4,7 @@ import (
 	"debug/elf"
 
 	"github.com/hashicorp/golang-lru/simplelru"
+	"golang.org/x/exp/maps"
 
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -43,22 +44,24 @@ func (soLoader *HostSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string
 
 // GetExportedSymbols try to get shared objects exported symbols from lru, and if fails read needed information
 // from ELF file.
+// The returned map is part of a cache, so if the user wants to modify it he should copy it and modify it there.
 func (soLoader *HostSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	return copyMap(syms.Exported), nil
+	return syms.Exported, nil
 }
 
 // GetImportedSymbols try to get shared objects imported symbols from lru, and if fails read needed information
 // from ELF file.
+// The returned map is part of a cache, so if the user wants to modify it he should copy it and modify it there.
 func (soLoader *HostSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	return copyMap(syms.Imported), nil
+	return syms.Imported, nil
 }
 
 func (soLoader *HostSymbolsLoader) loadSOSymbols(soInfo ObjInfo) (*dynamicSymbols, error) {
@@ -135,8 +138,6 @@ func parseDynamicSymbols(dynamicSymbols []elf.Symbol) *dynamicSymbols {
 
 func copyMap(source map[string]bool) map[string]bool {
 	copiedMap := make(map[string]bool, len(source))
-	for k, v := range source {
-		copiedMap[k] = v
-	}
+	maps.Copy(copiedMap, source)
 	return copiedMap
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

events: avoid copying cached map in symbols loader
Copying of the cached maps in the loader proved to be heavy on the
performance because its wide use.
By using the cached map, we avoid excessive copy of the maps.

events: introduce cache to symbols_loaded
Introduce caching mechanism for watched symbols check in the
symbols_loaded derive event function.
This should further improve the performance of this heavy event.

Fix #2466

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
