### PR TITLE
consume remaining events after ctx is done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -720,6 +720,7 @@ test-unit: \
 	$(CMD_GO) test \
 		-tags ebpf \
 		-short \
+		-race \
 		-v \
 		-coverprofile=coverage.txt \
 		./cmd/... \
@@ -733,6 +734,7 @@ test-types: \
 	# Note that we must changed the directory here because types is a standalone Go module.
 	cd ./types && $(CMD_GO) test \
 		-short \
+		-race \
 		-v \
 		-coverprofile=coverage.txt \
 		./...

--- a/Makefile
+++ b/Makefile
@@ -720,7 +720,6 @@ test-unit: \
 	$(CMD_GO) test \
 		-tags ebpf \
 		-short \
-		-race \
 		-v \
 		-coverprofile=coverage.txt \
 		./cmd/... \
@@ -734,7 +733,6 @@ test-types: \
 	# Note that we must changed the directory here because types is a standalone Go module.
 	cd ./types && $(CMD_GO) test \
 		-short \
-		-race \
 		-v \
 		-coverprofile=coverage.txt \
 		./...

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -71,7 +71,18 @@ func (r Runner) Run(ctx context.Context) error {
 		}
 	}()
 
-	return t.Run(ctx) // return when context is cancelled by signal
+	// This will block until the context is done
+	err = t.Run(ctx)
+
+	// Drain and print the remaining channel events that were sent before full termination
+	for {
+		select {
+		case event := <-r.TraceeConfig.ChanEvents:
+			broadcast.Print(event)
+		default:
+			return err
+		}
+	}
 }
 
 func PrintEventList(printRulesSet bool) {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1513,7 +1513,7 @@ func (t *Tracee) Close() {
 		logger.Errorw("Cgroups destroy", "error", err)
 	}
 
-	// set running to false only if there were no errors
+	// set running to false only after all resources are cleaned
 	t.running.Store(false)
 }
 


### PR DESCRIPTION
### 1. Explain what the PR does

    consume remaining tracee events after ctx is done
    
    This also extracts the dispatch logic into the function processEvent
    to reuse it in the drain loop.
    
    Tests has also been updated reordering object creation and had the race
    detector, "-race" flag, disabled. It must be re-enabled in the
    one binary test suite effort.

---

    drain and print events after tracee ctx is done

### 2. Explain how to test it

### 3. Other comments

Fixes: #1377
Fixes: #2171 