### PR TITLE
clang: fix nested loop unrolling

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2890,7 +2890,7 @@ static __always_inline int capture_file_write(struct pt_regs *ctx, u32 event_id)
         if (p.event->buf_off > ARGS_BUF_SIZE - MAX_STRING_SIZE)
             break;
 
-        if (has_prefix(
+        if (has_prefix_unrolled(
                 filter_p->path, (char *) &p.event->args[p.event->buf_off], MAX_PATH_PREF_SIZE)) {
             filter_match = true;
             break;


### PR DESCRIPTION
It turns out that nested loop unrolling makes the unrolling transformation not to work in clang (at least for eBPF architecture):

./pkg/ebpf/c/common/common.h:83:5: warning: loop not unrolled: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning]

    for (i = 0; i < n; prefix++, str++, i++) {
    ^

By having two "has_prefix" function versions, depending if the caller is already unrolling the loop or not, clang is able to transform the loop in multiple versions.

Fixes: #2624