### PR TITLE
Capabilities fixes

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -38,14 +38,8 @@ func main() {
 
 			// Capabilities command line flags
 
-			bypass := c.Bool("allcaps") || !isRoot() // non root has no practical use for capabilities drop
-			err := capabilities.Initialize(bypass)
-			if err != nil {
-				return err
-			}
-
 			if c.NumFlags() == 0 {
-				if err = cli.ShowAppHelp(c); err != nil {
+				if err := cli.ShowAppHelp(c); err != nil {
 					logger.Errorw("Failed to show app help", "error", err)
 				}
 				return errors.New("no flags specified")
@@ -68,6 +62,17 @@ func main() {
 				c.StringSlice("rules"),
 				c.Bool("rego-aio"),
 			)
+			if err != nil {
+				return err
+			}
+
+			// can't drop privileges before this point due to signature.Find(),
+			// orelse we would have to raise capabilities in Find() and it can't
+			// be done in the single binary case (capabilities initialization
+			// happens after Find() is called) in that case.
+
+			bypass := c.Bool("allcaps") || !isRoot()
+			err = capabilities.Initialize(bypass)
 			if err != nil {
 				return err
 			}

--- a/pkg/signatures/celsig/config.go
+++ b/pkg/signatures/celsig/config.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v2"
-	"kernel.org/pub/linux/libs/security/libcap/cap"
 
-	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/detect"
 )
@@ -105,32 +103,26 @@ func NewConfigsFromDir(dirPath string) ([]SignaturesConfig, error) {
 func walkFilesWithExtensions(rootDir string, extensions []string) ([]string, error) {
 	var files []string
 
-	err := capabilities.GetInstance().Specific(
-		func() error {
-			err := filepath.WalkDir(rootDir,
-				func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						return err
-					}
+	err := filepath.WalkDir(rootDir,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
 
-					if d.IsDir() {
-						return nil
-					}
+			if d.IsDir() {
+				return nil
+			}
 
-					for _, s := range extensions {
-						if strings.HasSuffix(strings.ToLower(path), "."+s) {
-							files = append(files, path)
-							return nil
-						}
-					}
-
+			for _, s := range extensions {
+				if strings.HasSuffix(strings.ToLower(path), "."+s) {
+					files = append(files, path)
 					return nil
-				})
-			return err
+				}
+			}
+
+			return nil
 		},
-		cap.DAC_OVERRIDE,
 	)
 
 	return files, err
-
 }

--- a/pkg/signatures/signature/signature.go
+++ b/pkg/signatures/signature/signature.go
@@ -10,10 +10,7 @@ import (
 	"plugin"
 	"strings"
 
-	"kernel.org/pub/linux/libs/security/libcap/cap"
-
 	embedded "github.com/aquasecurity/tracee"
-	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/signatures/celsig"
 	"github.com/aquasecurity/tracee/pkg/signatures/regosig"
@@ -61,39 +58,35 @@ func Find(target string, partialEval bool, signaturesDir string, signatures []st
 
 func findGoSigs(dir string) ([]detect.Signature, error) {
 	var res []detect.Signature
-	err := capabilities.GetInstance().Specific(
-		func() error {
-			err := filepath.WalkDir(dir,
-				func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						logger.Errorw("Finding golang sigs", "error", err)
-						return err
-					}
 
-					if d.IsDir() || filepath.Ext(d.Name()) != ".so" {
-						return nil
-					}
+	errWD := filepath.WalkDir(dir,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				logger.Errorw("Finding golang sigs", "error", err)
+				return err
+			}
 
-					p, err := plugin.Open(path)
-					if err != nil {
-						logger.Errorw("Opening plugin " + path + ": " + err.Error())
-						return err
-					}
-					export, err := p.Lookup("ExportedSignatures")
-					if err != nil {
-						logger.Errorw("Missing Export symbol in plugin " + d.Name())
-						return err
-					}
-					sigs := *export.(*[]detect.Signature)
-					res = append(res, sigs...)
-					return nil
-				})
-			return err
+			if d.IsDir() || filepath.Ext(d.Name()) != ".so" {
+				return nil
+			}
+
+			p, err := plugin.Open(path)
+			if err != nil {
+				logger.Errorw("Opening plugin " + path + ": " + err.Error())
+				return err
+			}
+			export, err := p.Lookup("ExportedSignatures")
+			if err != nil {
+				logger.Errorw("Missing Export symbol in plugin " + d.Name())
+				return err
+			}
+			sigs := *export.(*[]detect.Signature)
+			res = append(res, sigs...)
+			return nil
 		},
-		cap.DAC_OVERRIDE,
 	)
-	if err != nil {
-		logger.Errorw("Requested capabilities", "error", err)
+	if errWD != nil {
+		logger.Errorw("Walking dir", "error", errWD)
 	}
 
 	return res, nil
@@ -107,85 +100,79 @@ func findRegoSigs(target string, partialEval bool, dir string, aioEnabled bool) 
 
 	regoHelpers := []string{embedded.RegoHelpersCode}
 
-	err := capabilities.GetInstance().Specific(
-		func() error {
-			errWD := filepath.WalkDir(dir,
-				func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						logger.Errorw("Finding rego sigs", "error", err)
-						return err
-					}
-					if d.IsDir() || d.Name() == "helpers.rego" {
-						return nil
-					}
-					if !isHelper(d.Name()) {
-						return nil
-					}
-					helperCode, err := os.ReadFile(path)
-					if err != nil {
-						logger.Errorw("Reading file " + path + ": " + err.Error())
-						return nil
-					}
-
-					regoHelpers = append(regoHelpers, string(helperCode))
-					modules[path] = string(helperCode)
-					return nil
-				})
-			if errWD != nil {
-				logger.Errorw("Walking dir", "error", errWD)
+	errWD := filepath.WalkDir(dir,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				logger.Errorw("Finding rego sigs", "error", err)
+				return err
+			}
+			if d.IsDir() || d.Name() == "helpers.rego" {
+				return nil
+			}
+			if !isHelper(d.Name()) {
+				return nil
+			}
+			helperCode, err := os.ReadFile(path)
+			if err != nil {
+				logger.Errorw("Reading file " + path + ": " + err.Error())
+				return nil
 			}
 
-			errWD = filepath.WalkDir(dir,
-				func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						logger.Errorw("Finding rego sigs", "error", err)
-						return err
-					}
-					if d.IsDir() || !isRegoFile(d.Name()) || isHelper(d.Name()) {
-						return nil
-					}
-					regoCode, err := os.ReadFile(path)
-					if err != nil {
-						logger.Errorw("Reading file " + path + ": " + err.Error())
-						return nil
-					}
-					modules[path] = string(regoCode)
-					if aioEnabled {
-						return nil
-					}
-					sig, err := regosig.NewRegoSignature(target, partialEval, append(regoHelpers, string(regoCode))...)
-					if err != nil {
-						newlineOffset := bytes.Index(regoCode, []byte("\n"))
-						if newlineOffset == -1 {
-							codeLength := len(regoCode)
-							if codeLength < 22 {
-								newlineOffset = codeLength
-							} else {
-								newlineOffset = 22
-							}
-						}
-						logger.Errorw("Creating rego signature with: " + string(regoCode[0:newlineOffset]) + ": " + err.Error())
-						return nil
-					}
-					res = append(res, sig)
-					return nil
-				})
-			if errWD != nil {
-				logger.Errorw("Walking dir", "error", errWD)
-			}
-
+			regoHelpers = append(regoHelpers, string(helperCode))
+			modules[path] = string(helperCode)
 			return nil
 		},
-		cap.DAC_OVERRIDE,
 	)
-	if err != nil {
-		logger.Errorw("Requested capabilities", "error", err)
+	if errWD != nil {
+		logger.Errorw("Walking dir", "error", errWD)
+	}
+
+	errWD = filepath.WalkDir(dir,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				logger.Errorw("Finding rego sigs", "error", err)
+				return err
+			}
+			if d.IsDir() || !isRegoFile(d.Name()) || isHelper(d.Name()) {
+				return nil
+			}
+			regoCode, err := os.ReadFile(path)
+			if err != nil {
+				logger.Errorw("Reading file " + path + ": " + err.Error())
+				return nil
+			}
+			modules[path] = string(regoCode)
+			if aioEnabled {
+				return nil
+			}
+			sig, err := regosig.NewRegoSignature(target, partialEval, append(regoHelpers, string(regoCode))...)
+			if err != nil {
+				newlineOffset := bytes.Index(regoCode, []byte("\n"))
+				if newlineOffset == -1 {
+					codeLength := len(regoCode)
+					if codeLength < 22 {
+						newlineOffset = codeLength
+					} else {
+						newlineOffset = 22
+					}
+				}
+				logger.Errorw("Creating rego signature with: " + string(regoCode[0:newlineOffset]) + ": " + err.Error())
+				return nil
+			}
+			res = append(res, sig)
+			return nil
+		},
+	)
+	if errWD != nil {
+		logger.Errorw("Walking dir", "error", errWD)
 	}
 
 	if aioEnabled {
-		aio, err := regosig.NewAIO(modules,
+		aio, err := regosig.NewAIO(
+			modules,
 			regosig.OPATarget(target),
-			regosig.OPAPartial(partialEval))
+			regosig.OPAPartial(partialEval),
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
commit cb71563f (HEAD -> capabilities-fixes, origin/capabilities-fixes)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Apr 19 04:01:45 2023

    capabilities: fix legacy detachment for older kernels
    
    Legacy attachments (for now: cgroupv2 prog attachments under older
    kernels) might not be done using BpfLink logic. Without a file
    descriptor for the link, tracee needs to raise its capabilities
    in order to call bpf() syscall for the legacy detachment.
    
    This fixes error happening in older kernels when exiting tracee:
    
      {"level":"error","ts":1681876470.9877832,"msg":"failed to detach
      probes when closing tracee","err":"probes.(*probes).DetachAll:
      probes.(*cgroupProbe).detach: failed to detach program:
      cgroup_skb_ingress (failed to detach (legacy) program
      cgroup_skb_ingress from cgroupv2 /sys/fs/cgroup/unified)"}
    
    Fixes: #2998

commit b063b4b0
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Apr 19 03:16:46 2023

    capabilities: fix early call to cap raise
    
    When executing tracee-ebpf, the capabilities are dropped correctly, but
    when executing the single binary, they are not.
    
    That happens because the single binary calls a function to find
    signatures in a directory, and that function raised capabilities. Since
    the capabilities gwere not initialized at that moment (by tracee.New()),
    then they were initialized incorrectly (since GetInstace() initializes
    capabilities if it isn't yet).
    
    This commit removes capabilities raising from early stage functions,
    in tracee rules logic, and postpones a bit the full capabilities setup
    This way, both tracee-ebpf and tracee binaries can coexist with
    a working initialization logic.
    
    Fixes: #3004