### PR TITLE
Disable argument parsing by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -172,3 +172,5 @@ require (
 )
 
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0
+
+replace github.com/aquasecurity/tracee/types => ./types

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e6
 github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
-github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf h1:bSWqjqjFPGyn+thqof/rph4A5jSqd2d7xWJK5MGMb0I=
-github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -232,9 +232,6 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	runner.TraceeConfig = cfg
 	runner.Printer = p
 
-	// parse arguments must be enabled if the rule engine is part of the pipeline
-	runner.TraceeConfig.Output.ParseArguments = true
-
 	runner.TraceeConfig.EngineConfig = engine.Config{
 		Enabled:    true,
 		Signatures: sigs,

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -323,7 +323,7 @@ func (p tableEventPrinter) Print(event trace.Event) {
 			)
 		}
 	}
-	for i, arg := range event.Args {
+	for i, arg := range event.ParsedArgs {
 		if i == 0 {
 			fmt.Fprintf(p.out, "%s: %v", arg.Name, arg.Value)
 		} else {

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -23,8 +23,8 @@ func ParseArgs(event *trace.Event) error {
 	event.ParsedArgs = make([]trace.Argument, len(event.Args))
 	copy(event.ParsedArgs, event.Args)
 	for i := range event.ParsedArgs {
-		if ptr, isUintptr := event.Args[i].Value.(uintptr); isUintptr {
-			event.Args[i].Value = "0x" + strconv.FormatUint(uint64(ptr), 16)
+		if ptr, isUintptr := event.ParsedArgs[i].Value.(uintptr); isUintptr {
+			event.ParsedArgs[i].Value = "0x" + strconv.FormatUint(uint64(ptr), 16)
 		}
 	}
 

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -20,19 +20,21 @@ type fdArgTask struct {
 }
 
 func ParseArgs(event *trace.Event) error {
-	for i := range event.Args {
+	event.ParsedArgs = make([]trace.Argument, len(event.Args))
+	copy(event.ParsedArgs, event.Args)
+	for i := range event.ParsedArgs {
 		if ptr, isUintptr := event.Args[i].Value.(uintptr); isUintptr {
 			event.Args[i].Value = "0x" + strconv.FormatUint(uint64(ptr), 16)
 		}
 	}
 
-	emptyString := func(arg *trace.Argument) {
+	emptyStringArg := func(arg *trace.Argument) {
 		arg.Type = "string"
 		arg.Value = ""
 	}
 
 	parseOrEmptyString := func(arg *trace.Argument, sysArg helpers.SystemFunctionArgument, err error) {
-		emptyString(arg)
+		emptyStringArg(arg)
 		if err == nil {
 			arg.Value = sysArg.String()
 		}
@@ -40,26 +42,26 @@ func ParseArgs(event *trace.Event) error {
 
 	switch ID(event.EventID) {
 	case MemProtAlert:
-		if alertArg := GetArg(event, "alert"); alertArg != nil {
+		if alertArg := getParsedArg(event, "alert"); alertArg != nil {
 			if alert, isUint32 := alertArg.Value.(uint32); isUint32 {
 				alertArg.Value = trace.MemProtAlert(alert).String()
 				alertArg.Type = "string"
 			}
 		}
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := getParsedArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))
 				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
-		if prevProtArg := GetArg(event, "prev_prot"); prevProtArg != nil {
+		if prevProtArg := getParsedArg(event, "prev_prot"); prevProtArg != nil {
 			if prevProt, isInt32 := prevProtArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prevProt))
 				parseOrEmptyString(prevProtArg, mmapProtArgument, nil)
 			}
 		}
 	case SysEnter, SysExit:
-		if syscallArg := GetArg(event, "syscall"); syscallArg != nil {
+		if syscallArg := getParsedArg(event, "syscall"); syscallArg != nil {
 			if id, isInt32 := syscallArg.Value.(int32); isInt32 {
 				if Core.IsDefined(ID(id)) {
 					eventDefinition := Core.GetDefinitionByID(ID(id))
@@ -71,7 +73,7 @@ func ParseArgs(event *trace.Event) error {
 			}
 		}
 		if ID(event.EventID) == CapCapable {
-			if capArg := GetArg(event, "cap"); capArg != nil {
+			if capArg := getParsedArg(event, "cap"); capArg != nil {
 				if capability, isInt32 := capArg.Value.(int32); isInt32 {
 					capabilityFlagArgument, err := helpers.ParseCapability(uint64(capability))
 					parseOrEmptyString(capArg, capabilityFlagArgument, err)
@@ -79,150 +81,150 @@ func ParseArgs(event *trace.Event) error {
 			}
 		}
 	case SecurityMmapFile, DoMmap:
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := getParsedArg(event, "prot"); protArg != nil {
 			if prot, isUint64 := protArg.Value.(uint64); isUint64 {
 				mmapProtArgument := helpers.ParseMmapProt(prot)
 				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
 	case Mmap, Mprotect, PkeyMprotect:
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := getParsedArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))
 				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
 	case SecurityFileMprotect:
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := getParsedArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))
 				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
-		if prevProtArg := GetArg(event, "prev_prot"); prevProtArg != nil {
+		if prevProtArg := getParsedArg(event, "prev_prot"); prevProtArg != nil {
 			if prevProt, isInt32 := prevProtArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prevProt))
 				parseOrEmptyString(prevProtArg, mmapProtArgument, nil)
 			}
 		}
 	case Ptrace:
-		if reqArg := GetArg(event, "request"); reqArg != nil {
+		if reqArg := getParsedArg(event, "request"); reqArg != nil {
 			if req, isInt64 := reqArg.Value.(int64); isInt64 {
 				ptraceRequestArgument, err := helpers.ParsePtraceRequestArgument(uint64(req))
 				parseOrEmptyString(reqArg, ptraceRequestArgument, err)
 			}
 		}
 	case Prctl:
-		if optArg := GetArg(event, "option"); optArg != nil {
+		if optArg := getParsedArg(event, "option"); optArg != nil {
 			if opt, isInt32 := optArg.Value.(int32); isInt32 {
 				prctlOptionArgument, err := helpers.ParsePrctlOption(uint64(opt))
 				parseOrEmptyString(optArg, prctlOptionArgument, err)
 			}
 		}
 	case Socket:
-		if domArg := GetArg(event, "domain"); domArg != nil {
+		if domArg := getParsedArg(event, "domain"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				socketDomainArgument, err := helpers.ParseSocketDomainArgument(uint64(dom))
 				parseOrEmptyString(domArg, socketDomainArgument, err)
 			}
 		}
-		if typeArg := GetArg(event, "type"); typeArg != nil {
+		if typeArg := getParsedArg(event, "type"); typeArg != nil {
 			if typ, isInt32 := typeArg.Value.(int32); isInt32 {
 				socketTypeArgument, err := helpers.ParseSocketType(uint64(typ))
 				parseOrEmptyString(typeArg, socketTypeArgument, err)
 			}
 		}
 	case SecuritySocketCreate:
-		if domArg := GetArg(event, "family"); domArg != nil {
+		if domArg := getParsedArg(event, "family"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				socketDomainArgument, err := helpers.ParseSocketDomainArgument(uint64(dom))
 				parseOrEmptyString(domArg, socketDomainArgument, err)
 			}
 		}
-		if typeArg := GetArg(event, "type"); typeArg != nil {
+		if typeArg := getParsedArg(event, "type"); typeArg != nil {
 			if typ, isInt32 := typeArg.Value.(int32); isInt32 {
 				socketTypeArgument, err := helpers.ParseSocketType(uint64(typ))
 				parseOrEmptyString(typeArg, socketTypeArgument, err)
 			}
 		}
 	case Access, Faccessat:
-		if modeArg := GetArg(event, "mode"); modeArg != nil {
+		if modeArg := getParsedArg(event, "mode"); modeArg != nil {
 			if mode, isInt32 := modeArg.Value.(int32); isInt32 {
 				accessModeArgument, err := helpers.ParseAccessMode(uint64(mode))
 				parseOrEmptyString(modeArg, accessModeArgument, err)
 			}
 		}
 	case Execveat:
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := getParsedArg(event, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				execFlagArgument, err := helpers.ParseExecFlag(uint64(flags))
 				parseOrEmptyString(flagsArg, execFlagArgument, err)
 			}
 		}
 	case Open, Openat, SecurityFileOpen:
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := getParsedArg(event, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				openFlagArgument, err := helpers.ParseOpenFlagArgument(uint64(flags))
 				parseOrEmptyString(flagsArg, openFlagArgument, err)
 			}
 		}
 	case Mknod, Mknodat, Chmod, Fchmod, Fchmodat:
-		if modeArg := GetArg(event, "mode"); modeArg != nil {
+		if modeArg := getParsedArg(event, "mode"); modeArg != nil {
 			if mode, isUint32 := modeArg.Value.(uint32); isUint32 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
 				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case SecurityInodeMknod:
-		if modeArg := GetArg(event, "mode"); modeArg != nil {
+		if modeArg := getParsedArg(event, "mode"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
 				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case Clone:
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := getParsedArg(event, "flags"); flagsArg != nil {
 			if flags, isUint64 := flagsArg.Value.(uint64); isUint64 {
 				cloneFlagArgument, err := helpers.ParseCloneFlags(uint64(flags))
 				parseOrEmptyString(flagsArg, cloneFlagArgument, err)
 			}
 		}
 	case Bpf, SecurityBPF:
-		if cmdArg := GetArg(event, "cmd"); cmdArg != nil {
+		if cmdArg := getParsedArg(event, "cmd"); cmdArg != nil {
 			if cmd, isInt32 := cmdArg.Value.(int32); isInt32 {
 				bpfCommandArgument, err := helpers.ParseBPFCmd(uint64(cmd))
 				parseOrEmptyString(cmdArg, bpfCommandArgument, err)
 			}
 		}
 	case SecurityKernelReadFile, SecurityPostReadFile:
-		if typeArg := GetArg(event, "type"); typeArg != nil {
+		if typeArg := getParsedArg(event, "type"); typeArg != nil {
 			if readFileId, isInt32 := typeArg.Value.(trace.KernelReadType); isInt32 {
-				emptyString(typeArg)
+				emptyStringArg(typeArg)
 				typeArg.Value = readFileId.String()
 			}
 		}
 	case SchedProcessExec:
-		if modeArg := GetArg(event, "stdin_type"); modeArg != nil {
+		if modeArg := getParsedArg(event, "stdin_type"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
 				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case DirtyPipeSplice:
-		if modeArg := GetArg(event, "in_file_type"); modeArg != nil {
+		if modeArg := getParsedArg(event, "in_file_type"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
 				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case SecuritySocketSetsockopt, Setsockopt, Getsockopt:
-		if levelArg := GetArg(event, "level"); levelArg != nil {
+		if levelArg := getParsedArg(event, "level"); levelArg != nil {
 			if level, isInt := levelArg.Value.(int32); isInt {
 				levelArgument, err := helpers.ParseSocketLevel(uint64(level))
 				parseOrEmptyString(levelArg, levelArgument, err)
 			}
 		}
-		if optionNameArg := GetArg(event, "optname"); optionNameArg != nil {
+		if optionNameArg := getParsedArg(event, "optname"); optionNameArg != nil {
 			if opt, isInt := optionNameArg.Value.(int32); isInt {
 				var optionNameArgument helpers.SocketOptionArgument
 				var err error
@@ -235,13 +237,13 @@ func ParseArgs(event *trace.Event) error {
 			}
 		}
 	case BpfAttach:
-		if progTypeArg := GetArg(event, "prog_type"); progTypeArg != nil {
+		if progTypeArg := getParsedArg(event, "prog_type"); progTypeArg != nil {
 			if progType, isInt := progTypeArg.Value.(int32); isInt {
 				progTypeArgument, err := helpers.ParseBPFProgType(uint64(progType))
 				parseOrEmptyString(progTypeArg, progTypeArgument, err)
 			}
 		}
-		if helpersArg := GetArg(event, "prog_helpers"); helpersArg != nil {
+		if helpersArg := getParsedArg(event, "prog_helpers"); helpersArg != nil {
 			if helpersList, isUintSlice := helpersArg.Value.([]uint64); isUintSlice {
 				parsedHelpersList, err := parseBpfHelpersUsage(helpersList)
 				if err != nil {
@@ -251,23 +253,23 @@ func ParseArgs(event *trace.Event) error {
 				helpersArg.Value = parsedHelpersList
 			}
 		}
-		if attachTypeArg := GetArg(event, "attach_type"); attachTypeArg != nil {
+		if attachTypeArg := getParsedArg(event, "attach_type"); attachTypeArg != nil {
 			if attachType, isInt := attachTypeArg.Value.(int32); isInt {
 				attachTypestr, err := parseBpfAttachType(attachType)
-				emptyString(attachTypeArg)
+				emptyStringArg(attachTypeArg)
 				if err == nil {
 					attachTypeArg.Value = attachTypestr
 				}
 			}
 		}
 	case SecurityBpfProg:
-		if progTypeArg := GetArg(event, "type"); progTypeArg != nil {
+		if progTypeArg := getParsedArg(event, "type"); progTypeArg != nil {
 			if progType, isInt := progTypeArg.Value.(int32); isInt {
 				progTypeArgument, err := helpers.ParseBPFProgType(uint64(progType))
 				parseOrEmptyString(progTypeArg, progTypeArgument, err)
 			}
 		}
-		if helpersArg := GetArg(event, "helpers"); helpersArg != nil {
+		if helpersArg := getParsedArg(event, "helpers"); helpersArg != nil {
 			if helpersList, isUintSlice := helpersArg.Value.([]uint64); isUintSlice {
 				parsedHelpersList, err := parseBpfHelpersUsage(helpersList)
 				if err != nil {
@@ -283,7 +285,7 @@ func ParseArgs(event *trace.Event) error {
 }
 
 func ParseArgsFDs(event *trace.Event, fdArgPathMap *bpf.BPFMap) error {
-	if fdArg := GetArg(event, "fd"); fdArg != nil {
+	if fdArg := getParsedArg(event, "fd"); fdArg != nil {
 		if fd, isInt32 := fdArg.Value.(int32); isInt32 {
 			fdArgTask := &fdArgTask{
 				PID: uint32(event.ProcessID),
@@ -300,6 +302,15 @@ func ParseArgsFDs(event *trace.Event, fdArgPathMap *bpf.BPFMap) error {
 		}
 	}
 
+	return nil
+}
+
+func getParsedArg(event *trace.Event, argName string) *trace.Argument {
+	for i := range event.ParsedArgs {
+		if event.ParsedArgs[i].Name == argName {
+			return &event.ParsedArgs[i]
+		}
+	}
 	return nil
 }
 

--- a/pkg/events/parse_args_test.go
+++ b/pkg/events/parse_args_test.go
@@ -105,7 +105,7 @@ func TestParseArgs(t *testing.T) {
 			err := ParseArgs(&event)
 			require.NoError(t, err)
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(&event, expArg.Name)
+				arg := getParsedArg(&event, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		}
@@ -183,7 +183,7 @@ func TestParseArgs(t *testing.T) {
 			err := ParseArgs(event)
 			require.NoError(t, err)
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := getParsedArg(event, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		}

--- a/pkg/signatures/benchmark/signature/golang/code_injection.go
+++ b/pkg/signatures/benchmark/signature/golang/code_injection.go
@@ -65,11 +65,11 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	}
 	switch ee.EventName {
 	case "open", "openat":
-		flags, err := helpers.GetTraceeArgumentByName(ee, "flags", helpers.GetArgOps{DefaultArgs: false})
+		flags, err := helpers.GetTraceeIntArgumentByName(ee, "flags")
 		if err != nil {
 			return fmt.Errorf("%v %#v", err, ee)
 		}
-		if helpers.IsFileWrite(flags.Value.(string)) {
+		if helpers.IsFileWrite(flags) {
 			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname", helpers.GetArgOps{DefaultArgs: false})
 			if err != nil {
 				return err

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,12 +13,12 @@ import (
 
 type AntiDebuggingPtraceme struct {
 	cb            detect.SignatureHandler
-	ptraceTraceMe string
+	ptraceTraceMe int
 }
 
 func (sig *AntiDebuggingPtraceme) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptraceTraceMe = "PTRACE_TRACEME"
+	sig.ptraceTraceMe = int(libbpfgo.PTRACE_TRACEME.Value())
 	return nil
 }
 
@@ -52,7 +54,7 @@ func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/anti_debugging_ptraceme_test.go
+++ b/signatures/golang/anti_debugging_ptraceme_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_TRACEME"),
+							Value: interface{}(int64(helpers.PTRACE_TRACEME.Value())),
 						},
 					},
 				},
@@ -42,7 +44,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_TRACEME"),
+								Value: interface{}(int64(helpers.PTRACE_TRACEME.Value())),
 							},
 						},
 					}.ToProtocol(),
@@ -74,7 +76,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: interface{}(int64(helpers.PTRACE_PEEKTEXT.Value())),
 						},
 					},
 				},

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -57,7 +57,7 @@ func (sig *AslrInspection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/aslr_inspection_test.go
+++ b/signatures/golang/aslr_inspection_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestAslrInspection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -92,7 +94,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},
@@ -109,7 +111,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -59,7 +59,7 @@ func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) erro
 		}
 		basename := path.Base(pathname)
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_notify_on_release_modification_test.go
+++ b/signatures/golang/cgroup_notify_on_release_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -33,7 +35,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},
@@ -54,7 +56,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -92,7 +94,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 					},
 				},
@@ -115,7 +117,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -56,7 +56,7 @@ func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_release_agent_modification_test.go
+++ b/signatures/golang/cgroup_release_agent_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -33,7 +35,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},
@@ -54,7 +56,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -139,7 +141,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 					},
 				},
@@ -162,7 +164,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -58,7 +58,7 @@ func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/core_pattern_modification_test.go
+++ b/signatures/golang/core_pattern_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -33,7 +35,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -54,7 +56,7 @@ func TestCorePatternModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -92,7 +94,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -115,7 +117,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -59,7 +59,7 @@ func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/default_loader_modification_test.go
+++ b/signatures/golang/default_loader_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -33,7 +35,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -54,7 +56,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -139,7 +141,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -162,7 +164,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -61,7 +61,7 @@ func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/docker_abuse_test.go
+++ b/signatures/golang/docker_abuse_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -28,7 +30,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestDockerAbuse(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -138,7 +140,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -162,7 +164,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -11,12 +11,12 @@ import (
 
 type DynamicCodeLoading struct {
 	cb        detect.SignatureHandler
-	alertText string
+	alertType trace.MemProtAlert
 }
 
 func (sig *DynamicCodeLoading) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.alertText = "Protection changed from W to E!"
+	sig.alertType = trace.ProtAlertMprotectWXToX
 	return nil
 }
 
@@ -52,12 +52,13 @@ func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "mem_prot_alert":
-		alert, err := helpers.GetTraceeStringArgumentByName(eventObj, "alert")
+		alert, err := helpers.GetTraceeUintArgumentByName(eventObj, "alert")
 		if err != nil {
 			return err
 		}
+		memProtAlert := trace.MemProtAlert(alert)
 
-		if alert == sig.alertText {
+		if memProtAlert == sig.alertType {
 			metadata, err := sig.GetMetadata()
 			if err != nil {
 				return err

--- a/signatures/golang/dynamic_code_loading_test.go
+++ b/signatures/golang/dynamic_code_loading_test.go
@@ -27,7 +27,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed from W to E!"),
+							Value: uint32(trace.ProtAlertMprotectWXToX),
 						},
 					},
 				},
@@ -42,7 +42,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "alert",
 								},
-								Value: interface{}("Protection changed from W to E!"),
+								Value: uint32(trace.ProtAlertMprotectWXToX),
 							},
 						},
 					}.ToProtocol(),
@@ -74,7 +74,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed to Executable!"),
+							Value: uint32(trace.ProtAlertMmapWX),
 						},
 					},
 				},

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -70,7 +70,7 @@ func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/k8s_service_account_token_test.go
+++ b/signatures/golang/k8s_service_account_token_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -28,7 +30,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -89,7 +91,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -113,7 +115,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -137,7 +139,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/kernel_module_loading.go
+++ b/signatures/golang/kernel_module_loading.go
@@ -61,12 +61,12 @@ func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
 			Data:        nil,
 		})
 	case "security_kernel_read_file":
-		loadedType, err := helpers.GetTraceeStringArgumentByName(eventObj, "type")
+		loadedType, err := helpers.GetTraceeArgumentByName(eventObj, "type", helpers.GetArgOps{})
 		if err != nil {
 			return err
 		}
 
-		if loadedType == "kernel-module" {
+		if loadedType.Value.(trace.KernelReadType) == trace.KernelReadKernelModule {
 			metadata, err := sig.GetMetadata()
 			if err != nil {
 				return err

--- a/signatures/golang/kernel_module_loading_test.go
+++ b/signatures/golang/kernel_module_loading_test.go
@@ -58,7 +58,7 @@ func TestKernelModuleLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "type",
 							},
-							Value: interface{}("kernel-module"),
+							Value: trace.KernelReadKernelModule,
 						},
 					},
 				},
@@ -73,7 +73,7 @@ func TestKernelModuleLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "type",
 								},
-								Value: interface{}("kernel-module"),
+								Value: trace.KernelReadKernelModule,
 							},
 						},
 					}.ToProtocol(),
@@ -105,7 +105,7 @@ func TestKernelModuleLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "type",
 							},
-							Value: interface{}("firmware"),
+							Value: trace.KernelReadFirmware,
 						},
 					},
 				},

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -65,7 +65,7 @@ func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) erro
 			}
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/kubernetes_certificate_theft_attempt_test.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -28,7 +30,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -136,7 +138,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -160,7 +162,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -184,7 +186,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -85,7 +85,7 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ld_preload_test.go
+++ b/signatures/golang/ld_preload_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestLdPreload(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -192,7 +194,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -215,7 +217,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -58,7 +58,7 @@ func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_kcore_read_test.go
+++ b/signatures/golang/proc_kcore_read_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestProcKcoreRead(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -92,7 +94,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -115,7 +117,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -61,7 +61,7 @@ func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_access_test.go
+++ b/signatures/golang/proc_mem_access_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestProcMemAccess(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -86,7 +88,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +111,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -61,7 +61,7 @@ func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_code_injection_test.go
+++ b/signatures/golang/proc_mem_code_injection_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -86,7 +88,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +111,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,14 +13,14 @@ import (
 
 type PtraceCodeInjection struct {
 	cb             detect.SignatureHandler
-	ptracePokeText string
-	ptracePokeData string
+	ptracePokeText int
+	ptracePokeData int
 }
 
 func (sig *PtraceCodeInjection) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptracePokeText = "PTRACE_POKETEXT"
-	sig.ptracePokeData = "PTRACE_POKEDATA"
+	sig.ptracePokeText = int(libbpfgo.PTRACE_POKETEXT.Value())
+	sig.ptracePokeData = int(libbpfgo.PTRACE_POKEDATA.Value())
 	return nil
 }
 
@@ -54,7 +56,7 @@ func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ptrace_code_injection_test.go
+++ b/signatures/golang/ptrace_code_injection_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKETEXT"),
+							Value: int32(helpers.PTRACE_POKETEXT.Value()),
 						},
 					},
 				},
@@ -42,7 +44,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKETEXT"),
+								Value: int32(helpers.PTRACE_POKETEXT.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -74,7 +76,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKEDATA"),
+							Value: int32(helpers.PTRACE_POKEDATA.Value()),
 						},
 					},
 				},
@@ -89,7 +91,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKEDATA"),
+								Value: int32(helpers.PTRACE_POKEDATA.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -121,7 +123,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: int32(helpers.PTRACE_PEEKTEXT.Value()),
 						},
 					},
 				},

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -65,7 +65,7 @@ func (sig *RcdModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/rcd_modification_test.go
+++ b/signatures/golang/rcd_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -86,7 +88,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -107,7 +109,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -286,7 +288,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -309,7 +311,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -57,7 +57,7 @@ func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sched_debug_recon_test.go
+++ b/signatures/golang/sched_debug_recon_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestSchedDebugRecon(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -86,7 +88,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +111,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -65,7 +65,7 @@ func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/scheduled_task_modification_test.go
+++ b/signatures/golang/scheduled_task_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -27,7 +29,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -48,7 +50,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -86,7 +88,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -107,7 +109,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -286,7 +288,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -309,7 +311,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -59,7 +59,7 @@ func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 	switch eventObj.EventName {
 	case "security_file_open":
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sudoers_modification_test.go
+++ b/signatures/golang/sudoers_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -33,7 +35,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -54,7 +56,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -92,7 +94,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -113,7 +115,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -245,7 +247,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -268,7 +270,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -52,7 +52,7 @@ func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) err
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/system_request_key_config_modification_test.go
+++ b/signatures/golang/system_request_key_config_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -33,7 +35,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -54,7 +56,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -92,7 +94,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -115,7 +117,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/test_helpers.go
+++ b/signatures/golang/test_helpers.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/aquasecurity/libbpfgo/helpers"
+
+func buildFlagArgValue(flags ...helpers.SystemFunctionArgument) int32 {
+	var res int32
+	for _, flagVal := range flags {
+		res = res | int32(flagVal.Value())
+	}
+	return res
+}

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
 // IsFileWrite returns whether the passed file permissions string contains
 // o_wronly or o_rdwr
-func IsFileWrite(flags string) bool {
-	flagsLow := strings.ToLower(flags)
-	if strings.Contains(flagsLow, "o_wronly") || strings.Contains(flagsLow, "o_rdwr") {
+func IsFileWrite(flags int) bool {
+	accessMode := uint64(flags) & helpers.O_ACCMODE.Value()
+	if accessMode == helpers.O_WRONLY.Value() || accessMode == helpers.O_RDWR.Value() {
 		return true
 	}
 	return false
@@ -19,9 +21,10 @@ func IsFileWrite(flags string) bool {
 
 // IsFileRead returns whether the passed file permissions string contains
 // o_rdonly or o_rdwr
-func IsFileRead(flags string) bool {
-	flagsLow := strings.ToLower(flags)
-	if strings.Contains(flagsLow, "o_rdonly") || strings.Contains(flagsLow, "o_rdwr") {
+func IsFileRead(flags int) bool {
+	accessMode := uint64(flags) & helpers.O_ACCMODE.Value()
+
+	if accessMode == helpers.O_RDONLY.Value() || accessMode == helpers.O_RDWR.Value() {
 		return true
 	}
 	return false

--- a/signatures/rego/anti_debugging_ptraceme.rego
+++ b/signatures/rego/anti_debugging_ptraceme.rego
@@ -1,5 +1,7 @@
 package tracee.TRC_2
 
+import data.tracee.helpers
+
 __rego_metadoc__ := {
 	"id": "TRC-2",
 	"version": "0.1.0",
@@ -22,7 +24,6 @@ tracee_selected_events[eventSelector] {
 
 tracee_match {
 	input.eventName == "ptrace"
-	arg := input.args[_]
-	arg.name == "request"
-	arg.value == "PTRACE_TRACEME"
+	request := helpers.get_tracee_argument("request")
+	request == "PTRACE_TRACEME"
 }

--- a/signatures/rego/anti_debugging_ptraceme_test.rego
+++ b/signatures/rego/anti_debugging_ptraceme_test.rego
@@ -4,7 +4,7 @@ test_match_1 {
 	tracee_match with input as {
 		"eventName": "ptrace",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "request",
 			"value": "PTRACE_TRACEME",
 		}],
@@ -15,7 +15,7 @@ test_match_wrong_request {
 	not tracee_match with input as {
 		"eventName": "ptrace",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "request",
 			"value": "PTRACE_PEEKTEXT",
 		}],

--- a/signatures/rego/cgroup_release_agent_modification_test.rego
+++ b/signatures/rego/cgroup_release_agent_modification_test.rego
@@ -4,7 +4,7 @@ test_match_1 {
 	tracee_match with input as {
 		"eventName": "security_file_open",
 		"argsNum": 2,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "pathname",
 				"type": "const char*",
@@ -23,7 +23,7 @@ test_match_wrong_request {
 	not tracee_match with input as {
 		"eventName": "security_file_open",
 		"argsNum": 2,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "pathname",
 				"type": "const char*",

--- a/signatures/rego/code_injection_test.rego
+++ b/signatures/rego/code_injection_test.rego
@@ -4,7 +4,7 @@ test_match_1 {
 	tracee_match with input as {
 		"eventName": "ptrace",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "request",
 			"value": "PTRACE_POKETEXT",
 		}],
@@ -15,7 +15,7 @@ test_match_2 {
 	tracee_match with input as {
 		"eventName": "security_file_open",
 		"argsNum": 4,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "flags",
 				"value": "o_rdwr",
@@ -41,7 +41,7 @@ test_match_3 {
 		"eventName": "process_vm_writev",
 		"processId": 109,
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "pid",
 			"value": 101,
 		}],
@@ -52,7 +52,7 @@ test_match_wrong_request {
 	not tracee_match with input as {
 		"eventName": "ptrace",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "request",
 			"value": "PTRACE_PEEKDATA",
 		}],
@@ -63,7 +63,7 @@ test_match_wrong_pathname {
 	not tracee_match with input as {
 		"eventName": "security_file_open",
 		"argsNum": 4,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "flags",
 				"value": "o_rdwr",
@@ -89,7 +89,7 @@ test_match_pid {
 		"eventName": "process_vm_writev",
 		"processId": 101,
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "pid",
 			"value": 101,
 		}],

--- a/signatures/rego/disk_mount_test.rego
+++ b/signatures/rego/disk_mount_test.rego
@@ -6,7 +6,7 @@ test_match_1 {
 		"threadId": 8,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "dev_name",
 			"type": "const char*",
 			"value": "/dev/sda3",
@@ -20,7 +20,7 @@ test_match_2 {
 		"threadId": 8,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "dev_name",
 			"type": "const char*",
 			"value": "/dev/vda1",
@@ -34,7 +34,7 @@ test_match_wrong_device {
 		"threadId": 8,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "dev_name",
 			"type": "const char*",
 			"value": "/disk",
@@ -48,7 +48,7 @@ test_match_wrong_proc {
 		"threadId": 1,
 		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "dev_name",
 			"type": "const char*",
 			"value": "/dev/vda1",

--- a/signatures/rego/dropped_executable_test.rego
+++ b/signatures/rego/dropped_executable_test.rego
@@ -1,27 +1,57 @@
-package tracee.TRC_9
+package tracee.TRC_11
 
 test_match_1 {
-	tracee_match == {"file path": "new_file"} with input as {
-		"eventName": "magic_write",
-		"args": [
-			{
-				"name": "bytes",
-				"value": "f0VMRgIBAQAAAAAAAAAAAA==",
-			},
-			{
-				"name": "pathname",
-				"value": "new_file",
-			},
-		],
+	tracee_match with input as {
+		"processName": "mal",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/sda3",
+		}],
 	}
 }
 
-test_match_wrong_request {
+test_match_2 {
+	tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
+		}],
+	}
+}
+
+test_match_wrong_device {
 	not tracee_match with input as {
-		"eventName": "magic_write",
-		"args": [{
-			"name": "bytes",
-			"value": "fMMVMRgIBAQAAAAAAAAAAAA==",
+		"processName": "proc",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/disk",
+		}],
+	}
+}
+
+test_match_wrong_proc {
+	not tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 1,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
 		}],
 	}
 }

--- a/signatures/rego/dynamic_code_loading_test.rego
+++ b/signatures/rego/dynamic_code_loading_test.rego
@@ -4,7 +4,7 @@ test_match_1 {
 	tracee_match with input as {
 		"eventName": "mem_prot_alert",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "alert",
 			"value": "Protection changed from W to E!",
 		}],
@@ -15,7 +15,7 @@ test_match_wrong_message {
 	not tracee_match with input as {
 		"eventName": "mem_prot_alert",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "alert",
 			"value": "Protection changed to Executable!",
 		}],
@@ -26,7 +26,7 @@ test_match_wrong_event {
 	not tracee_match with input as {
 		"eventName": "ptrace",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "request",
 			"value": "PTRACE_PEEKDATA",
 		}],

--- a/signatures/rego/fileless_execution_test.rego
+++ b/signatures/rego/fileless_execution_test.rego
@@ -5,7 +5,7 @@ test_match_1 {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "someContainer",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "memfd://something/something",
 		}],
@@ -17,7 +17,7 @@ test_match_2 {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "someContainer",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "memfd:runc",
 		}],
@@ -29,7 +29,7 @@ test_match_3 {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "memfd://something/something",
 		}],
@@ -41,7 +41,7 @@ test_match_4 {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "memfd:runc",
 		}],
@@ -53,7 +53,7 @@ test_match_5 {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "someContainer",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "/dev/shm/something",
 		}],
@@ -65,7 +65,7 @@ test_match_6 {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "someContainer",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "/run/shm/something",
 		}],
@@ -77,7 +77,7 @@ test_match_wrong_pathname {
 		"eventName": "sched_process_exec",
 		"argsNum": 1,
 		"containerId": "someContainer",
-		"args": [{
+		"parsedArgs": [{
 			"name": "pathname",
 			"value": "/something/something",
 		}],

--- a/signatures/rego/helpers.rego
+++ b/signatures/rego/helpers.rego
@@ -1,7 +1,7 @@
 package tracee.helpers
 
 get_tracee_argument(arg_name) = res {
-	arg := input.args[_]
+	arg := input.parsedArgs[_]
 	arg.name == arg_name
 	res := arg.value
 }

--- a/signatures/rego/illegitimate_shell_test.rego
+++ b/signatures/rego/illegitimate_shell_test.rego
@@ -1,23 +1,57 @@
-package tracee.TRC_12
+package tracee.TRC_11
 
 test_match_1 {
 	tracee_match with input as {
-		"eventName": "security_bprm_check",
-		"processName": "apache2",
-		"args": [{
-			"name": "pathname",
-			"value": "/bin/dash",
+		"processName": "mal",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/sda3",
 		}],
 	}
 }
 
-test_match_wrong_request {
+test_match_2 {
+	tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
+		}],
+	}
+}
+
+test_match_wrong_device {
 	not tracee_match with input as {
-		"processName": "apache2",
-		"eventName": "security_bprm_check",
-		"args": [{
-			"name": "pathname",
-			"value": "/johnny_boy",
+		"processName": "proc",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/disk",
+		}],
+	}
+}
+
+test_match_wrong_proc {
+	not tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 1,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
 		}],
 	}
 }

--- a/signatures/rego/kernel_module_loading_test.rego
+++ b/signatures/rego/kernel_module_loading_test.rego
@@ -11,7 +11,7 @@ test_match_2 {
 	tracee_match with input as {
 		"eventName": "security_kernel_read_file",
 		"argsNum": 4,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "pathname",
 				"value": "/path/to/kernel/module.ko",
@@ -43,7 +43,7 @@ test_match_wrong_event {
 	not tracee_match with input as {
 		"eventName": "ptrace",
 		"argsNum": 1,
-		"args": [{
+		"parsedArgs": [{
 			"name": "request",
 			"value": "PTRACE_PEEKDATA",
 		}],
@@ -54,7 +54,7 @@ test_match_wrong_type {
 	not tracee_match with input as {
 		"eventName": "security_kernel_read_file",
 		"argsNum": 4,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "pathname",
 				"value": "/path/to/kernel/module.ko",

--- a/signatures/rego/kubernetes_certificate_theft_attempt_test.rego
+++ b/signatures/rego/kubernetes_certificate_theft_attempt_test.rego
@@ -1,35 +1,57 @@
-package tracee.TRC_10
+package tracee.TRC_11
 
 test_match_1 {
 	tracee_match with input as {
-		"eventName": "security_file_open",
-		"processName": "malware",
-		"args": [
-			{
-				"name": "flags",
-				"value": "O_RDONLY",
-			},
-			{
-				"name": "pathname",
-				"value": "/etc/kubernetes/pki/ca.crt",
-			},
-		],
+		"processName": "mal",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/sda3",
+		}],
 	}
 }
 
-test_match_wrong_request {
+test_match_2 {
+	tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
+		}],
+	}
+}
+
+test_match_wrong_device {
 	not tracee_match with input as {
-		"eventName": "security_file_open",
-		"processName": "kubelet",
-		"args": [
-			{
-				"name": "flags",
-				"value": "O_RDONLY",
-			},
-			{
-				"name": "pathname",
-				"value": "/etc/kubernetes/pki/ca.crt",
-			},
-		],
+		"processName": "proc",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/disk",
+		}],
+	}
+}
+
+test_match_wrong_proc {
+	not tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 1,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
+		}],
 	}
 }

--- a/signatures/rego/ld_preload_test.rego
+++ b/signatures/rego/ld_preload_test.rego
@@ -4,7 +4,7 @@ test_match_1 {
 	tracee_match with input as {
 		"eventName": "execve",
 		"argsNum": 2,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "envp",
 				"value": ["FOO=BAR", "LD_PRELOAD=/something"],
@@ -21,7 +21,7 @@ test_match_2 {
 	tracee_match with input as {
 		"eventName": "security_file_open",
 		"argsNum": 4,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "flags",
 				"value": "o_rdwr",
@@ -46,7 +46,7 @@ test_match_no_ld_preload {
 	not tracee_match with input as {
 		"eventName": "execve",
 		"argsNum": 2,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "envp",
 				"value": ["FOO=BAR"],
@@ -63,7 +63,7 @@ test_match_wrong_path {
 	not tracee_match with input as {
 		"eventName": "security_file_open",
 		"argsNum": 4,
-		"args": [
+		"parsedArgs": [
 			{
 				"name": "flags",
 				"value": "o_rdwr",

--- a/signatures/rego/proc_fops_hooking_test.rego
+++ b/signatures/rego/proc_fops_hooking_test.rego
@@ -1,23 +1,57 @@
-package tracee.TRC_16
+package tracee.TRC_11
 
-test_match_rootkit_output {
+test_match_1 {
 	tracee_match with input as {
-		"eventName": "hooked_proc_fops",
+		"processName": "mal",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
-			"name": "hooked_fops_pointers",
-			"value": [{"SymbolName": "struct file_operations pointer", "ModuleOwner": "phide"}, {"SymbolName": "iterate_shared", "ModuleOwner": "phide"}, {"SymbolName": "iterate", "ModuleOwner": "phide"}],
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/sda3",
 		}],
 	}
 }
 
-test_match_empty_array {
-	not tracee_match with input as {
-		"eventName": "hooked_proc_fops",
+test_match_2 {
+	tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
-			"name": "hooked_fops_pointers",
-			"value": [],
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
+		}],
+	}
+}
+
+test_match_wrong_device {
+	not tracee_match with input as {
+		"processName": "proc",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/disk",
+		}],
+	}
+}
+
+test_match_wrong_proc {
+	not tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 1,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
 		}],
 	}
 }

--- a/signatures/rego/syscall_table_hooking_test.rego
+++ b/signatures/rego/syscall_table_hooking_test.rego
@@ -1,34 +1,57 @@
-package tracee.TRC_15
+package tracee.TRC_11
 
-test_match_diamorphine_rootkit_output {
+test_match_1 {
 	tracee_match with input as {
-		"eventName": "hooked_syscalls",
+		"processName": "mal",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
-			"name": "hooked_syscalls",
-			"value": [{"SymbolName": "kill", "ModuleOwner": "diamorphine"}, {"SymbolName": "getdents", "ModuleOwner": "diamorphine"}, {"SymbolName": "getdents64", "ModuleOwner": "diamorphine"}],
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/sda3",
 		}],
 	}
 }
 
-test_match_custom_output {
+test_match_2 {
 	tracee_match with input as {
-		"eventName": "hooked_syscalls",
+		"processName": "runc:[init]",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
-			"name": "hooked_syscalls",
-			"value": [{"SymbolName": "open", "ModuleOwner": "diamorphine"}, {"SymbolName": "read", "ModuleOwner": "diamorphine"}],
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
 		}],
 	}
 }
 
-test_match_empty_array {
+test_match_wrong_device {
 	not tracee_match with input as {
-		"eventName": "hooked_syscalls",
+		"processName": "proc",
+		"threadId": 8,
+		"eventName": "security_sb_mount",
 		"argsNum": 1,
-		"args": [{
-			"name": "hooked_syscalls",
-			"value": [],
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/disk",
+		}],
+	}
+}
+
+test_match_wrong_proc {
+	not tracee_match with input as {
+		"processName": "runc:[init]",
+		"threadId": 1,
+		"eventName": "security_sb_mount",
+		"argsNum": 1,
+		"parsedArgs": [{
+			"name": "dev_name",
+			"type": "const char*",
+			"value": "/dev/vda1",
 		}],
 	}
 }

--- a/tests/e2e-inst-signatures/e2e-bpf_attach.go
+++ b/tests/e2e-inst-signatures/e2e-bpf_attach.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -48,14 +50,14 @@ func (sig *e2eBpfAttach) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		attachType, err := helpers.GetTraceeStringArgumentByName(eventObj, "attach_type")
+		attachType, err := helpers.GetTraceeIntArgumentByName(eventObj, "attach_type")
 		if err != nil {
 			return err
 		}
 
 		// check expected values from test for detection
 
-		if symbolName != "security_file_open" || attachType != "kprobe" {
+		if symbolName != "security_file_open" || attachType != int(libbpfgo.BPFProgTypeKprobe) {
 			return nil
 		}
 

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -43,6 +43,7 @@ type Event struct {
 	StackAddresses        []uint64     `json:"stackAddresses"`
 	ContextFlags          ContextFlags `json:"contextFlags"`
 	Args                  []Argument   `json:"args"` // Arguments are ordered according their appearance in the original event
+	ParsedArgs            []Argument   `json:"parsedArgs,omitempty"`
 	Metadata              *Metadata    `json:"metadata,omitempty"`
 }
 


### PR DESCRIPTION
### 1. Explain what the PR does

1. types: add separete ParsedArguments list
    
    Prepare for removing inline argument parsing.
    
    This was done in a separate list in order to make the choice between
    querying the parsed and non parsed list as seamless as possible.
    Since the list is a copy with inlined parsed arguments, it can be used
    just like the previous arguments list was just with a name change.
5.  events: parse arguments into separate list
    
    Populate the ParsedArguments list previously introduced.
    Use this list in the table printer for argument printing.

6. signatures: work without argument parsing
    
    Refactor the golang signatures and helpers to work without enabling
    -o option:parse-arguments in the CLI.
    
    This included changing the signatures themselves to use the libbpfgo
    helper package kernel constants where relevant and refactoring our own
    helpers package to work with non parsed arguments (for example flags).
    
    Additionally added in the GetTraceeArgumentByName helper an option to
    query the ParsedArguments list instead of the regular one.

7. signatures: make rego sigs work with parsed args
    
    Refactored the rego helpers and tests to use parsed arguments access.
    This means when running rego signatures and/or using our helpers tracee
    must be run with -o option:parse-arguments.

### 2. Explain how to test it

Tested by sanity testing some signatures for example
1. `anti_debugging` -> `strace ls`
2. `ld_preload` -> `sudo touch /etc/ld.so.preload`
3. `proc_fops_hooking` -> `phide rootkit`

For rego i've just updated the signatures and tests and made sure they pass.

Resolve #2177
Resolve #3008 
