### PR TITLE
fix: kernel version comparison

### DIFF
--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -459,8 +459,8 @@ func initKernelReadFileTypes() {
 			7: trace.KernelReadSecurityPolicy,
 			8: trace.KernelReadx509Certificate,
 		}
-	} else if kernel5818ComparedToRunningKernel == helpers.KernelVersionEqual /* Running kernel is 5.8.18*/ &&
-		(kernel570ComparedToRunningKernel == helpers.KernelVersionNewer && /* Running kernel is older than 5.7.0*/
+	} else if kernel5818ComparedToRunningKernel == helpers.KernelVersionEqual /* Running kernel is 5.8.18 */ ||
+		(kernel570ComparedToRunningKernel == helpers.KernelVersionNewer && /* Running kernel is older than 5.7.0 */
 			kernel4180ComparedToRunningKernel != helpers.KernelVersionOlder) /* Running kernel is 4.18 or newer */ {
 		// running kernel version: ==5.8.18 || (<5.7 && >=4.18)
 		kernelReadFileTypes = map[int32]trace.KernelReadType{


### PR DESCRIPTION
in `security_kernel_read_file` parsing of the argument `type` has an error in one condition - making it never true. thus the parsing fails in some kernel versions.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste your very well written git logs -->

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Mon May 1 13:54:53 2023 +0300

    fix: kernel version comparison

    fix never-true if condition when comparing kernel versions
    in initKernelReadFileTypes func
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
