### PR TITLE
containers: parse ContainerID by inner cgroup

### DIFF
--- a/pkg/events/derive/container_create.go
+++ b/pkg/events/derive/container_create.go
@@ -25,7 +25,7 @@ func deriveContainerCreateArgs(containers *containers.Containers) func(event tra
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
-		if info := containers.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
+		if info := containers.GetCgroupInfo(cgroupId); info.ContainerRoot {
 			args := []interface{}{
 				info.Runtime.String(),
 				info.Container.ContainerId,


### PR DESCRIPTION
Following changes are introduced:
1. New CgroupInfo field `ContainerRoot` is introduced to signify the directory being the root cgroup directory of a container (this solves podman container_create event duplication and is used to ensure no duplication in existing_container)
2. ContainerID from a cgroup path is now parsed by the last container id and runtime found.
This means for example that kind, a development kubernetes cluster deployed through docker and using containerd internally, will report its node containers as docker containers with their own ID and their internal pod containers as containerd containers with their ID, whereas before all containers would share the node container's runtime and ID.

How to test:

1. `tracee-ebpf -f e=container_create -o json`
2. `docker run --privileged --name dind -d -it --rm docker:stable-dind`
3. `docker exec -it dind /bin/ash`
4. `docker run --rm -d ubuntu`

The first `container_create` should have the first `container_id` in it's argument and no `container.id` in it's context.
The second `container_create` should have the internal `container_id` in it's argument and the first `container_id` argument in the `container.id` context field.

Fix #2896
