### PR TITLE
fix: use correct type for bpf helpers

### DIFF
--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -246,7 +246,7 @@ func ParseArgs(event *trace.Event) error {
 				if err != nil {
 					return err
 				}
-				helpersArg.Type = "char*"
+				helpersArg.Type = "const char**"
 				helpersArg.Value = parsedHelpersList
 			}
 		}
@@ -272,7 +272,7 @@ func ParseArgs(event *trace.Event) error {
 				if err != nil {
 					return err
 				}
-				helpersArg.Type = "char*"
+				helpersArg.Type = "const char**"
 				helpersArg.Value = parsedHelpersList
 			}
 		}


### PR DESCRIPTION
set type correctly for bpf helpers arg of the bpf_attach and security_bpf_prog events, so json unmarshalling will be done correctly

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste your very well written git logs -->

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Thu Mar 23 12:22:01 2023 +0200

    fix: use correct type for bpf helpers

    set type correctly for bpf helpers arg of the bpf_attach and 
    security_bpf_prog events, so json unmarshalling will be done correctly
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
