### PR TITLE
types: update tracee to use latest types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aquasecurity/libbpfgo v0.4.6-libbpf-1.1.0
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230419185754-a86b0b9a990f
+	github.com/aquasecurity/tracee/types v0.0.0-20230420201357-51135cc9bc89
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v20.10.24+incompatible
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/aquasecurity/libbpfgo v0.4.6-libbpf-1.1.0 h1:b4RQasaC8u+zvCFJO6z4e+Xo
 github.com/aquasecurity/libbpfgo v0.4.6-libbpf-1.1.0/go.mod h1:v+Nk+v6BtHLfdT4kVdsp+fYt4AeUa3cIG2P0y+nBuuY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
-github.com/aquasecurity/tracee/types v0.0.0-20230419185754-a86b0b9a990f h1:VHgOe06WUJLP3vHcT/Dq4B+547q8bW/VcDo56KACSwg=
-github.com/aquasecurity/tracee/types v0.0.0-20230419185754-a86b0b9a990f/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
+github.com/aquasecurity/tracee/types v0.0.0-20230420201357-51135cc9bc89 h1:Ko35zMOJE90+KM/NebyzT2SvQko67rM4CfVhN1bVpDU=
+github.com/aquasecurity/tracee/types v0.0.0-20230420201357-51135cc9bc89/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
This is needed after Tracee types JSON unmarshalling fixes.
