### PR TITLE
Revive

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -53,6 +53,11 @@ runs:
         GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@latest
         sudo cp $HOME/go/bin/staticcheck /usr/bin/
       shell: bash
+    - name: Install revive
+      run: |
+        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/mgechev/revive@latest
+        sudo cp $HOME/go/bin/revive /usr/bin/
+      shell: bash
     - name: Install goimports-reviser
       run: |
         GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,6 +60,9 @@ jobs:
             gofmt -s -d .
             exit 1
           fi
+      - name: Lint (Revive)
+        run: |
+          make check-lint
       - name: Check Code Style
         run: |
           make check-fmt

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,28 +1,28 @@
 severity = "warning"
 confidence = 0.8
-errorCode = 0
-warningCode = 0
+errorCode = 1
+warningCode = 1
 
 # Enable all available rules
 enableAllRules = true
 
-# Disabled rules
 [rule.add-constant]
     Disabled = true
 [rule.argument-limit]
-    Disabled = true
+    Disabled = false
+    Arguments = [5]
 [rule.atomic]
-    Disabled = true
+    Disabled = false
 [rule.bare-return]
-    Disabled = true
+    Disabled = false
 [rule.banned-characters]
     Disabled = true
 [rule.blank-imports]
-    Disabled = true
+    Disabled = false
 [rule.bool-literal-in-expr]
-    Disabled = true
+    Disabled = false
 [rule.call-to-gc]
-    Disabled = true
+    Disabled = false
 [rule.confusing-naming]
     Disabled = true
 [rule.comment-spacings]
@@ -32,130 +32,121 @@ enableAllRules = true
 [rule.cognitive-complexity]
     Disabled = true
 [rule.constant-logical-expr]
-    Disabled = true
+    Disabled = false
 [rule.context-as-argument]
-    Disabled = true
+    Disabled = false
 [rule.context-keys-type]
-    Disabled = true
+    Disabled = false
 [rule.cyclomatic]
     Disabled = true
 [rule.datarace]
-    Disabled = true
+    Disabled = false
 [rule.deep-exit]
     Disabled = true
 [rule.defer]
-    Disabled = true
+    Disabled = false
 [rule.dot-imports]
-    Disabled = true
+    Disabled = false
 [rule.duplicated-imports]
-    Disabled = true
+    Disabled = false
 [rule.early-return]
-    Disabled = true
+    Disabled = false
 [rule.empty-block]
-    Disabled = true
+    Disabled = false
 [rule.empty-lines]
-    Disabled = true
+    Disabled = false
 [rule.error-naming]
-    Disabled = true
+    Disabled = false
 [rule.error-return]
-    Disabled = true
+    Disabled = false
 [rule.error-strings]
-    Disabled = true
+    Disabled = false
 [rule.errorf]
-    Disabled = true
+    Disabled = false
 [rule.exported]
-    Disabled = true
+    Disabled = true # TODO: add comments to exported functions
 [rule.file-header]
     Disabled = true
 [rule.flag-parameter]
     Disabled = true
 [rule.function-result-limit]
-    Disabled = true
+    Disabled = false
+    Arguments = [3]
 [rule.function-length]
     Disabled = true
 [rule.get-return]
-    Disabled = true
+    Disabled = false
 [rule.identical-branches]
-    Disabled = true
+    Disabled = false
 [rule.if-return]
-    Disabled = true
+    Disabled = false
 [rule.increment-decrement]
-    Disabled = true
+    Disabled = false
 [rule.indent-error-flow]
-    Disabled = true
+    Disabled = false
 [rule.imports-blacklist]
     Disabled = true
 [rule.import-shadowing]
-    Disabled = true
+    Disabled = false
 [rule.line-length-limit]
-    Disabled = true
+    Disabled = true # TODO: set max length to 100 max
 [rule.max-public-structs]
     Disabled = true
 [rule.modifies-parameter]
-    Disabled = true
+    Disabled = false
 [rule.modifies-value-receiver]
     Disabled = true
 [rule.nested-structs]
     Disabled = true
 [rule.optimize-operands-order]
-    Disabled = true
+    Disabled = false
 [rule.package-comments]
-    Disabled = true
+    Disabled = true # TODO: add comments to all packages
 [rule.range]
-    Disabled = true
+    Disabled = false
 [rule.range-val-in-closure]
-    Disabled = true
+    Disabled = false
 [rule.range-val-address]
-    Disabled = true
+    Disabled = false
 [rule.receiver-naming]
-    Disabled = true
+    Disabled = false
 [rule.redefines-builtin-id]
     Disabled = true
 [rule.string-of-int]
     Disabled = true
 [rule.struct-tag]
-    Disabled = true
+    Disabled = true # TODO: interesting to check
 [rule.string-format]
-    Disabled = true
+    Disabled = true # TODO: interesting to check
 [rule.superfluous-else]
-    Disabled = true
+    Disabled = false
 [rule.time-equal]
-    Disabled = true
+    Disabled = false
 [rule.time-naming]
-    Disabled = true
+    Disabled = false
 [rule.var-naming]
-    Disabled = true
+    Disabled = true # TODO: rename variables correctly
 [rule.var-declaration]
-    Disabled = true
+    Disabled = false
 [rule.unconditional-recursion]
-    Disabled = true
+    Disabled = false
 [rule.unexported-naming]
-    Disabled = true
+    Disabled = false
 [rule.unexported-return]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.unhandled-error]
-    Disabled = true
+    Disabled = true # TODO: already being done by errcheck (change ?)
 [rule.unnecessary-stmt]
     Disabled = true
 [rule.unreachable-code]
-    Disabled = true
+    Disabled = false
 [rule.unused-parameter]
     Disabled = true
 [rule.unused-receiver]
     Disabled = true
 [rule.use-any]
-    Disabled = true
+    Disabled = true # TODO: should we rename interface{} to any ?
 [rule.useless-break]
-    Disabled = true
+    Disabled = false
 [rule.waitgroup-by-value]
-    Disabled = true
-
-# Rule tunning
-# [rule.argument-limit]
-#     Arguments = [5]
-# [rule.cyclomatic]
-#     Arguments = [10]
-# [rule.cognitive-complexity]
-#     Arguments = [7]
-# [rule.function-result-limit]
-#     Arguments = [3]
+    Disabled = false

--- a/.revive.toml
+++ b/.revive.toml
@@ -1,0 +1,161 @@
+severity = "warning"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+# Enable all available rules
+enableAllRules = true
+
+# Disabled rules
+[rule.add-constant]
+    Disabled = true
+[rule.argument-limit]
+    Disabled = true
+[rule.atomic]
+    Disabled = true
+[rule.bare-return]
+    Disabled = true
+[rule.banned-characters]
+    Disabled = true
+[rule.blank-imports]
+    Disabled = true
+[rule.bool-literal-in-expr]
+    Disabled = true
+[rule.call-to-gc]
+    Disabled = true
+[rule.confusing-naming]
+    Disabled = true
+[rule.comment-spacings]
+    Disabled = false
+[rule.confusing-results]
+    Disabled = true
+[rule.cognitive-complexity]
+    Disabled = true
+[rule.constant-logical-expr]
+    Disabled = true
+[rule.context-as-argument]
+    Disabled = true
+[rule.context-keys-type]
+    Disabled = true
+[rule.cyclomatic]
+    Disabled = true
+[rule.datarace]
+    Disabled = true
+[rule.deep-exit]
+    Disabled = true
+[rule.defer]
+    Disabled = true
+[rule.dot-imports]
+    Disabled = true
+[rule.duplicated-imports]
+    Disabled = true
+[rule.early-return]
+    Disabled = true
+[rule.empty-block]
+    Disabled = true
+[rule.empty-lines]
+    Disabled = true
+[rule.error-naming]
+    Disabled = true
+[rule.error-return]
+    Disabled = true
+[rule.error-strings]
+    Disabled = true
+[rule.errorf]
+    Disabled = true
+[rule.exported]
+    Disabled = true
+[rule.file-header]
+    Disabled = true
+[rule.flag-parameter]
+    Disabled = true
+[rule.function-result-limit]
+    Disabled = true
+[rule.function-length]
+    Disabled = true
+[rule.get-return]
+    Disabled = true
+[rule.identical-branches]
+    Disabled = true
+[rule.if-return]
+    Disabled = true
+[rule.increment-decrement]
+    Disabled = true
+[rule.indent-error-flow]
+    Disabled = true
+[rule.imports-blacklist]
+    Disabled = true
+[rule.import-shadowing]
+    Disabled = true
+[rule.line-length-limit]
+    Disabled = true
+[rule.max-public-structs]
+    Disabled = true
+[rule.modifies-parameter]
+    Disabled = true
+[rule.modifies-value-receiver]
+    Disabled = true
+[rule.nested-structs]
+    Disabled = true
+[rule.optimize-operands-order]
+    Disabled = true
+[rule.package-comments]
+    Disabled = true
+[rule.range]
+    Disabled = true
+[rule.range-val-in-closure]
+    Disabled = true
+[rule.range-val-address]
+    Disabled = true
+[rule.receiver-naming]
+    Disabled = true
+[rule.redefines-builtin-id]
+    Disabled = true
+[rule.string-of-int]
+    Disabled = true
+[rule.struct-tag]
+    Disabled = true
+[rule.string-format]
+    Disabled = true
+[rule.superfluous-else]
+    Disabled = true
+[rule.time-equal]
+    Disabled = true
+[rule.time-naming]
+    Disabled = true
+[rule.var-naming]
+    Disabled = true
+[rule.var-declaration]
+    Disabled = true
+[rule.unconditional-recursion]
+    Disabled = true
+[rule.unexported-naming]
+    Disabled = true
+[rule.unexported-return]
+    Disabled = true
+[rule.unhandled-error]
+    Disabled = true
+[rule.unnecessary-stmt]
+    Disabled = true
+[rule.unreachable-code]
+    Disabled = true
+[rule.unused-parameter]
+    Disabled = true
+[rule.unused-receiver]
+    Disabled = true
+[rule.use-any]
+    Disabled = true
+[rule.useless-break]
+    Disabled = true
+[rule.waitgroup-by-value]
+    Disabled = true
+
+# Rule tunning
+# [rule.argument-limit]
+#     Arguments = [5]
+# [rule.cyclomatic]
+#     Arguments = [10]
+# [rule.cognitive-complexity]
+#     Arguments = [7]
+# [rule.function-result-limit]
+#     Arguments = [3]

--- a/Makefile
+++ b/Makefile
@@ -771,11 +771,17 @@ fix-fmt::
 #
 	@$(MAKE) -f builder/Makefile.checkers fmt-fix
 
+.PHONY: check-lint
+check-lint::
+#
+	@$(MAKE) -f builder/Makefile.checkers lint-check
+
 .PHONY: check-code
 check-code:: \
 	tracee-ebpf
 #
 	@$(MAKE) -f builder/Makefile.checkers code-check
+
 
 .PHONY: check-vet
 check-vet: \

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -45,6 +45,11 @@ RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticc
 RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest && \
     cp $HOME/go/bin/goimports-reviser /usr/bin/
 
+# install revive
+
+RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install github.com/mgechev/revive@latest && \
+    cp $HOME/go/bin/revive /usr/bin/
+
 # install errcheck
 
 RUN GOROOT=/usr/lib/go GOPATH=$HOME/go go install github.com/kisielk/errcheck@latest && \

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -79,6 +79,11 @@ RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/stati
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@latest && \
     cp $HOME/go/bin/goimports-reviser /usr/bin/
 
+# install revive
+
+RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/mgechev/revive@latest && \
+    cp $HOME/go/bin/revive /usr/bin/
+
 # install errcheck
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/kisielk/errcheck@latest && \

--- a/builder/Makefile.checkers
+++ b/builder/Makefile.checkers
@@ -23,13 +23,10 @@ CMD_SED ?= sed
 CMD_TR ?= tr
 CMD_FIND ?= find
 CMD_CLANG ?= clang
-# clang-format-12 is mandatory for now (enum declarations incompatibilities w/ 13 and newer)
-CMD_CLANG_FMT ?= clang-format-12
+CMD_CLANG_FMT ?= clang-format-12 # mandatory for now, incompatible with 13 and newer
 CMD_GOFMT ?= gofmt
-# goimports-reviser
 CMD_GOIMPORTS ?= goimports-reviser
-CMD_GOIMPORTS_COMPANY_PREFIXES ?= "github.com/aquasecurity"
-CMD_GOIMPORTS_PROJECT ?= "github.com/aquasecurity/tracee"
+CMD_REVIVE ?= revive
 
 .check_%:
 #
@@ -81,6 +78,9 @@ help:
 #
 
 C_FILES_TO_BE_CHECKED = $(shell find ./pkg/ebpf/c/ -regextype posix-extended -regex '.*\.(h|c)' | xargs)
+
+CMD_GOIMPORTS_COMPANY_PREFIXES ?= "github.com/aquasecurity"
+CMD_GOIMPORTS_PROJECT ?= "github.com/aquasecurity/tracee"
 
 .PHONY: fmt-check
 fmt-check: | \
@@ -139,6 +139,19 @@ fmt-check: | \
 		exit 1
 	fi
 	rm -f /tmp/check-go-fmt
+
+#
+# golang linting (revive)
+#
+
+.PHONY: lint-check
+lint-check: | \
+	.check_tree \
+	.check_$(CMD_REVIVE)
+#
+	@errors=0
+	echo "Linting golang code..."
+	$(CMD_REVIVE) -config .revive.toml ./...
 
 #
 # fix formatting (clang-format, goimports-reviser, gofmt)

