### PR TITLE
tests: re-enable integration for policies

### DIFF
--- a/tests/integration/tester.sh
+++ b/tests/integration/tester.sh
@@ -9,13 +9,14 @@ do_ls() {
     ls > /dev/null
 }
 
-do_which_ls() {
-    which ls > /dev/nul
-}
-
 do_ls_uname() {
     # run on the same core to ensure event order
     taskset -c 0 ls; uname
+} > /dev/null
+
+do_uname_who() {
+    # run on the same core to ensure event order
+    taskset -c 0 uname; who
 } > /dev/null
 
 do_docker_run() {


### PR DESCRIPTION
### 1. Explain what the PR does

This re-enables the integration tests for policies, adding a new test based on `PrepareFilterMapFromPolicies()`.

This doesn't make efforts to improve integration tests, since we have a plan to rework them in the future (#2688).

### 2. Explain how to test it

`sudo make test-integration`

### 3. Other comments

It's part of #2665.