### PR TITLE
types: event policy name

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -13,33 +13,34 @@ import (
 
 // Event is a single result of an ebpf event process. It is used as a payload later delivered to tracee-rules.
 type Event struct {
-	Timestamp           int          `json:"timestamp"`
-	ThreadStartTime     int          `json:"threadStartTime"`
-	ProcessorID         int          `json:"processorId"`
-	ProcessID           int          `json:"processId"`
-	CgroupID            uint         `json:"cgroupId"`
-	ThreadID            int          `json:"threadId"`
-	ParentProcessID     int          `json:"parentProcessId"`
-	HostProcessID       int          `json:"hostProcessId"`
-	HostThreadID        int          `json:"hostThreadId"`
-	HostParentProcessID int          `json:"hostParentProcessId"`
-	UserID              int          `json:"userId"`
-	MountNS             int          `json:"mountNamespace"`
-	PIDNS               int          `json:"pidNamespace"`
-	ProcessName         string       `json:"processName"`
-	HostName            string       `json:"hostName"`
-	Container           Container    `json:"container,omitempty"`
-	Kubernetes          Kubernetes   `json:"kubernetes,omitempty"`
-	EventID             int          `json:"eventId,string"`
-	EventName           string       `json:"eventName"`
-	MatchedPolicies     uint64       `json:"matchedPolicies"`
-	ArgsNum             int          `json:"argsNum"`
-	ReturnValue         int          `json:"returnValue"`
-	Syscall             string       `json:"syscall"`
-	StackAddresses      []uint64     `json:"stackAddresses"`
-	ContextFlags        ContextFlags `json:"contextFlags"`
-	Args                []Argument   `json:"args"` //Arguments are ordered according their appearance in the original event
-	Metadata            *Metadata    `json:"metadata,omitempty"`
+	Timestamp            int          `json:"timestamp"`
+	ThreadStartTime      int          `json:"threadStartTime"`
+	ProcessorID          int          `json:"processorId"`
+	ProcessID            int          `json:"processId"`
+	CgroupID             uint         `json:"cgroupId"`
+	ThreadID             int          `json:"threadId"`
+	ParentProcessID      int          `json:"parentProcessId"`
+	HostProcessID        int          `json:"hostProcessId"`
+	HostThreadID         int          `json:"hostThreadId"`
+	HostParentProcessID  int          `json:"hostParentProcessId"`
+	UserID               int          `json:"userId"`
+	MountNS              int          `json:"mountNamespace"`
+	PIDNS                int          `json:"pidNamespace"`
+	ProcessName          string       `json:"processName"`
+	HostName             string       `json:"hostName"`
+	Container            Container    `json:"container,omitempty"`
+	Kubernetes           Kubernetes   `json:"kubernetes,omitempty"`
+	EventID              int          `json:"eventId,string"`
+	EventName            string       `json:"eventName"`
+	MatchedPolicies      uint64       `json:"-"` // omit bitmask of matched policies
+	MatchedPoliciesNames []string     `json:"matchedPolicies,omitempty"`
+	ArgsNum              int          `json:"argsNum"`
+	ReturnValue          int          `json:"returnValue"`
+	Syscall              string       `json:"syscall"`
+	StackAddresses       []uint64     `json:"stackAddresses"`
+	ContextFlags         ContextFlags `json:"contextFlags"`
+	Args                 []Argument   `json:"args"` //Arguments are ordered according their appearance in the original event
+	Metadata             *Metadata    `json:"metadata,omitempty"`
 }
 
 type Container struct {


### PR DESCRIPTION
### 1. Explain what the PR does

This adds the MatchedPoliciesNames field to the event struct. This field will be used to store the name of the policy that matched the event.

It also omits the MatchedPolicies bitmask from the event struct marshalling.

### 2. Explain how to test it

### 3. Other comments

This is required by #2923 