### PR TITLE
Policies mntns issue and Segfault fix

### DIFF
--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -110,8 +110,8 @@ func PrepareFilterMapFromPolicies(policies []PolicyFile) (FilterMap, error) {
 				return nil, err
 			}
 
-			// currently an event can only be used once in the policy,
-			// this might change in the future to allow multiple times the same event with different filters
+			// Currently, an event can only be used once in the policy. Support for using the same
+			// event, multiple times, with different filters, shall be implemented in the future.
 			if _, ok := events[r.Event]; ok {
 				return nil, errfmt.Errorf("policy %s, event %s is duplicated", p.Name, r.Event)
 			}
@@ -132,7 +132,7 @@ func PrepareFilterMapFromPolicies(policies []PolicyFile) (FilterMap, error) {
 				operatorIdx := strings.IndexAny(f, "=!<>")
 
 				if operatorIdx == -1 {
-					return nil, errfmt.Errorf("invalid filter: %s", f)
+					return nil, errfmt.Errorf("invalid filter operator: %s", f)
 				}
 
 				filterName := f[:operatorIdx]
@@ -227,7 +227,7 @@ func validateScope(policyName, s string) error {
 	scopes := []string{
 		"uid",
 		"pid",
-		"mntNS",
+		"mntns",
 		"pidns",
 		"uts",
 		"comm",

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -444,6 +444,10 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (
 		for {
 			select {
 			case event := <-in:
+				if event == nil {
+					continue // might happen during initialization (ctrl+c seg faults)
+				}
+
 				// Get a copy of our event before sending it down the pipeline.
 				// This is needed because later modification of the event (in
 				// particular of the matched policies) can affect the derivation

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -29,6 +29,10 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 		for {
 			select {
 			case event := <-in:
+				if event == nil {
+					continue // might happen during initialization (ctrl+c seg faults)
+				}
+
 				id := events.ID(event.EventID)
 
 				// if the event is marked as submit, we pass it to the engine


### PR DESCRIPTION

### 1. Explain what the PR does

commit 57fcacdc (HEAD -> policy-issues, rafaeldtinoco/policy-issues)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Mon Apr 3 23:43:23 2023

    policy: cmd/flags: fix incorrect mntns filter name
    
    - .. orelse when used, the following error is returned:
    
        {"level":"fatal","ts":1680575946.4342806,"msg":"App","error":
        "invalid filter option specified (mntNS!=100), use '--filter
        help' for more info"}
    
    - Update test to also try to create the Policies based on test data.

commit d1fdfc04
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Apr 4 00:50:19 2023

    fix: fix segfaults when ctrl+c is too fast
    
    When aborting tracee right in the beginning, user might face segfaults:
    
    panic: runtime error: invalid memory address or nil pointer dereference
    ...
    
    goroutine 71 [running]:
    github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).deriveEvents.func1()
            ... base/pkg/ebpf/events_pipeline.go:442 +0x185
    
    or
    
    goroutine 109 [running]:
    github.com/aquasecurity/tracee/pkg/ebpf.(*Tracee).engineEvents.func1()
            ... base/pkg/ebpf/signature_engine.go:32 +0x19c
    
    This commit fixes this issue.

