### PR TITLE
fix: detect container id from cgroup in  GitHub Action

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -270,6 +270,11 @@ func getContainerIdFromCgroup(cgroupPath string) (string, cruntime.RuntimeId, bo
 				runtime = cruntime.Docker
 			}
 
+			if runtime == cruntime.Unknown && i > 0 && cgroupParts[i-1] == "actions_job" {
+				// non-systemd docker with format in GitHub Actions: .../actions_job/01adbf...f26db7f/
+				runtime = cruntime.Docker
+			}
+
 			// return first match: closest to root dir path component
 			// (to have container id of the outer container)
 			// container root determined by being matched on the last path part


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix a bug related to detect container id when run docker on GitHub Action

### 2. Explain how to test it

run in Github Action `dist/tracee-ebpf -f e=container_create,existing_container,cgroup_mkdir -o json --containers`, run docker and check if the event contains the container id and other data.
