### PR TITLE
logger: errfmt: flags: prefix debug level only

### DIFF
--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -896,22 +896,22 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "empty option flag",
 			outputSlice:   []string{"option"},
-			expectedError: errors.New("parseOption: option flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("option flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:      "empty option flag 2",
 			outputSlice:   []string{"option:"},
-			expectedError: errors.New("parseOption: option flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("option flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:      "invalid option value",
 			outputSlice:   []string{"option:foo"},
-			expectedError: errors.New("setOption: invalid output option: foo, use '--output help' for more info"),
+			expectedError: errors.New("invalid output option: foo, use '--output help' for more info"),
 		},
 		{
 			testName:      "empty file for format",
 			outputSlice:   []string{"json:"},
-			expectedError: errors.New("parseFormat: format flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("format flag can't be empty, use '--output help' for more info"),
 		},
 		// formats
 		{
@@ -1070,17 +1070,17 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "two formats for stdout",
 			outputSlice:   []string{"table", "json"},
-			expectedError: errors.New("parseFormat: cannot use the same path for multiple outputs: stdout, use '--output help' for more info"),
+			expectedError: errors.New("cannot use the same path for multiple outputs: stdout, use '--output help' for more info"),
 		},
 		{
 			testName:      "format for the same file twice",
 			outputSlice:   []string{"table:/tmp/test,/tmp/test"},
-			expectedError: errors.New("parseFormat: cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+			expectedError: errors.New("cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
 		},
 		{
 			testName:      "two different formats for the same file",
 			outputSlice:   []string{"table:/tmp/test", "json:/tmp/test"},
-			expectedError: errors.New("parseFormat: cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+			expectedError: errors.New("cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
 		},
 		{
 			testName:    "none",
@@ -1106,17 +1106,17 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "empty forward flag",
 			outputSlice:   []string{"forward"},
-			expectedError: errors.New("validateURL: forward flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("forward flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:      "empty forward flag",
 			outputSlice:   []string{"forward:"},
-			expectedError: errors.New("validateURL: forward flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("forward flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:      "invalid forward url",
 			outputSlice:   []string{"forward:lalala"},
-			expectedError: errors.New("validateURL: invalid uri for forward output \"lalala\". Use '--output help' for more info"),
+			expectedError: errors.New("invalid uri for forward output \"lalala\". Use '--output help' for more info"),
 		},
 		{
 			testName:    "forward",
@@ -1132,17 +1132,17 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "empty webhook flag",
 			outputSlice:   []string{"webhook"},
-			expectedError: errors.New("validateURL: webhook flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("webhook flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:      "empty webhook flag",
 			outputSlice:   []string{"webhook:"},
-			expectedError: errors.New("validateURL: webhook flag can't be empty, use '--output help' for more info"),
+			expectedError: errors.New("webhook flag can't be empty, use '--output help' for more info"),
 		},
 		{
 			testName:      "invalid webhook url",
 			outputSlice:   []string{"webhook:lalala"},
-			expectedError: errors.New("validateURL: invalid uri for webhook output \"lalala\". Use '--output help' for more info"),
+			expectedError: errors.New("invalid uri for webhook output \"lalala\". Use '--output help' for more info"),
 		},
 		{
 			testName:    "webhook",

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -113,6 +113,7 @@ func PrepareLogger(logOptions []string) (logger.LoggingConfig, error) {
 	return logger.LoggingConfig{
 		Logger:        llogger,
 		Aggregate:     agg,
+		Level:         lvl,
 		FlushInterval: interval,
 	}, nil
 }

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -1418,7 +1418,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					Description: "",
 				},
 			},
-			expectedError: errors.New("flags.validatePolicy: policy empty_description, description cannot be empty"),
+			expectedError: errors.New("policy empty_description, description cannot be empty"),
 		},
 		{
 			testName: "empty scope",
@@ -1458,7 +1458,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.validateEvent: policy empty_event_name, event cannot be empty"),
+			expectedError: errors.New("policy empty_event_name, event cannot be empty"),
 		},
 		{
 			testName: "invalid event name",
@@ -1473,7 +1473,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.validateEvent: policy invalid_event_name, event non_existing_event is not valid"),
+			expectedError: errors.New("policy invalid_event_name, event non_existing_event is not valid"),
 		},
 		{
 			testName: "invalid_scope_operator",
@@ -1488,7 +1488,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.PrepareFilterMapFromPolicies: policy invalid_scope_operator, scope random is not valid"),
+			expectedError: errors.New("policy invalid_scope_operator, scope random is not valid"),
 		},
 		{
 			testName: "invalid_scope",
@@ -1503,7 +1503,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.validateScope: policy invalid_scope, scope random is not valid"),
+			expectedError: errors.New("policy invalid_scope, scope random is not valid"),
 		},
 		{
 			testName: "global scope must be unique",
@@ -1554,7 +1554,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.PrepareFilterMapFromPolicies: invalid filter operator: random"),
+			expectedError: errors.New("invalid filter operator: random"),
 		},
 		{
 			testName: "invalid filter",
@@ -1574,7 +1574,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.validateContext: policy invalid_filter, filter random is not valid"),
+			expectedError: errors.New("policy invalid_filter, filter random is not valid"),
 		},
 		{
 			testName: "empty policy action",
@@ -1588,7 +1588,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.validatePolicy: policy empty_policy_action, default action cannot be empty"),
+			expectedError: errors.New("policy empty_policy_action, default action cannot be empty"),
 		},
 		{
 			testName: "invalid policy action",
@@ -1603,7 +1603,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.validateAction: policy invalid_policy_action, action audit is not valid"),
+			expectedError: errors.New("policy invalid_policy_action, action audit is not valid"),
 		},
 		{
 			testName: "duplicated policy name",
@@ -1627,7 +1627,7 @@ func TestPrepareFilterScopesForPolicyValidations(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("flags.PrepareFilterMapFromPolicies: policy duplicated_policy_name already exist"),
+			expectedError: errors.New("policy duplicated_policy_name already exist"),
 		},
 
 		// invalid args?

--- a/pkg/errfmt/errfmt.go
+++ b/pkg/errfmt/errfmt.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 // funcName returns the name of the function that called it based on the
@@ -20,6 +22,11 @@ func funcName(skip int) string {
 // prefixFunc prefixes a given string with the name of the function that
 // called it based on the skip value.
 func prefixFunc(msg string, skip int) error {
+	// If the current log level is not debug, return the error as is.
+	if logger.Current().Level() > logger.DebugLevel {
+		return fmt.Errorf("%v", msg)
+	}
+
 	fName := funcName(skip + 1)
 
 	return fmt.Errorf("%v: %v", fName, msg)

--- a/pkg/errfmt/errfmt_test.go
+++ b/pkg/errfmt/errfmt_test.go
@@ -6,9 +6,18 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func TestErrorf(t *testing.T) {
+	// Initialize the logger to debug level, so that the error messages
+	// are prefixed with the function name.
+	logger.Init(logger.LoggingConfig{
+		Logger: logger.NewLogger(logger.NewDefaultLoggerConfig()),
+		Level:  logger.DebugLevel,
+	})
+
 	tests := []struct {
 		name   string
 		format string

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -87,6 +87,7 @@ const (
 type LoggingConfig struct {
 	Logger        LoggerInterface
 	Aggregate     bool
+	Level         Level
 	FlushInterval time.Duration
 }
 
@@ -283,6 +284,11 @@ func (l *Logger) Sync() error {
 	return l.l.Sync()
 }
 
+// Level returns the current logging level
+func (l *Logger) Level() Level {
+	return l.cfg.Level
+}
+
 var (
 	// Package-level Logger
 	pkgLogger *Logger = &Logger{}
@@ -306,12 +312,12 @@ func SetLogger(l LoggerInterface) {
 // Init sets the package-level base logger using given config
 // It's not thread safe so if required use it always at the beginning
 func Init(cfg LoggingConfig) {
-	// set the config
-	pkgLogger.cfg = cfg
-
 	if cfg.Logger == nil {
 		panic("can't initialize a nil Logger")
 	}
+
+	// set the config
+	pkgLogger.cfg = cfg
 
 	pkgLogger.l = cfg.Logger
 	pkgLogger.logCount = newLogCounter()


### PR DESCRIPTION
### 1. Explain what the PR does

    logger: errfmt: flags: prefix debug level only
    
    Make errfmt prefix only when debug level is set. This is to avoid
    noise in the output when debug level is not set and to facilitate
    unit testing, where there's a comparison between the output and
    the expected output.

### 2. Explain how to test it


### 3. Other comments

Fixes: #2992 
