### PR TITLE
skip arg filtering for PrintMemDump

### DIFF
--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -479,8 +479,8 @@ func (t *Tracee) processPrintMemDump(event *trace.Event) error {
 		return errfmt.WrapError(err)
 	}
 	arch = string(bytes.TrimRight(utsName.Machine[:], "\x00"))
-	event.Args = append(event.Args, trace.Argument{ArgMeta: trace.ArgMeta{Name: "arch", Type: "char*"}, Value: arch})
-	event.Args = append(event.Args, trace.Argument{ArgMeta: trace.ArgMeta{Name: "symbol_name", Type: "char*"}, Value: symbol.Name})
-	event.Args = append(event.Args, trace.Argument{ArgMeta: trace.ArgMeta{Name: "symbol_owner", Type: "char*"}, Value: symbol.Owner})
+	event.Args[4].Value = arch
+	event.Args[5].Value = symbol.Name
+	event.Args[6].Value = symbol.Owner
 	return nil
 }

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -32,6 +32,15 @@ func (filter *ArgFilter) Filter(eventID events.ID, args []trace.Argument) bool {
 		return true
 	}
 
+	// TODO: remove once events params are introduced
+	//       i.e. print_mem_dump.params.symbol_name=system:security_file_open
+	// events.PrintMemDump bypass was added due to issue #2546
+	// because it uses usermode applied filters as parameters for the event,
+	// which occurs after filtering
+	if eventID == events.PrintMemDump {
+		return true
+	}
+
 	for argName, filter := range filter.filters[eventID] {
 		found := false
 		var argVal interface{}
@@ -43,11 +52,7 @@ func (filter *ArgFilter) Filter(eventID events.ID, args []trace.Argument) bool {
 			}
 		}
 		if !found {
-			// TODO: remove once events arguments are introduced
-			// filter if argument does not exist
-			// the events.PrintMemDump bypass was added due to issue #2546
-			// because it uses usermode applied filters as parameters for the event, which occurs after filtering
-			return eventID == events.PrintMemDump
+			return false
 		}
 		// TODO: use type assertion instead of string conversion
 		if argName != "syscall" {


### PR DESCRIPTION
### 1. Explain what the PR does

commit 2d3094ce22e11186c96e3eea808a3f378b8114d8

    filters: args: skip arg filtering for PrintMemDump
    
    PrintMemDump event must not be filtered out by arguments filter, as it
    a special case that uses "args" as a way to pass "params" to the event.

commit 595ebeaca3a515a6cf1a891f0b42ae6ca45615d6

    ebpf: assign processPrintMemDump args values

    Instead of appending new args to processPrintMemDump event, assign
    values to its existing args. More on that in #2617.

### 2. Explain how to test it

```shell
sudo ./dist/tracee -f e=print_mem_dump -f print_mem_dump.args.symbol_name=system:security_file_open
```

![image](https://user-images.githubusercontent.com/3372117/227245080-df716d75-313f-46eb-9f55-f6a95b0cf4b0.png)


### 3. Other comments

Fixes: #2902
