### PR TITLE
Important Network Fixes for Tracee

### DIFF
--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -17,8 +17,12 @@
 // clang-format off
 
 //
-// Network packet related events (TODO: spin off all net_packet related code)
+// Network packet related events
 //
+
+// Function Prototypes
+
+static __always_inline u32 update_net_inodemap(struct socket *, event_data_t *);
 
 // NOTE: proto header structs need full type in vmlinux.h (for correct skb copy)
 
@@ -130,6 +134,15 @@ struct {
     __type(key, u64);                       // socket inode number ...
     __type(value, struct net_task_context); // ... linked to a task context
 } inodemap SEC(".maps");                    // relate sockets and tasks
+
+// sockmap (map two cloned "socket" representation structs ("sock"))
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 65535); // 9 MB     // simultaneous sockets being cloned
+    __type(key, u64);                       // *(struct sock *newsock) ...
+    __type(value, u64);                     // ... old sock->socket inode number
+} sockmap SEC(".maps");                     // relate a cloned sock struct with
 
 // entrymap
 

--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -83,7 +83,6 @@ typedef struct net_event_contextmd {
     u8 submit;
     u32 header_size;
     u8 captured;
-    u8 padding;
 } __attribute__((__packed__)) net_event_contextmd_t;
 
 typedef struct net_event_context {
@@ -95,7 +94,7 @@ typedef struct net_event_context {
     } __attribute__((__packed__)); // ... avoid address-of-packed-member warns
     // members bellow this point are metadata (not part of event to be sent)
     net_event_contextmd_t md;
-} net_event_context_t;
+} __attribute__((__packed__)) net_event_context_t;
 
 // network related maps
 

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -105,6 +105,7 @@ func Init(module *bpf.Module, netEnabled bool) (Probes, error) {
 		KallsymsLookupNameRet:      &traceProbe{eventName: "kallsyms_lookup_name", probeType: kretprobe, programName: "trace_ret_kallsyms_lookup_name"},
 		SockAllocFile:              &traceProbe{eventName: "sock_alloc_file", probeType: kprobe, programName: "trace_sock_alloc_file"},
 		SockAllocFileRet:           &traceProbe{eventName: "sock_alloc_file", probeType: kretprobe, programName: "trace_ret_sock_alloc_file"},
+		SecuritySkClone:            &traceProbe{eventName: "security_sk_clone", probeType: kprobe, programName: "trace_security_sk_clone"},
 		SecuritySocketSendmsg:      &traceProbe{eventName: "security_socket_sendmsg", probeType: kprobe, programName: "trace_security_socket_sendmsg"},
 		SecuritySocketRecvmsg:      &traceProbe{eventName: "security_socket_recvmsg", probeType: kprobe, programName: "trace_security_socket_recvmsg"},
 		CgroupBPFRunFilterSKB:      &traceProbe{eventName: "__cgroup_bpf_run_filter_skb", probeType: kprobe, programName: "cgroup_bpf_run_filter_skb"},
@@ -306,6 +307,7 @@ const (
 	KallsymsLookupNameRet
 	SockAllocFile
 	SockAllocFileRet
+	SecuritySkClone
 	SecuritySocketRecvmsg
 	SecuritySocketSendmsg
 	CgroupBPFRunFilterSKB

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1158,10 +1158,9 @@ func (t *Tracee) populateBPFMaps() error {
 		if err != nil {
 			return errfmt.WrapError(err)
 		}
-		/* the syscallsToCheckMap store the syscall numbers that we are fetching from the syscall table, like that:
-		 * [syscall num #1][syscall num #2][syscall num #3]...
-		 * with that, we can fetch the syscall address by accessing the syscall table in the syscall number index
-		 */
+		// the syscallsToCheckMap store the syscall numbers that we are fetching from the syscall table, like that:
+		// [syscall num #1][syscall num #2][syscall num #3]...
+		// with that, we can fetch the syscall address by accessing the syscall table in the syscall number index
 
 		for idx, val := range events.SyscallsToCheck() {
 			err = syscallsToCheckMap.Update(unsafe.Pointer(&(idx)), unsafe.Pointer(&val))
@@ -1186,41 +1185,78 @@ func (t *Tracee) populateBPFMaps() error {
 	return nil
 }
 
-// getTailCalls collects all tailcall dependencies from required events, and generates additional tailcall per syscall traced.
-// for syscall tracing, there are 4 different relevant tail calls:
+// getTailCalls collects all tailcall dependencies from required events, and
+// generates additional tailcall per syscall traced. For syscall tracing, there
+// are 4 different relevant tail calls:
+//
 // 1. sys_enter_init - syscall data saving is done here
 // 2. sys_enter_submit - some syscall submits are done here
 // 3. sys_exit_init - syscall validation on exit is done here
 // 4. sys_exit_submit - most syscalls are submitted at this point
-// this division is done because some events only require the syscall saving logic and not event submitting.
-// as such in order to actually track syscalls we need to initialize these 4 tail calls per syscall event requested for submission.
-// in pkg/events/events.go one can see that some events will require the sys_enter_init tail call, this is because they require syscall data saving
-// in their probe (for example security_file_open needs open, openat and openat2).
+//
+// This division is done because some events only require the syscall saving
+// logic, and not event submitting. As such, in order to actually track syscalls
+// we need to initialize, these 4 tail calls per syscall event requested for
+// submission. In pkg/events/events.go one can see that some events will
+// require the sys_enter_init tail call, this is because they require syscall
+// data saving in their probe (for example security_file_open needs open, openat
+// and openat2).
 func getTailCalls(eventConfigs map[events.ID]eventConfig) ([]events.TailCall, error) {
-	enterInitTailCall := events.TailCall{MapName: "sys_enter_init_tail", MapIndexes: []uint32{}, ProgName: "sys_enter_init"}
-	enterSubmitTailCall := events.TailCall{MapName: "sys_enter_submit_tail", MapIndexes: []uint32{}, ProgName: "sys_enter_submit"}
-	exitInitTailCall := events.TailCall{MapName: "sys_exit_init_tail", MapIndexes: []uint32{}, ProgName: "sys_exit_init"}
-	exitSubmitTailCall := events.TailCall{MapName: "sys_exit_submit_tail", MapIndexes: []uint32{}, ProgName: "sys_exit_submit"}
-	// for tracking only unique tail call, we use it's string form as the key in a "set" map (map[string]bool)
-	// we use a string and not the struct itself because it includes an array.
-	// in golang, map keys must be a comparable type, which are numerics and strings. structs can also be used as
-	// keys, but only if they are composed solely from comparable types.
-	// arrays/slices are not comparable, so we need to use the string form of the struct as a key instead.
-	// we then only append the actual tail call struct to a list if it's string form is not found in the map.
+
+	enterInitTailCall := events.TailCall{
+		MapName:    "sys_enter_init_tail",
+		MapIndexes: []uint32{},
+		ProgName:   "sys_enter_init",
+	}
+	enterSubmitTailCall := events.TailCall{
+		MapName:    "sys_enter_submit_tail",
+		MapIndexes: []uint32{},
+		ProgName:   "sys_enter_submit",
+	}
+	exitInitTailCall := events.TailCall{
+		MapName:    "sys_exit_init_tail",
+		MapIndexes: []uint32{},
+		ProgName:   "sys_exit_init",
+	}
+	exitSubmitTailCall := events.TailCall{
+		MapName:    "sys_exit_submit_tail",
+		MapIndexes: []uint32{},
+		ProgName:   "sys_exit_submit",
+	}
+
+	// For tracking only unique tail call, we use it's string form as the key in
+	// a "set" map (map[string]bool). We use a string, and not the struct
+	// itself, because it includes an array.
+	//
+	// NOTE: In golang, map keys must be a comparable type, which are numerics
+	//       and strings. structs can also be used as keys, but only if they are
+	//       composed solely from comparable types.
+	//
+	//       arrays/slices are not comparable, so we need to use the string form
+	//       of the struct as a key instead.  we then only append the actual
+	//       tail call struct to a list if it's string form is not found in the
+	//       map.
+
 	tailCallProgs := map[string]bool{}
 	tailCalls := []events.TailCall{}
+
 	for e, cfg := range eventConfigs {
 		def := events.Definitions.Get(e)
+
 		for _, tailCall := range def.Dependencies.TailCalls {
 			if len(tailCall.MapIndexes) == 0 {
-				// if tailcall has no indexes defined we can skip it
-				continue
+				continue // skip if tailcall has no indexes defined
 			}
 			for _, index := range tailCall.MapIndexes {
-				if index >= uint32(events.MaxCommonID) { // remove undefined syscalls (check arm64.go) and events
-					logger.Debugw("Removing index from tail call (over max event id)", "tail_call_map", tailCall.MapName, "index", index,
-						"max_event_id", events.MaxCommonID, "pkgName", pkgName)
-					tailCall.RemoveIndex(index)
+				if index >= uint32(events.MaxCommonID) {
+					logger.Debugw(
+						"Removing index from tail call (over max event id)",
+						"tail_call_map", tailCall.MapName,
+						"index", index,
+						"max_event_id", events.MaxCommonID,
+						"pkgName", pkgName,
+					)
+					tailCall.RemoveIndex(index) // remove undef syscalls (eg. arm64)
 				}
 			}
 			tailCallStr := fmt.Sprint(tailCall)
@@ -1229,6 +1265,7 @@ func getTailCalls(eventConfigs map[events.ID]eventConfig) ([]events.TailCall, er
 			}
 			tailCallProgs[tailCallStr] = true
 		}
+
 		// validate the event and add to the syscall tail calls
 		if def.Syscall && cfg.submit > 0 && e < events.MaxSyscallID {
 			enterInitTailCall.AddIndex(uint32(e))
@@ -1237,7 +1274,12 @@ func getTailCalls(eventConfigs map[events.ID]eventConfig) ([]events.TailCall, er
 			exitSubmitTailCall.AddIndex(uint32(e))
 		}
 	}
-	tailCalls = append(tailCalls, enterInitTailCall, enterSubmitTailCall, exitInitTailCall, exitSubmitTailCall)
+
+	tailCalls = append(
+		tailCalls, enterInitTailCall, enterSubmitTailCall,
+		exitInitTailCall, exitSubmitTailCall,
+	)
+
 	return tailCalls, nil
 }
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -626,47 +626,51 @@ func (t *Tracee) initTailCall(mapName string, mapIndexes []uint32, progName stri
 // derived and the corresponding function to derive into that Event.
 func (t *Tracee) initDerivationTable() error {
 
+	shouldSubmit := func(id events.ID) func() bool {
+		return func() bool { return t.events[id].submit > 0 }
+	}
+
 	t.eventDerivations = derive.Table{
 		events.CgroupMkdir: {
 			events.ContainerCreate: {
-				Enabled:        func() bool { return t.events[events.ContainerCreate].submit > 0 },
+				Enabled:        shouldSubmit(events.ContainerCreate),
 				DeriveFunction: derive.ContainerCreate(t.containers),
 			},
 		},
 		events.CgroupRmdir: {
 			events.ContainerRemove: {
-				Enabled:        func() bool { return t.events[events.ContainerRemove].submit > 0 },
+				Enabled:        shouldSubmit(events.ContainerRemove),
 				DeriveFunction: derive.ContainerRemove(t.containers),
 			},
 		},
 		events.PrintSyscallTable: {
 			events.HookedSyscalls: {
-				Enabled:        func() bool { return t.events[events.PrintSyscallTable].submit > 0 },
+				Enabled:        shouldSubmit(events.PrintSyscallTable),
 				DeriveFunction: derive.DetectHookedSyscall(t.kernelSymbols),
 			},
 		},
 		events.PrintNetSeqOps: {
 			events.HookedSeqOps: {
-				Enabled:        func() bool { return t.events[events.HookedSeqOps].submit > 0 },
+				Enabled:        shouldSubmit(events.HookedSeqOps),
 				DeriveFunction: derive.HookedSeqOps(t.kernelSymbols),
 			},
 		},
 		events.HiddenKernelModuleSeeker: {
 			events.HiddenKernelModule: {
-				Enabled:        func() bool { return t.events[events.HiddenKernelModuleSeeker].submit > 0 },
+				Enabled:        shouldSubmit(events.HiddenKernelModuleSeeker),
 				DeriveFunction: derive.HiddenKernelModule(),
 			},
 		},
 		events.SharedObjectLoaded: {
 			events.SymbolsLoaded: {
-				Enabled: func() bool { return t.events[events.SymbolsLoaded].submit > 0 },
+				Enabled: shouldSubmit(events.SymbolsLoaded),
 				DeriveFunction: derive.SymbolsLoaded(
 					t.contSymbolsLoader,
 					t.config.Policies,
 				),
 			},
 			events.SymbolsCollision: {
-				Enabled: func() bool { return t.events[events.SymbolsCollision].submit > 0 },
+				Enabled: shouldSubmit(events.SymbolsCollision),
 				DeriveFunction: derive.SymbolsCollision(
 					t.contSymbolsLoader,
 					t.config.Policies,
@@ -675,7 +679,7 @@ func (t *Tracee) initDerivationTable() error {
 		},
 		events.SchedProcessExec: {
 			events.SymbolsCollision: {
-				Enabled: func() bool { return t.events[events.SymbolsCollision].submit > 0 },
+				Enabled: shouldSubmit(events.SymbolsCollision),
 				DeriveFunction: derive.SymbolsCollision(
 					t.contSymbolsLoader,
 					t.config.Policies,
@@ -687,63 +691,63 @@ func (t *Tracee) initDerivationTable() error {
 		//
 		events.NetPacketIPBase: {
 			events.NetPacketIPv4: {
-				Enabled:        func() bool { return t.events[events.NetPacketIPv4].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketIPv4),
 				DeriveFunction: derive.NetPacketIPv4(),
 			},
 			events.NetPacketIPv6: {
-				Enabled:        func() bool { return t.events[events.NetPacketIPv6].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketIPv6),
 				DeriveFunction: derive.NetPacketIPv6(),
 			},
 		},
 		events.NetPacketTCPBase: {
 			events.NetPacketTCP: {
-				Enabled:        func() bool { return t.events[events.NetPacketTCP].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketTCP),
 				DeriveFunction: derive.NetPacketTCP(),
 			},
 		},
 		events.NetPacketUDPBase: {
 			events.NetPacketUDP: {
-				Enabled:        func() bool { return t.events[events.NetPacketUDP].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketUDP),
 				DeriveFunction: derive.NetPacketUDP(),
 			},
 		},
 		events.NetPacketICMPBase: {
 			events.NetPacketICMP: {
-				Enabled:        func() bool { return t.events[events.NetPacketICMP].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketICMP),
 				DeriveFunction: derive.NetPacketICMP(),
 			},
 		},
 		events.NetPacketICMPv6Base: {
 			events.NetPacketICMPv6: {
-				Enabled:        func() bool { return t.events[events.NetPacketICMPv6].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketICMPv6),
 				DeriveFunction: derive.NetPacketICMPv6(),
 			},
 		},
 		events.NetPacketDNSBase: {
 			events.NetPacketDNS: {
-				Enabled:        func() bool { return t.events[events.NetPacketDNS].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketDNS),
 				DeriveFunction: derive.NetPacketDNS(),
 			},
 			events.NetPacketDNSRequest: {
-				Enabled:        func() bool { return t.events[events.NetPacketDNSRequest].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketDNSRequest),
 				DeriveFunction: derive.NetPacketDNSRequest(),
 			},
 			events.NetPacketDNSResponse: {
-				Enabled:        func() bool { return t.events[events.NetPacketDNSResponse].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketDNSResponse),
 				DeriveFunction: derive.NetPacketDNSResponse(),
 			},
 		},
 		events.NetPacketHTTPBase: {
 			events.NetPacketHTTP: {
-				Enabled:        func() bool { return t.events[events.NetPacketHTTP].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketHTTP),
 				DeriveFunction: derive.NetPacketHTTP(),
 			},
 			events.NetPacketHTTPRequest: {
-				Enabled:        func() bool { return t.events[events.NetPacketHTTPRequest].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketHTTPRequest),
 				DeriveFunction: derive.NetPacketHTTPRequest(),
 			},
 			events.NetPacketHTTPResponse: {
-				Enabled:        func() bool { return t.events[events.NetPacketHTTPResponse].submit > 0 },
+				Enabled:        shouldSubmit(events.NetPacketHTTPResponse),
 				DeriveFunction: derive.NetPacketHTTPResponse(),
 			},
 		},

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -113,7 +113,7 @@ func parseUntilLayer7(event *trace.Event, pair *netPair) (gopacket.ApplicationLa
 	// parse packet with gopacket
 
 	packet := gopacket.NewPacket(
-		payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+		payload,
 		layerType,
 		gopacket.Default,
 	)

--- a/pkg/events/derive/net_packet_icmp.go
+++ b/pkg/events/derive/net_packet_icmp.go
@@ -44,7 +44,7 @@ func deriveNetPacketICMPArgs() deriveArgsFunction {
 		// parse packet
 
 		packet := gopacket.NewPacket(
-			payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+			payload,
 			layers.LayerTypeIPv4,
 			gopacket.Default,
 		)

--- a/pkg/events/derive/net_packet_icmpv6.go
+++ b/pkg/events/derive/net_packet_icmpv6.go
@@ -44,7 +44,7 @@ func deriveNetPacketICMPv6Args() deriveArgsFunction {
 		// parse packet
 
 		packet := gopacket.NewPacket(
-			payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+			payload,
 			layers.LayerTypeIPv6,
 			gopacket.Default,
 		)

--- a/pkg/events/derive/net_packet_ipv4.go
+++ b/pkg/events/derive/net_packet_ipv4.go
@@ -40,7 +40,7 @@ func deriveNetPacketIPv4Args() deriveArgsFunction {
 		// parse packet
 
 		packet := gopacket.NewPacket(
-			payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+			payload,
 			layers.LayerTypeIPv4,
 			gopacket.Default,
 		)

--- a/pkg/events/derive/net_packet_ipv6.go
+++ b/pkg/events/derive/net_packet_ipv6.go
@@ -39,7 +39,7 @@ func deriveNetPacketIPv6Args() deriveArgsFunction {
 		// parse packet
 
 		packet := gopacket.NewPacket(
-			payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+			payload,
 			layers.LayerTypeIPv6,
 			gopacket.Default,
 		)

--- a/pkg/events/derive/net_packet_tcp.go
+++ b/pkg/events/derive/net_packet_tcp.go
@@ -49,7 +49,7 @@ func deriveNetPacketTCPArgs() deriveArgsFunction {
 		// parse packet
 
 		packet := gopacket.NewPacket(
-			payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+			payload,
 			layerType,
 			gopacket.Default,
 		)

--- a/pkg/events/derive/net_packet_udp.go
+++ b/pkg/events/derive/net_packet_udp.go
@@ -49,7 +49,7 @@ func deriveNetPacketUDPArgs() deriveArgsFunction {
 		// parse packet
 
 		packet := gopacket.NewPacket(
-			payload[4:payloadSize], // base event argument is: |sizeof|[]byte|
+			payload,
 			layerType,
 			gopacket.Default,
 		)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -6431,6 +6431,7 @@ var Definitions = eventDefinitions{
 				{Handle: probes.CgroupBPFRunFilterSKB, Required: true},
 				{Handle: probes.SecuritySocketRecvmsg, Required: true},
 				{Handle: probes.SecuritySocketSendmsg, Required: true},
+				{Handle: probes.SecuritySkClone, Required: true},
 			},
 			Sets:   []string{"network_events"},
 			Params: []trace.ArgMeta{},


### PR DESCRIPTION
## Issue description

The exact problem is described at:

https://github.com/aquasecurity/tracee/issues/2739#issuecomment-1503605814

And a "prove" that this PR fixes the issue is at:

https://github.com/aquasecurity/tracee/issues/2739#issuecomment-1507142356

## How to test this

```
$ sudo cp /usr/bin/nc /usr/bin/othernc

# screen 1

$ sudo ./dist/tracee-ebpf --output format:json --filter event=net_packet_ipv4 --filter comm=othernc

# screen 2

$ othernc -4 -l 8080 &

$ dd if=/dev/zero bs=1024 count=1 | nc -i 5 -q 2 localhost 8080
```

And observe the pacotes in both: wireshark and tracee output. Each existing packet in wireshark should be described as one net_packet_ipv4 event in tracee output.

## PR description

commit 5b082b40 (HEAD -> rafaelchanges, rafaeldtinoco/rafaelchanges)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Apr 11 14:57:57 2023

    network: fix tracing for initial pakets on accepted socket
    
    When a "sock" is cloned because of a SYN packet, a new "sock" is created
    and the return value is the new "sock" (not the original one).
    
    There is a problem though, the "sock" does not contain a valid "socket"
    associated to it yet (sk_socket is NULL as this is running with SoftIRQ
    context). Without a "socket" we also don't have a "file" associated to
    it, nor an inode associated to that file. This is the way tracee links
    a network flow (packets) to a task.
    
    The only way we can relate this new "sock", just cloned by a kernel
    thread, to a task, is through the existence of the old "sock" struct,
    describing the listening socket (one accept() was called for).
    
    Then, by knowing the old "sock" (with an existing socket, an existing
    file, an existing inode), we're able to link this new "sock" to the task
    we're tracing for the old "sock".
    
    This patch fixes the issue. In bullets:
    
    - tracing a process that has a socket listening for connections.
    - it receives a SYN packet and a new socket can be created (accept).
    - a sock (socket descriptor) is created for the socket to be created.
    - no socket/inode exists yet (sock->sk_socket is NULL).
    - accept() traces are too late for initial pkts (socked does not exist).
    - by linking old "sock" to the new "sock" we can relate the task.
    - some of the initial packets, sometimes with big length, are traced now.
    
    Fixes: #2739

commit 9bfa2e0f
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Apr 5 22:15:15 2023

    network: fix net_event_context_t wrong padding
    
    When network code was added, the net_event_context_t was being padded
    in userland, instead of being correctly packed in eBPF code.
    
    This happened because I thought the initial 4 bytes (u32) of the
    []bytes length was together with the payload, when the events were
    being derived, but it wasn't. The initial 4 bytes was actually a
    padding I got right "by accident".
    
    NOTE: This is an important fix to all the network code, although the
    padding was being "somehow" done, and the wrong userland code was
    making it to work, side effects of this mistake are unknown.

commit 8cdfcb00
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Apr 5 15:47:42 2023

    derivation table: quick refactor for readability
