### PR TITLE
capabilities: drop capabilities by default

### DIFF
--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -38,17 +38,17 @@ RUN apk --no-cache add man-pages man-pages-posix bash-completion vim && \
 # install staticcheck
 
 RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    sudo cp $HOME/go/bin/staticcheck /usr/bin/
+    cp $HOME/go/bin/staticcheck /usr/bin/
 
 # install goimports-reviser
 
 RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest && \
-    sudo cp $HOME/go/bin/goimports-reviser /usr/bin/
+    cp $HOME/go/bin/goimports-reviser /usr/bin/
 
 # install errcheck
 
 RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install github.com/kisielk/errcheck@latest && \
-    sudo cp $HOME/go/bin/errcheck /usr/bin/
+    cp $HOME/go/bin/errcheck /usr/bin/
 
 # allow TRACEE* and LIBBPFGO* environment variables through sudo
 

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -72,17 +72,17 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 # install staticcheck
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@latest && \
-    sudo cp $HOME/go/bin/staticcheck /usr/bin/
+    cp $HOME/go/bin/staticcheck /usr/bin/
 
 # install goimports-reviser
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest && \
-    sudo cp $HOME/go/bin/goimports-reviser /usr/bin/
+    cp $HOME/go/bin/goimports-reviser /usr/bin/
 
 # install errcheck
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/kisielk/errcheck@latest && \
-    sudo cp $HOME/go/bin/errcheck /usr/bin/
+    cp $HOME/go/bin/errcheck /usr/bin/
 
 USER tracee
 ENV HOME /home/tracee

--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -180,7 +180,7 @@ func parseTraceeInputFile(option *traceeInputOptions, fileOpt string) error {
 		option.inputFile = os.Stdin
 		return nil
 	}
