### PR TITLE
add syscall support for print_mem_dump

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1671,7 +1671,18 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 				}
 				symbol, err := t.kernelSymbols.GetSymbolByName(owner, name)
 				if err != nil {
-					return errfmt.WrapError(err)
+					// Checking if the user specified a syscall name
+					if owner == "system" {
+						for _, prefix := range []string{"sys_", "__x64_sys_", "__arm64_sys_"} {
+							symbol, err = t.kernelSymbols.GetSymbolByName(owner, prefix+name)
+							if err == nil {
+								break
+							}
+						}
+					}
+					if err != nil {
+						return errfmt.WrapError(err)
+					}
 				}
 				_ = t.triggerMemDumpCall(symbol.Address, length, uint64(eventHandle))
 			}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

add support to syscalls for the `print_mem_dump` event.

### 2. Explain how to test it

`tracee-ebpf -f e=print_mem_dump -f print_mem_dump.args.symbol_name=execve`
see the event pop up.

### 3. Other comments

