### PR TITLE
fix: base event filters

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -252,10 +252,11 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 				Syscall:             syscall,
 			}
 
-			// base events for derived ones should be filtered in later stage
-			if _, ok := t.eventDerivations[eventId]; !ok {
-				if !t.shouldProcessEvent(&evt) {
-					_ = t.stats.EventsFiltered.Increment()
+			if !t.shouldProcessEvent(&evt) {
+				_ = t.stats.EventsFiltered.Increment()
+				// we can stop processing the event if it doesn't have derivatives.
+				// otherwise, since it has MatchedPolicies==0 it won't be emitted later anyway.
+				if _, ok := t.eventDerivations[eventId]; !ok {
 					continue
 				}
 			}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Event filters for events which derive other events didn't work. For example:
`./dist/tracee -f e=sched_process_exec -f sched_process_exec.context.uid=0` didn't filter uid as expected.

Base event filtering was skipped in order to derive its derivatives, however, it shouldn't have been. This PR fixes this issue by computing matched policies first, and breaking the pipeline only if the event doesn't have derivatives. Anyway, even if it does have derivatives but it should have been filtered out, it won't be emitted since we computed its matched policies to be 0.

Fix #2868 

### 2. Explain how to test it

`./dist/tracee -f e=sched_process_exec -f sched_process_exec.context.uid=0`

before this patch the above uid filter didn't work, with the patch it does

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