-	err := capabilities.GetInstance().Requested(
+	err := capabilities.GetInstance().Specific(
 		func() error {
 			_, err := os.Stat(fileOpt)
 			if err != nil {

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -38,9 +38,7 @@ func main() {
 
 			// Capabilities command line flags
 
-			// if the user is not root, we will bypass capabilities raising,
-			// which means default capabilities will be used
-			bypass := c.Bool("allcaps") || !isRoot()
+			bypass := c.Bool("allcaps") || !isRoot() // non root has no practical use for capabilities drop
 			err := capabilities.Initialize(bypass)
 			if err != nil {
 				return err

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -73,7 +73,7 @@ func main() {
 			}
 
 			var loadedSigIDs []string
-			err = capabilities.GetInstance().Requested(
+			err = capabilities.GetInstance().Specific(
 				func() error {
 					for _, s := range sigs {
 						m, err := s.GetMetadata()

--- a/docs/classic-docs/docs/deep-dive/dropping-capabilities.md
+++ b/docs/classic-docs/docs/deep-dive/dropping-capabilities.md
@@ -5,10 +5,12 @@
 For the purpose of performing permission checks, traditional UNIX
 implementations distinguish two categories of processes: privileged processes
 (whose effective user ID is 0, referred to as superuser or root), and
-unprivileged processes (whose effective UID is nonzero). Privileged processes
-bypass all kernel permission checks, while unprivileged processes are subject to
-full permission checking based on the process's credentials (usually: effective
-UID, effective GID, and supplementary group list).
+unprivileged processes (whose effective UID is nonzero).
+
+Privileged processes bypass all kernel permission checks, while unprivileged
+processes are subject to full permission checking based on the process's
+credentials (usually: effective UID, effective GID, and supplementary group
+list).
 
 Linux divides the privileges traditionally associated with superuser into
 distinct units, known as capabilities, which can be independently enabled and
@@ -35,13 +37,14 @@ the capabilities that are gained during execve(2).
 
 ## Tracee and capabilities
 
-**tracee-ebpf** and **tracee-rules** both try to reduce their capabilities
-during their execution. The way they do is through "protection rings":
+**tracee**, **tracee-ebpf**, and **tracee-rules**, try to reduce their
+capabilities during their execution. The way they do is through different 
+"execution protection rings":
 
-* Privileged   (ring 0): all capabilities are Effective (almost never)
-* Required     (ring 1): only required (by events) capabilities are Effective (during config)
-* Requested    (ring 2): single time requested capabilities are Effective (special needs)
-* Unprivileged (ring 3): no capabilities are Effective at all (most of the time)
+* Full:     All capabilities are effective (less secure)
+* EBPF:     eBPF needed capabilities + Base capabilities
+* Specific: Specific capabilities (from time to time) + Base Capabilities
+* Base:     None or Some capabilities always effective (more secure)
 
 ## Listing available capabilities
 
@@ -56,8 +59,9 @@ command line flag.
 ## Bypass capabilities dropping feature
 
 !!! Attention
-    This session is important if you're facing errors while **tracee-ebpf** is
-    trying to drop its capabilities or any other permissions errors.
+    This session is important if you're facing errors while **tracee** or 
+    **tracee-ebpf** are trying to drop its capabilities or any other permissions
+    errors.
 
 Some environments **won't allow capabilities dropping** because of permission
 issues (for example - **AWS Lambdas**).
@@ -69,10 +73,9 @@ Failure in capabilities dropping will result tracee's exit with a matching
 error, to **guarantee that tracee isn't running with excess capabilities
 without the user agreement**.
 
-To **allow tracee-ebpf to run with high capabilities**, and prevent those
-errors, the `--capabilities bypass=1` flag can be used. For the docker
-container users, the environment variable `CAPABILITIES_BYPASS=0|1` will have
-the same effect.
+To **allow tracee to run with high capabilities**, and prevent those errors, the
+`--capabilities bypass=true` flag can be used. For the docker container users,
+the environment variable `CAPABILITIES_BYPASS=0|1` will have the same effect.
 
 > For tracee-rules, CAPABILITIES_BYPASS=1 will set the "--allcaps" command line
 > flag and allow it to run with full capabilities.
@@ -94,7 +97,9 @@ is to rely on following 2 command line flags:
 - `--capabilities add=cap_X,cap_Y` (docker env variable CAPABILITIES_ADD)
 - `--capabilities drop=cap_Y,capZ` (docker env variable CAPABILITIES_DROP)
 
-The first will add given capabilities to the Required ring (so events might be
-able to work). The last will remove the capabilities from that same ring.
+The first will add given capabilities to the Base ring, the ring that describe
+capabilities that will always be effective while tracee is running, so events
+might be able to work. The last will remove the capabilities from that same
+ring.
 
 > Tracee-rules do not support adding or removing specific capabilities.

--- a/docs/docs/deep-dive/dropping-capabilities.md
+++ b/docs/docs/deep-dive/dropping-capabilities.md
@@ -37,8 +37,8 @@ the capabilities that are gained during execve(2).
 
 ## Tracee and capabilities
 
-**tracee** tries to reduce its capabilities during their execution. The way they
-do is through different "execution protection rings":
+**tracee** tries to reduce its capabilities during its execution. The way it
+does is through different "execution protection rings":
 
 * Full:     All capabilities are effective (less secure)
 * EBPF:     eBPF needed capabilities + Base capabilities

--- a/docs/docs/deep-dive/dropping-capabilities.md
+++ b/docs/docs/deep-dive/dropping-capabilities.md
@@ -37,9 +37,8 @@ the capabilities that are gained during execve(2).
 
 ## Tracee and capabilities
 
-**tracee**, **tracee-ebpf**, and **tracee-rules**, try to reduce their
-capabilities during their execution. The way they do is through different 
-"execution protection rings":
+**tracee** tries to reduce its capabilities during their execution. The way they
+do is through different "execution protection rings":
 
 * Full:     All capabilities are effective (less secure)
 * EBPF:     eBPF needed capabilities + Base capabilities
@@ -59,9 +58,8 @@ command line flag.
 ## Bypass capabilities dropping feature
 
 !!! Attention
-    This session is important if you're facing errors while **tracee** or 
-    **tracee-ebpf** are trying to drop its capabilities or any other permissions
-    errors.
+    This session is important if you're facing errors related to **tracee**
+    dropping its capabilities OR any other permission related errors.
 
 Some environments **won't allow capabilities dropping** because of permission
 issues (for example - **AWS Lambdas**).
@@ -77,13 +75,9 @@ To **allow tracee to run with high capabilities**, and prevent those errors, the
 `--capabilities bypass=true` flag can be used. For the docker container users,
 the environment variable `CAPABILITIES_BYPASS=0|1` will have the same effect.
 
-> For tracee-rules, CAPABILITIES_BYPASS=1 will set the "--allcaps" command line
-> flag and allow it to run with full capabilities.
-
 !!! Note
-    Bypassing the capabilities drop will run tracee-ebpf and/or tracee-rules
-    with all capabilities set as Effective and it is only recommended if you
-    know what you are doing.
+    Bypassing the capabilities drop will run **tracee** with all capabilities
+    set as Effective and it is only recommended if you know what you are doing.
 
 ## Capabilities Errors (Missing or Too Permissive)
 
@@ -101,5 +95,3 @@ The first will add given capabilities to the Base ring, the ring that describe
 capabilities that will always be effective while tracee is running, so events
 might be able to work. The last will remove the capabilities from that same
 ring.
-
-> Tracee-rules do not support adding or removing specific capabilities.

--- a/docs/getting-started/installing/prerequisites.md
+++ b/docs/getting-started/installing/prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites for running Tracee
 
-A long-term supported kernel: 5.4, 5.10, 5.15, 5.18, 5.19. Check
+A longterm supported kernel: 5.4, 5.10, 5.15, 5.18, 6.1, 6.2. Check
 [kernel.org](https://kernel.org) for current supported kernels.
 
 !!! Note
@@ -30,7 +30,7 @@ capabilities:
 * Load and Attach eBPF programs:
     1. `CAP_BPF`+`CAP_PERFMON` for recent kernels (>=5.8) where the kernel perf paranoid value in `/proc/sys/kernel/perf_event_paranoid` is equal to 2 or less
     2. or `CAP_SYS_ADMIN` otherwise
-* `CAP_SYS_PTRACE` (to collect information about processes upon startup)
+* `CAP_SYS_PTRACE` (to collect information about processes)
 * `CAP_NET_ADMIN` (to use tc for packets capture)
 * `CAP_SETPCAP` (if given - used to reduce bounding set capabilities)
 * `CAP_SYSLOG` (to access kernel symbols through /proc/kallsyms)
@@ -38,7 +38,7 @@ capabilities:
 * On cgroup v1 environments, `CAP_SYS_ADMIN` is recommended if running from a
   container in order to allow tracee to mount the cpuset cgroup controller.
 
-> Alternatively, run as `root` or with **Docker** `--pid=host --cgroupns=host --privileged` flags.
+> Alternatively, you may [bypass the capabilities dropping feature](../../docs/deep-dive/dropping-capabilities.md) if facing any issue.
 
 [libbpf CO-RE documentation]: https://github.com/libbpf/libbpf#bpf-co-re-compile-once--run-everywhere
 [BTFHUB]: https://github.com/aquasecurity/btfhub-archive

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -28,7 +28,7 @@ const (
 	Privileged   ringType = iota // ring0 (all capabilities enabled, startup/shutdown)
 	Required                     // ring1 (needed capabilities only: config time)
 	Requested                    // ring2 (temporary specific capabilities)
-	Unprivileged                 // ring3 (no capabilities: runtime)
+	Unprivileged                 // ring3 (minimum required capabilities: runtime)
 )
 
 type Capabilities struct {
@@ -118,7 +118,6 @@ func (c *Capabilities) initialize(bypass bool) error {
 		logger.Debugw("Paranoid: Value in /proc/sys/kernel/perf_event_paranoid is > 2")
 		logger.Debugw("Paranoid: Tracee needs CAP_SYS_ADMIN instead of CAP_BPF + CAP_PERFMON")
 		logger.Debugw("Paranoid: To change that behavior set perf_event_paranoid to 2 or less.")
-		err = c.Require(cap.SYS_ADMIN)
 		if err != nil {
 			logger.Fatalw("Requiring capabilities", "error", err)
 		}
@@ -326,9 +325,9 @@ func (c *Capabilities) apply(t ringType) error {
 	logger.Debugw("Capabilities change")
 
 	for k, v := range c.all {
-		if v[t] {
-			logger.Debugw("Enabling cap", "cap", k)
-		}
+		// if v[t] {
+		// 	logger.Debugw("Enabling cap", "cap", k)
+		// }
 		err = c.have.SetFlag(cap.Effective, v[t], k)
 		if err != nil {
 			return errfmt.WrapError(err)

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -17,10 +17,10 @@ var caps *Capabilities // singleton for all packages
 
 var once sync.Once
 
-type ringType int
+type RingType int
 
 const (
-	Full     ringType = iota // All capabilties are effective
+	Full     RingType = iota // All capabilties are effective
 	EBPF                     // eBPF needed capabilities are effective
 	Specific                 // Specific requested capabilities are effective
 	Base                     // Capabilities that are always effective
@@ -28,7 +28,7 @@ const (
 
 type Capabilities struct {
 	have   *cap.Set
-	all    map[cap.Value]map[ringType]bool
+	all    map[cap.Value]map[RingType]bool
 	bypass bool
 	lock   *sync.Mutex // big lock to guarantee all threads are on the same ring
 }
@@ -65,10 +65,10 @@ func (c *Capabilities) initialize(bypass bool) error {
 	}
 
 	c.lock = new(sync.Mutex)
-	c.all = make(map[cap.Value]map[ringType]bool)
+	c.all = make(map[cap.Value]map[RingType]bool)
 
 	for v := cap.Value(0); v < cap.MaxBits(); v++ {
-		c.all[v] = make(map[ringType]bool)
+		c.all[v] = make(map[RingType]bool)
 		c.all[v][Full] = true // all capabilities are effective in Full
 		// all other ring types are false by default
 	}
@@ -252,7 +252,7 @@ func (c *Capabilities) EBPFRingRemove(values ...cap.Value) error {
 func (c *Capabilities) BaseRingAdd(values ...cap.Value) error {
 	logger.Debugw("Adding capabilities to base ring", "capability", values)
 
-	rings := []ringType{
+	rings := []RingType{
 		Base,
 		EBPF,
 		Specific,
@@ -272,7 +272,7 @@ func (c *Capabilities) BaseRingAdd(values ...cap.Value) error {
 func (c *Capabilities) BaseRingRemove(values ...cap.Value) error {
 	logger.Debugw("Removing capabilities from the base ring", "capability", values)
 
-	rings := []ringType{
+	rings := []RingType{
 		Base,
 		EBPF,
 		Specific,
@@ -291,7 +291,7 @@ func (c *Capabilities) BaseRingRemove(values ...cap.Value) error {
 
 // Private Methods
 
-func (c *Capabilities) ringAdd(ring ringType, values ...cap.Value) error {
+func (c *Capabilities) ringAdd(ring RingType, values ...cap.Value) error {
 	var err error
 
 	if c.bypass {
@@ -305,7 +305,7 @@ func (c *Capabilities) ringAdd(ring ringType, values ...cap.Value) error {
 	return errfmt.WrapError(err)
 }
 
-func (c *Capabilities) ringRemove(ring ringType, values ...cap.Value) error {
+func (c *Capabilities) ringRemove(ring RingType, values ...cap.Value) error {
 	var err error
 
 	if c.bypass {
@@ -339,7 +339,7 @@ func (c *Capabilities) setProc() error {
 	return nil
 }
 
-func (c *Capabilities) set(t ringType, values ...cap.Value) error {
+func (c *Capabilities) set(t RingType, values ...cap.Value) error {
 	for _, v := range values {
 		c.all[v][t] = true
 	}
@@ -347,7 +347,7 @@ func (c *Capabilities) set(t ringType, values ...cap.Value) error {
 	return nil
 }
 
-func (c *Capabilities) unset(t ringType, values ...cap.Value) error {
+func (c *Capabilities) unset(t RingType, values ...cap.Value) error {
 	for _, v := range values {
 		c.all[v][t] = false
 	}
@@ -355,7 +355,7 @@ func (c *Capabilities) unset(t ringType, values ...cap.Value) error {
 	return nil
 }
 
-func (c *Capabilities) apply(t ringType) error {
+func (c *Capabilities) apply(t RingType) error {
 	var err error
 
 	err = c.getProc()

--- a/pkg/cmd/flags/capabilities.go
+++ b/pkg/cmd/flags/capabilities.go
@@ -26,7 +26,7 @@ Available capabilities:
 
 func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) {
 	capsConfig := tracee.CapabilitiesConfig{
-		BypassCaps: false, // bypass capabilities by default
+		BypassCaps: false, // do not bypass capabilities by default
 	}
 
 	for _, slice := range capsSlice {

--- a/pkg/cmd/flags/capabilities.go
+++ b/pkg/cmd/flags/capabilities.go
@@ -26,15 +26,15 @@ Available capabilities:
 
 func PrepareCapabilities(capsSlice []string) (tracee.CapabilitiesConfig, error) {
 	capsConfig := tracee.CapabilitiesConfig{
-		BypassCaps: true, // bypass capabilities by default
+		BypassCaps: false, // bypass capabilities by default
 	}
 
 	for _, slice := range capsSlice {
 		if strings.Contains(slice, "bypass=") {
 			b := strings.TrimPrefix(slice, "bypass=")
-			if b == "0" || b == "false" {
-				capsConfig.BypassCaps = false
-			} else if b != "1" && b != "true" {
+			if b == "1" || b == "true" {
+				capsConfig.BypassCaps = true
+			} else if b != "0" && b != "false" {
 				return capsConfig, errfmt.Errorf("bypass should either be true or false")
 			}
 		}

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -130,6 +130,7 @@ func GetContainerIdFromTaskDir(taskPath string) (string, error) {
 
 // populate walks the cgroup fs informing CgroupUpdate() about existing dirs.
 func (c *Containers) populate() error {
+
 	fn := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			logger.Errorw("WalkDir func", "error", err)

--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -6,20 +6,24 @@ import (
 	"os"
 	"strings"
 
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+
 	"github.com/aquasecurity/tracee/pkg/bucketscache"
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
-// ContainerPathResolver generates an accessible absolute path from the root mount namespace to a
-// relative path in a container. **NOTE**: to resolve host mount namespace, tracee reads from
-// /proc/1/ns, requiring CAP_SYS_PTRACE capability.
+// ContainerPathResolver generates an accessible absolute path from the root
+// mount namespace to a relative path in a container. **NOTE**: to resolve host
+// mount namespace, tracee reads from /proc/1/ns, requiring CAP_SYS_PTRACE
+// capability.
 type ContainerPathResolver struct {
 	fs               fs.FS
 	mountNSPIDsCache *bucketscache.BucketsCache
 }
 
-// InitContainerPathResolver creates a resolver for paths from within containers.
+// InitContainerPathResolver creates a resolver for paths from within
+// containers.
 func InitContainerPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) *ContainerPathResolver {
 	return &ContainerPathResolver{
 		fs:               os.DirFS("/"),
@@ -27,34 +31,51 @@ func InitContainerPathResolver(mountNSPIDsCache *bucketscache.BucketsCache) *Con
 	}
 }
 
-// GetHostAbsPath translates an absolute path, which might be inside a container, to the
-// correspondent abs path in the host mount namespace.
+// GetHostAbsPath translates an absolute path, which might be inside a
+// container, to the correspondent abs path in the host mount namespace.
 func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string, mountNS int) (
 	string, error,
 ) {
+	var err error
+
 	// path should be absolute, except, for example, memfd_create files
 	if mountNSAbsolutePath == "" || mountNSAbsolutePath[0] != '/' {
 		return "", errfmt.Errorf("file path is not absolute in its container mount point")
 	}
-	// try to access the root fs via another process in the same mount namespace
-	// (since the current process might have already died)
+
+	// Current process has already died, try to access the root fs from another
+	// process of the same mount namespace.
+
 	pids := cPathRes.mountNSPIDsCache.GetBucket(uint32(mountNS))
-	for _, pid := range pids {
-		procRootPath := fmt.Sprintf("/proc/%d/root", int(pid))
-		// fs.FS interface requires relative paths, so the '/' prefix should be trimmed.
-		err := capabilities.GetInstance().Required(func() error {
-			entries, err := fs.ReadDir(cPathRes.fs, strings.TrimPrefix(procRootPath, "/"))
-			if err != nil {
-				return errfmt.WrapError(err)
+
+	retMountNSAbsolutePath := ""
+
+	err = capabilities.GetInstance().Requested(
+		func() error {
+
+			for _, pid := range pids {
+				procRootPath := fmt.Sprintf("/proc/%d/root", int(pid))
+				// fs.FS interface requires relative paths, so the '/' prefix should be trimmed.
+				entries, err := fs.ReadDir(cPathRes.fs, strings.TrimPrefix(procRootPath, "/"))
+				if err != nil {
+					return errfmt.WrapError(err)
+				}
+				if len(entries) == 0 {
+					return errfmt.Errorf("empty directory")
+				}
+				if err == nil {
+					retMountNSAbsolutePath = fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath)
+					return nil
+				}
 			}
-			if len(entries) == 0 {
-				return errfmt.Errorf("empty directory")
-			}
-			return nil
-		})
-		if err == nil {
-			return fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath), nil
-		}
+			return errfmt.Errorf("has no access to container fs - no living task of mountns %d", mountNS)
+
+		},
+		cap.SYS_PTRACE,
+	)
+	if err == nil {
+		return retMountNSAbsolutePath, nil
 	}
-	return "", errfmt.Errorf("has no access to container fs - no living task of mountns %d", mountNS)
+
+	return "", err
 }

--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -53,17 +53,15 @@ func ValidateKsymbolsTable(ksyms helpers.KernelSymbolTable) bool {
 }
 
 func (t *Tracee) NewKernelSymbols() error {
-	var kernelSymbols helpers.KernelSymbolTable
-	var err error
 
-	kernelSymbols, err = helpers.NewLazyKernelSymbolsMap()
+	// reading kallsyms needs CAP_SYSLOG
+	kernelSymbols, err := helpers.NewLazyKernelSymbolsMap()
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
 
 	if !ValidateKsymbolsTable(kernelSymbols) {
-		// debug.PrintStack()
-		return errfmt.Errorf("invalid ksymbol table")
+		return errfmt.Errorf("invalid ksymbol table (capabilities issue ?)")
 	}
 	t.kernelSymbols = kernelSymbols
 

--- a/pkg/events/derive/hidden_kernel_module.go
+++ b/pkg/events/derive/hidden_kernel_module.go
@@ -86,7 +86,8 @@ func ClearModulesState(modsMap *bpf.BPFMap) {
 }
 
 func FillModulesFromProcFs(kernelSymbols helpers.KernelSymbolTable, modulesFromProcFs *bpf.BPFMap) error {
-	err := capabilities.GetInstance().Requested(
+
+	return capabilities.GetInstance().Specific(
 		func() error {
 			file, err := os.Open("/proc/modules")
 			if err != nil {
@@ -149,6 +150,4 @@ func FillModulesFromProcFs(kernelSymbols helpers.KernelSymbolTable, modulesFromP
 		},
 		cap.DAC_OVERRIDE,
 	)
-	return err
-
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -13,7 +13,7 @@ type dependencies struct {
 	Events       []eventDependency    // Events required to be loaded and/or submitted for the event to happen
 	KSymbols     *[]kSymbolDependency // nil pointer means no symbols needed, empty slice indicates for dynamic symbols which their names aren't known at the time of compilation
 	TailCalls    []TailCall
-	Capabilities []cap.Value
+	Capabilities []cap.Value // Capabilities needed in events processor or derivation phases
 }
 
 type probeDependency struct {
@@ -5578,12 +5578,10 @@ var Definitions = eventDefinitions{
 			},
 		},
 		InitNamespaces: {
-			ID32Bit: sys32undefined,
-			Name:    "init_namespaces",
-			Sets:    []string{},
-			Dependencies: dependencies{
-				Capabilities: []cap.Value{cap.SYS_PTRACE},
-			},
+			ID32Bit:      sys32undefined,
+			Name:         "init_namespaces",
+			Sets:         []string{},
+			Dependencies: dependencies{},
 			Params: []trace.ArgMeta{
 				{Type: "u32", Name: "cgroup"},
 				{Type: "u32", Name: "ipc"},
@@ -5836,6 +5834,7 @@ var Definitions = eventDefinitions{
 					{EventID: DoInitModule},
 					{EventID: PrintSyscallTable},
 				},
+				Capabilities: []cap.Value{cap.SYSLOG}, // read /proc/kallsyms
 			},
 			Sets: []string{},
 			Params: []trace.ArgMeta{
@@ -5906,10 +5905,7 @@ var Definitions = eventDefinitions{
 					{EventID: SharedObjectLoaded},
 					{EventID: SchedProcessExec}, // Used to get mount namespace cache
 				},
-				Capabilities: []cap.Value{
-					cap.SYS_PTRACE,   // Used to get host mount NS for bucket cache
-					cap.DAC_OVERRIDE, // Used to open files across the system
-				},
+				Capabilities: []cap.Value{},
 			},
 			Sets: []string{"derived", "fs", "security_alert"},
 			Params: []trace.ArgMeta{
@@ -5927,10 +5923,7 @@ var Definitions = eventDefinitions{
 					{EventID: SharedObjectLoaded},
 					{EventID: SchedProcessExec}, // Used to get mount namespace cache
 				},
-				Capabilities: []cap.Value{
-					cap.SYS_PTRACE,   // Used to get host mount NS for bucket cache
-					cap.DAC_OVERRIDE, // Used to open files across the system
-				},
+				Capabilities: []cap.Value{},
 			},
 			Sets: []string{"lsm_hooks", "fs", "fs_file_ops", "proc", "proc_mem"},
 			Params: []trace.ArgMeta{
@@ -5965,11 +5958,8 @@ var Definitions = eventDefinitions{
 			Name:     "capture_exec",
 			Internal: true,
 			Dependencies: dependencies{
-				Events: []eventDependency{{EventID: SchedProcessExec}},
-				Capabilities: []cap.Value{
-					cap.SYS_PTRACE,
-					cap.DAC_OVERRIDE,
-				},
+				Events:       []eventDependency{{EventID: SchedProcessExec}},
+				Capabilities: []cap.Value{},
 			},
 		},
 		CaptureModule: {
@@ -6079,6 +6069,7 @@ var Definitions = eventDefinitions{
 				Events: []eventDependency{
 					{EventID: DoInitModule},
 				},
+				Capabilities: []cap.Value{cap.SYSLOG}, // read /proc/kallsyms
 			},
 			Sets: []string{},
 			Params: []trace.ArgMeta{
@@ -6120,6 +6111,7 @@ var Definitions = eventDefinitions{
 					{EventID: PrintNetSeqOps},
 					{EventID: DoInitModule},
 				},
+				Capabilities: []cap.Value{cap.SYSLOG}, // read /proc/kallsyms
 			},
 			Sets: []string{},
 			Params: []trace.ArgMeta{

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5047,6 +5047,7 @@ var Definitions = eventDefinitions{
 				TailCalls: []TailCall{
 					{MapName: "prog_array_tp", MapIndexes: []uint32{tailSchedProcessExecEventSubmit}, ProgName: "sched_process_exec_event_submit_tail"},
 				},
+				Capabilities: []cap.Value{cap.SYS_PTRACE}, // CopyRegularFileByRelativePath()
 			},
 			Sets: []string{"default", "proc"},
 			Params: []trace.ArgMeta{
@@ -5885,6 +5886,9 @@ var Definitions = eventDefinitions{
 			Name:    "shared_object_loaded",
 			Probes: []probeDependency{
 				{Handle: probes.SecurityMmapFile, Required: true},
+			},
+			Dependencies: dependencies{
+				Capabilities: []cap.Value{cap.SYS_PTRACE}, // loadSharedObjectDynamicSymbols()
 			},
 			Sets: []string{"lsm_hooks", "fs", "fs_file_ops", "proc", "proc_mem"},
 			Params: []trace.ArgMeta{

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -5579,10 +5579,12 @@ var Definitions = eventDefinitions{
 			},
 		},
 		InitNamespaces: {
-			ID32Bit:      sys32undefined,
-			Name:         "init_namespaces",
-			Sets:         []string{},
-			Dependencies: dependencies{},
+			ID32Bit: sys32undefined,
+			Name:    "init_namespaces",
+			Sets:    []string{},
+			Dependencies: dependencies{
+				Capabilities: []cap.Value{cap.SYS_PTRACE},
+			},
 			Params: []trace.ArgMeta{
 				{Type: "u32", Name: "cgroup"},
 				{Type: "u32", Name: "ipc"},

--- a/pkg/events/usermode.go
+++ b/pkg/events/usermode.go
@@ -1,11 +1,18 @@
 // Invoked tracee-ebpf events from user mode
-// This utility can prove itself useful to generate information needed by signatures that is not provided by normal
-// events in the kernel.
-// Because the events in the kernel are invoked by other programs behavior, we cannot anticipate which events will be
-// invoked and as a result what information will be extracted.
-// This is critical because tracee-rules is independent, and doesn't have to run on the same machine as tracee-ebpf.
-// This means that tracee-rules might lack basic information of the operating machine needed for some signatures.
-// By creating user mode events this information could be intentionally collected and passed to tracee-ebpf afterwards.
+//
+// This utility can be useful to generate information needed by signatures that
+// is not provided by normal events in the kernel.
+//
+// Because the events in the kernel are invoked by other programs behavior, we
+// cannot anticipate which events will be invoked and as a result what
+// information will be extracted.
+//
+// This is critical because tracee-rules is independent, and doesn't have to run
+// on the same machine as tracee-ebpf. This means that tracee-rules might lack
+// basic information of the operating machine needed for some signatures.
+//
+// By creating user mode events this information could be intentionally
+// collected and passed to tracee-ebpf afterwards.
 package events
 
 import (
@@ -16,17 +23,23 @@ import (
 	"strings"
 	"time"
 
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+
+	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/containers"
 	"github.com/aquasecurity/tracee/pkg/containers/runtime"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
 const InitProcNsDir = "/proc/1/ns"
 
-// InitNamespacesEvent collect the init process namespaces and create event from them.
+// InitNamespacesEvent collect the init process namespaces and create event from
+// them.
 func InitNamespacesEvent() trace.Event {
 	initNamespacesDef := Definitions.Get(InitNamespaces)
 	initNamespacesArgs := getInitNamespaceArguments()
+
 	initNamespacesEvent := trace.Event{
 		Timestamp:   int(time.Now().UnixNano()),
 		ProcessName: "tracee-ebpf",
@@ -35,40 +48,64 @@ func InitNamespacesEvent() trace.Event {
 		ArgsNum:     len(initNamespacesArgs),
 		Args:        initNamespacesArgs,
 	}
+
 	return initNamespacesEvent
 }
 
-// getInitNamespaceArguments Fetch the namespaces of the init process and parse them into event arguments.
+// getInitNamespaceArguments fetches the namespaces of the init process and
+// parse them into event arguments.
 func getInitNamespaceArguments() []trace.Argument {
 	initNamespaces := fetchInitNamespaces()
 	eventDefinition := Definitions.Get(InitNamespaces)
 	initNamespacesArgs := make([]trace.Argument, len(eventDefinition.Params))
+
 	for i, arg := range initNamespacesArgs {
 		arg.ArgMeta = eventDefinition.Params[i]
 		arg.Value = initNamespaces[arg.Name]
 		initNamespacesArgs[i] = arg
 	}
+
 	return initNamespacesArgs
 }
 
-// fetchInitNamespaces fetch the namespaces values from the /proc/1/ns directory
+// fetchInitNamespaces fetches the namespaces values from the /proc/1/ns
+// directory
 func fetchInitNamespaces() map[string]uint32 {
+	var err error
+	var namespacesLinks []os.DirEntry
+
 	initNamespacesMap := make(map[string]uint32)
 	namespaceValueReg := regexp.MustCompile(":[[[:digit:]]*]")
-	namespacesLinks, _ := os.ReadDir(InitProcNsDir)
-	for _, namespaceLink := range namespacesLinks {
-		linkString, _ := os.Readlink(filepath.Join(InitProcNsDir, namespaceLink.Name()))
-		trim := strings.Trim(namespaceValueReg.FindString(linkString), "[]:")
-		namespaceNumber, _ := strconv.ParseUint(trim, 10, 32)
-		initNamespacesMap[namespaceLink.Name()] = uint32(namespaceNumber)
+
+	err = capabilities.GetInstance().Requested(
+		func() error {
+			namespacesLinks, err = os.ReadDir(InitProcNsDir)
+			if err != nil {
+				return err
+			}
+			for _, namespaceLink := range namespacesLinks {
+				linkString, _ := os.Readlink(filepath.Join(InitProcNsDir, namespaceLink.Name()))
+				trim := strings.Trim(namespaceValueReg.FindString(linkString), "[]:")
+				namespaceNumber, _ := strconv.ParseUint(trim, 10, 32)
+				initNamespacesMap[namespaceLink.Name()] = uint32(namespaceNumber)
+			}
+			return nil
+		},
+		cap.SYS_PTRACE,
+	)
+	if err != nil {
+		logger.Errorw("fetching init namespaces", "error", err)
 	}
+
 	return initNamespacesMap
 }
 
 // ExistingContainersEvents returns a list of events for each existing container
 func ExistingContainersEvents(containers *containers.Containers, enrich bool) []trace.Event {
 	var events []trace.Event
+
 	def := Definitions.Get(ExistingContainer)
+
 	for id, info := range containers.GetContainers() {
 		container := runtime.ContainerMetadata{}
 		if enrich {
@@ -96,5 +133,6 @@ func ExistingContainersEvents(containers *containers.Containers, enrich bool) []
 		}
 		events = append(events, existingContainerEvent)
 	}
+
 	return events
 }

--- a/pkg/events/usermode.go
+++ b/pkg/events/usermode.go
@@ -77,7 +77,7 @@ func fetchInitNamespaces() map[string]uint32 {
 	initNamespacesMap := make(map[string]uint32)
 	namespaceValueReg := regexp.MustCompile(":[[[:digit:]]*]")
 
-	err = capabilities.GetInstance().Requested(
+	err = capabilities.GetInstance().Specific(
 		func() error {
 			namespacesLinks, err = os.ReadDir(InitProcNsDir)
 			if err != nil {

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -6,11 +6,8 @@ import (
 	"strings"
 	"unsafe"
 
-	"kernel.org/pub/linux/libs/security/libcap/cap"
-
 	bpf "github.com/aquasecurity/libbpfgo"
 
-	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/pkg/utils/proc"
@@ -39,15 +36,9 @@ func getHostMntNS() (uint32, error) {
 	var ns int
 	var err error
 
-	err = capabilities.GetInstance().Requested(func() error {
-		ns, err = proc.GetProcNS(1, "mnt")
-		return errfmt.WrapError(err)
-	},
-		cap.DAC_READ_SEARCH,
-		cap.SYS_PTRACE,
-	)
+	ns, err = proc.GetProcNS(1, "mnt")
 	if err != nil {
-		return 0, err
+		return 0, errfmt.WrapError(err)
 	}
 
 	return uint32(ns), nil

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -79,7 +79,8 @@ func (m *MountOnce) Mount() error {
 	m.target = mp
 
 	// mount the filesystem to the target dir
-	err = capabilities.GetInstance().Requested( // ring2
+
+	err = capabilities.GetInstance().Requested(
 		func() error {
 			return syscall.Mount(m.fsType, m.target, m.fsType, 0, m.data)
 		},
@@ -101,8 +102,10 @@ func (m *MountOnce) Mount() error {
 
 func (m *MountOnce) Umount() error {
 	if m.managed && m.mounted {
+
 		// umount the filesystem from the target dir
-		err := capabilities.GetInstance().Requested( // ring2
+
+		err := capabilities.GetInstance().Requested(
 			func() error {
 				return syscall.Unmount(m.target, 0)
 			},

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -80,7 +80,7 @@ func (m *MountOnce) Mount() error {
 
 	// mount the filesystem to the target dir
 
-	err = capabilities.GetInstance().Requested(
+	err = capabilities.GetInstance().Specific(
 		func() error {
 			return syscall.Mount(m.fsType, m.target, m.fsType, 0, m.data)
 		},
@@ -105,7 +105,7 @@ func (m *MountOnce) Umount() error {
 
 		// umount the filesystem from the target dir
 
-		err := capabilities.GetInstance().Requested(
+		err := capabilities.GetInstance().Specific(
 			func() error {
 				return syscall.Unmount(m.target, 0)
 			},

--- a/pkg/signatures/celsig/config.go
+++ b/pkg/signatures/celsig/config.go
@@ -105,7 +105,7 @@ func NewConfigsFromDir(dirPath string) ([]SignaturesConfig, error) {
 func walkFilesWithExtensions(rootDir string, extensions []string) ([]string, error) {
 	var files []string
 
-	err := capabilities.GetInstance().Requested(
+	err := capabilities.GetInstance().Specific(
 		func() error {
 			err := filepath.WalkDir(rootDir,
 				func(path string, d fs.DirEntry, err error) error {

--- a/pkg/signatures/signature/signature.go
+++ b/pkg/signatures/signature/signature.go
@@ -61,7 +61,7 @@ func Find(target string, partialEval bool, signaturesDir string, signatures []st
 
 func findGoSigs(dir string) ([]detect.Signature, error) {
 	var res []detect.Signature
-	err := capabilities.GetInstance().Requested(
+	err := capabilities.GetInstance().Specific(
 		func() error {
 			err := filepath.WalkDir(dir,
 				func(path string, d fs.DirEntry, err error) error {
@@ -107,7 +107,7 @@ func findRegoSigs(target string, partialEval bool, dir string, aioEnabled bool) 
 
 	regoHelpers := []string{embedded.RegoHelpersCode}
 
-	err := capabilities.GetInstance().Requested(
+	err := capabilities.GetInstance().Specific(
 		func() error {
 			errWD := filepath.WalkDir(dir,
 				func(path string, d fs.DirEntry, err error) error {

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -100,7 +100,9 @@ func CopyRegularFileByPath(src, dst string) error {
 	return nil
 }
 
-// CopyRegularFileByRelativePath copies a file from src to dst, where destination is relative to a given directory
+// CopyRegularFileByRelativePath copies a file from src to dst, where
+// destination is relative to a given directory. This function needs needed
+// capabilities to be set before it is called.
 func CopyRegularFileByRelativePath(srcName string, dstDir *os.File, dstName string) error {
 	sourceFileStat, err := os.Stat(srcName)
 	if err != nil {


### PR DESCRIPTION
**STILL MISSING**

- [x] perf delta among bypass=true and regular dropping
- [x] all captures enabled/tested (likely need raising caps there)
- [ ] final test with e2e (local e2e passes and looks good)

But reviews can be made I believe.

# Description

commit b07efe93 (HEAD -> policies-rebased, rafaeldtinoco/policies)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Mar 28 17:14:11 2023

    capabilities: change ring names and create base cap

    Instead of ring names such as Required, Requested, create simple names
    for the rings:

    Full         // All capabilties are effective
    EBPF         // eBPF needed capabilities are effective
    Specific     // Specific requested capabilities are effective
    Base         // Capabilities that are always effective

    The idea is: Tracee will always be running with **at least** the
    capabilities from "Base" ring as **effective**. If developer raises
    the ring to "Specific", then Tracee will have capabilities from the
    "Base" ring PLUS a specific requested capability as **effective**.

    The EBPF ring is a ring used for eBPF related code. Instead of simply
    raising privileges to "Specific" ring capabilities, a new ring is needed
    because it will contain different capabilities depending on the
    environment Tracee is running at. It contains all the "Base" ring
    capabilities PLUS the capabilities related to running eBPF code.

    The Full ring is self-explanatory.

     Note: The "Base" capabilities are definied in `events.go` file,
           together with the event that needs that capability. The ring
           will only have that capability as **effective** if the event
           is being traced.

commit 4e0a5e96
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Mar 28 04:12:39 2023

    capabilities: drop capabilities by default

    - Set capabilities dropping as a default
    - Remove event capabilities from Required ring
    - Raise specific capabilities where needed
    - Make e2e tests satisfied with capabilities dropping/raising

    TODOs (in following commits):

    - Dropping and raising capabilities is expensive (syscall)

    - Change capabilities rings to something simpler, such as:
      - Base (base capabilities, always effective, performance reasons)
      - Specific (requested capabilities temporarily requested/effective)
      - Full (all capabilities effective)

    - In the future, a privileged process/server might allow full
      capabilities dropping without a need for a base set (then
      the base set can become "Unprivileged" set).


> This baseline is passing E2E tests.

Fixes: #2397 

# How to test

```
$ while true; do for cap in $(sudo cat /proc/$(pidof tracee-ebpf)/status | grep CapEff | awk '{print $2}'); do capsh --decode=$cap; done; done
```

You will observe tracee-ebpf effective capabilities changing from the beginning of tracee execution to its constant base ring (just very few capabilities as effective). From time to time it might raise privileges if needed because of a process in the pipeline (only the ones that happen from time to time, if events are too frequency they will rely in the capabilities from the "base ring" and be declared in `events.go` as an event dependency.

Example:

### paranoid = 0, default set in 5.19 kernel

```
0x000001ffffffffff=cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,cap_audit_read,cap_perfmon,cap_bpf,cap_checkpoint_restore
0x000001ffffffffff=cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,cap_audit_read,cap_perfmon,cap_bpf,cap_checkpoint_restore

0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
0x000000c001005000=cap_net_admin,cap_ipc_lock,cap_sys_resource,cap_perfmon,cap_bpf
...

0x0000000000001000=cap_net_admin <= NETWORK EVENTS, BASE RING
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
0x0000000000001000=cap_net_admin
...
<raising privileges when needed>
```

### paranoid = 4, using symbols_loaded in 5.19 kernel (cap_sys_admin is used)

```
0x000001ffffffffff=cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,cap_audit_read,cap_perfmon,cap_bpf,cap_checkpoint_restore
0x000001ffffffffff=cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,cap_audit_read,cap_perfmon,cap_bpf,cap_checkpoint_restore
0x000001ffffffffff=cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_linux_immutable,cap_net_bind_service,cap_net_broadcast,cap_net_admin,cap_net_raw,cap_ipc_lock,cap_ipc_owner,cap_sys_module,cap_sys_rawio,cap_sys_chroot,cap_sys_ptrace,cap_sys_pacct,cap_sys_admin,cap_sys_boot,cap_sys_nice,cap_sys_resource,cap_sys_time,cap_sys_tty_config,cap_mknod,cap_lease,cap_audit_write,cap_audit_control,cap_setfcap,cap_mac_override,cap_mac_admin,cap_syslog,cap_wake_alarm,cap_block_suspend,cap_audit_read,cap_perfmon,cap_bpf,cap_checkpoint_restore

0x0000000000080002=cap_dac_override,cap_sys_ptrace

0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
0x0000000001284000=cap_ipc_lock,cap_sys_ptrace,cap_sys_admin,cap_sys_resource
...

0x0000000000080000=cap_sys_ptrace => SYMBOLS LOADED, BASE RING
0x0000000000080000=cap_sys_ptrace
0x0000000000080000=cap_sys_ptrace
0x0000000000080000=cap_sys_ptrace
0x0000000000080000=cap_sys_ptrace
0x0000000000080000=cap_sys_ptrace
0x0000000000080000=cap_sys_ptrace
0x0000000000080000=cap_sys_ptrace
<raising privileges when needed>
```

# E2E tests passing:

```
2023-03-28 23:11:17,614 [root] INFO Starting Tracee End to End Tests
2023-03-28 23:11:17,614 [root] INFO ====================================

2023-03-28 23:11:17,616 [root] INFO Building Test Images
cv_java found!
cv_code_injection found!
cv_container_escapes found!
cv_container_detection found!
cv_kernel found!
cv_execution found!
cv_network_nmap found!
cv_writing found!
cv_kali found!
cv_malware_unpack_memory found!
cv_network found!
cv_priv_escalation found!
cv_express found!
cv_interactive_container found!
cv_persistence found!
cv_switch_namespaces_to_host found!
2023-03-28 23:11:17,629 [root] INFO cv_ultra_e2e_tests image already exists!
2023-03-28 23:11:17,629 [root] INFO ====================================

2023-03-28 23:11:17,629 [root] INFO Deploying Tracee...
2023-03-28 23:11:17,630 [root] INFO Running tracee-ebpf with json format...
2023-03-28 23:11:25,638 [root] INFO Deploying Test Images...

...

2023-03-28 23:11:39,791 [root] INFO Waiting for Test Images to Finish
2023-03-28 23:11:39,791 [root] INFO ====================================

2023-03-28 23:11:39,800 [root] INFO cv_java stopped
2023-03-28 23:11:39,809 [root] INFO cv_code_injection stopped
2023-03-28 23:11:39,822 [root] INFO cv_container_escapes stopped
2023-03-28 23:11:39,831 [root] INFO cv_container_detection stopped
2023-03-28 23:11:40,127 [root] INFO cv_execution stopped
2023-03-28 23:11:40,137 [root] INFO cv_network_nmap stopped
2023-03-28 23:11:40,148 [root] INFO cv_writing stopped
2023-03-28 23:11:40,166 [root] INFO cv_malware_unpack_memory stopped
2023-03-28 23:11:40,180 [root] INFO cv_priv_escalation stopped
2023-03-28 23:11:40,195 [root] INFO cv_interactive_container stopped
2023-03-28 23:11:40,202 [root] INFO cv_persistence stopped
2023-03-28 23:11:40,209 [root] INFO cv_switch_namespaces_to_host stopped
2023-03-28 23:11:45,254 [root] INFO cv_network stopped
2023-03-28 23:11:45,262 [root] INFO cv_express stopped
2023-03-28 23:11:50,278 [root] INFO cv_kernel stopped
2023-03-28 23:11:55,296 [root] INFO cv_kali stopped
2023-03-28 23:12:00,306 [root] INFO ====================================

2023-03-28 23:12:00,306 [root] INFO Test Images Finished Execution
2023-03-28 23:12:30,336 [root] INFO Stopping Tracee...
2023-03-28 23:12:32,700 [root] INFO tracee-ebpf (pid 1577) stopped
2023-03-28 23:12:32,700 [root] INFO Running tracee-rules on e2e_results/ebpf_events.json...
2023-03-28 23:12:35,645 [root] INFO ====================================

2023-03-28 23:12:35,646 [root] INFO Validating Expected Results...
2023-03-28 23:12:35,646 [root] INFO Validating e2e results on json output

...

2023-03-28 23:12:35,685 [root] INFO Checking test results on json foramt
2023-03-28 23:12:35,685 [root] INFO json: Validation succeeded!
2023-03-28 23:12:35,685 [root] INFO Finished - PASSED
```