### PR TITLE
Enable a Debug Shell for Test Runners

### DIFF
--- a/.github/workflows/debug-shell.yaml
+++ b/.github/workflows/debug-shell.yaml
@@ -1,0 +1,262 @@
+name: Debug Distro Shell
+on:
+  workflow_dispatch:
+    inputs:
+      distro:
+        type: choice
+        description: Distro Image to Debug
+        required: true
+        options:
+          - alma418
+          - alma418-arm64
+          - amzn2510
+          - amzn2510-arm64
+          - gke54
+          - gke510
+          - gke515
+          - gke515-arm64
+          - focal54
+          - focal54-arm64
+          - focal513
+          - focal513-arm64
+          - jammy515
+          - jammy515-arm64
+          - jammy519
+          - jammy519-arm64
+          - focal419
+          - focal419-arm64
+jobs:
+  alma418:
+    if: ${{ github.event.inputs.distro == 'alma418' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0256d27c94fd8654b_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  alma418-arm64:
+    if: ${{ github.event.inputs.distro == 'alma418-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-06bf1de0491bed185_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  amzn2510:
+    if: ${{ github.event.inputs.distro == 'amzn2510' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0d099424e2075f1a4_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  amzn2510-arm64:
+    if: ${{ github.event.inputs.distro == 'amzn2510-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-00c130a5b3b61db15_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  gke54:
+    if: ${{ github.event.inputs.distro == 'gke54' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0ba301555616a1dbd_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  gke510:
+    if: ${{ github.event.inputs.distro == 'gke510' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-060404a5b1dc571e6_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  gke515:
+    if: ${{ github.event.inputs.distro == 'gke515' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0d96f848dbe84ee3e_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  gke515-arm64:
+    if: ${{ github.event.inputs.distro == 'gke515-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0ffd52e93f1a0370b_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  focal54:
+    if: ${{ github.event.inputs.distro == 'focal54' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0215ef3ceac330d0a_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  focal54-arm64:
+    if: ${{ github.event.inputs.distro == 'focal54-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0964f99b81de934a3_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  focal513:
+    if: ${{ github.event.inputs.distro == 'focal513' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0f23165db12015479_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  focal513-arm64:
+    if: ${{ github.event.inputs.distro == 'focal513-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0f12d300b01df6d27_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  jammy515:
+    if: ${{ github.event.inputs.distro == 'jammy515' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0238444dc8524d8c7_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  jammy515-arm64:
+    if: ${{ github.event.inputs.distro == 'jammy515-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0870bd48b77710358_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  jammy519:
+    if: ${{ github.event.inputs.distro == 'jammy519' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0f14a28ff0b2d6279_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  jammy519-arm64:
+    if: ${{ github.event.inputs.distro == 'jammy519-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0d40904002284d8de_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  focal419:
+    if: ${{ github.event.inputs.distro == 'focal419' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-06c844d8e084a6328_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  focal419-arm64:
+    if: ${{ github.event.inputs.distro == 'focal419-arm64' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0956bf30569c0bce9_${{ github.event.number }}-${{ github.run_id }}",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh

--- a/tests/remotessh.sh
+++ b/tests/remotessh.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+die() {
+    echo ${@}
+    exit 1
+}
+
+. /etc/os-release
+
+CMDS="sshpass"
+
+# variables
+
+SSH_IP="${SSH_IP:=154.53.35.3}"
+SSH_PORT="${SSH_PORT:=2222}"
+SSH_USER="${SSH_USER:=github}"
+SSH_PASS="${SSH_PASS:=changeme}"
+
+HOST_IP="${HOST_IP:=0.0.0.0}"
+HOST_PORT=$((8000 + ($RANDOM % 999))) # port to direct to given IP
+
+LOCAL_IP=127.0.0.1 # ip to be external to the world
+LOCAL_PORT=22      # port to be external to the world
+
+# environment
+
+GOPATH="${GOPATH:=/tmp/go}"
+GOCACHE="${GOCACHE:=/tmp/go-cache}"
+GOROOT="${GOROOT:=/usr/local/go}"
+
+# sanity checks
+
+ping -w3 -c1 $SSH_IP >/dev/null 2>&1 || die "can't access $SSH_IP"
+
+# set user password
+
+if [[ $ID == ubuntu ]]; then
+    HOST_USER="ubuntu"
+    HOST_SERVICE="ssh"
+fi
+if [[ $ID == almalinux ]]; then
+    HOST_USER="ec2-user"
+    HOST_SERVICE="sshd"
+fi
+
+printf "changeme\nchangeme\n" | passwd $HOST_USER 2>&1 > /dev/null 2>&1
+sed -Ei 's:.*PasswordAuthentication.*:PasswordAuthentication yes:g' /etc/ssh/sshd_config
+systemctl restart $HOST_SERVICE
+
+# requirements
+
+if [[ $UID -eq 0 ]]; then
+    echo
+    echo Updating Package List ...
+    echo
+    if [[ $ID == ubuntu ]]; then
+        apt-get update -y 2>&1 >/dev/null
+    fi
+fi
+
+for cmd in $CMDS; do
+    if [[ $UID -eq 0 ]]; then
+        if [[ $ID == ubuntu ]]; then
+            dpkg -l | grep -q $cmd || apt-get install -y $cmd 2>&1 > /dev/null
+        fi
+        if [[ $ID == almalinux ]]; then
+            rpm -aq | grep -q $cmd || yum install -y $cmd 2>&1 > /dev/null
+        fi
+    fi
+    command -v $cmd >/dev/null || die "$cmd not found"
+done
+
+# execute debug shell
+
+echo
+echo "######                                #####                              "
+echo "#     # ###### #####  #    #  ####   #     # #    # ###### #      #      "
+echo "#     # #      #    # #    # #    #  #       #    # #      #      #      "
+echo "#     # #####  #####  #    # #        #####  ###### #####  #      #      "
+echo "#     # #      #    # #    # #  ###        # #    # #      #      #      "
+echo "#     # #      #    # #    # #    #  #     # #    # #      #      #      "
+echo "######  ###### #####   ####   ####    #####  #    # ###### ###### ###### "
+echo
+echo "You may now connect:"
+echo
+echo "ssh -p $HOST_PORT $HOST_USER@$SSH_IP (pw: changeme)"
+echo
+echo "To get access to the debug shell."
+echo
+echo "NOTE 1: You may also use VSCODE for remove development."
+echo "NOTE 2: Please change your password as soon as you connect."
+echo "NOTE 3: Shutdown the VM when you're done !!!"
+echo
+
+sshpass -p $SSH_PASS \
+    ssh \
+    -oStrictHostKeyChecking=no \
+    -oUserKnownHostsFile=/dev/null \
+    -p $SSH_PORT $SSH_USER@$SSH_IP -N \
+    -R $HOST_IP:$HOST_PORT:$LOCAL_IP:$LOCAL_PORT &
+
+# sleep forever (until VM shuts down)
+
+while true; do
+    sleep 30;
+    echo "You can: ssh -p $HOST_PORT $HOST_USER@$SSH_IP (pw: changeme)."
+done


### PR DESCRIPTION
commit 8913fc09 (HEAD -> debug-shell, rafaeldtinoco/debug-shell)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Apr 18 10:15:10 2023

    workflow: introduce distro image debug shell
    
    This commit introduces a workflow that makes possible triggering a VM
    debug shell, to be ssh'ed to, that allows a developer to debug
    development issues happening on specific kernel versions. With that,
    the developer has the same environment used on PR tests, provisioned
    so they can fix issues more easily.
    
    The workflow shall be triggered manually whenever a debug shell is
    needed, and the provisioned VM should be shutdown at the end of its
    usage. Provisioning VMs require repository write access so, engineers
    that have only triage permissions should ask maintainers for debug
    shells.