--- a/cmd/tracee-bench/main.go
+++ b/cmd/tracee-bench/main.go
@@ -118,7 +118,6 @@ func main() {
 						}
 					case now := <-ticker.C:
 						{
-
 							measurement := measurement{}
 							wg := sync.WaitGroup{}
 							wg.Add((len(queries)))

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -24,7 +24,6 @@ func main() {
 		Usage:   "Trace OS events and syscalls using eBPF",
 		Version: version,
 		Action: func(c *cli.Context) error {
-
 			if c.NArg() > 0 {
 				return cli.ShowAppHelp(c) // no args, only flags supported
 			}
@@ -49,7 +48,6 @@ func main() {
 			defer stop()
 
 			return runner.Run(ctx)
-
 		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{

--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -96,9 +96,8 @@ func setupTraceeGobInputSource(opts *traceeInputOptions) (chan protocol.Event, e
 			if err != nil {
 				if err == io.EOF {
 					break
-				} else {
-					logger.Errorw("Decoding event: " + err.Error())
 				}
+				logger.Errorw("Decoding event: " + err.Error())
 			} else {
 				res <- event.ToProtocol()
 			}

--- a/cmd/tracee-rules/input.go
+++ b/cmd/tracee-rules/input.go
@@ -34,7 +34,6 @@ type traceeInputOptions struct {
 }
 
 func setupTraceeInputSource(opts *traceeInputOptions) (chan protocol.Event, error) {
-
 	if opts.inputFormat == jsonInputFormat {
 		return setupTraceeJSONInputSource(opts)
 	}
@@ -133,7 +132,6 @@ func setupTraceeJSONInputSource(opts *traceeInputOptions) (chan protocol.Event, 
 }
 
 func parseTraceeInputOptions(inputOptions []string) (*traceeInputOptions, error) {
-
 	var (
 		inputSourceOptions traceeInputOptions
 		err                error

--- a/cmd/tracee-rules/input_test.go
+++ b/cmd/tracee-rules/input_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestParseTraceeInputOptions(t *testing.T) {
-
 	testCases := []struct {
 		testName              string
 		optionStringSlice     []string
@@ -94,7 +93,6 @@ func TestParseTraceeInputOptions(t *testing.T) {
 }
 
 func TestSetupTraceeJSONInputSource(t *testing.T) {
-
 	testCases := []struct {
 		testName      string
 		events        []trace.Event
@@ -125,7 +123,6 @@ func TestSetupTraceeJSONInputSource(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-
 			// Setup temp file that tracee-rules reads from
 			f, err := os.CreateTemp("", "TestSetupTraceeJSONInputSource-")
 			if err != nil {
@@ -169,7 +166,6 @@ func TestSetupTraceeJSONInputSource(t *testing.T) {
 }
 
 func TestSetupTraceeGobInputSource(t *testing.T) {
-
 	testCases := []struct {
 		testName      string
 		events        []trace.Event
@@ -215,7 +211,6 @@ func TestSetupTraceeGobInputSource(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-
 			// Setup temp file that tracee-rules reads from
 			f, err := os.CreateTemp("", "TestSetupTraceeGobInputSource-")
 			if err != nil {

--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -32,7 +32,6 @@ func main() {
 		Name:  "tracee-rules",
 		Usage: "A rule engine for Runtime Security",
 		Action: func(c *cli.Context) error {
-
 			// Logger Setup
 			logger.Init(logger.NewDefaultLoggingConfig())
 

--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -205,7 +205,6 @@ func Test_sendToWebhook(t *testing.T) {
 				assert.NoError(t, actualError, tc.name)
 			}
 		})
-
 	}
 }
 
@@ -276,7 +275,6 @@ func TestOutputTemplates(t *testing.T) {
 			assert.JSONEq(t, tc.expectedJson, buf.String())
 		})
 	}
-
 }
 
 type SyncBuffer struct {

--- a/cmd/tracee/main_test.go
+++ b/cmd/tracee/main_test.go
@@ -65,7 +65,6 @@ func newFakeSignature(name string, deps []string) detect.Signature {
 			return detect.SignatureMetadata{
 				EventName: name,
 			}, nil
-
 		},
 		FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 			selectedEvents := make([]detect.SignatureEventSelector, 0, len(deps))

--- a/pkg/bucketscache/bucketscache.go
+++ b/pkg/bucketscache/bucketscache.go
@@ -56,11 +56,10 @@ func (c *BucketsCache) addBucketItem(key uint32, value uint32, force bool) {
 		c.bucketsMutex.Unlock()
 	}
 	if len(b) >= c.bucketLimit {
-		if force {
-			b[0] = value
-		} else {
+		if !force {
 			return
 		}
+		b[0] = value
 	} else {
 		c.bucketsMutex.Lock()
 		c.buckets[key] = append(b, value)

--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -206,7 +206,7 @@ func (decoder *EbpfDecoder) DecodeBool(msg *bool) error {
 		return errfmt.Errorf("can't read context from buffer: buffer too short")
 	}
 	*msg = (decoder.buffer[offset] != 0)
-	decoder.cursor += 1
+	decoder.cursor++
 	return nil
 }
 

--- a/pkg/bufferdecoder/decoder_test.go
+++ b/pkg/bufferdecoder/decoder_test.go
@@ -327,7 +327,6 @@ func TestDecodeIntArray(t *testing.T) {
 	assert.Equal(t, nil, err)
 	// checking decoding works as expected
 	assert.Equal(t, expected, obtained)
-
 }
 
 func TestDecodeSlimCred(t *testing.T) {
@@ -445,7 +444,6 @@ func TestDecodeMprotectWriteMeta(t *testing.T) {
 	err = d.DecodeMprotectWriteMeta(&obtained)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, expected, obtained)
-
 }
 
 func BenchmarkDecodeContext(*testing.B) {
@@ -926,7 +924,6 @@ func BenchmarkBinaryKernelModuleMeta(*testing.B) {
 }
 
 func BenchmarkDecodeMprotectWriteMeta(*testing.B) {
-
 	/*
 		s := MprotectWriteMeta{
 			Ts: 123,
@@ -944,7 +941,6 @@ func BenchmarkDecodeMprotectWriteMeta(*testing.B) {
 }
 
 func BenchmarkBinaryMprotectWriteMeta(*testing.B) {
-
 	/*
 		s := MprotectWriteMeta{
 			Ts: 123,

--- a/pkg/bufferdecoder/decoder_test.go
+++ b/pkg/bufferdecoder/decoder_test.go
@@ -249,7 +249,7 @@ func TestDecodeInt64(t *testing.T) {
 
 func TestDecodeBoolTrue(t *testing.T) {
 	buf := new(bytes.Buffer)
-	var expected bool = true
+	expected := true
 	err := binary.Write(buf, binary.LittleEndian, expected)
 	// checking no error
 	assert.Equal(t, nil, err)
@@ -269,7 +269,7 @@ func TestDecodeBoolTrue(t *testing.T) {
 
 func TestDecodeBoolFalse(t *testing.T) {
 	buf := new(bytes.Buffer)
-	var expected bool = false
+	expected := false
 	err := binary.Write(buf, binary.LittleEndian, expected)
 	// checking no error
 	assert.Equal(t, nil, err)
@@ -320,7 +320,7 @@ func TestDecodeIntArray(t *testing.T) {
 	var obtained [2]int32
 	err := decoder.DecodeIntArray(obtained[:], 2)
 	assert.Equal(t, nil, err)
-	var rawcp []byte = append(raw, 1, 2, 3, 4, 5, 6, 7, 8)
+	rawcp := append(raw, 1, 2, 3, 4, 5, 6, 7, 8)
 	dataBuff := bytes.NewBuffer(rawcp)
 	var expected [2]int32
 	err = binary.Read(dataBuff, binary.LittleEndian, &expected)

--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -108,7 +108,7 @@ func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.A
 	case credT:
 		var data SlimCred
 		err = ebpfMsgDecoder.DecodeSlimCred(&data)
-		res = trace.SlimCred(data) //here we cast to trace.SlimCred to ensure we send the public interface and not bufferdecoder.SlimCred
+		res = trace.SlimCred(data) // here we cast to trace.SlimCred to ensure we send the public interface and not bufferdecoder.SlimCred
 	case strT:
 		res, err = readStringFromBuff(ebpfMsgDecoder)
 	case strArrT:
@@ -291,7 +291,7 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 				sa_family_t    sin_family; // address family: AF_INET
 				in_port_t      sin_port;   // port in network byte order
 				struct in_addr sin_addr;   // internet address
-				// byte        padding[8]; //https://elixir.bootlin.com/linux/v4.20.17/source/include/uapi/linux/in.h#L232
+				// byte        padding[8];// https://elixir.bootlin.com/linux/v4.20.17/source/include/uapi/linux/in.h#L232
 			};
 			struct in_addr {
 				uint32_t       s_addr;     // address in network byte order
@@ -365,7 +365,7 @@ func readStringFromBuff(ebpfMsgDecoder *EbpfDecoder) (string, error) {
 	if size > 4096 {
 		return "", errfmt.Errorf("string size too big: %d", size)
 	}
-	res, err := ReadByteSliceFromBuff(ebpfMsgDecoder, int(size-1)) //last byte is string terminating null
+	res, err := ReadByteSliceFromBuff(ebpfMsgDecoder, int(size-1)) // last byte is string terminating null
 	defer func() {
 		var dummy int8
 		err := ebpfMsgDecoder.DecodeInt8(&dummy) // discard last byte which is string terminating null

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -20,7 +20,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "intT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, //-1
+				0xFF, 0xFF, 0xFF, 0xFF, // -1
 			},
 			params:      []trace.ArgMeta{{Type: "int", Name: "int0"}},
 			expectedArg: int32(-1),
@@ -28,7 +28,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "uintT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, //4294967295
+				0xFF, 0xFF, 0xFF, 0xFF, // 4294967295
 			},
 			params:      []trace.ArgMeta{{Type: "unsigned int", Name: "uint0"}},
 			expectedArg: uint32(4294967295),
@@ -36,7 +36,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "longT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //-1
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // -1
 			},
 			params:      []trace.ArgMeta{{Type: "long", Name: "long0"}},
 			expectedArg: int64(-1),
@@ -44,7 +44,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "ulongT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 18446744073709551615
 			},
 			params:      []trace.ArgMeta{{Type: "unsigned long", Name: "ulong0"}},
 			expectedArg: uint64(18446744073709551615),
@@ -52,7 +52,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "modeT",
 			input: []byte{0,
-				0xB6, 0x11, 0x0, 0x0, //0x000011B6 == 010666 == S_IFIFO|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH
+				0xB6, 0x11, 0x0, 0x0, // 0x000011B6 == 010666 == S_IFIFO|S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH
 			},
 			params:      []trace.ArgMeta{{Type: "mode_t", Name: "modeT0"}},
 			expectedArg: uint32(0x11b6),
@@ -60,7 +60,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "devT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, //4294967295
+				0xFF, 0xFF, 0xFF, 0xFF, // 4294967295
 			},
 			params:      []trace.ArgMeta{{Type: "dev_t", Name: "devT0"}},
 			expectedArg: uint32(4294967295),
@@ -68,7 +68,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "offT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 18446744073709551615
 			},
 			params:      []trace.ArgMeta{{Type: "off_t", Name: "offT0"}},
 			expectedArg: uint64(18446744073709551615),
@@ -76,7 +76,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "loffT",
 			input: []byte{0,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 18446744073709551615
 			},
 			params:      []trace.ArgMeta{{Type: "loff_t", Name: "loffT0"}},
 			expectedArg: uint64(18446744073709551615),
@@ -92,7 +92,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "strT",
 			input: []byte{0,
-				16, 0, 0, 0, //len=16
+				16, 0, 0, 0, // len=16
 				47, 117, 115, 114, 47, 98, 105, 110, 47, 100, 111, 99, 107, 101, 114, 0, // /usr/bin/docker
 			},
 			params:      []trace.ArgMeta{{Type: "const char*", Name: "str0"}},
@@ -101,11 +101,11 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "strArrT",
 			input: []byte{0,
-				2,          //element number
-				9, 0, 0, 0, //len=9
+				2,          // element number
+				9, 0, 0, 0, // len=9
 				47, 117, 115, 114, 47, 98, 105, 110, 0, // /usr/bin
-				7, 0, 0, 0, //len=7
-				100, 111, 99, 107, 101, 114, 0, //docker
+				7, 0, 0, 0, // len=7
+				100, 111, 99, 107, 101, 114, 0, // docker
 			},
 			params:      []trace.ArgMeta{{Type: "const char*const*", Name: "strArr0"}},
 			expectedArg: []string{"/usr/bin", "docker"},
@@ -113,10 +113,10 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "argsArrT",
 			input: []byte{0,
-				16, 0, 0, 0, //array len
-				2, 0, 0, 0, //number of arguments
+				16, 0, 0, 0, // array len
+				2, 0, 0, 0, // number of arguments
 				47, 117, 115, 114, 47, 98, 105, 110, 0, // /usr/bin
-				100, 111, 99, 107, 101, 114, 0, //docker
+				100, 111, 99, 107, 101, 114, 0, // docker
 			},
 			params:      []trace.ArgMeta{{Type: "const char**", Name: "argsArr0"}},
 			expectedArg: []string{"/usr/bin", "docker"},
@@ -124,10 +124,10 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "sockAddrT - AF_INET",
 			input: []byte{0,
-				2, 0, //sa_family=AF_INET
-				0xFF, 0xFF, //sin_port=65535
-				0xFF, 0xFF, 0xFF, 0xFF, //sin_addr=255.255.255.255
-				0, 0, 0, 0, 0, 0, 0, 0, //padding[8]
+				2, 0, // sa_family=AF_INET
+				0xFF, 0xFF, // sin_port=65535
+				0xFF, 0xFF, 0xFF, 0xFF, // sin_addr=255.255.255.255
+				0, 0, 0, 0, 0, 0, 0, 0, // padding[8]
 			},
 			params:      []trace.ArgMeta{{Type: "struct sockaddr*", Name: "sockAddr0"}},
 			expectedArg: map[string]string(map[string]string{"sa_family": "AF_INET", "sin_addr": "255.255.255.255", "sin_port": "65535"}),
@@ -135,7 +135,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "sockAddrT - AF_UNIX",
 			input: []byte{0,
-				1, 0, //sa_family=AF_UNIX
+				1, 0, // sa_family=AF_UNIX
 				47, 116, 109, 112, 47, 115, 111, 99, 107, 101, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 101, 110, 0, 0, 0, // sun_path=/tmp/socket
 			},
 			params:      []trace.ArgMeta{{Type: "struct sockaddr*", Name: "sockAddr0"}},
@@ -149,7 +149,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "strT too big",
 			input: []byte{0,
-				0, 0, 0, 1, //len=16777216
+				0, 0, 0, 1, // len=16777216
 			},
 			params:        []trace.ArgMeta{{Type: "const char*", Name: "str0"}},
 			expectedError: errors.New("string size too big: 16777216"),
@@ -157,7 +157,7 @@ func TestReadArgFromBuff(t *testing.T) {
 		{
 			name: "multiple params",
 			input: []byte{1,
-				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, //18446744073709551615
+				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 18446744073709551615
 			},
 			params:      []trace.ArgMeta{{Type: "const char*", Name: "str0"}, {Type: "off_t", Name: "offT1"}},
 			expectedArg: uint64(18446744073709551615),

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -175,9 +175,8 @@ func TestReadArgFromBuff(t *testing.T) {
 
 		if tc.name == "unknown" {
 			continue
-		} else {
-			assert.Empty(t, decoder.BuffLen()-decoder.ReadAmountBytes(), tc.name) // passed in buffer should be emptied out
 		}
+		assert.Empty(t, decoder.BuffLen()-decoder.ReadAmountBytes(), tc.name) // passed in buffer should be emptied out
 	}
 }
 

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -37,14 +37,14 @@ type Context struct {
 	Comm            [16]byte
 	UtsName         [16]byte
 	Flags           uint32
-	EventID         events.ID //int32
+	EventID         events.ID // int32
 	Syscall         int32
 	MatchedPolicies uint64
 	Retval          int64
 	StackID         uint32
 	ProcessorId     uint16
 	Argnum          uint8
-	_               [1]byte //padding
+	_               [1]byte // padding
 }
 
 func (Context) GetSizeBytes() uint32 {

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -53,8 +53,8 @@ func GetInstance() *Capabilities {
 		if err != nil {
 			return nil
 		}
-
 	}
+
 	return caps
 }
 

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -382,8 +382,8 @@ func (c *Capabilities) apply(t RingType) error {
 // Error Functions
 //
 
-func couldNotFindCapability(cap string) error {
-	return fmt.Errorf("could not find capability: %v", cap)
+func couldNotFindCapability(c string) error {
+	return fmt.Errorf("could not find capability: %v", c)
 }
 
 func couldNotReadPerfEventParanoid() error {

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -444,16 +444,16 @@ func getKernelPerfEventParanoidValue() (int, error) {
 	//  2 = disallow kernel profiling for unpriv
 	//  4 = disallow all unpriv perf event use (not in all distros)
 	//
-	const MaxParanoiaLevel = 4
+	const maxParanoiaLevel = 4
 
 	value, err := os.ReadFile("/proc/sys/kernel/perf_event_paranoid")
 	if err != nil {
-		return MaxParanoiaLevel, couldNotReadPerfEventParanoid()
+		return maxParanoiaLevel, couldNotReadPerfEventParanoid()
 	}
 
 	intVal, err := strconv.ParseInt(strings.TrimSuffix(string(value), "\n"), 0, 16)
 	if err != nil {
-		return MaxParanoiaLevel, couldNotReadPerfEventParanoid()
+		return maxParanoiaLevel, couldNotReadPerfEventParanoid()
 	}
 
 	return int(intVal), nil

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -88,7 +88,6 @@ func NewCgroups() (*Cgroups, error) {
 	// at least one (or both) has to be supported
 	if cgroupv1 == nil && cgroupv2 == nil {
 		return nil, NoCgroupSupport()
-
 	}
 
 	hid := 0
@@ -191,7 +190,6 @@ type CgroupV1 struct {
 }
 
 func (c *CgroupV1) init() error {
-
 	// 0. check if cgroup type is supported
 	supported, err := mount.IsFileSystemSupported(CgroupVersion1.String())
 	if err != nil {

--- a/pkg/cgroup/errors.go
+++ b/pkg/cgroup/errors.go
@@ -22,5 +22,4 @@ func ErrorParsingFile(file string, err error) error {
 
 func CouldNotOpenFile(file string, err error) error {
 	return fmt.Errorf("could not open %s: %w", file, err)
-
 }

--- a/pkg/cmd/flags/capabilities.go
+++ b/pkg/cmd/flags/capabilities.go
@@ -9,7 +9,6 @@ import (
 )
 
 func capabilitiesHelp() string {
-
 	availCaps := strings.Join(capabilities.ListAvailCaps(), "\n  ")
 
 	return `

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -83,37 +83,37 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 
 	var filterFileWrite []string
 	for i := range captureSlice {
-		cap := captureSlice[i]
-		if strings.HasPrefix(cap, "artifact:write") ||
-			strings.HasPrefix(cap, "artifact:exec") ||
-			strings.HasPrefix(cap, "artifact:mem") ||
-			strings.HasPrefix(cap, "artifact:module") {
-			cap = strings.TrimPrefix(cap, "artifact:")
+		c := captureSlice[i]
+		if strings.HasPrefix(c, "artifact:write") ||
+			strings.HasPrefix(c, "artifact:exec") ||
+			strings.HasPrefix(c, "artifact:mem") ||
+			strings.HasPrefix(c, "artifact:module") {
+			c = strings.TrimPrefix(c, "artifact:")
 		}
-		if cap == "write" {
+		if c == "write" {
 			capture.FileWrite = true
-		} else if strings.HasPrefix(cap, "write=") && strings.HasSuffix(cap, "*") {
+		} else if strings.HasPrefix(c, "write=") && strings.HasSuffix(c, "*") {
 			capture.FileWrite = true
-			pathPrefix := strings.TrimSuffix(strings.TrimPrefix(cap, "write="), "*")
+			pathPrefix := strings.TrimSuffix(strings.TrimPrefix(c, "write="), "*")
 			if len(pathPrefix) == 0 {
 				return tracee.CaptureConfig{}, errfmt.Errorf("capture write filter cannot be empty")
 			}
 			filterFileWrite = append(filterFileWrite, pathPrefix)
-		} else if cap == "exec" {
+		} else if c == "exec" {
 			capture.Exec = true
-		} else if cap == "module" {
+		} else if c == "module" {
 			capture.Module = true
-		} else if cap == "mem" {
+		} else if c == "mem" {
 			capture.Mem = true
-		} else if cap == "bpf" {
+		} else if c == "bpf" {
 			capture.Bpf = true
-		} else if cap == "network" || cap == "net" || cap == "pcap" {
+		} else if c == "network" || c == "net" || c == "pcap" {
 			// default capture mode: a single pcap file with all traffic
 			capture.Net.CaptureSingle = true
 			capture.Net.CaptureLength = 96 // default payload
-		} else if strings.HasPrefix(cap, "pcap:") {
+		} else if strings.HasPrefix(c, "pcap:") {
 			capture.Net.CaptureSingle = false // remove default mode
-			context := strings.TrimPrefix(cap, "pcap:")
+			context := strings.TrimPrefix(c, "pcap:")
 			fields := strings.Split(context, ",")
 			for _, field := range fields {
 				if field == "single" {
@@ -130,16 +130,16 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 				}
 			}
 			capture.Net.CaptureLength = 96 // default payload
-		} else if strings.HasPrefix(cap, "pcap-options:") {
-			context := strings.TrimPrefix(cap, "pcap-options:")
+		} else if strings.HasPrefix(c, "pcap-options:") {
+			context := strings.TrimPrefix(c, "pcap-options:")
 			context = strings.ToLower(context) // normalize
 			if context == "none" {
 				capture.Net.CaptureFiltered = false // proforma
 			} else if context == "filtered" {
 				capture.Net.CaptureFiltered = true
 			}
-		} else if strings.HasPrefix(cap, "pcap-snaplen:") {
-			context := strings.TrimPrefix(cap, "pcap-snaplen:")
+		} else if strings.HasPrefix(c, "pcap-snaplen:") {
+			context := strings.TrimPrefix(c, "pcap-snaplen:")
 			var amount uint64
 			var err error
 			context = strings.ToLower(context) // normalize
@@ -168,10 +168,10 @@ func PrepareCapture(captureSlice []string) (tracee.CaptureConfig, error) {
 				amount = (1 << 16) - 1
 			}
 			capture.Net.CaptureLength = uint32(amount) // of packet length to be captured in bytes
-		} else if cap == "clear-dir" {
+		} else if c == "clear-dir" {
 			clearDir = true
-		} else if strings.HasPrefix(cap, "dir:") {
-			outDir = strings.TrimPrefix(cap, "dir:")
+		} else if strings.HasPrefix(c, "dir:") {
+			outDir = strings.TrimPrefix(c, "dir:")
 			if len(outDir) == 0 {
 				return tracee.CaptureConfig{}, errfmt.Errorf("capture output dir cannot be empty")
 			}

--- a/pkg/cmd/flags/filter_map.go
+++ b/pkg/cmd/flags/filter_map.go
@@ -33,7 +33,6 @@ func parseFilterFlag(flag string) (*filterFlag, error) {
 
 	if operatorIdx == -1 || // no operator, as a set flag
 		(operatorIdx == 0 && flag[0] == '!') { // negation, as an unset flag
-
 		return &filterFlag{
 			full:              flag,
 			filterName:        flag,
@@ -62,7 +61,6 @@ func parseFilterFlag(flag string) (*filterFlag, error) {
 
 	if strings.HasPrefix(value, " ") || strings.HasPrefix(value, "\t") ||
 		strings.HasSuffix(value, " ") || strings.HasSuffix(value, "\t") {
-
 		return nil, errfmt.WrapError(InvalidFlagValue(flag))
 	}
 

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -1281,7 +1281,6 @@ func TestPrepareOutput(t *testing.T) {
 				assert.Equal(t, testcase.expectedOutput.TraceeConfig, output.TraceeConfig)
 
 				assertPrinterConfigs(t, testcase.expectedOutput.PrinterConfigs, output.PrinterConfigs)
-
 			}
 		})
 	}

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -40,7 +40,6 @@ func PrepareLogger(logOptions []string) (logger.LoggingConfig, error) {
 	)
 
 	for _, opt := range logOptions {
-
 		if strings.HasPrefix(opt, "file") {
 			vals := strings.Split(opt, ":")
 

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -66,7 +66,7 @@ func PrepareOutput(outputSlice []string) (OutputConfig, error) {
 	outConfig := OutputConfig{}
 	traceeConfig := &tracee.OutputConfig{}
 
-	//outpath:format
+	// outpath:format
 	printerMap := make(map[string]string)
 
 	for _, o := range outputSlice {

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -196,7 +196,6 @@ func parseFormat(outputParts []string, printerMap map[string]string) error {
 	}
 
 	for _, outPath := range strings.Split(outputParts[1], ",") {
-
 		if outPath == "" {
 			return errfmt.Errorf("format flag can't be empty, use '--output help' for more info")
 		}

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -102,7 +102,7 @@ func PrepareFilterMapFromPolicies(policies []PolicyFile) (FilterMap, error) {
 			})
 		}
 
-		events := make(map[string]bool)
+		evts := make(map[string]bool)
 
 		for _, r := range p.Rules {
 			err := validateEvent(p.Name, r.Event)
@@ -112,11 +112,11 @@ func PrepareFilterMapFromPolicies(policies []PolicyFile) (FilterMap, error) {
 
 			// Currently, an event can only be used once in the policy. Support for using the same
 			// event, multiple times, with different filters, shall be implemented in the future.
-			if _, ok := events[r.Event]; ok {
+			if _, ok := evts[r.Event]; ok {
 				return nil, errfmt.Errorf("policy %s, event %s is duplicated", p.Name, r.Event)
 			}
 
-			events[r.Event] = true
+			evts[r.Event] = true
 
 			filterFlags = append(filterFlags, &filterFlag{
 				full:              fmt.Sprintf("event=%s", r.Event),

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -1393,7 +1393,6 @@ func TestPolicyEventFilter(t *testing.T) {
 			for k, v := range test.expected {
 				assert.Equal(t, v, filterMap[k])
 			}
-
 		})
 	}
 }

--- a/pkg/cmd/gptdocs.go
+++ b/pkg/cmd/gptdocs.go
@@ -43,7 +43,6 @@ type WorkRet struct {
 var once sync.Once
 
 func (r GPTDocsRunner) Run(ctx context.Context) error {
-
 	template, err := os.ReadFile(eventsTemplate)
 	if err != nil {
 		return fmt.Errorf("error reading events template: %v", err)
@@ -177,7 +176,6 @@ func (r GPTDocsRunner) GenerateSyscall(
 ) (
 	string, error,
 ) {
-
 	once.Do(func() {
 		if os.MkdirAll(outputDirectory, 0755) != nil {
 			logger.Errorw("Error creating output directory")

--- a/pkg/cmd/initialize/bpfobject.go
+++ b/pkg/cmd/initialize/bpfobject.go
@@ -21,7 +21,7 @@ import (
 // installation path and a version string. The function unpacks the CO-RE eBPF
 // object binary, checks if BTF is enabled, unpacks the BTF file from BTF Hub if
 // necessary, and assigns the kernel configuration and BPF object bytes.
-func BpfObject(config *tracee.Config, kConfig *helpers.KernelConfig, OSInfo *helpers.OSInfo, installPath string, version string) error {
+func BpfObject(config *tracee.Config, kConfig *helpers.KernelConfig, osInfo *helpers.OSInfo, installPath string, version string) error {
 	btfFilePath, err := checkEnvPath("TRACEE_BTF_FILE")
 	if btfFilePath == "" && err != nil {
 		return errfmt.WrapError(err)
@@ -39,7 +39,7 @@ func BpfObject(config *tracee.Config, kConfig *helpers.KernelConfig, OSInfo *hel
 	// BTF unavailable: check embedded BTF files
 	if !helpers.OSBTFEnabled() && btfFilePath != "" {
 		unpackBTFFile := filepath.Join(installPath, "/tracee.btf")
-		err = unpackBTFHub(unpackBTFFile, OSInfo)
+		err = unpackBTFHub(unpackBTFFile, osInfo)
 		if err == nil {
 			logger.Debugw("BTF: btfhub embedded BTF file", "file", unpackBTFFile)
 			config.BTFObjPath = unpackBTFFile
@@ -82,13 +82,13 @@ func unpackCOREBinary() ([]byte, error) {
 // an OSInfo struct containing information about the OS, including OS ID,
 // version ID, kernel release, and architecture. It returns an error if any of
 // the directory creation, file opening, or file copying operations fail.
-func unpackBTFHub(outFilePath string, OSInfo *helpers.OSInfo) error {
+func unpackBTFHub(outFilePath string, osInfo *helpers.OSInfo) error {
 	var btfFilePath string
 
-	osId := OSInfo.GetOSReleaseFieldValue(helpers.OS_ID)
-	versionId := strings.Replace(OSInfo.GetOSReleaseFieldValue(helpers.OS_VERSION_ID), "\"", "", -1)
-	kernelRelease := OSInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE)
-	arch := OSInfo.GetOSReleaseFieldValue(helpers.OS_ARCH)
+	osId := osInfo.GetOSReleaseFieldValue(helpers.OS_ID)
+	versionId := strings.Replace(osInfo.GetOSReleaseFieldValue(helpers.OS_VERSION_ID), "\"", "", -1)
+	kernelRelease := osInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE)
+	arch := osInfo.GetOSReleaseFieldValue(helpers.OS_ARCH)
 
 	if err := os.MkdirAll(filepath.Dir(outFilePath), 0755); err != nil {
 		return errfmt.Errorf("could not create temp dir: %s", err.Error())

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -365,15 +365,15 @@ type templateEventPrinter struct {
 
 func (p *templateEventPrinter) Init() error {
 	tmplPath := p.templatePath
-	if tmplPath != "" {
-		tmpl, err := template.ParseFiles(tmplPath)
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
-		p.templateObj = &tmpl
-	} else {
+	if tmplPath == "" {
 		return errfmt.Errorf("please specify a gotemplate for event-based output")
 	}
+	tmpl, err := template.ParseFiles(tmplPath)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+	p.templateObj = &tmpl
+
 	return nil
 }
 

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -155,5 +155,5 @@ func getPad(padChar string, padLength int) (pad string) {
 	for i := 0; i < padLength; i++ {
 		pad += padChar
 	}
-	return
+	return pad
 }

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -156,7 +156,6 @@ func GetTraceeRunner(c *cli.Context, version string, newBinary bool) (cmd.Runner
 	}
 	if err == nil && lockdown == helpers.CONFIDENTIALITY {
 		return runner, errfmt.Errorf("kernel lockdown is set to 'confidentiality', can't load eBPF programs")
-
 	}
 
 	logger.Debugw("OSInfo", "security_lockdown", lockdown)
@@ -276,9 +275,7 @@ func getPolicies(paths []string) ([]flags.PolicyFile, error) {
 			}
 
 			// TODO: support json
-			if strings.HasSuffix(file.Name(), ".yaml") ||
-				strings.HasSuffix(file.Name(), ".yml") {
-
+			if strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml") {
 				policy, err := getPoliciesFromFile(filepath.Join(path, file.Name()))
 				if err != nil {
 					return nil, err

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -57,19 +57,19 @@ func GetTraceeRunner(c *cli.Context, version string, newBinary bool) (cmd.Runner
 
 	// OS release information
 
-	OSInfo, err := helpers.GetOSInfo()
+	osInfo, err := helpers.GetOSInfo()
 	if err != nil {
 		logger.Debugw("OSInfo", "warning: os-release file could not be found", "error", err) // only to be enforced when BTF needs to be downloaded, later on
-		logger.Debugw("OSInfo", "os_release_field", helpers.OS_KERNEL_RELEASE, "OS_KERNEL_RELEASE", OSInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE))
+		logger.Debugw("OSInfo", "os_release_field", helpers.OS_KERNEL_RELEASE, "OS_KERNEL_RELEASE", osInfo.GetOSReleaseFieldValue(helpers.OS_KERNEL_RELEASE))
 	} else {
 		osInfoSlice := make([]interface{}, 0)
-		for k, v := range OSInfo.GetOSReleaseAllFieldValues() {
+		for k, v := range osInfo.GetOSReleaseAllFieldValues() {
 			osInfoSlice = append(osInfoSlice, k.String(), v)
 		}
 		logger.Debugw("OSInfo", osInfoSlice...)
 	}
 
-	cfg.OSInfo = OSInfo
+	cfg.OSInfo = osInfo
 
 	// Container Runtime command line flags
 
@@ -180,7 +180,7 @@ func GetTraceeRunner(c *cli.Context, version string, newBinary bool) (cmd.Runner
 	// Decide BTF & BPF files to use (based in the kconfig, release & environment info)
 
 	traceeInstallPath := c.String("install-path")
-	err = initialize.BpfObject(&cfg, kernelConfig, OSInfo, traceeInstallPath, version)
+	err = initialize.BpfObject(&cfg, kernelConfig, osInfo, traceeInstallPath, version)
 	if err != nil {
 		return runner, errfmt.Errorf("failed preparing BPF object: %v", err)
 	}

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -130,7 +130,6 @@ func GetContainerIdFromTaskDir(taskPath string) (string, error) {
 
 // populate walks the cgroup fs informing CgroupUpdate() about existing dirs.
 func (c *Containers) populate() error {
-
 	fn := func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			logger.Errorw("WalkDir func", "error", err)

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -206,7 +206,7 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 	// There might be a performance overhead with the cancel
 	// But, I think it will be negligible since this code path shouldn't be reached too frequently
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	metadata, err := c.enricher.Get(containerId, runtime, ctx)
+	metadata, err := c.enricher.Get(ctx, containerId, runtime)
 	defer cancel()
 	// if enrichment fails, just return early
 	if err != nil {

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -61,7 +61,7 @@ func New(
 
 	runtimeService := RuntimeInfoService(sockets)
 
-	//attempt to register for all supported runtimes
+	// attempt to register for all supported runtimes
 	err := runtimeService.Register(cruntime.Containerd, cruntime.ContainerdEnricher)
 	if err != nil {
 		logger.Debugw("Enricher", "error", err)
@@ -191,7 +191,7 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 	info, ok := c.cgroupsMap[uint32(cgroupId)]
 	c.mtx.RUnlock()
 
-	//if there is no cgroup anymore for some reason, return early
+	// if there is no cgroup anymore for some reason, return early
 	if !ok {
 		return metadata, errfmt.Errorf("no cgroup to enrich")
 	}
@@ -203,20 +203,20 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 		return metadata, errfmt.Errorf("no containerId")
 	}
 
-	//There might be a performance overhead with the cancel
-	//But, I think it will be negligible since this code path shouldn't be reached too frequently
+	// There might be a performance overhead with the cancel
+	// But, I think it will be negligible since this code path shouldn't be reached too frequently
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	metadata, err := c.enricher.Get(containerId, runtime, ctx)
 	defer cancel()
-	//if enrichment fails, just return early
+	// if enrichment fails, just return early
 	if err != nil {
 		return metadata, errfmt.WrapError(err)
 	}
 
 	info.Container = metadata
 	c.mtx.Lock()
-	//we read the dictionary again to make sure the cgroup still exists
-	//otherwise we risk reintroducing it despite not existing
+	// we read the dictionary again to make sure the cgroup still exists
+	// otherwise we risk reintroducing it despite not existing
 	_, ok = c.cgroupsMap[uint32(cgroupId)]
 	if ok {
 		c.cgroupsMap[uint32(cgroupId)] = info

--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -44,7 +44,6 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 	pids := cPathRes.mountNSPIDsCache.GetBucket(uint32(mountNS))
 
 	for _, pid := range pids {
-
 		// cap.SYS_PTRACE is needed here. Instead of raising privileges, since
 		// this is called too frequently, if the needed event is being traced,
 		// the needed capabilities are added to the Base ring and are always set

--- a/pkg/containers/path_resolver_test.go
+++ b/pkg/containers/path_resolver_test.go
@@ -149,5 +149,4 @@ func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
 			})
 		}
 	})
-
 }

--- a/pkg/containers/runtime/containerd.go
+++ b/pkg/containers/runtime/containerd.go
@@ -45,7 +45,7 @@ func ContainerdEnricher(socket string) (ContainerEnricher, error) {
 	return &enricher, nil
 }
 
-func (e *containerdEnricher) Get(containerId string, ctx context.Context) (ContainerMetadata, error) {
+func (e *containerdEnricher) Get(ctx context.Context, containerId string) (ContainerMetadata, error) {
 	metadata := ContainerMetadata{
 		ContainerId: containerId,
 	}

--- a/pkg/containers/runtime/containerd.go
+++ b/pkg/containers/runtime/containerd.go
@@ -57,13 +57,13 @@ func (e *containerdEnricher) Get(containerId string, ctx context.Context) (Conta
 		nsCtx := namespaces.WithNamespace(ctx, namespace)
 		container, err := e.containers.Get(nsCtx, containerId)
 		if err != nil {
-			//if containers is not in current namespace, search the next one
+			// if containers is not in current namespace, search the next one
 			continue
 		} else {
 			imageName := container.Image
 			imageDigest := container.Image
 			image := container.Image
-			//container may not have image name as id, if so fetch from the sha256 id
+			// container may not have image name as id, if so fetch from the sha256 id
 			if strings.HasPrefix(image, "sha256:") {
 				imageInfo, err := e.images.ImageStatus(ctx, &cri.ImageStatusRequest{
 					Image: &cri.ImageSpec{
@@ -83,7 +83,7 @@ func (e *containerdEnricher) Get(containerId string, ctx context.Context) (Conta
 				}
 			}
 
-			//if in k8s we can extract pod info from labels
+			// if in k8s we can extract pod info from labels
 			if container.Labels != nil {
 				labels := container.Labels
 
@@ -94,7 +94,7 @@ func (e *containerdEnricher) Get(containerId string, ctx context.Context) (Conta
 					Sandbox:   e.isSandbox(labels),
 				}
 
-				//containerd containers normally have no names unless set from k8s
+				// containerd containers normally have no names unless set from k8s
 				metadata.Name = labels[ContainerNameLabel]
 			}
 			metadata.Image = imageName

--- a/pkg/containers/runtime/crio.go
+++ b/pkg/containers/runtime/crio.go
@@ -30,7 +30,7 @@ func CrioEnricher(socket string) (ContainerEnricher, error) {
 	return enricher, nil
 }
 
-func (e *crioEnricher) Get(containerId string, ctx context.Context) (ContainerMetadata, error) {
+func (e *crioEnricher) Get(ctx context.Context, containerId string) (ContainerMetadata, error) {
 	metadata := ContainerMetadata{
 		ContainerId: containerId,
 	}

--- a/pkg/containers/runtime/crio.go
+++ b/pkg/containers/runtime/crio.go
@@ -42,7 +42,7 @@ func (e *crioEnricher) Get(containerId string, ctx context.Context) (ContainerMe
 		return metadata, errfmt.WrapError(err)
 	}
 
-	//if in k8s we can extract pod info from labels
+	// if in k8s we can extract pod info from labels
 	labels := resp.Status.Labels
 	if labels != nil {
 		metadata.Pod = PodMetadata{

--- a/pkg/containers/runtime/docker.go
+++ b/pkg/containers/runtime/docker.go
@@ -49,7 +49,6 @@ func (e *dockerEnricher) Get(ctx context.Context, containerId string) (Container
 
 		// if in k8s extract pod data from the labels
 		if resp.Config.Labels != nil {
-
 			labels := resp.Config.Labels
 			metadata.Pod = PodMetadata{
 				Name:      labels[PodNameLabel],
@@ -58,7 +57,6 @@ func (e *dockerEnricher) Get(ctx context.Context, containerId string) (Container
 				Sandbox:   e.isSandbox(labels),
 			}
 		}
-
 	}
 
 	// attempt to get image name from registry (image from config usually has tag as sha/no tag at all)

--- a/pkg/containers/runtime/docker.go
+++ b/pkg/containers/runtime/docker.go
@@ -26,7 +26,7 @@ func DockerEnricher(socket string) (ContainerEnricher, error) {
 	return enricher, nil
 }
 
-func (e *dockerEnricher) Get(containerId string, ctx context.Context) (ContainerMetadata, error) {
+func (e *dockerEnricher) Get(ctx context.Context, containerId string) (ContainerMetadata, error) {
 	metadata := ContainerMetadata{
 		ContainerId: containerId,
 	}

--- a/pkg/containers/runtime/docker.go
+++ b/pkg/containers/runtime/docker.go
@@ -43,11 +43,11 @@ func (e *dockerEnricher) Get(containerId string, ctx context.Context) (Container
 		metadata.Name = container.Name[1:]
 	}
 
-	//get initial image name from docker's container config
+	// get initial image name from docker's container config
 	if resp.Config != nil {
 		metadata.Image = resp.Config.Image
 
-		//if in k8s extract pod data from the labels
+		// if in k8s extract pod data from the labels
 		if resp.Config.Labels != nil {
 
 			labels := resp.Config.Labels
@@ -61,11 +61,11 @@ func (e *dockerEnricher) Get(containerId string, ctx context.Context) (Container
 
 	}
 
-	//attempt to get image name from registry (image from config usually has tag as sha/no tag at all)
+	// attempt to get image name from registry (image from config usually has tag as sha/no tag at all)
 	imageId := container.Image
 	image, _, err := e.client.ImageInspectWithRaw(ctx, imageId)
 	if err != nil {
-		//if we can't fetch the image or image has no name, return the metadata with the image found in config
+		// if we can't fetch the image or image has no name, return the metadata with the image found in config
 		return metadata, nil
 	}
 

--- a/pkg/containers/runtime/runtime.go
+++ b/pkg/containers/runtime/runtime.go
@@ -31,7 +31,7 @@ const (
 )
 
 type ContainerEnricher interface {
-	Get(containerId string, ctx context.Context) (ContainerMetadata, error)
+	Get(ctx context.Context, containerId string) (ContainerMetadata, error)
 }
 
 // Represents the internal ID of a container runtime

--- a/pkg/containers/service.go
+++ b/pkg/containers/service.go
@@ -36,27 +36,27 @@ func (e *runtimeInfoService) Register(runtime runtime.RuntimeId, enricherBuilder
 
 // Get calls the inner enricher's Get, based on the containerRuntime parameter if a relevant enricher was registered
 // If an unknown runtime is received, enrichment will be attempted through all registered enrichers
-func (e *runtimeInfoService) Get(containerId string, containerRuntime runtime.RuntimeId, ctx context.Context) (runtime.ContainerMetadata, error) {
+func (e *runtimeInfoService) Get(ctx context.Context, containerId string, containerRuntime runtime.RuntimeId) (runtime.ContainerMetadata, error) {
 	if containerRuntime == runtime.Unknown {
-		return e.getFromUnknownRuntime(containerId, ctx)
+		return e.getFromUnknownRuntime(ctx, containerId)
 	}
 
-	return e.getFromKnownRuntime(containerId, containerRuntime, ctx)
+	return e.getFromKnownRuntime(ctx, containerId, containerRuntime)
 }
 
 // standard case when we can query the known runtime from the get go
-func (e *runtimeInfoService) getFromKnownRuntime(containerId string, containerRuntime runtime.RuntimeId, ctx context.Context) (runtime.ContainerMetadata, error) {
+func (e *runtimeInfoService) getFromKnownRuntime(ctx context.Context, containerId string, containerRuntime runtime.RuntimeId) (runtime.ContainerMetadata, error) {
 	enricher := e.enrichers[containerRuntime]
 	if enricher != nil {
-		return enricher.Get(containerId, ctx)
+		return enricher.Get(ctx, containerId)
 	}
 	return runtime.ContainerMetadata{}, errfmt.Errorf("unsupported runtime")
 }
 
 // in case where we don't know the container's runtime, we query through all the registered enrichers
-func (e *runtimeInfoService) getFromUnknownRuntime(containerId string, ctx context.Context) (runtime.ContainerMetadata, error) {
+func (e *runtimeInfoService) getFromUnknownRuntime(ctx context.Context, containerId string) (runtime.ContainerMetadata, error) {
 	for _, enricher := range e.enrichers {
-		metadata, err := enricher.Get(containerId, ctx)
+		metadata, err := enricher.Get(ctx, containerId)
 
 		if err == nil {
 			return metadata, nil

--- a/pkg/containers/service.go
+++ b/pkg/containers/service.go
@@ -21,16 +21,16 @@ func RuntimeInfoService(sockets runtime.Sockets) runtimeInfoService {
 }
 
 // Register associates some ContainerEnricher with a runtime, the service can then use it for relevant queries
-func (e *runtimeInfoService) Register(runtime runtime.RuntimeId, enricherBuilder func(socket string) (runtime.ContainerEnricher, error)) error {
-	if !e.sockets.Supports(runtime) {
-		return errfmt.Errorf("error registering enricher: unsupported runtime %s", runtime.String())
+func (e *runtimeInfoService) Register(rtime runtime.RuntimeId, enricherBuilder func(socket string) (runtime.ContainerEnricher, error)) error {
+	if !e.sockets.Supports(rtime) {
+		return errfmt.Errorf("error registering enricher: unsupported runtime %s", rtime.String())
 	}
-	socket := e.sockets.Socket(runtime)
+	socket := e.sockets.Socket(rtime)
 	enricher, err := enricherBuilder(socket)
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
-	e.enrichers[runtime] = enricher
+	e.enrichers[rtime] = enricher
 	return nil
 }
 

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -365,21 +365,18 @@ func parseSyscallID(syscallID int, isCompat bool, compatTranslationMap map[event
 		def, ok := events.Definitions.GetSafe(events.ID(syscallID))
 		if ok {
 			return def.Name, nil
-		} else {
-			return "", errfmt.Errorf("no syscall event with syscall id %d", syscallID)
 		}
-	} else {
-		id, ok := compatTranslationMap[events.ID(syscallID)]
-		if ok {
-			def, ok := events.Definitions.GetSafe(id)
-			if !ok { // Should never happen, as the translation map should be initialized from events.Definition
-				return "", errfmt.Errorf("no syscall event with compat syscall id %d, translated to ID %d", syscallID, id)
-			}
-			return def.Name, nil
-		} else {
-			return "", errfmt.Errorf("no syscall event with compat syscall id %d", syscallID)
-		}
+		return "", errfmt.Errorf("no syscall event with syscall id %d", syscallID)
 	}
+	id, ok := compatTranslationMap[events.ID(syscallID)]
+	if ok {
+		def, ok := events.Definitions.GetSafe(id)
+		if !ok { // Should never happen, as the translation map should be initialized from events.Definition
+			return "", errfmt.Errorf("no syscall event with compat syscall id %d, translated to ID %d", syscallID, id)
+		}
+		return def.Name, nil
+	}
+	return "", errfmt.Errorf("no syscall event with compat syscall id %d", syscallID)
 }
 
 func (t *Tracee) processEvents(ctx context.Context, in <-chan *trace.Event) (<-chan *trace.Event, <-chan error) {

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -372,11 +372,10 @@ func parseSyscallID(syscallID int, isCompat bool, compatTranslationMap map[event
 		id, ok := compatTranslationMap[events.ID(syscallID)]
 		if ok {
 			def, ok := events.Definitions.GetSafe(id)
-			if ok {
-				return def.Name, nil
-			} else { // Should never happen, as the translation map should be initialized from events.Definition
+			if !ok { // Should never happen, as the translation map should be initialized from events.Definition
 				return "", errfmt.Errorf("no syscall event with compat syscall id %d, translated to ID %d", syscallID, id)
 			}
+			return def.Name, nil
 		} else {
 			return "", errfmt.Errorf("no syscall event with compat syscall id %d", syscallID)
 		}

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -261,7 +261,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 					ArgMeta: trace.ArgMeta{Name: "sha256", Type: "const char*"},
 					Value:   currentHash,
 				})
-				event.ArgsNum += 1
+				event.ArgsNum++
 			}
 			if true { // so loop is conditionally terminated (#SA4044)
 				break

--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -43,7 +43,6 @@ func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helper
 // given. The chosen symbol used here is "security_file_open" because it is a
 // must-have symbol for tracee to run.
 func ValidateKsymbolsTable(ksyms helpers.KernelSymbolTable) bool {
-
 	sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "security_file_open")
 	if err != nil || sym.Address == 0 {
 		return false
@@ -53,7 +52,6 @@ func ValidateKsymbolsTable(ksyms helpers.KernelSymbolTable) bool {
 }
 
 func (t *Tracee) NewKernelSymbols() error {
-
 	// reading kallsyms needs CAP_SYSLOG
 	kernelSymbols, err := helpers.NewLazyKernelSymbolsMap()
 	if err != nil {

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -191,7 +191,6 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 		udpHeaderLengthValue := uint32(0)
 
 		switch v := layer3.(type) {
-
 		case (*layers.IPv4):
 			// Fake L2 header: IPv4 (BSD encap header spec)
 			binary.BigEndian.PutUint32(payloadLayer2, 2) // set value 2 to first 4 bytes (uint32)

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1737,7 +1737,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 				if err != nil {
 					return errfmt.WrapError(err)
 				}
-				//lint:ignore SA4004 we only want the first argument
+				// lint:ignore SA4004 we only want the first argument
 				break
 			}
 		}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1723,19 +1723,17 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 			continue
 		}
 
-		lengthFilter, ok := printMemDumpFilters["length"].(*filters.StringFilter)
 		var length uint64
 		var err error
+
+		lengthFilter, ok := printMemDumpFilters["length"].(*filters.StringFilter)
 		if lengthFilter == nil || !ok || len(lengthFilter.Equal()) == 0 {
 			length = maxMemDumpLength // default mem dump length
 		} else {
-			for _, field := range lengthFilter.Equal() {
-				length, err = strconv.ParseUint(field, 10, 64)
-				if err != nil {
-					return errfmt.WrapError(err)
-				}
-				// lint:ignore SA4004 we only want the first argument
-				break
+			field := lengthFilter.Equal()[0]
+			length, err = strconv.ParseUint(field, 10, 64)
+			if err != nil {
+				return errfmt.WrapError(err)
 			}
 		}
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1039,9 +1039,9 @@ func (t *Tracee) populateBPFMaps() error {
 		return errfmt.WrapError(err)
 	}
 	for id, event := range events.Definitions.Events() {
-		ID32BitU32 := uint32(event.ID32Bit) // ID32Bit is int32
-		IDU32 := uint32(id)                 // ID is int32
-		if err := sys32to64BPFMap.Update(unsafe.Pointer(&ID32BitU32), unsafe.Pointer(&IDU32)); err != nil {
+		id32BitU32 := uint32(event.ID32Bit) // ID32Bit is int32
+		idU32 := uint32(id)                 // ID is int32
+		if err := sys32to64BPFMap.Update(unsafe.Pointer(&id32BitU32), unsafe.Pointer(&idU32)); err != nil {
 			return errfmt.WrapError(err)
 		}
 	}
@@ -1143,8 +1143,8 @@ func (t *Tracee) populateBPFMaps() error {
 	}
 
 	for i := uint32(0); i < uint32(len(t.config.Capture.FilterFileWrite)); i++ {
-		FilterFileWriteBytes := []byte(t.config.Capture.FilterFileWrite[i])
-		if err = fileFilterMap.Update(unsafe.Pointer(&i), unsafe.Pointer(&FilterFileWriteBytes[0])); err != nil {
+		filterFileWriteBytes := []byte(t.config.Capture.FilterFileWrite[i])
+		if err = fileFilterMap.Update(unsafe.Pointer(&i), unsafe.Pointer(&filterFileWriteBytes[0])); err != nil {
 			return errfmt.WrapError(err)
 		}
 	}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -395,7 +395,6 @@ func New(cfg Config) (*Tracee, error) {
 // initialization logic, especially one that causes side effects, should go
 // here and not New().
 func (t *Tracee) Init() error {
-
 	// Initialize needed values
 
 	initReq, err := t.generateInitValues()
@@ -624,7 +623,6 @@ func (t *Tracee) initTailCall(mapName string, mapIndexes []uint32, progName stri
 // event, represented through its ID, we declare to which other events it can be
 // derived and the corresponding function to derive into that Event.
 func (t *Tracee) initDerivationTable() error {
-
 	shouldSubmit := func(id events.ID) func() bool {
 		return func() bool { return t.events[id].submit > 0 }
 	}
@@ -1201,7 +1199,6 @@ func (t *Tracee) populateBPFMaps() error {
 // data saving in their probe (for example security_file_open needs open, openat
 // and openat2).
 func getTailCalls(eventConfigs map[events.ID]eventConfig) ([]events.TailCall, error) {
-
 	enterInitTailCall := events.TailCall{
 		MapName:    "sys_enter_init_tail",
 		MapIndexes: []uint32{},

--- a/pkg/ebpf/write_capture.go
+++ b/pkg/ebpf/write_capture.go
@@ -20,7 +20,7 @@ func (t *Tracee) processFileWrites(ctx context.Context) {
 	defer logger.Debugw("Stopped processFileWrites go routine")
 
 	const (
-		//S_IFMT uint32 = 0170000 // bit mask for the file type bit field
+		// S_IFMT uint32 = 0170000 // bit mask for the file type bit field
 		S_IFSOCK uint32 = 0140000 // socket
 		S_IFLNK  uint32 = 0120000 // symbolic link
 		S_IFREG  uint32 = 0100000 // regular file

--- a/pkg/ebpf/write_capture.go
+++ b/pkg/ebpf/write_capture.go
@@ -20,14 +20,14 @@ func (t *Tracee) processFileWrites(ctx context.Context) {
 	defer logger.Debugw("Stopped processFileWrites go routine")
 
 	const (
-		// S_IFMT uint32 = 0170000 // bit mask for the file type bit field
-		S_IFSOCK uint32 = 0140000 // socket
-		S_IFLNK  uint32 = 0120000 // symbolic link
-		S_IFREG  uint32 = 0100000 // regular file
-		S_IFBLK  uint32 = 0060000 // block device
-		S_IFDIR  uint32 = 0040000 // directory
-		S_IFCHR  uint32 = 0020000 // character device
-		S_IFIFO  uint32 = 0010000 // FIFO
+		// stat_S_IFMT uint32 = 0170000 // bit mask for the file type bit field
+		_S_IFSOCK uint32 = 0140000 // socket
+		_S_IFLNK  uint32 = 0120000 // symbolic link
+		_S_IFREG  uint32 = 0100000 // regular file
+		_S_IFBLK  uint32 = 0060000 // block device
+		_S_IFDIR  uint32 = 0040000 // directory
+		_S_IFCHR  uint32 = 0020000 // character device
+		_S_IFIFO  uint32 = 0010000 // FIFO
 	)
 
 	for {
@@ -76,7 +76,7 @@ func (t *Tracee) processFileWrites(ctx context.Context) {
 					t.handleError(err)
 					continue
 				}
-				if vfsMeta.Mode&S_IFSOCK == S_IFSOCK || vfsMeta.Mode&S_IFCHR == S_IFCHR || vfsMeta.Mode&S_IFIFO == S_IFIFO {
+				if vfsMeta.Mode&_S_IFSOCK == _S_IFSOCK || vfsMeta.Mode&_S_IFCHR == _S_IFCHR || vfsMeta.Mode&_S_IFIFO == _S_IFIFO {
 					appendFile = true
 				}
 				if vfsMeta.Pid == 0 {

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -10,21 +10,21 @@ import (
 
 // ContainerRemove receives a containers.Containers object as a closure argument to track it's containers.
 // If it receives a cgroup_rmdir event, it can derive a container_remove event from it.
-func ContainerRemove(containers *containers.Containers) DeriveFunction {
-	return deriveSingleEvent(events.ContainerRemove, deriveContainerRemoveArgs(containers))
+func ContainerRemove(cts *containers.Containers) DeriveFunction {
+	return deriveSingleEvent(events.ContainerRemove, deriveContainerRemoveArgs(cts))
 }
 
-func deriveContainerRemoveArgs(containers *containers.Containers) deriveArgsFunction {
+func deriveContainerRemoveArgs(cts *containers.Containers) deriveArgsFunction {
 	return func(event trace.Event) ([]interface{}, error) {
 		// if cgroup_id is from non default hid (v1 case), the cgroup info query will fail, so we skip
-		if check, err := isCgroupEventInHid(&event, containers); !check {
+		if check, err := isCgroupEventInHid(&event, cts); !check {
 			return nil, errfmt.WrapError(err)
 		}
 		cgroupId, err := parse.ArgVal[uint64](&event, "cgroup_id")
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
-		if info := containers.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
+		if info := cts.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
 			return []interface{}{info.Runtime.String(), info.Container.ContainerId}, nil
 		}
 		return nil, nil

--- a/pkg/events/derive/hidden_kernel_module.go
+++ b/pkg/events/derive/hidden_kernel_module.go
@@ -45,9 +45,9 @@ func deriveHiddenKernelModulesArgs() deriveArgsFunction {
 
 		if _, found := foundHiddenKernModsCache.Get(address); found {
 			return nil, nil // already reported this event - no need to report again
-		} else {
-			foundHiddenKernModsCache.Add(address, struct{}{}) // so we won't report multiple times
 		}
+
+		foundHiddenKernModsCache.Add(address, struct{}{}) // so we won't report multiple times
 
 		addrHex := fmt.Sprintf("0x%x", address)
 		if len(addrHex) == 2 {

--- a/pkg/events/derive/net_packet_dns.go
+++ b/pkg/events/derive/net_packet_dns.go
@@ -154,9 +154,9 @@ func deriveDNSResponseEvents(event trace.Event) ([]interface{}, error) {
 // eventToProtoDNS turns a trace event into a ProtoDNS type, a type used by the
 // new network code for DNS events
 func eventToProtoDNS(event *trace.Event) (*netPair, *trace.ProtoDNS, error) {
-	var DnsNetPair netPair
+	var dnsNetPair netPair
 
-	layer7, err := parseUntilLayer7(event, &DnsNetPair)
+	layer7, err := parseUntilLayer7(event, &dnsNetPair)
 	if err != nil {
 		return nil, nil, errfmt.WrapError(err)
 	}
@@ -165,15 +165,15 @@ func eventToProtoDNS(event *trace.Event) (*netPair, *trace.ProtoDNS, error) {
 	case (*layers.DNS):
 		var dns trace.ProtoDNS
 		copyDNSToProtoDNS(l7, &dns)
-		return &DnsNetPair, &dns, nil
+		return &dnsNetPair, &dns, nil
 	default:
-		if DnsNetPair.srcPort != 53 && DnsNetPair.dstPort != 53 {
+		if dnsNetPair.srcPort != 53 && dnsNetPair.dstPort != 53 {
 			// TCP packets (connection related), no event
-			return &DnsNetPair, nil, notProtoPacketError("DNS")
+			return &dnsNetPair, nil, notProtoPacketError("DNS")
 		}
 	}
 
-	return &DnsNetPair, nil, nil
+	return &dnsNetPair, nil, nil
 }
 
 // convertProtoDNSQuestionToDnsRequest converts the network packet dns event

--- a/pkg/events/derive/net_packet_dns.go
+++ b/pkg/events/derive/net_packet_dns.go
@@ -182,7 +182,6 @@ func eventToProtoDNS(event *trace.Event) (*netPair, *trace.ProtoDNS, error) {
 func convertProtoDNSQuestionToDnsRequest(
 	questions []trace.ProtoDNSQuestion,
 ) []trace.DnsQueryData {
-
 	var requests []trace.DnsQueryData
 
 	for _, question := range questions {
@@ -204,7 +203,6 @@ func convertProtoDNSResourceRecordToDnsResponse(
 	dnsQueryData trace.DnsQueryData,
 	dnsResourceRecord []trace.ProtoDNSResourceRecord,
 ) []trace.DnsResponseData {
-
 	var dnsAnswers []trace.DnsAnswer
 
 	for _, record := range dnsResourceRecord {

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -69,14 +69,14 @@ const (
 // convertNetPairToPktMeta converts the local netPair type, used by this code,
 // to PktMeta type, expected by the old dns events, which, for now, we want the
 // new network packet simple dns events to be compatible with.
-func convertNetPairToPktMeta(net *netPair) *trace.PktMeta {
+func convertNetPairToPktMeta(n *netPair) *trace.PktMeta {
 	return &trace.PktMeta{
-		SrcIP:     net.srcIP.String(),
-		DstIP:     net.dstIP.String(),
-		SrcPort:   net.srcPort,
-		DstPort:   net.dstPort,
-		Protocol:  net.proto,
-		PacketLen: net.length,
+		SrcIP:     n.srcIP.String(),
+		DstIP:     n.dstIP.String(),
+		SrcPort:   n.srcPort,
+		DstPort:   n.dstPort,
+		Protocol:  n.proto,
+		PacketLen: n.length,
 		Iface:     "any", // TODO: pick iface index from the kernel ?
 	}
 }

--- a/pkg/events/derive/net_packet_http.go
+++ b/pkg/events/derive/net_packet_http.go
@@ -25,11 +25,11 @@ func deriveHTTP() deriveArgsFunction {
 }
 
 func deriveHTTPEvents(event trace.Event) ([]interface{}, error) {
-	net, http, err := eventToProtoHTTP(&event)
+	net, h, err := eventToProtoHTTP(&event)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	if http == nil {
+	if h == nil {
 		return nil, nil // connection related packets
 	}
 	if net == nil {
@@ -41,7 +41,7 @@ func deriveHTTPEvents(event trace.Event) ([]interface{}, error) {
 		net.dstIP,
 		net.srcPort,
 		net.dstPort,
-		http,
+		h,
 	}, nil
 }
 
@@ -58,11 +58,11 @@ func deriveHTTPRequest() deriveArgsFunction {
 }
 
 func deriveHTTPRequestEvents(event trace.Event) ([]interface{}, error) {
-	net, http, err := eventToProtoHTTPRequest(&event)
+	net, h, err := eventToProtoHTTPRequest(&event)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	if http == nil {
+	if h == nil {
 		return nil, nil // not a request
 	}
 	if net == nil {
@@ -73,7 +73,7 @@ func deriveHTTPRequestEvents(event trace.Event) ([]interface{}, error) {
 
 	return []interface{}{
 		*meta,
-		http,
+		h,
 	}, nil
 }
 
@@ -90,11 +90,11 @@ func deriveHTTPResponse() deriveArgsFunction {
 }
 
 func deriveHTTPResponseEvents(event trace.Event) ([]interface{}, error) {
-	net, http, err := eventToProtoHTTPResponse(&event)
+	net, h, err := eventToProtoHTTPResponse(&event)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	if http == nil {
+	if h == nil {
 		return nil, nil // // not a response
 	}
 	if net == nil {
@@ -105,7 +105,7 @@ func deriveHTTPResponseEvents(event trace.Event) ([]interface{}, error) {
 
 	return []interface{}{
 		*meta,
-		http,
+		h,
 	}, nil
 }
 

--- a/pkg/events/derive/net_packet_http.go
+++ b/pkg/events/derive/net_packet_http.go
@@ -130,23 +130,19 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 
 		// event retval encodes HTTP direction
 		if event.ReturnValue&protoHttpRequest == protoHttpRequest {
-
 			httpReq, err = http.ReadRequest(reader)
 			if err != nil {
 				return nil, nil, errfmt.WrapError(err)
 			}
 
 			copyHTTPReqToProtoHTTP(httpReq, &protoHttp)
-
 		} else if event.ReturnValue&protoHttpResponse == protoHttpResponse {
-
 			httpRes, err = http.ReadResponse(reader, nil)
 			if err != nil {
 				return nil, nil, errfmt.WrapError(err)
 			}
 
 			copyHTTPResToProtoHTTP(httpRes, &protoHttp)
-
 		} else {
 			return &httpNetPair, nil, errfmt.Errorf("unspecified direction for HTTP packet")
 		}

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -26,7 +26,6 @@ import (
 
 func SymbolsCollision(soLoader sharedobjs.DynamicSymbolsLoader, policies *policy.Policies,
 ) DeriveFunction {
-
 	symbolsCollisionFilters := map[string]filters.Filter{}
 
 	// pick white and black lists from the filters (TODO: change this)
@@ -69,7 +68,6 @@ func initSOCollisionsEventGenerator(
 	symbolsBlackList []string,
 	symbolsWhiteList []string,
 ) *SymbolsCollisionArgsGenerator {
-
 	noCallback := simplelru.EvictCallback(func(key interface{}, value interface{}) {})
 	loadedObsPerProcessLRU, _ := simplelru.NewLRU(1024, noCallback)
 	collisionChecksLRU, _ := simplelru.NewLRU(1024, noCallback)

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -363,7 +363,7 @@ func (so *loadingSharedObj) GetSymbols() []string {
 	i := 0
 	for sym := range so.exportedSymbols {
 		symbols[i] = sym
-		i += 1
+		i++
 	}
 
 	return symbols

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -21,7 +21,6 @@ func SymbolsLoaded(
 	soLoader sharedobjs.DynamicSymbolsLoader,
 	policies *policy.Policies,
 ) DeriveFunction {
-
 	symbolsLoadedFilters := map[string]filters.Filter{}
 
 	for p := range policies.Map() {
@@ -80,7 +79,6 @@ func initSymbolsLoadedEventGenerator(
 	watchedSymbols []string,
 	whitelistedLibsPrefixes []string,
 ) *symbolsLoadedEventGenerator {
-
 	watchedSymbolsMap := make(map[string]bool)
 	for _, sym := range watchedSymbols {
 		watchedSymbolsMap[sym] = true
@@ -109,8 +107,9 @@ func initSymbolsLoadedEventGenerator(
 
 func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(
 	event trace.Event,
-) ([]interface{}, error) {
-
+) (
+	[]interface{}, error,
+) {
 	loadingObjectInfo, err := getSharedObjectInfo(event)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
@@ -162,7 +161,6 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(
 
 // isWhitelist check if a SO's path is in the whitelist given in initialization
 func (symbsLoadedGen *symbolsLoadedEventGenerator) isWhitelist(soPath string) bool {
-
 	// Check absolute path libraries whitelist
 	for _, prefix := range symbsLoadedGen.pathPrefixWhitelist {
 		if strings.HasPrefix(soPath, prefix) {

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -123,9 +123,8 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(
 	if ok {
 		if len(matchedSyms) > 0 {
 			return []interface{}{loadingObjectInfo.Path, matchedSyms}, nil
-		} else {
-			return nil, nil
 		}
+		return nil, nil
 	}
 
 	soSyms, err := symbsLoadedGen.soLoader.GetExportedSymbols(loadingObjectInfo)

--- a/pkg/events/derive/symbols_loaded_test.go
+++ b/pkg/events/derive/symbols_loaded_test.go
@@ -30,17 +30,15 @@ func initLoaderMock(shouldFail bool) symbolsLoaderMock {
 func (loader symbolsLoaderMock) GetDynamicSymbols(info sharedobjs.ObjInfo) (map[string]bool, error) {
 	if loader.shouldFail {
 		return nil, errors.New("loading error")
-	} else {
-		return loader.cache[info], nil
 	}
+	return loader.cache[info], nil
 }
 
 func (loader symbolsLoaderMock) GetExportedSymbols(info sharedobjs.ObjInfo) (map[string]bool, error) {
 	if loader.shouldFail {
 		return nil, errors.New("loading error")
-	} else {
-		return loader.cache[info], nil
 	}
+	return loader.cache[info], nil
 }
 
 func (loader symbolsLoaderMock) GetImportedSymbols(info sharedobjs.ObjInfo) (map[string]bool, error) {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -170,14 +170,14 @@ func (e *eventDefinitions) NamesToIDs() map[string]ID {
 }
 
 func (e *eventDefinitions) IDs32ToIDs() map[ID]ID {
-	IDs32ToIDs := make(map[ID]ID, len(e.events))
+	idS32ToIDs := make(map[ID]ID, len(e.events))
 
 	for id, evt := range e.events {
 		if evt.ID32Bit != sys32undefined {
-			IDs32ToIDs[evt.ID32Bit] = id
+			idS32ToIDs[evt.ID32Bit] = id
 		}
 	}
-	return IDs32ToIDs
+	return idS32ToIDs
 }
 
 func (e *eventDefinitions) GetID(eventName string) (ID, bool) {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -89,7 +89,6 @@ type Event struct {
 }
 
 func (e *Event) IsASignatureEvent() bool {
-
 	for _, s := range e.Sets {
 		if s == "signatures" {
 			return true

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -91,5 +91,4 @@ func TestAdd(t *testing.T) {
 			assert.Equal(t, test.evt, event)
 		})
 	}
-
 }

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -26,13 +26,13 @@ func ParseArgs(event *trace.Event) error {
 		}
 	}
 
-	EmptyString := func(arg *trace.Argument) {
+	emptyString := func(arg *trace.Argument) {
 		arg.Type = "string"
 		arg.Value = ""
 	}
 
-	ParseOrEmptyString := func(arg *trace.Argument, sysArg helpers.SystemFunctionArgument, err error) {
-		EmptyString(arg)
+	parseOrEmptyString := func(arg *trace.Argument, sysArg helpers.SystemFunctionArgument, err error) {
+		emptyString(arg)
 		if err == nil {
 			arg.Value = sysArg.String()
 		}
@@ -49,13 +49,13 @@ func ParseArgs(event *trace.Event) error {
 		if protArg := GetArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))
-				ParseOrEmptyString(protArg, mmapProtArgument, nil)
+				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
 		if prevProtArg := GetArg(event, "prev_prot"); prevProtArg != nil {
 			if prevProt, isInt32 := prevProtArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prevProt))
-				ParseOrEmptyString(prevProtArg, mmapProtArgument, nil)
+				parseOrEmptyString(prevProtArg, mmapProtArgument, nil)
 			}
 		}
 	case SysEnter, SysExit:
@@ -73,7 +73,7 @@ func ParseArgs(event *trace.Event) error {
 			if capArg := GetArg(event, "cap"); capArg != nil {
 				if capability, isInt32 := capArg.Value.(int32); isInt32 {
 					capabilityFlagArgument, err := helpers.ParseCapability(uint64(capability))
-					ParseOrEmptyString(capArg, capabilityFlagArgument, err)
+					parseOrEmptyString(capArg, capabilityFlagArgument, err)
 				}
 			}
 		}
@@ -81,122 +81,122 @@ func ParseArgs(event *trace.Event) error {
 		if protArg := GetArg(event, "prot"); protArg != nil {
 			if prot, isUint64 := protArg.Value.(uint64); isUint64 {
 				mmapProtArgument := helpers.ParseMmapProt(prot)
-				ParseOrEmptyString(protArg, mmapProtArgument, nil)
+				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
 	case Mmap, Mprotect, PkeyMprotect:
 		if protArg := GetArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))
-				ParseOrEmptyString(protArg, mmapProtArgument, nil)
+				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
 	case SecurityFileMprotect:
 		if protArg := GetArg(event, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prot))
-				ParseOrEmptyString(protArg, mmapProtArgument, nil)
+				parseOrEmptyString(protArg, mmapProtArgument, nil)
 			}
 		}
 		if prevProtArg := GetArg(event, "prev_prot"); prevProtArg != nil {
 			if prevProt, isInt32 := prevProtArg.Value.(int32); isInt32 {
 				mmapProtArgument := helpers.ParseMmapProt(uint64(prevProt))
-				ParseOrEmptyString(prevProtArg, mmapProtArgument, nil)
+				parseOrEmptyString(prevProtArg, mmapProtArgument, nil)
 			}
 		}
 	case Ptrace:
 		if reqArg := GetArg(event, "request"); reqArg != nil {
 			if req, isInt64 := reqArg.Value.(int64); isInt64 {
 				ptraceRequestArgument, err := helpers.ParsePtraceRequestArgument(uint64(req))
-				ParseOrEmptyString(reqArg, ptraceRequestArgument, err)
+				parseOrEmptyString(reqArg, ptraceRequestArgument, err)
 			}
 		}
 	case Prctl:
 		if optArg := GetArg(event, "option"); optArg != nil {
 			if opt, isInt32 := optArg.Value.(int32); isInt32 {
 				prctlOptionArgument, err := helpers.ParsePrctlOption(uint64(opt))
-				ParseOrEmptyString(optArg, prctlOptionArgument, err)
+				parseOrEmptyString(optArg, prctlOptionArgument, err)
 			}
 		}
 	case Socket:
 		if domArg := GetArg(event, "domain"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				socketDomainArgument, err := helpers.ParseSocketDomainArgument(uint64(dom))
-				ParseOrEmptyString(domArg, socketDomainArgument, err)
+				parseOrEmptyString(domArg, socketDomainArgument, err)
 			}
 		}
 		if typeArg := GetArg(event, "type"); typeArg != nil {
 			if typ, isInt32 := typeArg.Value.(int32); isInt32 {
 				socketTypeArgument, err := helpers.ParseSocketType(uint64(typ))
-				ParseOrEmptyString(typeArg, socketTypeArgument, err)
+				parseOrEmptyString(typeArg, socketTypeArgument, err)
 			}
 		}
 	case SecuritySocketCreate:
 		if domArg := GetArg(event, "family"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				socketDomainArgument, err := helpers.ParseSocketDomainArgument(uint64(dom))
-				ParseOrEmptyString(domArg, socketDomainArgument, err)
+				parseOrEmptyString(domArg, socketDomainArgument, err)
 			}
 		}
 		if typeArg := GetArg(event, "type"); typeArg != nil {
 			if typ, isInt32 := typeArg.Value.(int32); isInt32 {
 				socketTypeArgument, err := helpers.ParseSocketType(uint64(typ))
-				ParseOrEmptyString(typeArg, socketTypeArgument, err)
+				parseOrEmptyString(typeArg, socketTypeArgument, err)
 			}
 		}
 	case Access, Faccessat:
 		if modeArg := GetArg(event, "mode"); modeArg != nil {
 			if mode, isInt32 := modeArg.Value.(int32); isInt32 {
 				accessModeArgument, err := helpers.ParseAccessMode(uint64(mode))
-				ParseOrEmptyString(modeArg, accessModeArgument, err)
+				parseOrEmptyString(modeArg, accessModeArgument, err)
 			}
 		}
 	case Execveat:
 		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				execFlagArgument, err := helpers.ParseExecFlag(uint64(flags))
-				ParseOrEmptyString(flagsArg, execFlagArgument, err)
+				parseOrEmptyString(flagsArg, execFlagArgument, err)
 			}
 		}
 	case Open, Openat, SecurityFileOpen:
 		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				openFlagArgument, err := helpers.ParseOpenFlagArgument(uint64(flags))
-				ParseOrEmptyString(flagsArg, openFlagArgument, err)
+				parseOrEmptyString(flagsArg, openFlagArgument, err)
 			}
 		}
 	case Mknod, Mknodat, Chmod, Fchmod, Fchmodat:
 		if modeArg := GetArg(event, "mode"); modeArg != nil {
 			if mode, isUint32 := modeArg.Value.(uint32); isUint32 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
-				ParseOrEmptyString(modeArg, inodeModeArgument, err)
+				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case SecurityInodeMknod:
 		if modeArg := GetArg(event, "mode"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
-				ParseOrEmptyString(modeArg, inodeModeArgument, err)
+				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case Clone:
 		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
 			if flags, isUint64 := flagsArg.Value.(uint64); isUint64 {
 				cloneFlagArgument, err := helpers.ParseCloneFlags(uint64(flags))
-				ParseOrEmptyString(flagsArg, cloneFlagArgument, err)
+				parseOrEmptyString(flagsArg, cloneFlagArgument, err)
 			}
 		}
 	case Bpf, SecurityBPF:
 		if cmdArg := GetArg(event, "cmd"); cmdArg != nil {
 			if cmd, isInt32 := cmdArg.Value.(int32); isInt32 {
 				bpfCommandArgument, err := helpers.ParseBPFCmd(uint64(cmd))
-				ParseOrEmptyString(cmdArg, bpfCommandArgument, err)
+				parseOrEmptyString(cmdArg, bpfCommandArgument, err)
 			}
 		}
 	case SecurityKernelReadFile, SecurityPostReadFile:
 		if typeArg := GetArg(event, "type"); typeArg != nil {
 			if readFileId, isInt32 := typeArg.Value.(trace.KernelReadType); isInt32 {
-				EmptyString(typeArg)
+				emptyString(typeArg)
 				typeArg.Value = readFileId.String()
 			}
 		}
@@ -204,21 +204,21 @@ func ParseArgs(event *trace.Event) error {
 		if modeArg := GetArg(event, "stdin_type"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
-				ParseOrEmptyString(modeArg, inodeModeArgument, err)
+				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case DirtyPipeSplice:
 		if modeArg := GetArg(event, "in_file_type"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				inodeModeArgument, err := helpers.ParseInodeMode(uint64(mode))
-				ParseOrEmptyString(modeArg, inodeModeArgument, err)
+				parseOrEmptyString(modeArg, inodeModeArgument, err)
 			}
 		}
 	case SecuritySocketSetsockopt, Setsockopt, Getsockopt:
 		if levelArg := GetArg(event, "level"); levelArg != nil {
 			if level, isInt := levelArg.Value.(int32); isInt {
 				levelArgument, err := helpers.ParseSocketLevel(uint64(level))
-				ParseOrEmptyString(levelArg, levelArgument, err)
+				parseOrEmptyString(levelArg, levelArgument, err)
 			}
 		}
 		if optionNameArg := GetArg(event, "optname"); optionNameArg != nil {
@@ -230,14 +230,14 @@ func ParseArgs(event *trace.Event) error {
 				} else {
 					optionNameArgument, err = helpers.ParseSetSocketOption(uint64(opt))
 				}
-				ParseOrEmptyString(optionNameArg, optionNameArgument, err)
+				parseOrEmptyString(optionNameArg, optionNameArgument, err)
 			}
 		}
 	case BpfAttach:
 		if progTypeArg := GetArg(event, "prog_type"); progTypeArg != nil {
 			if progType, isInt := progTypeArg.Value.(int32); isInt {
 				progTypeArgument, err := helpers.ParseBPFProgType(uint64(progType))
-				ParseOrEmptyString(progTypeArg, progTypeArgument, err)
+				parseOrEmptyString(progTypeArg, progTypeArgument, err)
 			}
 		}
 		if helpersArg := GetArg(event, "prog_helpers"); helpersArg != nil {
@@ -253,7 +253,7 @@ func ParseArgs(event *trace.Event) error {
 		if perfTypeArg := GetArg(event, "perf_type"); perfTypeArg != nil {
 			if perfType, isInt := perfTypeArg.Value.(int32); isInt {
 				perfTypestr, err := parseBpfAttachPerfType(perfType)
-				EmptyString(perfTypeArg)
+				emptyString(perfTypeArg)
 				if err == nil {
 					perfTypeArg.Value = perfTypestr
 				}
@@ -263,7 +263,7 @@ func ParseArgs(event *trace.Event) error {
 		if progTypeArg := GetArg(event, "type"); progTypeArg != nil {
 			if progType, isInt := progTypeArg.Value.(int32); isInt {
 				progTypeArgument, err := helpers.ParseBPFProgType(uint64(progType))
-				ParseOrEmptyString(progTypeArg, progTypeArgument, err)
+				parseOrEmptyString(progTypeArg, progTypeArgument, err)
 			}
 		}
 		if helpersArg := GetArg(event, "helpers"); helpersArg != nil {

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -324,7 +324,6 @@ func (arg CustomFunctionArgument) Value() uint64 {
 }
 
 func parseBpfHelpersUsage(helpersList []uint64) ([]string, error) {
-
 	var usedHelpers []string
 
 	for i := 0; i < len(helpersList)*64; i++ {

--- a/pkg/events/queue/queue_mem_list.go
+++ b/pkg/events/queue/queue_mem_list.go
@@ -85,35 +85,35 @@ func (q *eventQueueMem) getQueueSizeInEvents() int {
 	// each cached event (defined by experimentation)
 	eventSize := 1024
 
-	KBtoB := func(amountInKB int) int {
+	kbToB := func(amountInKB int) int {
 		return amountInKB * 1024
 	}
-	MBtoKB := func(amountInMB int) int {
+	mbToKB := func(amountInMB int) int {
 		return amountInMB * 1024
 	}
-	GBtoMB := func(amountInGB int) int {
+	gbToMB := func(amountInGB int) int {
 		return amountInGB * 1024
 	}
-	AmountOfEvents := func(amountInMB int) int {
-		return MBtoKB(KBtoB(amountInMB)) / eventSize
+	amountOfEvents := func(amountInMB int) int {
+		return mbToKB(kbToB(amountInMB)) / eventSize
 	}
 
 	// EventsCacheMemSize was provided, return exact amount of events for it
 	if q.eventsCacheMemSizeMB > 0 {
-		return AmountOfEvents(q.eventsCacheMemSizeMB)
+		return amountOfEvents(q.eventsCacheMemSizeMB)
 	}
 
 	switch {
-	case q.eventsCacheMemSizeMB <= GBtoMB(1): // up to 1GB, cache = ~256MB in events #
-		return AmountOfEvents(256)
-	case q.eventsCacheMemSizeMB <= GBtoMB(4): // up to 4GB, cache = ~512MB in events #
-		return AmountOfEvents(512)
-	case q.eventsCacheMemSizeMB <= GBtoMB(8): // up to 8GB, cache = ~1GB in events #
-		return AmountOfEvents(GBtoMB(1))
-	case q.eventsCacheMemSizeMB <= GBtoMB(16): // up to 16GB, cache = ~2GB in events #
-		return AmountOfEvents(GBtoMB(2))
+	case q.eventsCacheMemSizeMB <= gbToMB(1): // up to 1GB, cache = ~256MB in events #
+		return amountOfEvents(256)
+	case q.eventsCacheMemSizeMB <= gbToMB(4): // up to 4GB, cache = ~512MB in events #
+		return amountOfEvents(512)
+	case q.eventsCacheMemSizeMB <= gbToMB(8): // up to 8GB, cache = ~1GB in events #
+		return amountOfEvents(gbToMB(1))
+	case q.eventsCacheMemSizeMB <= gbToMB(16): // up to 16GB, cache = ~2GB in events #
+		return amountOfEvents(gbToMB(2))
 	}
 
 	// bigger hosts, cache = ~4GB in events #
-	return AmountOfEvents(GBtoMB(4))
+	return amountOfEvents(gbToMB(4))
 }

--- a/pkg/events/sorting/pool.go
+++ b/pkg/events/sorting/pool.go
@@ -26,7 +26,7 @@ type eventsPool struct {
 // If there isn't, it will allocate new one.
 func (p *eventsPool) Alloc(event *trace.Event) (*eventNode, error) {
 	p.poolMutex.Lock()
-	p.allocationsCount += 1
+	p.allocationsCount++
 	node := p.head
 	if node != nil {
 		if node.isAllocated {
@@ -38,7 +38,7 @@ func (p *eventsPool) Alloc(event *trace.Event) (*eventNode, error) {
 		node.isAllocated = true
 		node.previous = nil
 		node.next = nil
-		p.poolSize -= 1
+		p.poolSize--
 		p.poolMutex.Unlock()
 		return node, nil
 	}
@@ -62,7 +62,7 @@ func (p *eventsPool) Free(node *eventNode) error {
 	node.isAllocated = false
 	node.previous = nil
 	node.next = nil
-	p.allocationsCount -= 1
+	p.allocationsCount--
 	// Free memory in case of pooling too many nodes
 	if p.poolSize >= p.allocationsCount &&
 		p.poolSize >= minPoolFreeingSize {
@@ -79,7 +79,7 @@ func (p *eventsPool) Free(node *eventNode) error {
 			p.head.next = node
 			p.head = node
 		}
-		p.poolSize += 1
+		p.poolSize++
 	}
 	return nil
 }

--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -243,7 +243,7 @@ func (sorter *EventsChronologicalSorter) updateSavedTimestamps() {
 // It also returns the timestamp of its head event, to be used for race condition checks.
 // Return nil and timestamp of 0 if no valid queue found.
 func (sorter *EventsChronologicalSorter) getMostDelayingEventCPUQueue() (*cpuEventsQueue, int, error) {
-	var mostDelayingEventQueue *cpuEventsQueue = nil
+	var mostDelayingEventQueue *cpuEventsQueue
 	mostDelayingEventQueueHeadTimestamp := 0
 	for i := 0; i < len(sorter.cpuEventsQueues); i++ {
 		cq := &sorter.cpuEventsQueues[i]

--- a/pkg/events/sorting/sorting_test.go
+++ b/pkg/events/sorting/sorting_test.go
@@ -114,7 +114,6 @@ func TestEventsChronologicalSorter_addEvent(t *testing.T) {
 				assert.Equal(t, testCase.expectedCpuQueuesLens[cpuid], eventsCounter)
 			}
 		})
-
 	}
 }
 

--- a/pkg/events/sorting/sorting_test.go
+++ b/pkg/events/sorting/sorting_test.go
@@ -104,11 +104,11 @@ func TestEventsChronologicalSorter_addEvent(t *testing.T) {
 				require.Contains(t, testCase.expectedCpuQueuesLens, cpuid)
 				eventsCounter := 0
 				if cpuEventsQueue.head != nil {
-					eventsCounter += 1
+					eventsCounter++
 					for testEvent := cpuEventsQueue.head; testEvent.previous != nil; testEvent = testEvent.previous {
 						require.NotEqual(t, testEvent, testEvent.previous) // Prevent infinite loops
 						assert.True(t, testEvent.event.Timestamp < testEvent.previous.event.Timestamp)
-						eventsCounter += 1
+						eventsCounter++
 					}
 				}
 				assert.Equal(t, testCase.expectedCpuQueuesLens[cpuid], eventsCounter)
@@ -288,7 +288,7 @@ func retrieveEventsFromSorter(expectedEventsAmount int, sorterOutputChan <-chan 
 				return outputList, nil
 			}
 			outputList = append(outputList, *event)
-			eventsReceived += 1
+			eventsReceived++
 			if eventsReceived > expectedEventsAmount {
 				return outputList, fmt.Errorf("more events returned from sorter than expected")
 			}

--- a/pkg/events/sorting/sorting_test.go
+++ b/pkg/events/sorting/sorting_test.go
@@ -297,9 +297,8 @@ func retrieveEventsFromSorter(expectedEventsAmount int, sorterOutputChan <-chan 
 		case <-ticker.C:
 			if eventsReceived != expectedEventsAmount {
 				return nil, fmt.Errorf("not all events received until timeout")
-			} else {
-				return outputList, nil
 			}
+			return outputList, nil
 		}
 	}
 }

--- a/pkg/events/usermode.go
+++ b/pkg/events/usermode.go
@@ -89,15 +89,15 @@ func fetchInitNamespaces() map[string]uint32 {
 }
 
 // ExistingContainersEvents returns a list of events for each existing container
-func ExistingContainersEvents(containers *containers.Containers, enrich bool) []trace.Event {
+func ExistingContainersEvents(cts *containers.Containers, enrich bool) []trace.Event {
 	var events []trace.Event
 
 	def := Definitions.Get(ExistingContainer)
 
-	for id, info := range containers.GetContainers() {
+	for id, info := range cts.GetContainers() {
 		container := runtime.ContainerMetadata{}
 		if enrich {
-			container, _ = containers.EnrichCgroupInfo(uint64(id))
+			container, _ = cts.EnrichCgroupInfo(uint64(id))
 		}
 		args := []trace.Argument{
 			{ArgMeta: def.Params[0], Value: info.Runtime.String()},

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -73,7 +73,6 @@ func (filter *ArgFilter) Parse(filterName string, operatorAndValues string, even
 	parts := strings.Split(filterName, ".")
 	if len(parts) != 3 {
 		return InvalidExpression(filterName + operatorAndValues)
-
 	}
 	if parts[1] != "args" {
 		return InvalidExpression(filterName + operatorAndValues)

--- a/pkg/filters/benchmarks/string_test.go
+++ b/pkg/filters/benchmarks/string_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aquasecurity/tracee/pkg/filters"
 )
 
-func matchFilter(filters []string, argValStr string) bool {
-	for _, f := range filters {
+func matchFilter(fils []string, argValStr string) bool {
+	for _, f := range fils {
 		prefixCheck := f[len(f)-1] == '*'
 		if prefixCheck {
 			f = f[0 : len(f)-1]
@@ -34,9 +34,9 @@ func matchFilter(filters []string, argValStr string) bool {
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // generate random strings with 50% to match a prefix
-func randStringRunes(n int, filters []string) string {
+func randStringRunes(n int, fs []string) string {
 	symbols := []string{}
-	for _, filter := range filters {
+	for _, filter := range fs {
 		symbol := strings.TrimSuffix(filter, "*")
 		symbol = strings.TrimPrefix(symbol, "*")
 		symbols = append(symbols, symbol)

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -180,7 +180,6 @@ func (f *BPFBinaryFilter) UpdateBPF(bpfModule *bpf.Module, policyID uint) error 
 }
 
 func (f *BPFBinaryFilter) populateBinaryMap(bpfModule *bpf.Module, policyID uint) error {
-
 	binMap, err := bpfModule.GetMap(f.binaryMapName)
 	if err != nil {
 		return errfmt.WrapError(err)

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -140,9 +140,8 @@ func (f *BinaryFilter) Enabled() bool {
 func (f *BinaryFilter) FilterOut() bool {
 	if len(f.equal) > 0 && len(f.notEqual) == 0 {
 		return false
-	} else {
-		return true
 	}
+	return true
 }
 
 type BPFBinaryFilter struct {

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -257,7 +257,7 @@ func (f *BPFBinaryFilter) populateProcInfoMap(bpfModule *bpf.Module) error {
 
 	for _, bin := range binsToTrack {
 		procs := binsProcs[bin.path]
-		for _, proc := range procs {
+		for _, p := range procs {
 			binBytes := make([]byte, maxBpfBinPathSize)
 			copy(binBytes, bin.path)
 			binBytesCopy := (*[maxBpfBinPathSize]byte)(binBytes)
@@ -268,7 +268,7 @@ func (f *BPFBinaryFilter) populateProcInfoMap(bpfModule *bpf.Module) error {
 				binaryBytes:    *binBytesCopy,
 				binNoMnt:       0, // always 0, see bin_no_mnt in tracee.bpf.c
 			}
-			err := procInfoMap.Update(unsafe.Pointer(&proc), unsafe.Pointer(&procInfo))
+			err := procInfoMap.Update(unsafe.Pointer(&p), unsafe.Pointer(&procInfo))
 			if err != nil {
 				return errfmt.WrapError(err)
 			}

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -140,8 +140,5 @@ func (f *BoolFilter) Value() bool {
 }
 
 func (f *BoolFilter) FilterOut() bool {
-	if f.Value() {
-		return false
-	}
-	return true
+	return !f.Value()
 }

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -15,20 +15,20 @@ func NewBoolFilter() *BoolFilter {
 	return &BoolFilter{}
 }
 
-func (filter *BoolFilter) Filter(val interface{}) bool {
+func (f *BoolFilter) Filter(val interface{}) bool {
 	filterable, ok := val.(bool)
 	if !ok {
 		return false
 	}
-	return filter.filter(filterable)
+	return f.filter(filterable)
 }
 
-func (filter *BoolFilter) filter(val bool) bool {
-	if !filter.Enabled() {
+func (f *BoolFilter) filter(val bool) bool {
+	if !f.Enabled() {
 		return true
 	}
-	trueEnabled := filter.trueEnabled
-	falseEnabled := filter.falseEnabled
+	trueEnabled := f.trueEnabled
+	falseEnabled := f.falseEnabled
 	if trueEnabled && falseEnabled {
 		return true
 	}
@@ -49,12 +49,12 @@ func (filter *BoolFilter) filter(val bool) bool {
 // field=false
 // field!=true
 // field!=false
-func (filter *BoolFilter) Parse(operatorAndValues string) error {
+func (f *BoolFilter) Parse(operatorAndValues string) error {
 	if len(operatorAndValues) < 1 {
 		return InvalidExpression(operatorAndValues)
 	}
 
-	filter.Enable()
+	f.Enable()
 
 	// case of =bools...
 	if operatorAndValues[0] == '=' {
@@ -65,7 +65,7 @@ func (filter *BoolFilter) Parse(operatorAndValues string) error {
 			if err != nil {
 				return InvalidValue(val)
 			}
-			if err = filter.add(boolVal, Equal); err != nil {
+			if err = f.add(boolVal, Equal); err != nil {
 				return err
 			}
 		}
@@ -84,7 +84,7 @@ func (filter *BoolFilter) Parse(operatorAndValues string) error {
 			if err != nil {
 				return InvalidValue(val)
 			}
-			if err = filter.add(boolVal, NotEqual); err != nil {
+			if err = f.add(boolVal, NotEqual); err != nil {
 				return err
 			}
 		}
@@ -93,29 +93,29 @@ func (filter *BoolFilter) Parse(operatorAndValues string) error {
 
 	// case of !field
 	if operatorAndValues[0] == '!' {
-		filter.falseEnabled = true
+		f.falseEnabled = true
 		return nil
 	}
 
 	// final case just field
-	filter.trueEnabled = true
+	f.trueEnabled = true
 
 	return nil
 }
 
-func (filter *BoolFilter) add(val bool, operator Operator) error {
+func (f *BoolFilter) add(val bool, operator Operator) error {
 	switch operator {
 	case Equal:
 		if val {
-			filter.trueEnabled = true
+			f.trueEnabled = true
 		} else {
-			filter.falseEnabled = true
+			f.falseEnabled = true
 		}
 	case NotEqual:
 		if val {
-			filter.falseEnabled = true
+			f.falseEnabled = true
 		} else {
-			filter.trueEnabled = true
+			f.trueEnabled = true
 		}
 	default:
 		return UnsupportedOperator(operator)
@@ -135,12 +135,12 @@ func (f *BoolFilter) Enabled() bool {
 	return f.enabled
 }
 
-func (filter *BoolFilter) Value() bool {
-	return filter.trueEnabled
+func (f *BoolFilter) Value() bool {
+	return f.trueEnabled
 }
 
-func (filter *BoolFilter) FilterOut() bool {
-	if filter.Value() {
+func (f *BoolFilter) FilterOut() bool {
+	if f.Value() {
 		return false
 	}
 	return true

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -38,7 +38,7 @@ func (filter *BoolFilter) filter(val bool) bool {
 	if !trueEnabled && falseEnabled {
 		return !val
 	}
-	return false //last case is !trueEnabled && !falseEnabled which means no filter was added
+	return false // last case is !trueEnabled && !falseEnabled which means no filter was added
 }
 
 // BoolFilter can support the following expressions

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -142,7 +142,6 @@ func (filter *BoolFilter) Value() bool {
 func (filter *BoolFilter) FilterOut() bool {
 	if filter.Value() {
 		return false
-	} else {
-		return true
 	}
+	return true
 }

--- a/pkg/filters/containers.go
+++ b/pkg/filters/containers.go
@@ -21,7 +21,7 @@ func NewContainerFilter(mapName string) *ContainerFilter {
 	}
 }
 
-func (f *ContainerFilter) UpdateBPF(bpfModule *bpf.Module, containers *containers.Containers, policyID uint) error {
+func (f *ContainerFilter) UpdateBPF(bpfModule *bpf.Module, cts *containers.Containers, policyID uint) error {
 	if !f.Enabled() {
 		return nil
 	}
@@ -35,7 +35,7 @@ func (f *ContainerFilter) UpdateBPF(bpfModule *bpf.Module, containers *container
 
 	// first initialize notEqual values since equality should take precedence
 	for _, notEqualFilter := range f.NotEqual() {
-		cgroupIDs := containers.FindContainerCgroupID32LSB(notEqualFilter)
+		cgroupIDs := cts.FindContainerCgroupID32LSB(notEqualFilter)
 		if cgroupIDs == nil {
 			return errfmt.Errorf("container id not found: %s", notEqualFilter)
 		}
@@ -63,7 +63,7 @@ func (f *ContainerFilter) UpdateBPF(bpfModule *bpf.Module, containers *container
 
 	// now - setup equality filters
 	for _, equalFilter := range f.Equal() {
-		cgroupIDs := containers.FindContainerCgroupID32LSB(equalFilter)
+		cgroupIDs := cts.FindContainerCgroupID32LSB(equalFilter)
 		if cgroupIDs == nil {
 			return errfmt.Errorf("container id not found: %s", equalFilter)
 		}

--- a/pkg/filters/context.go
+++ b/pkg/filters/context.go
@@ -144,36 +144,36 @@ func (f *eventCtxFilter) Disable() {
 	f.enabled = false
 }
 
-func (filter *eventCtxFilter) Filter(evt trace.Event) bool {
-	if !filter.enabled {
+func (f *eventCtxFilter) Filter(evt trace.Event) bool {
+	if !f.enabled {
 		return true
 	}
 
 	// TODO: optimize the order of filter calls
 	// if we order this by most to least likely filter to be set
 	// we can short circuit this logic.
-	return filter.containerFilter.Filter(evt.Container.ID != "") &&
-		filter.processNameFilter.Filter(evt.ProcessName) &&
-		filter.timestampFilter.Filter(int64(evt.Timestamp)) &&
-		filter.cgroupIDFilter.Filter(uint64(evt.CgroupID)) &&
-		filter.containerIDFilter.Filter(evt.Container.ID) &&
-		filter.containerImageFilter.Filter(evt.Container.ImageName) &&
-		filter.containerNameFilter.Filter(evt.Container.Name) &&
-		filter.hostNameFilter.Filter(evt.HostName) &&
-		filter.hostPidFilter.Filter(int64(evt.HostProcessID)) &&
-		filter.hostPpidFilter.Filter(int64(evt.HostParentProcessID)) &&
-		filter.syscallFilter.Filter(evt.Syscall) &&
-		filter.hostTidFilter.Filter(int64(evt.HostThreadID)) &&
-		filter.mntNSFilter.Filter(int64(evt.MountNS)) &&
-		filter.pidFilter.Filter(int64(evt.ProcessID)) &&
-		filter.ppidFilter.Filter(int64(evt.ParentProcessID)) &&
-		filter.pidNSFilter.Filter(int64(evt.PIDNS)) &&
-		filter.processorIDFilter.Filter(int64(evt.ProcessorID)) &&
-		filter.podNameFilter.Filter(evt.Kubernetes.PodName) &&
-		filter.podNSFilter.Filter(evt.Kubernetes.PodNamespace) &&
-		filter.podUIDFilter.Filter(evt.Kubernetes.PodUID) &&
-		filter.tidFilter.Filter(int64(evt.ThreadID)) &&
-		filter.uidFilter.Filter(int64(evt.UserID))
+	return f.containerFilter.Filter(evt.Container.ID != "") &&
+		f.processNameFilter.Filter(evt.ProcessName) &&
+		f.timestampFilter.Filter(int64(evt.Timestamp)) &&
+		f.cgroupIDFilter.Filter(uint64(evt.CgroupID)) &&
+		f.containerIDFilter.Filter(evt.Container.ID) &&
+		f.containerImageFilter.Filter(evt.Container.ImageName) &&
+		f.containerNameFilter.Filter(evt.Container.Name) &&
+		f.hostNameFilter.Filter(evt.HostName) &&
+		f.hostPidFilter.Filter(int64(evt.HostProcessID)) &&
+		f.hostPpidFilter.Filter(int64(evt.HostParentProcessID)) &&
+		f.syscallFilter.Filter(evt.Syscall) &&
+		f.hostTidFilter.Filter(int64(evt.HostThreadID)) &&
+		f.mntNSFilter.Filter(int64(evt.MountNS)) &&
+		f.pidFilter.Filter(int64(evt.ProcessID)) &&
+		f.ppidFilter.Filter(int64(evt.ParentProcessID)) &&
+		f.pidNSFilter.Filter(int64(evt.PIDNS)) &&
+		f.processorIDFilter.Filter(int64(evt.ProcessorID)) &&
+		f.podNameFilter.Filter(evt.Kubernetes.PodName) &&
+		f.podNSFilter.Filter(evt.Kubernetes.PodNamespace) &&
+		f.podUIDFilter.Filter(evt.Kubernetes.PodUID) &&
+		f.tidFilter.Filter(int64(evt.ThreadID)) &&
+		f.uidFilter.Filter(int64(evt.UserID))
 }
 
 func (f *eventCtxFilter) Parse(field string, operatorAndValues string) error {

--- a/pkg/filters/context.go
+++ b/pkg/filters/context.go
@@ -55,7 +55,6 @@ func (filter *ContextFilter) Parse(filterName string, operatorAndValues string) 
 	parts := strings.Split(filterName, ".")
 	if len(parts) != 3 {
 		return InvalidExpression(filterName + operatorAndValues)
-
 	}
 	if parts[1] != "context" {
 		return InvalidExpression(filterName + operatorAndValues)

--- a/pkg/filters/int.go
+++ b/pkg/filters/int.go
@@ -141,7 +141,7 @@ func (f *IntFilter[T]) add(val int64, operator Operator) error {
 	return nil
 }
 
-func (filter *IntFilter[T]) Parse(operatorAndValues string) error {
+func (f *IntFilter[T]) Parse(operatorAndValues string) error {
 	if len(operatorAndValues) < 2 {
 		return InvalidExpression(operatorAndValues)
 	}
@@ -174,13 +174,13 @@ func (filter *IntFilter[T]) Parse(operatorAndValues string) error {
 		if err != nil {
 			return InvalidValue(val)
 		}
-		err = filter.add(valInt, operator)
+		err = f.add(valInt, operator)
 		if err != nil {
 			return errfmt.WrapError(err)
 		}
 	}
 
-	filter.Enable()
+	f.Enable()
 
 	return nil
 }

--- a/pkg/filters/sets/suffixset.go
+++ b/pkg/filters/sets/suffixset.go
@@ -35,7 +35,6 @@ func (set *SuffixSet) Put(suffix string) {
 	if suffixLength < set.minLen {
 		set.minLen = suffixLength
 	}
-
 }
 
 func (set *SuffixSet) Exists(suffix string) bool {

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -216,9 +216,8 @@ func (f *StringFilter) NotEqual() []string {
 func (filter *StringFilter) FilterOut() bool {
 	if len(filter.Equal()) > 0 && len(filter.NotEqual()) == 0 {
 		return false
-	} else {
-		return true
 	}
+	return true
 }
 
 type BPFStringFilter struct {

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -213,8 +213,8 @@ func (f *StringFilter) NotEqual() []string {
 	return res
 }
 
-func (filter *StringFilter) FilterOut() bool {
-	if len(filter.Equal()) > 0 && len(filter.NotEqual()) == 0 {
+func (f *StringFilter) FilterOut() bool {
+	if len(f.Equal()) > 0 && len(f.NotEqual()) == 0 {
 		return false
 	}
 	return true

--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -308,7 +308,6 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, policyID uint) 
 func (filter *UIntFilter[T]) FilterOut() bool {
 	if len(filter.equal) > 0 && len(filter.notEqual) == 0 && filter.min == MinNotSetUInt && filter.max == MaxNotSetUInt {
 		return false
-	} else {
-		return true
 	}
+	return true
 }

--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -161,7 +161,7 @@ func (f *UIntFilter[T]) add(val uint64, operator Operator) error {
 	return nil
 }
 
-func (filter *UIntFilter[T]) Parse(operatorAndValues string) error {
+func (f *UIntFilter[T]) Parse(operatorAndValues string) error {
 	if len(operatorAndValues) < 2 {
 		return InvalidExpression(operatorAndValues)
 	}
@@ -198,13 +198,13 @@ func (filter *UIntFilter[T]) Parse(operatorAndValues string) error {
 		if operator == Lower && valInt == 0 {
 			return InvalidExpression(operatorAndValues)
 		}
-		err = filter.add(valInt, operator)
+		err = f.add(valInt, operator)
 		if err != nil {
 			return errfmt.WrapError(err)
 		}
 	}
 
-	filter.Enable()
+	f.Enable()
 
 	return nil
 }
@@ -305,8 +305,8 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, policyID uint) 
 	return nil
 }
 
-func (filter *UIntFilter[T]) FilterOut() bool {
-	if len(filter.equal) > 0 && len(filter.notEqual) == 0 && filter.min == MinNotSetUInt && filter.max == MaxNotSetUInt {
+func (f *UIntFilter[T]) FilterOut() bool {
+	if len(f.equal) > 0 && len(f.notEqual) == 0 && f.min == MinNotSetUInt && f.max == MaxNotSetUInt {
 		return false
 	}
 	return true

--- a/pkg/logger/logcounter.go
+++ b/pkg/logger/logcounter.go
@@ -24,8 +24,7 @@ func (lc *logCounter) Lookup(key logOrigin) (count uint32, found bool) {
 	lc.rwMutex.RLock()
 	defer lc.rwMutex.RUnlock()
 	count, found = lc.data[key]
-
-	return
+	return count, found
 }
 
 func (lc *logCounter) dump(flush bool) map[logOrigin]uint32 {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -285,7 +285,7 @@ func (l *Logger) Sync() error {
 
 var (
 	// Package-level Logger
-	pkgLogger *Logger = &Logger{}
+	pkgLogger = &Logger{}
 )
 
 // Current returns the package-level base logger

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -102,7 +102,6 @@ func (m *MountOnce) Mount() error {
 
 func (m *MountOnce) Umount() error {
 	if m.managed && m.mounted {
-
 		// umount the filesystem from the target dir
 
 		err := capabilities.GetInstance().Specific(

--- a/pkg/pcaps/cache.go
+++ b/pkg/pcaps/cache.go
@@ -49,12 +49,12 @@ func (p *PcapCache) get(event *trace.Event) (*Pcap, error) {
 	i, ok = p.itemCache.Get(getItemIndexFromEvent(event, p.itemType))
 	if !ok {
 		// create an item and return it
-		new, err := NewPcap(event, p.itemType)
+		n, err := NewPcap(event, p.itemType)
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
-		p.itemCache.Add(getItemIndexFromEvent(event, p.itemType), new)
-		item = new
+		p.itemCache.Add(getItemIndexFromEvent(event, p.itemType), n)
+		item = n
 	} else {
 		// return the cached item
 		item, ok = i.(*Pcap)

--- a/pkg/pcaps/cache.go
+++ b/pkg/pcaps/cache.go
@@ -15,7 +15,6 @@ type PcapCache struct {
 }
 
 func newPcapCache(itemType PcapType) (*PcapCache, error) {
-
 	cache, err := lru.NewWithEvict(
 		pcapsToCache,
 		func(_ interface{}, value interface{},
@@ -67,7 +66,6 @@ func (p *PcapCache) get(event *trace.Event) (*Pcap, error) {
 }
 
 func (p *PcapCache) destroy() error {
-
 	for _, k := range p.itemCache.Keys() {
 		switch key := k.(type) {
 		case *Pcap:

--- a/pkg/pcaps/pcaps.go
+++ b/pkg/pcaps/pcaps.go
@@ -71,7 +71,6 @@ func New(simple Config, output *os.File) (*Pcaps, error) {
 
 // Write writes a packet to all opened pcap files from all supported pcap types
 func (p *Pcaps) Write(event *trace.Event, payload []byte) error {
-
 	// sanity check
 	if events.ID(event.EventID) != events.NetPacketCapture {
 		return errfmt.Errorf("wrong event type given to pcap")
@@ -93,7 +92,6 @@ func (p *Pcaps) Write(event *trace.Event, payload []byte) error {
 
 // Destroy destroys all opened pcap files from all supported pcap types
 func (p *Pcaps) Destroy() error {
-
 	for k := range p.pcapCaches {
 		err := p.pcapCaches[k].destroy()
 		if err != nil {

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -89,7 +89,6 @@ func (ps *Policies) Compute() {
 			p.ContextFilter.Enabled() ||
 			(p.UIDFilter.Enabled() && ps.UIDFilterableInUserSpace()) ||
 			(p.PIDFilter.Enabled() && ps.PIDFilterableInUserSpace()) {
-
 			userSpaceMap[p] = p.ID
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -90,13 +90,13 @@ func (s *Server) EnablePProfEndpoint() {
 // EnablePyroAgent enables pyroscope agent in golang push mode
 // TODO: make this configurable
 func (s *Server) EnablePyroAgent() error {
-	profiler, err := profiler.Start(
+	p, err := profiler.Start(
 		profiler.Config{
 			ApplicationName: "tracee",
 			ServerAddress:   "http://localhost:4040",
 		},
 	)
-	s.pyroProfiler = profiler
+	s.pyroProfiler = p
 
 	return err
 }

--- a/pkg/signatures/benchmark/helpers_test.go
+++ b/pkg/signatures/benchmark/helpers_test.go
@@ -196,9 +196,8 @@ func ProduceEventsFromGobFile(n int, path string) (engine.EventSources, error) {
 		if err != nil {
 			if err == io.EOF {
 				break
-			} else {
-				return engine.EventSources{}, fmt.Errorf("decoding event: %v", err)
 			}
+			return engine.EventSources{}, fmt.Errorf("decoding event: %v", err)
 		} else {
 			e := event.ToProtocol()
 			eventsCh <- e

--- a/pkg/signatures/benchmark/helpers_test.go
+++ b/pkg/signatures/benchmark/helpers_test.go
@@ -194,14 +194,13 @@ func ProduceEventsFromGobFile(n int, path string) (engine.EventSources, error) {
 		var event trace.Event
 		err := dec.Decode(&event)
 		if err != nil {
-			if err == io.EOF {
-				break
+			if err != io.EOF {
+				return engine.EventSources{}, fmt.Errorf("decoding event: %v", err)
 			}
-			return engine.EventSources{}, fmt.Errorf("decoding event: %v", err)
-		} else {
-			e := event.ToProtocol()
-			eventsCh <- e
+			break
 		}
+		e := event.ToProtocol()
+		eventsCh <- e
 	}
 
 	close(eventsCh)

--- a/pkg/signatures/benchmark/signature/golang/code_injection.go
+++ b/pkg/signatures/benchmark/signature/golang/code_injection.go
@@ -76,7 +76,7 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 			}
 			if sig.processMemFileRegexp.MatchString(pathname.Value.(string)) {
 				sig.cb(detect.Finding{
-					//Signature: sig,
+					// Signature: sig,
 					SigMetadata: sig.metadata,
 					Event:       event,
 					Data: map[string]interface{}{
@@ -94,7 +94,7 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 		requestString := request.Value.(string)
 		if requestString == "PTRACE_POKETEXT" || requestString == "PTRACE_POKEDATA" {
 			sig.cb(detect.Finding{
-				//Signature: sig,
+				// Signature: sig,
 				SigMetadata: sig.metadata,
 				Event:       event,
 				Data: map[string]interface{}{
@@ -103,7 +103,8 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 			})
 		}
 		// TODO Commenting out the execve case to make it equivalent to Rego signature
-		//case "execve":
+		//
+		// case "execve":
 		//	envs, err := helpers.GetTraceeArgumentByName(ee, "envp", helpers.GetArgOps{DefaultArgs: false})
 		//	if err != nil {
 		//		break
@@ -116,7 +117,7 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 		//				return err
 		//			}
 		//			sig.cb(detect.Finding{
-		//				//Signature: sig,
+		// Signature: sig,
 		//				SigMetadata: sig.metadata,
 		//				Payload:     ee,
 		//				Data: map[string]interface{}{

--- a/pkg/signatures/benchmark/signature/wasm/signatures.go
+++ b/pkg/signatures/benchmark/signature/wasm/signatures.go
@@ -79,19 +79,19 @@ type signature struct {
 
 func NewSignature(metadata detect.SignatureMetadata, selector []detect.SignatureEventSelector, regoCodes []string) (detect.Signature, error) {
 	compiledRego, pkgName := compileRego(regoCodes)
-	rego := rego.New(
+	r := rego.New(
 		rego.Compiler(compiledRego),
 		rego.Query(fmt.Sprintf("data.%s.tracee_match = x", pkgName)),
 		rego.Target("wasm"),
 	)
-	pq, err := rego.PrepareForEval(context.Background())
+	pq, err := r.PrepareForEval(context.Background())
 	if err != nil {
 		return nil, err
 	}
 	return &signature{
 		metadata: metadata,
 		selector: selector,
-		rego:     rego,
+		rego:     r,
 		pq:       pq,
 	}, nil
 }

--- a/pkg/signatures/celsig/signature_test.go
+++ b/pkg/signatures/celsig/signature_test.go
@@ -212,7 +212,6 @@ input.sockaddrArg('addr').sin_addr == "216.58.215.110"`,
 			assert.Equal(t, tc.finding, holder.FirstValue())
 		})
 	}
-
 }
 
 // go test -run=XXX -bench=. -benchmem -cpu=1

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -279,7 +279,7 @@ func (engine *Engine) loadSignature(signature detect.Signature) (string, error) 
 	}
 	engine.signaturesMutex.RUnlock()
 	if err := signature.Init(detect.SignatureContext{Callback: engine.matchHandler, Logger: logger.Current()}); err != nil {
-		//failed to initialize
+		// failed to initialize
 		return "", fmt.Errorf("error initializing signature %s: %w", metadata.Name, err)
 	}
 	c := make(chan protocol.Event, engine.config.SignatureBufferSize)

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -22,7 +22,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 	testCases := []struct {
 		name              string
 		inputEvent        protocol.Event
-		inputSignature    signature.FakeSignature
+		inputSignature    *signature.FakeSignature
 		expectedNumEvents int
 		expectedError     string
 		expectedEvent     interface{}
@@ -43,7 +43,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 					},
 				},
 			}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -64,7 +64,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			inputEvent: trace.Event{
 				EventName: "execve",
 			}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -81,7 +81,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			inputEvent: trace.Event{
 				EventName: "execve",
 			}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -99,7 +99,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		{
 			name:       "happy path - with all events selector, no name",
 			inputEvent: trace.Event{EventName: "execve"}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -129,7 +129,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 					},
 				},
 			}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -164,7 +164,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 					},
 				},
 			}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -194,7 +194,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 					},
 				},
 			}.ToProtocol(),
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -213,7 +213,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		},
 		{
 			name: "sad path - with all events selector, no source",
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -226,7 +226,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		},
 		{
 			name: "sad path - signature init fails",
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeInit: func(ctx detect.SignatureContext) error {
 					return errors.New("init failed")
 				},
@@ -236,7 +236,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		},
 		{
 			name: "sad path - getSelectedEvents returns an error",
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return nil, errors.New("getSelectedEvents error")
 				},
@@ -245,7 +245,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		},
 		{
 			name: "sad path - getMetadata returns an error",
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetMetadata: func() (detect.SignatureMetadata, error) {
 					return detect.SignatureMetadata{}, errors.New("getMetadata error")
 				},
@@ -264,7 +264,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 				},
 				Payload: "a great payload",
 			},
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -289,7 +289,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 				},
 				Payload: "a great payload",
 			},
-			inputSignature: signature.FakeSignature{
+			inputSignature: &signature.FakeSignature{
 				FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
 					return []detect.SignatureEventSelector{
 						{
@@ -339,7 +339,7 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			)
 
 			var sigs []detect.Signature
-			sigs = append(sigs, &tc.inputSignature)
+			sigs = append(sigs, tc.inputSignature)
 
 			// FIXME We should use another Go concurrency pattern to make this test logically correct.
 			//       The gotNumEvents variable is causing data race, because it's accessed

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -477,7 +477,7 @@ func TestEngine_LoadSignature(t *testing.T) {
 				assert.Equal(t, metadata.ID, id)
 			}
 
-			//check that signature stats were correctly incremented
+			// check that signature stats were correctly incremented
 			assert.Equal(t, tc.expectedCount, int(engine.Stats().Signatures.Read()))
 			close(input)
 		})

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -482,5 +482,4 @@ func TestEngine_LoadSignature(t *testing.T) {
 			close(input)
 		})
 	}
-
 }

--- a/pkg/signatures/regosig/traceerego.go
+++ b/pkg/signatures/regosig/traceerego.go
@@ -46,11 +46,10 @@ func NewRegoSignature(target string, partialEval bool, regoCodes ...string) (det
 	for _, regoCode := range regoCodes {
 		var regoModuleName string
 		splittedName := strings.Split(re.FindString(regoCode), " ")
-		if len(splittedName) > 1 {
-			regoModuleName = splittedName[1]
-		} else {
+		if len(splittedName) <= 1 {
 			return nil, fmt.Errorf("invalid rego code received")
 		}
+		regoModuleName = splittedName[1]
 		if !strings.Contains(regoCode, "package tracee.helpers") {
 			pkgName = regoModuleName
 		}

--- a/pkg/signatures/signature/signature.go
+++ b/pkg/signatures/signature/signature.go
@@ -2,7 +2,6 @@ package signature
 
 import (
 	"bytes"
-	_ "embed"
 	"fmt"
 	"io/fs"
 	"os"

--- a/pkg/signatures/signature/signature_test.go
+++ b/pkg/signatures/signature/signature_test.go
@@ -124,11 +124,10 @@ func Test_findRegoSigs(t *testing.T) {
 func copyExampleSig(exampleName, destDir string) error {
 	var exampleDir string
 	extension := filepath.Ext(exampleName)
-	if extension == ".rego" {
-		exampleDir = exampleRulesDir + "/%s"
-	} else {
+	if extension != ".rego" {
 		return errors.New("unsupported signature type")
 	}
+	exampleDir = exampleRulesDir + "/%s"
 
 	// copy example signature
 	exampleFile := fmt.Sprintf(exampleDir, exampleName)

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -13,12 +13,12 @@ import (
 )
 
 // OpenExistingDir open a directory with given path, and return the os.File of it.
-func OpenExistingDir(path string) (*os.File, error) {
-	outDirFD, err := unix.Open(path, unix.O_DIRECTORY|unix.O_PATH, 0)
+func OpenExistingDir(p string) (*os.File, error) {
+	outDirFD, err := unix.Open(p, unix.O_DIRECTORY|unix.O_PATH, 0)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	return os.NewFile(uintptr(outDirFD), path), nil
+	return os.NewFile(uintptr(outDirFD), p), nil
 }
 
 // OpenAt is a wrapper function to the `openat` syscall using golang types.

--- a/pkg/utils/proc/exe.go
+++ b/pkg/utils/proc/exe.go
@@ -34,7 +34,6 @@ func GetAllBinaryProcs() (map[string][]uint32, error) {
 	procs, err := procDir.Readdirnames(-1)
 	if err != nil {
 		return nil, errfmt.Errorf("could not open procfs dir: %v", err)
-
 	}
 	binProcs := map[string][]uint32{}
 	for _, proc := range procs {

--- a/pkg/utils/sharedobjs/host_symbols_loader.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader.go
@@ -94,9 +94,9 @@ func (soCache *dynamicSymbolsLRUCache) Get(objID ObjID) (*dynamicSymbols, bool) 
 	if ok {
 		objInfo := objInfoIface.(*dynamicSymbols)
 		return objInfo, true
-	} else {
-		return nil, false
 	}
+
+	return nil, false
 }
 
 func (soCache *dynamicSymbolsLRUCache) Add(obj ObjInfo, dynamicSymbols *dynamicSymbols) {

--- a/pkg/utils/sharedobjs/host_symbols_loader_test.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader_test.go
@@ -146,7 +146,6 @@ func TestHostSharedObjectSymbolsLoader_GetImportedSymbols(t *testing.T) {
 }
 
 func TestHostSharedObjectSymbolsLoader_loadSOSymbols(t *testing.T) {
-
 	t.Run("Cached SO", func(t *testing.T) {
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -45,14 +45,12 @@ func (sig *AntiDebuggingPtraceme) GetSelectedEvents() ([]detect.SignatureEventSe
 }
 
 func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "ptrace":
 		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
 		if err != nil {
@@ -70,8 +68,8 @@ func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
+
 	return nil
 }
 

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -45,16 +45,13 @@ func (sig *AslrInspection) GetSelectedEvents() ([]detect.SignatureEventSelector,
 }
 
 func (sig *AslrInspection) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -46,16 +46,13 @@ func (sig *CgroupNotifyOnReleaseModification) GetSelectedEvents() ([]detect.Sign
 }
 
 func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -79,6 +76,7 @@ func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) erro
 			})
 		}
 	}
+
 	return nil
 }
 

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -47,7 +47,6 @@ func (sig *CgroupReleaseAgentModification) GetSelectedEvents() ([]detect.Signatu
 }
 
 func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -56,9 +55,7 @@ func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 	basename := ""
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
@@ -72,16 +69,13 @@ func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 
 			basename = path.Base(pathname)
 		}
-
 	case "security_inode_rename":
-
 		newPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "new_path")
 		if err != nil {
 			return err
 		}
 
 		basename = path.Base(newPath)
-
 	}
 
 	if basename == sig.releaseAgentName {

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -46,16 +46,13 @@ func (sig *CorePatternModification) GetSelectedEvents() ([]detect.SignatureEvent
 }
 
 func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -77,7 +74,6 @@ func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -50,7 +50,6 @@ func (sig *DefaultLoaderModification) GetSelectedEvents() ([]detect.SignatureEve
 }
 
 func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -59,9 +58,7 @@ func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 	path := ""
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
@@ -75,7 +72,6 @@ func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 
 			path = pathname
 		}
-
 	case "security_inode_rename":
 		newPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "new_path")
 		if err != nil {

--- a/signatures/golang/disk_mount.go
+++ b/signatures/golang/disk_mount.go
@@ -46,16 +46,13 @@ func (sig *DiskMount) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 }
 
 func (sig *DiskMount) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_sb_mount":
-
 		if !eventObj.ContextFlags.ContainerStarted {
 			return nil
 		}
@@ -76,7 +73,6 @@ func (sig *DiskMount) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -47,7 +47,6 @@ func (sig *DockerAbuse) GetSelectedEvents() ([]detect.SignatureEventSelector, er
 }
 
 func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -56,9 +55,7 @@ func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 	path := ""
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -72,9 +69,7 @@ func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 		if helpers.IsFileWrite(flags) {
 			path = pathname
 		}
-
 	case "security_socket_connect":
-
 		addr, err := helpers.GetRawAddrArgumentByName(eventObj, "remote_addr")
 		if err != nil {
 			return err

--- a/signatures/golang/dropped_executable.go
+++ b/signatures/golang/dropped_executable.go
@@ -43,16 +43,13 @@ func (sig *DroppedExecutable) GetSelectedEvents() ([]detect.SignatureEventSelect
 }
 
 func (sig *DroppedExecutable) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "magic_write":
-
 		bytes, err := helpers.GetTraceeBytesSliceArgumentByName(eventObj, "bytes")
 		if err != nil {
 			return err
@@ -76,7 +73,6 @@ func (sig *DroppedExecutable) OnEvent(event protocol.Event) error {
 				},
 			})
 		}
-
 	}
 	return nil
 }

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -45,16 +45,13 @@ func (sig *DynamicCodeLoading) GetSelectedEvents() ([]detect.SignatureEventSelec
 }
 
 func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "mem_prot_alert":
-
 		alert, err := helpers.GetTraceeStringArgumentByName(eventObj, "alert")
 		if err != nil {
 			return err
@@ -71,7 +68,6 @@ func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/examples/example.go
+++ b/signatures/golang/examples/example.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
-//lint:ignore U1000 This is an example file with no real usage
+// lint:ignore U1000 This is an example file with no real usage
 
 // counter is a simple demo signature that counts towards a target
 type counter struct {
@@ -38,7 +38,7 @@ func (sig *counter) GetMetadata() (detect.SignatureMetadata, error) {
 func (sig *counter) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{{
 		Source: "tracee",
-		//Name:   "execve",
+		// Name:   "execve",
 	}}, nil
 }
 

--- a/signatures/golang/fileless_execution.go
+++ b/signatures/golang/fileless_execution.go
@@ -43,16 +43,13 @@ func (sig *FilelessExecution) GetSelectedEvents() ([]detect.SignatureEventSelect
 }
 
 func (sig *FilelessExecution) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "sched_process_exec":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -69,7 +66,6 @@ func (sig *FilelessExecution) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/hidden_file_created.go
+++ b/signatures/golang/hidden_file_created.go
@@ -46,16 +46,13 @@ func (sig *HiddenFileCreated) GetSelectedEvents() ([]detect.SignatureEventSelect
 }
 
 func (sig *HiddenFileCreated) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "magic_write":
-
 		bytes, err := helpers.GetTraceeBytesSliceArgumentByName(eventObj, "bytes")
 		if err != nil {
 			return err
@@ -77,7 +74,6 @@ func (sig *HiddenFileCreated) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/illegitimate_shell.go
+++ b/signatures/golang/illegitimate_shell.go
@@ -48,16 +48,13 @@ func (sig *IllegitimateShell) GetSelectedEvents() ([]detect.SignatureEventSelect
 }
 
 func (sig *IllegitimateShell) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_bprm_check":
-
 		for _, webServersProcessName := range sig.webServersProcessNames {
 			if webServersProcessName == eventObj.ProcessName {
 				pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
@@ -82,7 +79,6 @@ func (sig *IllegitimateShell) OnEvent(event protocol.Event) error {
 				}
 			}
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -51,14 +51,12 @@ func (sig *K8SServiceAccountToken) GetSelectedEvents() ([]detect.SignatureEventS
 }
 
 func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
 		// check process touching token is not on allow list
 		for _, legitProc := range sig.legitProcs {
@@ -89,6 +87,7 @@ func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 			})
 		}
 	}
+
 	return nil
 }
 

--- a/signatures/golang/kernel_module_loading.go
+++ b/signatures/golang/kernel_module_loading.go
@@ -44,14 +44,12 @@ func (sig *KernelModuleLoading) GetSelectedEvents() ([]detect.SignatureEventSele
 }
 
 func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "init_module":
 		metadata, err := sig.GetMetadata()
 		if err != nil {
@@ -62,9 +60,7 @@ func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
 			Event:       event,
 			Data:        nil,
 		})
-
 	case "security_kernel_read_file":
-
 		loadedType, err := helpers.GetTraceeStringArgumentByName(eventObj, "type")
 		if err != nil {
 			return err
@@ -81,7 +77,6 @@ func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/kubernetes_api_connection.go
+++ b/signatures/golang/kubernetes_api_connection.go
@@ -45,7 +45,6 @@ func (sig *K8sApiConnection) GetSelectedEvents() ([]detect.SignatureEventSelecto
 }
 
 func (sig *K8sApiConnection) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("failed to cast event's payload")
@@ -57,9 +56,7 @@ func (sig *K8sApiConnection) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "sched_process_exec":
-
 		envVars, err := helpers.GetTraceeSliceStringArgumentByName(eventObj, "env")
 		if err != nil {
 			return nil
@@ -69,9 +66,7 @@ func (sig *K8sApiConnection) OnEvent(event protocol.Event) error {
 		if apiIPAddress != "" {
 			sig.apiAddressContainerId[containerID] = apiIPAddress
 		}
-
 	case "security_socket_connect":
-
 		apiAddress, exists := sig.apiAddressContainerId[containerID]
 		if !exists {
 			return nil
@@ -106,6 +101,7 @@ func (sig *K8sApiConnection) OnEvent(event protocol.Event) error {
 			})
 		}
 	}
+
 	return nil
 }
 

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -49,7 +49,6 @@ func (sig *KubernetesCertificateTheftAttempt) GetSelectedEvents() ([]detect.Sign
 }
 
 func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -58,9 +57,7 @@ func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) erro
 	path := ""
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		// check process touching certificate is not on allow list
 		for _, legitProc := range sig.legitProcs {
 			if legitProc == eventObj.ProcessName {
@@ -81,16 +78,13 @@ func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) erro
 
 			path = pathname
 		}
-
 	case "security_inode_rename":
-
 		oldPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "old_path")
 		if err != nil {
 			return err
 		}
 
 		path = oldPath
-
 	}
 
 	if strings.HasPrefix(path, sig.k8sCertificatesDir) {

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -50,7 +50,6 @@ func (sig *LdPreload) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 }
 
 func (sig *LdPreload) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -58,7 +57,6 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "sched_process_exec":
-
 		envVars, err := helpers.GetTraceeSliceStringArgumentByName(eventObj, "env")
 		if err != nil {
 			return nil
@@ -81,9 +79,7 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 				}
 			}
 		}
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -105,9 +101,7 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	case "security_inode_rename":
-
 		newPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "new_path")
 		if err != nil {
 			return err
@@ -124,7 +118,6 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/proc_fops_hooking.go
+++ b/signatures/golang/proc_fops_hooking.go
@@ -43,16 +43,13 @@ func (sig *ProcFopsHooking) GetSelectedEvents() ([]detect.SignatureEventSelector
 }
 
 func (sig *ProcFopsHooking) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "hooked_proc_fops":
-
 		hookedSymbolSlice, err := helpers.GetTraceeHookedSymbolDataArgumentByName(eventObj, "hooked_fops_pointers")
 		if err != nil {
 			return err
@@ -69,7 +66,6 @@ func (sig *ProcFopsHooking) OnEvent(event protocol.Event) error {
 				Data:        map[string]interface{}{"Hooked proc file operations": hookedSymbolSlice},
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -46,14 +46,12 @@ func (sig *ProcKcoreRead) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 }
 
 func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
@@ -76,7 +74,6 @@ func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -49,16 +49,13 @@ func (sig *ProcMemAccess) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 }
 
 func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -80,8 +77,8 @@ func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
+
 	return nil
 }
 

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -49,16 +49,13 @@ func (sig *ProcMemCodeInjection) GetSelectedEvents() ([]detect.SignatureEventSel
 }
 
 func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -80,8 +77,8 @@ func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
+
 	return nil
 }
 

--- a/signatures/golang/process_vm_write_code_injection.go
+++ b/signatures/golang/process_vm_write_code_injection.go
@@ -44,16 +44,13 @@ func (sig *ProcessVmWriteCodeInjection) GetSelectedEvents() ([]detect.SignatureE
 }
 
 func (sig *ProcessVmWriteCodeInjection) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "process_vm_writev":
-
 		dstPid, err := helpers.GetTraceeIntArgumentByName(eventObj, "pid")
 		if err != nil {
 			return err
@@ -70,8 +67,8 @@ func (sig *ProcessVmWriteCodeInjection) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
+
 	return nil
 }
 

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -47,14 +47,12 @@ func (sig *PtraceCodeInjection) GetSelectedEvents() ([]detect.SignatureEventSele
 }
 
 func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "ptrace":
 		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
 		if err != nil {
@@ -72,8 +70,8 @@ func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
 				Data:        nil,
 			})
 		}
-
 	}
+
 	return nil
 }
 

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -53,16 +53,13 @@ func (sig *RcdModification) GetSelectedEvents() ([]detect.SignatureEventSelector
 }
 
 func (sig *RcdModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -76,18 +73,14 @@ func (sig *RcdModification) OnEvent(event protocol.Event) error {
 		if helpers.IsFileWrite(flags) {
 			return sig.checkFileOrDir(event, pathname)
 		}
-
 	case "security_inode_rename":
-
 		newPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "new_path")
 		if err != nil {
 			return err
 		}
 
 		return sig.checkFileOrDir(event, newPath)
-
 	case "sched_process_exec":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -97,8 +90,8 @@ func (sig *RcdModification) OnEvent(event protocol.Event) error {
 		if basename == sig.rcdCommand {
 			return sig.match(event)
 		}
-
 	}
+
 	return nil
 }
 

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -45,16 +45,13 @@ func (sig *SchedDebugRecon) GetSelectedEvents() ([]detect.SignatureEventSelector
 }
 
 func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -66,7 +63,6 @@ func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 		}
 
 		if helpers.IsFileRead(flags) {
-
 			for _, schedDebugPath := range sig.schedDebugPaths {
 				if pathname == schedDebugPath {
 					metadata, err := sig.GetMetadata()

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -53,16 +53,13 @@ func (sig *ScheduledTaskModification) GetSelectedEvents() ([]detect.SignatureEve
 }
 
 func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err
@@ -76,18 +73,14 @@ func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 		if helpers.IsFileWrite(flags) {
 			return sig.checkFileOrDir(event, pathname)
 		}
-
 	case "security_inode_rename":
-
 		newPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "new_path")
 		if err != nil {
 			return err
 		}
 
 		return sig.checkFileOrDir(event, newPath)
-
 	case "sched_process_exec":
-
 		pathname, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err

--- a/signatures/golang/stdio_over_socket.go
+++ b/signatures/golang/stdio_over_socket.go
@@ -46,7 +46,6 @@ func (sig *StdioOverSocket) GetSelectedEvents() ([]detect.SignatureEventSelector
 }
 
 func (sig *StdioOverSocket) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -56,21 +55,16 @@ func (sig *StdioOverSocket) OnEvent(event protocol.Event) error {
 	var err error
 
 	switch eventObj.EventName {
-
 	case "security_socket_connect":
-
 		sockfd, err = helpers.GetTraceeIntArgumentByName(eventObj, "sockfd")
 		if err != nil {
 			return err
 		}
-
 	case "socket_dup":
-
 		sockfd, err = helpers.GetTraceeIntArgumentByName(eventObj, "newfd")
 		if err != nil {
 			return err
 		}
-
 	}
 
 	if sockfd != 0 && sockfd != 1 && sockfd != 2 {

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -49,7 +49,6 @@ func (sig *SudoersModification) GetSelectedEvents() ([]detect.SignatureEventSele
 }
 
 func (sig *SudoersModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
@@ -58,7 +57,6 @@ func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 	path := ""
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
 
 		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
@@ -74,9 +72,7 @@ func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 
 			path = pathname
 		}
-
 	case "security_inode_rename":
-
 		newPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "new_path")
 		if err != nil {
 			return err

--- a/signatures/golang/syscall_table_hooking.go
+++ b/signatures/golang/syscall_table_hooking.go
@@ -43,16 +43,13 @@ func (sig *SyscallTableHooking) GetSelectedEvents() ([]detect.SignatureEventSele
 }
 
 func (sig *SyscallTableHooking) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "hooked_syscalls":
-
 		hookedSymbolSlice, err := helpers.GetTraceeHookedSymbolDataArgumentByName(eventObj, "hooked_syscalls")
 		if err != nil {
 			return err
@@ -69,7 +66,6 @@ func (sig *SyscallTableHooking) OnEvent(event protocol.Event) error {
 				Data:        map[string]interface{}{"Hooked syscalls": hookedSymbolSlice},
 			})
 		}
-
 	}
 
 	return nil

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -45,16 +45,13 @@ func (sig *SystemRequestKeyConfigModification) GetSelectedEvents() ([]detect.Sig
 }
 
 func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) error {
-
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
 		return fmt.Errorf("invalid event")
 	}
 
 	switch eventObj.EventName {
-
 	case "security_file_open":
-
 		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
@@ -82,7 +79,6 @@ func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) err
 				}
 			}
 		}
-
 	}
 
 	return nil

--- a/signatures/helpers/arguments_helpers.go
+++ b/signatures/helpers/arguments_helpers.go
@@ -127,18 +127,18 @@ func GetTraceeHookedSymbolDataArgumentByName(event trace.Event, argName string) 
 	hookedSymbols, ok := hookedSymbolsPtr.Value.([]trace.HookedSymbolData)
 	if ok {
 		return hookedSymbols, nil
-	} else {
-		argSlice, ok := hookedSymbolsPtr.Value.([]interface{})
-		if ok {
-			for _, v := range argSlice {
-				hookedSymbol, err := getHookedSymbolData(v)
-				if err != nil {
-					continue
-				}
-				hookedSymbols = append(hookedSymbols, hookedSymbol)
+	}
+
+	argSlice, ok := hookedSymbolsPtr.Value.([]interface{})
+	if ok {
+		for _, v := range argSlice {
+			hookedSymbol, err := getHookedSymbolData(v)
+			if err != nil {
+				continue
 			}
-			return hookedSymbols, nil
+			hookedSymbols = append(hookedSymbols, hookedSymbol)
 		}
+		return hookedSymbols, nil
 	}
 
 	return hookedSymbols, fmt.Errorf("can't convert argument %v to []trace.HookedSymbolData", argName)

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -49,7 +49,6 @@ func IsElf(bytesArray []byte) bool {
 }
 
 func GetFamilyFromRawAddr(addr map[string]string) (string, error) {
-
 	family, exists := addr["sa_family"]
 	if !exists {
 		return "", fmt.Errorf("family not found in address")
@@ -59,7 +58,6 @@ func GetFamilyFromRawAddr(addr map[string]string) (string, error) {
 }
 
 func IsInternetFamily(addr map[string]string) (bool, error) {
-
 	family, err := GetFamilyFromRawAddr(addr)
 	if err != nil {
 		return false, err
@@ -73,7 +71,6 @@ func IsInternetFamily(addr map[string]string) (bool, error) {
 }
 
 func IsUnixFamily(addr map[string]string) (bool, error) {
-
 	family, err := GetFamilyFromRawAddr(addr)
 	if err != nil {
 		return false, err
@@ -87,7 +84,6 @@ func IsUnixFamily(addr map[string]string) (bool, error) {
 }
 
 func GetIPFromRawAddr(addr map[string]string) (string, error) {
-
 	family, err := GetFamilyFromRawAddr(addr)
 	if err != nil {
 		return "", err
@@ -97,29 +93,24 @@ func GetIPFromRawAddr(addr map[string]string) (string, error) {
 	var exists bool
 
 	switch family {
-
 	case "AF_INET":
 		ip, exists = addr["sin_addr"]
 		if !exists {
 			return "", fmt.Errorf("ip not found in address")
 		}
-
 	case "AF_INET6":
 		ip, exists = addr["sin6_addr"]
 		if !exists {
 			return "", fmt.Errorf("ip not found in address")
 		}
-
 	default:
 		return "", fmt.Errorf("address family not supported")
-
 	}
 
 	return ip, nil
 }
 
 func GetPortFromRawAddr(addr map[string]string) (string, error) {
-
 	family, err := GetFamilyFromRawAddr(addr)
 	if err != nil {
 		return "", err
@@ -129,29 +120,24 @@ func GetPortFromRawAddr(addr map[string]string) (string, error) {
 	var exists bool
 
 	switch family {
-
 	case "AF_INET":
 		port, exists = addr["sin_port"]
 		if !exists {
 			return "", fmt.Errorf("port not found in address")
 		}
-
 	case "AF_INET6":
 		port, exists = addr["sin6_port"]
 		if !exists {
 			return "", fmt.Errorf("port not found in address")
 		}
-
 	default:
 		return "", fmt.Errorf("address family not supported")
-
 	}
 
 	return port, nil
 }
 
 func GetPathFromRawAddr(addr map[string]string) (string, error) {
-
 	family, err := GetFamilyFromRawAddr(addr)
 	if err != nil {
 		return "", err
@@ -161,16 +147,13 @@ func GetPathFromRawAddr(addr map[string]string) (string, error) {
 	var exists bool
 
 	switch family {
-
 	case "AF_UNIX":
 		path, exists = addr["sun_path"]
 		if !exists {
 			return "", fmt.Errorf("path not found in address")
 		}
-
 	default:
 		return "", fmt.Errorf("address family not supported")
-
 	}
 
 	return path, nil

--- a/tests/e2e-instrumentation-signatures/e2e-file_modification.go
+++ b/tests/e2e-instrumentation-signatures/e2e-file_modification.go
@@ -42,9 +42,7 @@ func (sig *e2eFileModification) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "file_modification":
-
 		filePath, err := helpers.GetTraceeStringArgumentByName(eventObj, "file_path")
 		if err != nil {
 			return err

--- a/tests/e2e-instrumentation-signatures/e2e-security_inode_rename.go
+++ b/tests/e2e-instrumentation-signatures/e2e-security_inode_rename.go
@@ -41,9 +41,7 @@ func (sig *e2eSecurityInodeRename) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "security_inode_rename":
-
 		oldPath, err := helpers.GetTraceeStringArgumentByName(eventObj, "old_path")
 		if err != nil {
 			return err

--- a/tests/e2e-instrumentation-signatures/e2e-vfs_write.go
+++ b/tests/e2e-instrumentation-signatures/e2e-vfs_write.go
@@ -42,9 +42,7 @@ func (sig *e2eVfsWrite) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "vfs_write":
-
 		filePath, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-icmp.go
+++ b/tests/e2e-net-signatures/e2e-icmp.go
@@ -41,9 +41,7 @@ func (sig *e2eICMP) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "net_packet_icmp":
-
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-icmpv6.go
+++ b/tests/e2e-net-signatures/e2e-icmpv6.go
@@ -41,9 +41,7 @@ func (sig *e2eICMPv6) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "net_packet_icmpv6":
-
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-ipv4.go
+++ b/tests/e2e-net-signatures/e2e-ipv4.go
@@ -41,9 +41,7 @@ func (sig *e2eIPv4) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "net_packet_ipv4":
-
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-ipv6.go
+++ b/tests/e2e-net-signatures/e2e-ipv6.go
@@ -41,9 +41,7 @@ func (sig *e2eIPv6) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "net_packet_ipv6":
-
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-tcp.go
+++ b/tests/e2e-net-signatures/e2e-tcp.go
@@ -41,9 +41,7 @@ func (sig *e2eTCP) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "net_packet_tcp":
-
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-udp.go
+++ b/tests/e2e-net-signatures/e2e-udp.go
@@ -41,9 +41,7 @@ func (sig *e2eUDP) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-
 	case "net_packet_udp":
-
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -344,7 +344,7 @@ func TestEventFilters(t *testing.T) {
 				}
 			}()
 
-			trc := startTracee(t, ctx, config, nil, nil)
+			trc := startTracee(ctx, t, config, nil, nil)
 
 			waitforTraceeStart(t, trc, time.Now())
 
@@ -544,7 +544,7 @@ func TestEventPolicies(t *testing.T) {
 				}
 			}()
 
-			trc := startTracee(t, ctx, config, nil, nil)
+			trc := startTracee(ctx, t, config, nil, nil)
 
 			waitforTraceeStart(t, trc, time.Now())
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -266,11 +266,11 @@ func TestEventFilters(t *testing.T) {
 			filterArgs: []string{"uid>0", "comm=ls"},
 			eventFunc:  checkUidNonZero,
 		},
-		//TODO: Add pid=0,1
-		//TODO: Add pid=0 pid=1
-		//TODO: Add uid>0
-		//TODO: Add pid>0 pid<1000
-		//TODO: Add u>0 u!=1000
+		// TODO: Add pid=0,1
+		// TODO: Add pid=0 pid=1
+		// TODO: Add uid>0
+		// TODO: Add pid>0 pid<1000
+		// TODO: Add u>0 u!=1000
 		{
 			name:       "trace filesystem events from comm ls",
 			filterArgs: []string{"s=fs", "comm=ls"},

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -42,7 +42,6 @@ func TestInitNamespacesEvent(t *testing.T) {
 
 // small set of actions to trigger a magic write event
 func checkMagicwrite(t *testing.T, gotOutput *eventOutput) {
-
 	_, err := forkAndExecFunction(doMagicWrite)
 	require.NoError(t, err)
 
@@ -510,7 +509,6 @@ func TestEventPolicies(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			filterMap, err := flags.PrepareFilterMapFromPolicies(tc.policies)
 			require.NoError(t, err)
 
@@ -575,7 +573,6 @@ var testerscript []byte
 // This is so Tracee running in the current pid can pick the command up.
 // It returns the output of the process and a possible error.
 func forkAndExecFunction(funcName testFunc) ([]byte, error) {
-
 	f, err := os.CreateTemp("", "tracee-integration-test-script")
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create temp file for script: %w", err)

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -17,7 +17,7 @@ import (
 )
 
 // load tracee into memory with args
-func startTracee(t *testing.T, ctx context.Context, config tracee.Config, output *tracee.OutputConfig, capture *tracee.CaptureConfig) *tracee.Tracee {
+func startTracee(ctx context.Context, t *testing.T, config tracee.Config, output *tracee.OutputConfig, capture *tracee.CaptureConfig) *tracee.Tracee {
 	initialize.SetLibbpfgoCallbacks()
 
 	kernelConfig, err := initialize.KernelConfig()

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -25,10 +25,10 @@ func startTracee(ctx context.Context, t *testing.T, config tracee.Config, output
 
 	config.KernelConfig = kernelConfig
 
-	OSInfo, err := helpers.GetOSInfo()
+	osInfo, err := helpers.GetOSInfo()
 	require.NoError(t, err)
 
-	err = initialize.BpfObject(&config, kernelConfig, OSInfo, "/tmp/tracee", "")
+	err = initialize.BpfObject(&config, kernelConfig, osInfo, "/tmp/tracee", "")
 	require.NoError(t, err)
 
 	if capture == nil {
@@ -121,12 +121,12 @@ func (e *eventOutput) len() int {
 
 // wait for tracee buffer to fill or timeout to occur, whichever comes first
 func waitForTraceeOutput(t *testing.T, gotOutput *eventOutput, now time.Time, failOnTimeout bool) {
-	const CheckTimeout = 5 * time.Second
+	const checkTimeout = 5 * time.Second
 	for {
 		if gotOutput.len() > 0 {
 			break
 		}
-		if time.Since(now) > CheckTimeout {
+		if time.Since(now) > checkTimeout {
 			if failOnTimeout {
 				t.Logf("timed out on output\n")
 				t.FailNow()
@@ -137,12 +137,12 @@ func waitForTraceeOutput(t *testing.T, gotOutput *eventOutput, now time.Time, fa
 }
 
 func waitforTraceeStart(t *testing.T, trc *tracee.Tracee, now time.Time) {
-	const CheckTimeout = 10 * time.Second
+	const checkTimeout = 10 * time.Second
 	for {
 		if trc.Running() {
 			break
 		}
-		if time.Since(now) > CheckTimeout {
+		if time.Since(now) > checkTimeout {
 			t.Logf("timed out on running tracee\n")
 			t.FailNow()
 		}

--- a/types/detect/detect.go
+++ b/types/detect/detect.go
@@ -7,17 +7,17 @@ import (
 
 // Signature is the basic unit of business logic for the rule-engine
 type Signature interface {
-	//GetMetadata allows the signature to declare information about itself
+	// GetMetadata allows the signature to declare information about itself
 	GetMetadata() (SignatureMetadata, error)
-	//GetSelectedEvents allows the signature to declare which events it subscribes to
+	// GetSelectedEvents allows the signature to declare which events it subscribes to
 	GetSelectedEvents() ([]SignatureEventSelector, error)
-	//Init allows the signature to initialize its internal state
+	// Init allows the signature to initialize its internal state
 	Init(ctx SignatureContext) error
-	//Close cleans the signature after Init operation
+	// Close cleans the signature after Init operation
 	Close()
-	//OnEvent allows the signature to process events passed by the Engine. this is the business logic of the signature
+	// OnEvent allows the signature to process events passed by the Engine. this is the business logic of the signature
 	OnEvent(event protocol.Event) error
-	//OnSignal allows the signature to handle lifecycle events of the signature
+	// OnSignal allows the signature to handle lifecycle events of the signature
 	OnSignal(signal Signal) error
 }
 
@@ -56,7 +56,7 @@ type SignalSourceComplete string
 // Finding is the main output of a signature. It represents a match result for the signature business logic
 type Finding struct {
 	Data        map[string]interface{}
-	Event       protocol.Event //Event is the causal event of the Finding
+	Event       protocol.Event // Event is the causal event of the Finding
 	SigMetadata SignatureMetadata
 }
 

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -207,8 +207,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 			arg.Value = []string{}
 		}
 
-		break
-
 	case "trace.ProtoIPv4":
 		var argProtoIPv4 ProtoIPv4
 		if arg.Value != nil {
@@ -223,8 +221,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoIPv4
-
-		break
 
 	case "trace.ProtoIPv6":
 		var argProtoIPv6 ProtoIPv6
@@ -241,8 +237,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = argProtoIPv6
 
-		break
-
 	case "trace.ProtoTCP":
 		var argProtoTCP ProtoTCP
 		if arg.Value != nil {
@@ -257,8 +251,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoTCP
-
-		break
 
 	case "trace.ProtoUDP":
 		var argProtoUDP ProtoUDP
@@ -275,8 +267,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = argProtoUDP
 
-		break
-
 	case "trace.ProtoICMP":
 		var argProtoICMP ProtoICMP
 		if arg.Value != nil {
@@ -291,8 +281,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoICMP
-
-		break
 
 	case "trace.ProtoICMPv6":
 		var argProtoICMPv6 ProtoICMPv6
@@ -309,8 +297,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = argProtoICMPv6
 
-		break
-
 	case "trace.PktMeta":
 		var argPktMeta PktMeta
 		if arg.Value != nil {
@@ -326,8 +312,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = argPktMeta
 
-		break
-
 	case "trace.ProtoDNS":
 		var argProtoDNS ProtoDNS
 		if arg.Value != nil {
@@ -342,8 +326,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoDNS
-
-		break
 
 	case "[]trace.DnsQueryData":
 		var dnsQuries []DnsQueryData
@@ -370,8 +352,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = dnsQuries
 
-		break
-
 	case "[]trace.DnsResponseData":
 		var dnsResponses []DnsResponseData
 		if arg.Value != nil {
@@ -397,8 +377,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = dnsResponses
 
-		break
-
 	case "trace.ProtoHTTP":
 		var argProtoHTTP ProtoHTTP
 		if arg.Value != nil {
@@ -413,8 +391,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoHTTP
-
-		break
 
 	case "trace.ProtoHTTPRequest":
 		var argProtoHTTPRequest ProtoHTTPRequest
@@ -431,8 +407,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 
 		arg.Value = argProtoHTTPRequest
 
-		break
-
 	case "trace.ProtoHTTPResponse":
 		var argProtoHTTPResponse ProtoHTTPResponse
 		if arg.Value != nil {
@@ -447,8 +421,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoHTTPResponse
-
-		break
 
 	}
 

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -40,7 +40,7 @@ type Event struct {
 	Syscall              string       `json:"syscall"`
 	StackAddresses       []uint64     `json:"stackAddresses"`
 	ContextFlags         ContextFlags `json:"contextFlags"`
-	Args                 []Argument   `json:"args"` //Arguments are ordered according their appearance in the original event
+	Args                 []Argument   `json:"args"` // Arguments are ordered according their appearance in the original event
 	Metadata             *Metadata    `json:"metadata,omitempty"`
 }
 
@@ -124,7 +124,7 @@ type ArgMeta struct {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (arg *Argument) UnmarshalJSON(b []byte) error {
-	type argument Argument //alias Argument so we can unmarshal it within the unmarshaler implementation
+	type argument Argument // alias Argument so we can unmarshal it within the unmarshaler implementation
 	d := json.NewDecoder(bytes.NewReader(b))
 	d.UseNumber()
 	if err := d.Decode((*argument)(arg)); err != nil {

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -206,7 +206,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		} else {
 			arg.Value = []string{}
 		}
-
 	case "trace.ProtoIPv4":
 		var argProtoIPv4 ProtoIPv4
 		if arg.Value != nil {
@@ -221,7 +220,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoIPv4
-
 	case "trace.ProtoIPv6":
 		var argProtoIPv6 ProtoIPv6
 		if arg.Value != nil {
@@ -236,7 +234,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoIPv6
-
 	case "trace.ProtoTCP":
 		var argProtoTCP ProtoTCP
 		if arg.Value != nil {
@@ -251,7 +248,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoTCP
-
 	case "trace.ProtoUDP":
 		var argProtoUDP ProtoUDP
 		if arg.Value != nil {
@@ -266,7 +262,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoUDP
-
 	case "trace.ProtoICMP":
 		var argProtoICMP ProtoICMP
 		if arg.Value != nil {
@@ -281,7 +276,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoICMP
-
 	case "trace.ProtoICMPv6":
 		var argProtoICMPv6 ProtoICMPv6
 		if arg.Value != nil {
@@ -296,7 +290,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoICMPv6
-
 	case "trace.PktMeta":
 		var argPktMeta PktMeta
 		if arg.Value != nil {
@@ -311,7 +304,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argPktMeta
-
 	case "trace.ProtoDNS":
 		var argProtoDNS ProtoDNS
 		if arg.Value != nil {
@@ -326,7 +318,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoDNS
-
 	case "[]trace.DnsQueryData":
 		var dnsQuries []DnsQueryData
 		if arg.Value != nil {
@@ -351,7 +342,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = dnsQuries
-
 	case "[]trace.DnsResponseData":
 		var dnsResponses []DnsResponseData
 		if arg.Value != nil {
@@ -376,7 +366,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = dnsResponses
-
 	case "trace.ProtoHTTP":
 		var argProtoHTTP ProtoHTTP
 		if arg.Value != nil {
@@ -391,7 +380,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoHTTP
-
 	case "trace.ProtoHTTPRequest":
 		var argProtoHTTPRequest ProtoHTTPRequest
 		if arg.Value != nil {
@@ -406,7 +394,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoHTTPRequest
-
 	case "trace.ProtoHTTPResponse":
 		var argProtoHTTPResponse ProtoHTTPResponse
 		if arg.Value != nil {
@@ -421,7 +408,6 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		}
 
 		arg.Value = argProtoHTTPResponse
-
 	}
 
 	return nil
@@ -1213,7 +1199,6 @@ func jsonConvertToPktMetaArg(argMap map[string]interface{}) (PktMeta, error) {
 }
 
 func jsonConvertToDnsResponseDataType(argMap map[string]interface{}) (DnsResponseData, error) {
-
 	// convert query_data
 
 	queryData, exists := argMap["query_data"]

--- a/types/trace/trace_test.go
+++ b/types/trace/trace_test.go
@@ -156,7 +156,6 @@ func TestEvent_Origin(t *testing.T) {
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expected, tc.event.Origin())
 	}
-
 }
 
 func TestEvent_ToProtocol(t *testing.T) {

--- a/types/trace/trace_test.go
+++ b/types/trace/trace_test.go
@@ -33,11 +33,10 @@ func TestEventUnmarshalJSON(t *testing.T) {
 		var res Event
 		err := json.Unmarshal([]byte(tc.json), &res)
 		if err != nil {
-			if !tc.expectError {
-				t.Error(err)
-			} else {
+			if tc.expectError {
 				continue
 			}
+			t.Error(err)
 		}
 		if !reflect.DeepEqual(tc.expect, res) {
 			for _, arg := range res.Args {
@@ -108,11 +107,10 @@ func TestArgumentUnmarshalJSON(t *testing.T) {
 		var res Argument
 		err := json.Unmarshal([]byte(tc.json), &res)
 		if err != nil {
-			if !tc.expectError {
-				t.Error(err)
-			} else {
+			if tc.expectError {
 				continue
 			}
+			t.Error(err)
 		}
 		if !reflect.DeepEqual(tc.expect, res) {
 			t.Errorf("want %v (Value type %T), have %v (Value type %T)", tc.expect, tc.expect.Value, res, res.Value)


### PR DESCRIPTION
* fd6b7921 - linting: add revive as golang linter (22 seconds ago) <Rafael David Tinoco>
* 78c5d019 - linting: unexported naming (60 minutes ago) <Rafael David Tinoco>
* fddbf10b - linting: consistent receiver names (5 hours ago) <Rafael David Tinoco>
* 2b11b80e - linting: range variables reused (5 hours ago) <Rafael David Tinoco>
* de198047 - linting: remove import shadowing (5 hours ago) <Rafael David Tinoco>
* 66b7e11d - linting: redundant else-blocks (5 hours ago) <Rafael David Tinoco>
* 3e320784 - linting: increment & decrement (5 hours ago) <Rafael David Tinoco>
* 16dd4e9b - linting: empty lines (5 hours ago) <Rafael David Tinoco>
* 48fbd980 - linting: earlier returns (6 hours ago) <Rafael David Tinoco>
* 57883ca6 - linting: ctx should be first argument (6 hours ago) <Rafael David Tinoco>
* cef0a301 - linting: remove blank imports (6 hours ago) <Rafael David Tinoco>
* 5a840c54 - linting: fix bare returns (6 hours ago) <Rafael David Tinoco>
* 7dc8e01e - linting: omit unneeded types from declarations (6 hours ago) <Rafael David Tinoco>
* 7435775f - linting: remove superfluous else statements (7 hours ago) <Rafael David Tinoco>
* 68211ec0 - linting: fix built-in vars redefined (7 hours ago) <Rafael David Tinoco>
* 644b85ef - linting: remove brake statements (7 hours ago) <Rafael David Tinoco>
* 68e06b8c - linting: fix golang comment styling (19 hours ago) <Rafael David Tinoco>
* 94bd74ed - linting: add revive config file (19 hours ago) <Rafael David Tinoco>