### PR TITLE
fix multiple symbols prints bug

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1670,8 +1670,6 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 			continue
 		}
 
-		eventHandle := t.triggerContexts.Store(event)
-
 		lengthFilter, ok := printMemDumpFilters["length"].(*filters.StringFilter)
 		var length uint64
 		var err error
@@ -1695,7 +1693,8 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 				if err != nil {
 					return errfmt.WrapError(err)
 				}
-				_ = t.triggerMemDumpCall(address, length, uint64(eventHandle))
+				eventHandle := t.triggerContexts.Store(event)
+				_ = t.triggerMemDumpCall(address, length, eventHandle)
 			}
 		}
 
@@ -1730,6 +1729,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 						return errfmt.WrapError(err)
 					}
 				}
+				eventHandle := t.triggerContexts.Store(event)
 				_ = t.triggerMemDumpCall(symbol.Address, length, uint64(eventHandle))
 			}
 		}


### PR DESCRIPTION
### 1. Explain what the PR does

Fix a bug related to the context saved on the `print_mem_dump` event.

fix #2993 
### 2. Explain how to test it

run `dist/tracee-ebpf -f e=print_mem_dump -f print_mem_dump.args.symbol_name=execve,kill` and see if there are errors

