### PR TITLE
types: add container and kubernetes context fields

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -28,13 +28,8 @@ type Event struct {
 	PIDNS               int          `json:"pidNamespace"`
 	ProcessName         string       `json:"processName"`
 	HostName            string       `json:"hostName"`
-	ContainerID         string       `json:"containerId"`
-	ContainerImage      string       `json:"containerImage"`
-	ContainerName       string       `json:"containerName"`
-	PodName             string       `json:"podName"`
-	PodNamespace        string       `json:"podNamespace"`
-	PodUID              string       `json:"podUID"`
-	PodSandbox          bool         `json:"podSandbox"`
+	Container           Container    `json:"container,omitempty"`
+	Kubernetes          Kubernetes   `json:"kubernetes,omitempty"`
 	EventID             int          `json:"eventId,string"`
 	EventName           string       `json:"eventName"`
 	MatchedPolicies     uint64       `json:"matchedPolicies"`
@@ -45,6 +40,20 @@ type Event struct {
 	ContextFlags        ContextFlags `json:"contextFlags"`
 	Args                []Argument   `json:"args"` //Arguments are ordered according their appearance in the original event
 	Metadata            *Metadata    `json:"metadata,omitempty"`
+}
+
+type Container struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ImageName   string `json:"image,omitempty"`
+	ImageDigest string `json:"imageDigest,omitempty"`
+}
+
+type Kubernetes struct {
+	PodName      string `json:"podName,omitempty"`
+	PodNamespace string `json:"podNamespace,omitempty"`
+	PodUID       string `json:"podUID,omitempty"`
+	PodSandbox   bool   `json:"podSandbox,omitempty"`
 }
 
 // Metadata is a struct that holds metadata about an event
@@ -75,7 +84,7 @@ func (e Event) Origin() EventOrigin {
 	if e.ContextFlags.ContainerStarted {
 		return ContainerOrigin
 	}
-	if e.ContainerID != "" {
+	if e.Container.ID != "" {
 		return ContainerInitOrigin
 	}
 	return HostOrigin

--- a/types/trace/trace_test.go
+++ b/types/trace/trace_test.go
@@ -140,7 +140,7 @@ func TestEvent_Origin(t *testing.T) {
 				EventName:     "execve",
 				HostProcessID: 321,
 				ProcessID:     123,
-				ContainerID:   "ab123",
+				Container:     Container{ID: "ab123"},
 				ContextFlags:  ContextFlags{ContainerStarted: true},
 			},
 			expected: ContainerOrigin,
@@ -148,7 +148,7 @@ func TestEvent_Origin(t *testing.T) {
 		{
 			event: Event{
 				EventName:    "runc",
-				ContainerID:  "ab123",
+				Container:    Container{ID: "ab123"},
 				ContextFlags: ContextFlags{ContainerStarted: false},
 			},
 			expected: ContainerInitOrigin,
@@ -217,7 +217,7 @@ func TestEvent_ToProtocol(t *testing.T) {
 		{
 			payload: Event{
 				EventName:    "open",
-				ContainerID:  "abc123",
+				Container:    Container{ID: "abc123"},
 				ContextFlags: ContextFlags{ContainerStarted: false},
 			},
 			expected: protocol.Event{
@@ -230,7 +230,7 @@ func TestEvent_ToProtocol(t *testing.T) {
 				},
 				Payload: Event{
 					EventName:    "open",
-					ContainerID:  "abc123",
+					Container:    Container{ID: "abc123"},
 					ContextFlags: ContextFlags{ContainerStarted: false},
 				},
 			},


### PR DESCRIPTION
Split the Container and Pod fields into separate Containers and Kubernetes struct fields.
Add an ImageDigest field to the Container struct which represents the container image's SHA digest.

Types PR required for #2760 
