### PR TITLE
release: crane is buggy, remove until fixed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,10 +31,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4 # v0.2
       - name: Build and Release
         run:
-          crane auth login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }} docker.io
           make -f builder/Makefile.release PUSH_DOCKER_REPO=aquasec/tracee
   release-arm64:
     name: Release ARM64
@@ -61,5 +59,4 @@ jobs:
       # TODO: check if sigstore/cosign-installer@main supports arm64
       - name: Build and Release
         run: |
-          crane auth login -u ${{ secrets.DOCKERHUB_USER }} -p ${{ secrets.DOCKERHUB_TOKEN }} docker.io
           make -f builder/Makefile.release PUSH_DOCKER_REPO=aquasec/tracee

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -217,19 +217,11 @@ ifeq ($(ARCH),x86_64)
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(IMAGE_TAG)
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):full
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(IMAGE_TAG)-full
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):latest)
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):$(IMAGE_TAG))
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):full)
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):$(IMAGE_TAG)-full)
 endif
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(ARCH)
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(ARCH)-full
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(ARCH)-$(IMAGE_TAG)
 	$(CMD_DOCKER) push $(PUSH_DOCKER_REPO):$(ARCH)-$(IMAGE_TAG)-full
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):$(ARCH))
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):$(ARCH)-full)
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):$(ARCH)-$(IMAGE_TAG))
-	COSIGN_EXPERIMENTAL=1 $(CMD_COSIGN) sign $(PUSH_DOCKER_REPO)@$(shell crane digest $(PUSH_DOCKER_REPO):$(ARCH)-$(IMAGE_TAG)-full)
 #
 # create release notes (x86_64 only, other arches will be added after release)
 #


### PR DESCRIPTION
crane workflow logic did not work for v0.13.0. Remove it so tracee can be released. Revert this with plausible fix after the release.
