### PR TITLE
fix: add file to error message when parsing yaml

### DIFF
--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -297,12 +297,12 @@ func getPoliciesFromFile(filePath string) (flags.PolicyFile, error) {
 
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return p, err
+		return p, errfmt.Errorf("error reading %s: %v", filePath, err)
 	}
 
 	err = yaml.Unmarshal(data, &p)
 	if err != nil {
-		return p, err
+		return p, errfmt.Errorf("error parsing %s: %v", filePath, err)
 	}
 
 	return p, nil


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Improve error message, adding the file which is failing the parsing:

before:

```
{"level":"fatal","ts":1681236515.5112734,"msg":"App","error":"yaml: line 5: found character that cannot start any token"}
```

after:

```
{"level":"fatal","ts":1681236535.9763668,"msg":"App","error":"urfave.getPoliciesFromFile: error parsing /home/josedonizetti/code/aquasecurity/tracee-action/policies/file_writes.yaml: yaml: line 5: found character that cannot start any token"}
```

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
