### PR TITLE
events: prevent symbols map cache corruption

### DIFF
--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -402,9 +402,16 @@ func (so *loadingSharedObj) FilterSymbols(filterSymbols map[string]bool) {
 
 // FilterOutSymbols removes all exported symbols which ARE in the filter map.
 func (so *loadingSharedObj) FilterOutSymbols(filterSymbols map[string]bool) {
+	if len(filterSymbols) == 0 {
+		return
+	}
+
+	filteredSymbols := make(map[string]bool)
 	for exSymbol := range so.exportedSymbols {
-		if filterSymbols[exSymbol] {
-			delete(so.exportedSymbols, exSymbol)
+		if !filterSymbols[exSymbol] {
+			filteredSymbols[exSymbol] = true
 		}
 	}
+
+	so.exportedSymbols = filteredSymbols
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The current `events_collisions` event might corrupt in some cases the cache map, as it is now returned from the loader class as a reference. Change the event to copy on change the map.

Fix #2930

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
