### PR TITLE
logger: refactor logger configuration

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -16,24 +16,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
-func init() {
-	// Avoiding to override package-level logger
-	// when it's already set by logger environment variables
-	if !logger.IsSetFromEnv() {
-		// Logger Setup
-		logger.Init(
-			&logger.LoggerConfig{
-				Writer:    os.Stderr,
-				Level:     logger.InfoLevel,
-				Encoder:   logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
-				Aggregate: false,
-			},
-		)
-	}
-
-	initialize.SetLibbpfgoCallbacks()
-}
-
 var version string
 
 func main() {
@@ -47,12 +29,16 @@ func main() {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
 
+			// Logger Setup
+			logger.Init(logger.NewDefaultLoggingConfig())
+
 			flags.PrintAndExitIfHelp(c, false)
 
 			if c.Bool("list") {
 				cmd.PrintEventList(false) // list events
 				return nil
 			}
+			initialize.SetLibbpfgoCallbacks()
 
 			runner, err := urfave.GetTraceeRunner(c, version, false)
 			if err != nil {

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -23,22 +23,6 @@ import (
 	"github.com/aquasecurity/tracee/types/detect"
 )
 
-func init() {
-	// Avoiding to override package-level logger
-	// when it's already set by logger environment variables
-	if !logger.IsSetFromEnv() {
-		// Logger Setup
-		logger.Init(
-			&logger.LoggerConfig{
-				Writer:    os.Stderr,
-				Level:     logger.InfoLevel,
-				Encoder:   logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
-				Aggregate: false,
-			},
-		)
-	}
-}
-
 const (
 	signatureBufferFlag = "sig-buffer"
 )
@@ -48,6 +32,9 @@ func main() {
 		Name:  "tracee-rules",
 		Usage: "A rule engine for Runtime Security",
 		Action: func(c *cli.Context) error {
+
+			// Logger Setup
+			logger.Init(logger.NewDefaultLoggingConfig())
 
 			// Capabilities command line flags
 

--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -21,24 +21,6 @@ import (
 	"github.com/aquasecurity/tracee/types/detect"
 )
 
-func init() {
-	// Avoiding to override package-level logger
-	// when it's already set by logger environment variables
-	if !logger.IsSetFromEnv() {
-		// Logger Setup
-		logger.Init(
-			&logger.LoggerConfig{
-				Writer:    os.Stderr,
-				Level:     logger.InfoLevel,
-				Encoder:   logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
-				Aggregate: false,
-			},
-		)
-	}
-
-	initialize.SetLibbpfgoCallbacks()
-}
-
 var version string
 
 func main() {
@@ -50,6 +32,8 @@ func main() {
 			if c.NArg() > 0 {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
+
+			logger.Init(logger.NewDefaultLoggingConfig())
 
 			flags.PrintAndExitIfHelp(c, true)
 
@@ -81,6 +65,8 @@ func main() {
 				cmd.PrintEventList(true) // list events
 				return nil
 			}
+
+			initialize.SetLibbpfgoCallbacks()
 
 			runner, err := urfave.GetTraceeRunner(c, version, true)
 			if err != nil {

--- a/pkg/cmd/flags/logger_test.go
+++ b/pkg/cmd/flags/logger_test.go
@@ -15,15 +15,14 @@ func TestPrepareLogger(t *testing.T) {
 	testCases := []struct {
 		testName       string
 		logOptions     []string
-		expectedReturn *logger.LoggerConfig
+		expectedReturn logger.LoggingConfig
 		expectedError  error
 	}{
 		// valid log level
 		{
 			testName:   "valid log level",
 			logOptions: []string{"debug"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.DebugLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     false,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -32,8 +31,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log level",
 			logOptions: []string{"info"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.InfoLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     false,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -42,8 +40,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log level",
 			logOptions: []string{"warn"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.WarnLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     false,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -52,8 +49,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log level",
 			logOptions: []string{"error"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.ErrorLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     false,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -62,8 +58,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log level",
 			logOptions: []string{"fatal"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.FatalLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     false,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -73,13 +68,13 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:       "invalid log level",
 			logOptions:     []string{"invalid-level"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("invalid-level"),
 		},
 		{
 			testName:       "invalid log level",
 			logOptions:     []string{""},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption(""),
 		},
 
@@ -87,8 +82,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log aggregate",
 			logOptions: []string{"aggregate"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.DefaultLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     true,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -97,8 +91,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log aggregate",
 			logOptions: []string{"aggregate:10s"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.DefaultLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     true,
 				FlushInterval: 10 * time.Second,
 			},
@@ -107,8 +100,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log aggregate",
 			logOptions: []string{"aggregate:2m"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.DefaultLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     true,
 				FlushInterval: 2 * time.Minute,
 			},
@@ -118,43 +110,43 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"invalid-aggregate"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("invalid-aggregate"),
 		},
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"aggregate:"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("aggregate:"),
 		},
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"aggregate:s"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("aggregate:s"),
 		},
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"aggregate:-1"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("aggregate:-1"),
 		},
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"aggregate:abc"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("aggregate:abc"),
 		},
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"aggregate:15"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("aggregate:15"),
 		},
 		{
 			testName:       "invalid log aggregate",
 			logOptions:     []string{"aggregate:1ms"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("aggregate:1ms"),
 		},
 
@@ -162,8 +154,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log level + aggregate",
 			logOptions: []string{"debug", "aggregate"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.DebugLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     true,
 				FlushInterval: logger.DefaultFlushInterval,
 			},
@@ -172,8 +163,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:   "valid log level + aggregate",
 			logOptions: []string{"debug", "aggregate:10s"},
-			expectedReturn: &logger.LoggerConfig{
-				Level:         logger.DebugLevel,
+			expectedReturn: logger.LoggingConfig{
 				Aggregate:     true,
 				FlushInterval: 10 * time.Second,
 			},
@@ -182,7 +172,7 @@ func TestPrepareLogger(t *testing.T) {
 		{
 			testName:       "invalid log file",
 			logOptions:     []string{"file:"},
-			expectedReturn: nil,
+			expectedReturn: logger.LoggingConfig{},
 			expectedError:  flags.InvalidLogOption("file:"),
 		},
 	}
@@ -191,14 +181,13 @@ func TestPrepareLogger(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			logCfg, err := flags.PrepareLogger(tc.logOptions)
 			if tc.expectedError != nil {
-				require.Nil(t, logCfg)
+				require.Equal(t, logger.LoggingConfig{}, logCfg)
 				require.Error(t, err)
 				assert.ErrorContains(t, err, tc.expectedError.Error())
 			}
 			if tc.expectedError == nil {
 				require.Nil(t, err)
 				require.NotNil(t, logCfg)
-				assert.Equal(t, tc.expectedReturn.Level, logCfg.Level)
 				assert.Equal(t, tc.expectedReturn.Aggregate, logCfg.Aggregate)
 				assert.Equal(t, tc.expectedReturn.FlushInterval, logCfg.FlushInterval)
 			}

--- a/pkg/events/derive/symbols_loaded_test.go
+++ b/pkg/events/derive/symbols_loaded_test.go
@@ -163,13 +163,13 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 		},
 	}
 	pid := 1
-	baseLogger := logger.Base()
+	baseLogger := logger.Current()
 
 	t.Run("Happy flow", func(t *testing.T) {
 		for _, testCase := range happyFlowTestCases {
 			t.Run(testCase.name, func(t *testing.T) {
 				errChan := setMockLogger(logger.DebugLevel)
-				defer logger.SetBase(baseLogger)
+				defer logger.SetLogger(baseLogger)
 
 				mockLoader := initLoaderMock(false)
 				mockLoader.addSOSymbols(testCase.loadingSO)
@@ -195,7 +195,7 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 	t.Run("Errors flow", func(t *testing.T) {
 		t.Run("Debug", func(t *testing.T) {
 			errChan := setMockLogger(logger.DebugLevel)
-			defer logger.SetBase(baseLogger)
+			defer logger.SetLogger(baseLogger)
 			mockLoader := initLoaderMock(true)
 			gen := initSymbolsLoadedEventGenerator(mockLoader, nil, nil)
 
@@ -215,7 +215,7 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 		})
 		t.Run("No debug", func(t *testing.T) {
 			errChan := setMockLogger(logger.WarnLevel)
-			defer logger.SetBase(baseLogger)
+			defer logger.SetLogger(baseLogger)
 			mockLoader := initLoaderMock(true)
 			gen := initSymbolsLoadedEventGenerator(mockLoader, nil, nil)
 
@@ -240,14 +240,13 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 func setMockLogger(l logger.Level) <-chan []byte {
 	mw, errChan := newMockWriter()
 	mockLogger := logger.NewLogger(
-		&logger.LoggerConfig{
-			Writer:    mw,
-			Level:     l,
-			Encoder:   logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
-			Aggregate: false,
+		logger.LoggerConfig{
+			Writer:  mw,
+			Level:   l,
+			Encoder: logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
 		},
 	)
-	logger.SetBase(mockLogger)
+	logger.SetLogger(mockLogger)
 	return errChan
 }
 

--- a/pkg/logger/callerinfo.go
+++ b/pkg/logger/callerinfo.go
@@ -1,0 +1,76 @@
+package logger
+
+import (
+	"runtime"
+	"strings"
+)
+
+type callerInfo struct {
+	pkg       string
+	file      string
+	line      int
+	functions []string
+}
+
+// getCallerInfo returns package, file and line from a function
+// based on the given number of skips (stack frames).
+func getCallerInfo(skip int) *callerInfo {
+	var (
+		pkg       string
+		file      string
+		line      int
+		functions []string
+	)
+
+	// maximum depth of 20
+	pcs := make([]uintptr, 20)
+	n := runtime.Callers(skip+2, pcs)
+	pcs = pcs[:n-1]
+
+	frames := runtime.CallersFrames(pcs)
+	firstCaller := true
+	for {
+		frame, more := frames.Next()
+		if !more {
+			break
+		}
+
+		fn := frame.Function
+		fnStart := strings.LastIndexByte(fn, '/')
+		if fnStart == -1 {
+			fnStart = 0
+		} else {
+			fnStart++
+		}
+
+		fn = fn[fnStart:]
+		pkgEnd := strings.IndexByte(fn, '.')
+		if pkgEnd == -1 {
+			fnStart = 0
+		} else {
+			fnStart = pkgEnd + 1
+		}
+		functions = append(functions, fn[fnStart:])
+
+		if firstCaller {
+			line = frame.Line
+			file = frame.File
+			// set file as relative path
+			pat := "tracee/"
+			traceeIndex := strings.Index(file, pat)
+			if traceeIndex != -1 {
+				file = file[traceeIndex+len(pat):]
+			}
+			pkg = fn[:pkgEnd]
+
+			firstCaller = false
+		}
+	}
+
+	return &callerInfo{
+		pkg:       pkg,
+		file:      file,
+		line:      line,
+		functions: functions,
+	}
+}

--- a/pkg/logger/logcounter.go
+++ b/pkg/logger/logcounter.go
@@ -1,0 +1,57 @@
+package logger
+
+import "sync"
+
+type logOrigin struct {
+	File  string
+	Line  int
+	Level Level
+	Msg   string
+}
+
+type logCounter struct {
+	rwMutex sync.RWMutex
+	data    map[logOrigin]uint32
+}
+
+func (lc *logCounter) update(lo logOrigin) {
+	lc.rwMutex.Lock()
+	defer lc.rwMutex.Unlock()
+	lc.data[lo]++
+}
+
+func (lc *logCounter) Lookup(key logOrigin) (count uint32, found bool) {
+	lc.rwMutex.RLock()
+	defer lc.rwMutex.RUnlock()
+	count, found = lc.data[key]
+
+	return
+}
+
+func (lc *logCounter) dump(flush bool) map[logOrigin]uint32 {
+	lc.rwMutex.RLock()
+	defer lc.rwMutex.RUnlock()
+	dump := make(map[logOrigin]uint32, len(lc.data))
+	for k, v := range lc.data {
+		dump[k] = v
+		if flush {
+			delete(lc.data, k)
+		}
+	}
+	return dump
+}
+
+func (lc *logCounter) Dump() map[logOrigin]uint32 {
+	return lc.dump(false)
+}
+
+func (lc *logCounter) Flush() map[logOrigin]uint32 {
+	return lc.dump(true)
+}
+
+func newLogCounter() *logCounter {
+	return &logCounter{
+		rwMutex: sync.RWMutex{},
+		data:    map[logOrigin]uint32{},
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -49,31 +47,30 @@ var (
 	NewProductionEncoderConfig  = zap.NewProductionEncoderConfig
 )
 
+type LoggerInterface interface {
+	Debugw(msg string, keyAndValues ...interface{})
+	Infow(msg string, keyAndValues ...interface{})
+	Warnw(msg string, keyAndValues ...interface{})
+	Errorw(msg string, keyAndValues ...interface{})
+	Fatalw(msg string, keyAndValues ...interface{})
+	Sync() error
+}
+
 // Logger struct
 type Logger struct {
-	l   *zap.SugaredLogger
-	cfg *LoggerConfig
+	l   LoggerInterface
+	cfg LoggingConfig
 
-	LogCount *LogCounter // updated only on debug level and cfg.Aggregate == true
+	logCount *logCounter // updated only on debug level and cfg.Aggregate == true
 }
 
 // NewLogger function
-func NewLogger(cfg *LoggerConfig) *Logger {
-	if cfg == nil {
-		panic("LoggerConfig cannot be nil")
-	}
-
-	core := zapcore.NewCore(
+func NewLogger(cfg LoggerConfig) LoggerInterface {
+	return zap.New(zapcore.NewCore(
 		cfg.Encoder,
 		zapcore.AddSync(cfg.Writer),
 		zapcore.Level(cfg.Level),
-	)
-
-	return &Logger{
-		l:        zap.New(core).Sugar(),
-		cfg:      cfg,
-		LogCount: newLogCounter(),
-	}
+	)).Sugar()
 }
 
 const (
@@ -81,154 +78,47 @@ const (
 	DefaultFlushInterval = time.Duration(3) * time.Second
 )
 
-type LoggerConfig struct {
-	Writer        io.Writer
-	Level         Level
-	Encoder       Encoder
+// LoggingConfig defines the configuration of the package level logging.
+//
+// Users importing tracee as a library may choose to construct a tracee flavored logger with
+// NewLogger() or supply their own interface.
+//
+// Tracee offers aggregation support on top of any logger implementation complying to it's interface.
+type LoggingConfig struct {
+	Logger        LoggerInterface
 	Aggregate     bool
 	FlushInterval time.Duration
+}
+
+// LoggerConfig defines the configuration parameters for constructing tracee's logger implementation.
+type LoggerConfig struct {
+	Writer  io.Writer
+	Level   Level
+	Encoder Encoder
 }
 
 func defaultEncoder() Encoder {
 	return NewJSONEncoder(NewProductionEncoderConfig())
 }
 
-func NewDefaultLoggerConfig() *LoggerConfig {
-	return &LoggerConfig{
-		Writer:        os.Stderr,
-		Level:         DefaultLevel,
-		Encoder:       defaultEncoder(),
+func NewDefaultLoggerConfig() LoggerConfig {
+	return LoggerConfig{
+		Writer:  os.Stderr,
+		Level:   DefaultLevel,
+		Encoder: defaultEncoder(),
+	}
+}
+
+func NewDefaultLoggingConfig() LoggingConfig {
+	return LoggingConfig{
+		Logger:        NewLogger(NewDefaultLoggerConfig()),
 		Aggregate:     false,
 		FlushInterval: DefaultFlushInterval,
 	}
 }
 
-type LogOrigin struct {
-	File  string
-	Line  int
-	Level Level
-	Msg   string
-}
-
-type LogCounter struct {
-	rwMutex sync.RWMutex
-	data    map[LogOrigin]uint32
-}
-
-func (lc *LogCounter) update(lo LogOrigin) {
-	lc.rwMutex.Lock()
-	defer lc.rwMutex.Unlock()
-	lc.data[lo]++
-}
-
-func (lc *LogCounter) Lookup(key LogOrigin) (count uint32, found bool) {
-	lc.rwMutex.RLock()
-	defer lc.rwMutex.RUnlock()
-	count, found = lc.data[key]
-
-	return
-}
-
-func (lc *LogCounter) dump(flush bool) map[LogOrigin]uint32 {
-	lc.rwMutex.RLock()
-	defer lc.rwMutex.RUnlock()
-	dump := make(map[LogOrigin]uint32, len(lc.data))
-	for k, v := range lc.data {
-		dump[k] = v
-		if flush {
-			delete(lc.data, k)
-		}
-	}
-	return dump
-}
-
-func (lc *LogCounter) Dump() map[LogOrigin]uint32 {
-	return lc.dump(false)
-}
-
-func (lc *LogCounter) Flush() map[LogOrigin]uint32 {
-	return lc.dump(true)
-}
-
-func newLogCounter() *LogCounter {
-	return &LogCounter{
-		rwMutex: sync.RWMutex{},
-		data:    map[LogOrigin]uint32{},
-	}
-}
-
-type callerInfo struct {
-	pkg       string
-	file      string
-	line      int
-	functions []string
-}
-
-// getCallerInfo returns package, file and line from a function
-// based on the given number of skips (stack frames).
-func getCallerInfo(skip int) *callerInfo {
-	var (
-		pkg       string
-		file      string
-		line      int
-		functions []string
-	)
-
-	// maximum depth of 20
-	pcs := make([]uintptr, 20)
-	n := runtime.Callers(skip+2, pcs)
-	pcs = pcs[:n-1]
-
-	frames := runtime.CallersFrames(pcs)
-	firstCaller := true
-	for {
-		frame, more := frames.Next()
-		if !more {
-			break
-		}
-
-		fn := frame.Function
-		fnStart := strings.LastIndexByte(fn, '/')
-		if fnStart == -1 {
-			fnStart = 0
-		} else {
-			fnStart++
-		}
-
-		fn = fn[fnStart:]
-		pkgEnd := strings.IndexByte(fn, '.')
-		if pkgEnd == -1 {
-			fnStart = 0
-		} else {
-			fnStart = pkgEnd + 1
-		}
-		functions = append(functions, fn[fnStart:])
-
-		if firstCaller {
-			line = frame.Line
-			file = frame.File
-			// set file as relative path
-			pat := "tracee/"
-			traceeIndex := strings.Index(file, pat)
-			if traceeIndex != -1 {
-				file = file[traceeIndex+len(pat):]
-			}
-			pkg = fn[:pkgEnd]
-
-			firstCaller = false
-		}
-	}
-
-	return &callerInfo{
-		pkg:       pkg,
-		file:      file,
-		line:      line,
-		functions: functions,
-	}
-}
-
 func (l *Logger) updateCounter(file string, line int, lvl Level, msg string) {
-	l.LogCount.update(LogOrigin{
+	l.logCount.update(logOrigin{
 		File:  file,
 		Line:  line,
 		Level: lvl,
@@ -290,9 +180,9 @@ func Log(lvl Level, innerAggregation bool, msg string, keysAndValues ...interfac
 }
 
 func formatCallFlow(funcNames []string) string {
-	fns := make([]string, 0)
-	for _, fName := range funcNames {
-		fns = append(fns, fName+"()")
+	fns := make([]string, len(funcNames))
+	for i, fName := range funcNames {
+		fns[i] = fName + "()"
 	}
 
 	return strings.Join(fns, " < ")
@@ -393,162 +283,44 @@ func (l *Logger) Sync() error {
 	return l.l.Sync()
 }
 
-const (
-	TRACEE_LOGGER_LVL       = "TRACEE_LOGGER_LVL"
-	TRACEE_LOGGER_ENCODER   = "TRACEE_LOGGER_ENCODER"
-	TRACEE_LOGGER_AGGREGATE = "TRACEE_LOGGER_AGGREGATE"
-)
-
-// getLoggerLevelFromEnv returns logger level set through TRACEE_LOGGER_LVL
-// environment variable, updating the flag setFromEnv.
-// If the given level is not correct, this returns the default level.
-func getLoggerLevelFromEnv() (lvl Level) {
-	lvlEnv := os.Getenv(TRACEE_LOGGER_LVL)
-	fromEnv := true
-
-	switch lvlEnv {
-	case "debug":
-		lvl = DebugLevel
-	case "info":
-		lvl = InfoLevel
-	case "warn":
-		lvl = WarnLevel
-	case "error":
-		lvl = ErrorLevel
-	case "dpanic":
-		lvl = DPanicLevel
-	case "panic":
-		lvl = PanicLevel
-	case "fatal":
-		lvl = FatalLevel
-	default:
-		fromEnv = false
-		lvl = DefaultLevel
-	}
-
-	if !setFromEnv {
-		setFromEnv = fromEnv
-	}
-	return
-}
-
-// getLoggerEncoderFromEnv returns logger encoder set through TRACEE_LOGGER_ENCODER
-// environment variable, updating the flag setFromEnv.
-// If the given encoder is not correct, this returns the default encoder.
-func getLoggerEncoderFromEnv(lvl Level) (enc Encoder) {
-	encEnv := os.Getenv(TRACEE_LOGGER_ENCODER)
-	fromEnv := true
-	devEncoderConfig := NewDevelopmentEncoderConfig()
-	prodEncoderConfig := NewProductionEncoderConfig()
-
-	switch encEnv {
-	case "json":
-		if lvl == DebugLevel {
-			enc = NewJSONEncoder(devEncoderConfig)
-		} else {
-			enc = NewJSONEncoder(prodEncoderConfig)
-		}
-	case "console":
-		if lvl == DebugLevel {
-			enc = NewConsoleEncoder(devEncoderConfig)
-		} else {
-			enc = NewConsoleEncoder(prodEncoderConfig)
-		}
-	default:
-		fromEnv = false
-		enc = defaultEncoder()
-	}
-
-	if !setFromEnv {
-		setFromEnv = fromEnv
-	}
-	return
-}
-
-// getLoggerAggregateFromEnv returns logger Aggregate boolean set through TRACEE_LOGGER_AGGREGATE
-// environment variable, updating the flag setFromEnv.
-// If the given value is not correct, this returns false.
-func getLoggerAggregateFromEnv() (aggregate bool) {
-	aggEnv := os.Getenv(TRACEE_LOGGER_AGGREGATE)
-	fromEnv := true
-
-	switch aggEnv {
-	case "true":
-		aggregate = true
-	case "false":
-		aggregate = false
-	default:
-		fromEnv = false
-		aggregate = false
-	}
-
-	if !setFromEnv {
-		setFromEnv = fromEnv
-	}
-	return
-}
-
 var (
 	// Package-level Logger
-	pkgLogger *Logger
-
-	setFromEnv bool
+	pkgLogger *Logger = &Logger{}
 )
 
-func IsSetFromEnv() bool {
-	return setFromEnv
-}
-
-// NOTE: init() functions are executed in the lexical order (package names).
-func init() {
-	// It may have already been initialized from another package
-	if pkgLogger != nil {
-		return
-	}
-
-	lvl := getLoggerLevelFromEnv()
-	enc := getLoggerEncoderFromEnv(lvl)
-	agg := getLoggerAggregateFromEnv()
-
-	pkgLogger = NewLogger(
-		&LoggerConfig{
-			Writer:    os.Stderr,
-			Level:     lvl,
-			Encoder:   enc,
-			Aggregate: agg,
-		},
-	)
-}
-
-// Base returns the package-level base logger
-func Base() *Logger {
+// Current returns the package-level base logger
+func Current() *Logger {
 	return pkgLogger
 }
 
-// SetBase sets package-level base logger
+// SetLogger sets package-level base logger
 // It's not thread safe so if required use it always at the beginning
-func SetBase(l *Logger) {
+func SetLogger(l LoggerInterface) {
 	if l == nil {
 		panic("Logger cannot be nil")
 	}
 
-	pkgLogger = l
+	pkgLogger.l = l
 }
 
 // Init sets the package-level base logger using given config
 // It's not thread safe so if required use it always at the beginning
-func Init(cfg *LoggerConfig) {
-	if cfg == nil {
-		panic("LoggerConfig cannot be nil")
+func Init(cfg LoggingConfig) {
+	// set the config
+	pkgLogger.cfg = cfg
+
+	if cfg.Logger == nil {
+		panic("can't initialize a nil Logger")
 	}
 
-	SetBase(NewLogger(cfg))
+	pkgLogger.l = cfg.Logger
+	pkgLogger.logCount = newLogCounter()
 
 	// Flush aggregated logs every interval
 	if pkgLogger.cfg.Aggregate {
 		go func() {
 			for range time.Tick(pkgLogger.cfg.FlushInterval) {
-				for lo, count := range pkgLogger.LogCount.Flush() {
+				for lo, count := range pkgLogger.logCount.Flush() {
 					Log(lo.Level, false, lo.Msg,
 						"origin", fmt.Sprintf("%s:%d", lo.File, lo.Line),
 						"count", count,
@@ -559,16 +331,7 @@ func Init(cfg *LoggerConfig) {
 	}
 }
 
-// GetLevel returns the logger level
-func GetLevel() Level {
-	return pkgLogger.cfg.Level
-}
-
-// HasDebugLevel returns true if logger has debug level
-func HasDebugLevel() bool {
-	return pkgLogger.cfg.Level == DebugLevel
-}
-
-func Current() *Logger {
-	return pkgLogger
+// Make sure tests don't crash when logging
+func init() {
+	Init(NewDefaultLoggingConfig())
 }

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -313,16 +313,16 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		var logBuf []byte
 		loggerBuf := bytes.NewBuffer(logBuf)
-		if !logger.IsSetFromEnv() {
-			logger.Init(
-				&logger.LoggerConfig{
-					Writer:    loggerBuf,
-					Level:     logger.InfoLevel,
-					Encoder:   logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
-					Aggregate: false,
-				},
-			)
-		}
+		logger.Init(
+			logger.LoggingConfig{
+				Logger: logger.NewLogger(logger.LoggerConfig{
+					Writer:  loggerBuf,
+					Level:   logger.InfoLevel,
+					Encoder: logger.NewJSONEncoder(logger.NewProductionConfig().EncoderConfig),
+				}),
+				Aggregate: false,
+			},
+		)
 
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -177,6 +177,7 @@ func checkNewContainers(t *testing.T, gotOutput *eventOutput) {
 	containerIdBytes, err := forkAndExecFunction(doDockerRun)
 	require.NoError(t, err)
 	containerId := strings.TrimSuffix(string(containerIdBytes), "\n")
+	require.NotEmpty(t, containerId)
 	containerIds := []string{}
 	output := gotOutput.getEventsCopy()
 	for _, evt := range output {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -174,6 +174,12 @@ func checkSetFs(t *testing.T, gotOutput *eventOutput) {
 }
 
 func checkNewContainers(t *testing.T, gotOutput *eventOutput) {
+	// pull alpine image first otherwise pull might happen
+	// on docker run and cause output to be too delayed
+	_, err := forkAndExecFunction(doPullAlpine)
+	require.NoError(t, err)
+
+	// start test
 	containerIdBytes, err := forkAndExecFunction(doDockerRun)
 	require.NoError(t, err)
 	containerId := strings.TrimSuffix(string(containerIdBytes), "\n")
@@ -557,6 +563,7 @@ const (
 	doLsUname     testFunc = "do_ls_uname"
 	doUnameWho    testFunc = "do_uname_who"
 	doDockerRun   testFunc = "do_docker_run"
+	doPullAlpine  testFunc = "do_docker_pull_alpine"
 	doFileOpen    testFunc = "do_file_open"
 	getDockerdPid testFunc = "get_dockerd_pid"
 )

--- a/tests/integration/tester.sh
+++ b/tests/integration/tester.sh
@@ -19,6 +19,10 @@ do_uname_who() {
     taskset -c 0 uname; who
 } > /dev/null
 
+do_docker_pull_alpine() {
+    docker pull alpine
+} > /dev/null
+
 do_docker_run() {
     outputFileName=$1
     output=$(docker run -d --rm alpine)


### PR DESCRIPTION
Removed the option for configuring the logger from environemnt variables in favor of programmatic configuration.
This further exposes the option of supplying your own logger implementation and replacing tracee's default implemenation for library consumers of tracee.

Clean up the package to separate files for the utilities (log counters and caller info).

Fix #2475 
