### PR TITLE
pkg/ebpf: add declarations for C functions

### DIFF
--- a/pkg/ebpf/c/common/bpf_prog.h
+++ b/pkg/ebpf/c/common/bpf_prog.h
@@ -1,5 +1,5 @@
-#ifndef __TRACEE_BPF_H__
-#define __TRACEE_BPF_H__
+#ifndef __TRACEE_BPF_PROG_H__
+#define __TRACEE_BPF_PROG_H__
 
 #define BPF_PROG_LOAD 5
 

--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -15,6 +15,26 @@
 #include "common/network.h"
 #include "maps.h"
 
+// DECLARATIONS -----------------------------------------------------------------------------------
+
+static __always_inline buf_t *get_buf(int idx);
+static __always_inline int save_to_submit_buf(event_data_t *event, void *ptr, u32 size, u8 index);
+static __always_inline int save_bytes_to_buf(event_data_t *event, void *ptr, u32 size, u8 index);
+static __always_inline int save_str_to_buf(event_data_t *event, void *ptr, u8 index);
+static __always_inline int
+add_u64_elements_to_buf(event_data_t *event, const u64 __user *ptr, int len, volatile u32 count_off);
+static __always_inline int
+save_u64_arr_to_buf(event_data_t *event, const u64 __user *ptr, int len, u8 index);
+static __always_inline int
+save_str_arr_to_buf(event_data_t *event, const char __user *const __user *ptr, u8 index);
+static __always_inline int save_args_str_arr_to_buf(
+    event_data_t *event, const char *start, const char *end, int elem_num, u8 index);
+static __always_inline int save_sockaddr_to_buf(event_data_t *event, struct socket *sock, u8 index);
+static __always_inline int events_perf_submit(program_data_t *p, u32 id, long ret);
+static __always_inline int save_args_to_submit_buf(event_data_t *event, args_t *args);
+
+// IMPLEMENTATIONS -----------------------------------------------------------------------------------
+
 static __always_inline buf_t *get_buf(int idx)
 {
     return bpf_map_lookup_elem(&bufs, &idx);

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -17,6 +17,18 @@
 #include <types.h>
 #include <maps.h>
 
+
+// DECLARATIONS -----------------------------------------------------------------------------------
+
+static __always_inline int
+init_context(void *ctx, event_context_t *context, struct task_struct *task, u32 options);
+static __always_inline bool context_changed(task_context_t *old, task_context_t *new);
+static __always_inline int init_program_data(program_data_t *p, void *ctx);
+static __always_inline int init_tailcall_program_data(program_data_t *p, void *ctx);
+static __always_inline void reset_event_args(program_data_t *p);
+
+// IMPLEMENTATIONS -----------------------------------------------------------------------------------
+
 static __always_inline int
 init_context(void *ctx, event_context_t *context, struct task_struct *task, u32 options)
 {

--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -15,6 +15,28 @@
 #include "memory.h"
 #include "maps.h"
 
+// DECLARATIONS -----------------------------------------------------------------------------------
+
+static __always_inline u64 get_time_nanosec_timespec(struct timespec64 *ts);
+static __always_inline u64 get_ctime_nanosec_from_inode(struct inode *inode);
+static __always_inline struct dentry *get_mnt_root_ptr_from_vfsmnt(struct vfsmount *vfsmnt);
+static __always_inline struct dentry *get_d_parent_ptr_from_dentry(struct dentry *dentry);
+static __always_inline struct qstr get_d_name_from_dentry(struct dentry *dentry);
+static __always_inline dev_t get_dev_from_file(struct file *file);
+static __always_inline u64 get_ctime_nanosec_from_file(struct file *file);
+static __always_inline struct path get_path_from_file(struct file *file);
+static __always_inline struct file *get_struct_file_from_fd(u64 fd_num);
+static __always_inline int check_fd_type(u64 fd, u16 type);
+static __always_inline dev_t get_dev_from_dentry(struct dentry *dentry);
+static __always_inline u64 get_ctime_nanosec_from_dentry(struct dentry *dentry);
+static __always_inline void *get_path_str(struct path *path);
+static __always_inline void *get_dentry_path_str(struct dentry *dentry);
+static __always_inline file_info_t get_file_info(struct file *file);
+static __always_inline struct inode *get_inode_from_file(struct file *file);
+static __always_inline struct super_block *get_super_block_from_inode(struct inode *f_inode);
+
+// IMPLEMENTATIONS -----------------------------------------------------------------------------------
+
 static __always_inline u64 get_time_nanosec_timespec(struct timespec64 *ts)
 {
     time64_t sec = READ_KERN(ts->tv_sec);

--- a/pkg/ebpf/c/common/filtering.h
+++ b/pkg/ebpf/c/common/filtering.h
@@ -38,6 +38,19 @@
 #define FILTER_MAX_NOT_SET 0
 #define FILTER_MIN_NOT_SET ULLONG_MAX
 
+// DECLARATIONS -----------------------------------------------------------------------------------
+
+static __always_inline u64
+uint_filter_range_matches(u64 filter_out_scopes, void *filter_map, u64 value, u64 max, u64 min);
+static __always_inline u64 binary_filter_matches(u64 filter_out_scopes, proc_info_t *proc_info);
+static __always_inline u64 bool_filter_matches(u64 filter_out_scopes, bool val);
+static __always_inline u64 compute_scopes(program_data_t *p);
+static __always_inline u64 should_trace(program_data_t *p);
+static __always_inline u64 should_submit(u32 event_id, event_data_t *event);
+static __always_inline u64 should_submit_by_ctx(u32 event_id, event_context_t *ctx);
+
+// IMPLEMENTATIONS -----------------------------------------------------------------------------------
+
 static __always_inline u64
 uint_filter_range_matches(u64 filter_out_scopes, void *filter_map, u64 value, u64 max, u64 min)
 {

--- a/pkg/ebpf/c/common/ksymbols.h
+++ b/pkg/ebpf/c/common/ksymbols.h
@@ -6,6 +6,15 @@
 #include <bpf/bpf_helpers.h>
 #include "maps.h"
 
+// DECLARATIONS -----------------------------------------------------------------------------------
+
+static __always_inline void *get_symbol_addr(char *symbol_name);
+static __always_inline void *get_stext_addr();
+static __always_inline void *get_etext_addr();
+static __always_inline struct pipe_inode_info *get_file_pipe_info(struct file *file);
+
+// IMPLEMENTATIONS -----------------------------------------------------------------------------------
+
 static __always_inline void *get_symbol_addr(char *symbol_name)
 {
     char new_ksym_name[MAX_KSYM_NAME_SIZE] = {};

--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -186,6 +186,52 @@ struct {
 
 #endif
 
+// DECLARATIONS -----------------------------------------------------------------------------------
+
+static __always_inline u32 get_inet_rcv_saddr(struct inet_sock *inet);
+static __always_inline u32 get_inet_saddr(struct inet_sock *inet);
+static __always_inline u32 get_inet_daddr(struct inet_sock *inet);
+static __always_inline u16 get_inet_sport(struct inet_sock *inet);
+static __always_inline u16 get_inet_num(struct inet_sock *inet);
+static __always_inline u16 get_inet_dport(struct inet_sock *inet);
+static __always_inline struct sock *get_socket_sock(struct socket *socket);
+static __always_inline u16 get_sock_family(struct sock *sock);
+static __always_inline u16 get_sock_protocol(struct sock *sock);
+static __always_inline u16 get_sockaddr_family(struct sockaddr *address);
+static __always_inline struct in6_addr get_sock_v6_rcv_saddr(struct sock *sock);
+static __always_inline struct in6_addr get_ipv6_pinfo_saddr(struct ipv6_pinfo *np);
+static __always_inline struct in6_addr get_sock_v6_daddr(struct sock *sock);
+static __always_inline struct ipv6_pinfo *get_inet_pinet6(struct inet_sock *inet);
+static __always_inline struct sockaddr_un get_unix_sock_addr(struct unix_sock *sock);
+static __always_inline int
+get_network_details_from_sock_v4(struct sock *sk, net_conn_v4_t *net_details, int peer);
+static __always_inline struct ipv6_pinfo *inet6_sk_own_impl(struct sock *__sk,
+                                                            struct inet_sock *inet);
+static __always_inline int
+get_network_details_from_sock_v6(struct sock *sk, net_conn_v6_t *net_details, int peer);
+static __always_inline int get_local_sockaddr_in_from_network_details(struct sockaddr_in *addr,
+                                                                      net_conn_v4_t *net_details,
+                                                                      u16 family);
+static __always_inline int get_remote_sockaddr_in_from_network_details(struct sockaddr_in *addr,
+                                                                       net_conn_v4_t *net_details,
+                                                                       u16 family);
+static __always_inline int get_local_sockaddr_in6_from_network_details(struct sockaddr_in6 *addr,
+                                                                       net_conn_v6_t *net_details,
+                                                                       u16 family);
+static __always_inline int get_remote_sockaddr_in6_from_network_details(struct sockaddr_in6 *addr,
+                                                                        net_conn_v6_t *net_details,
+                                                                        u16 family);
+static __always_inline int get_local_net_id_from_network_details_v4(struct sock *sk,
+                                                                    net_id_t *connect_id,
+                                                                    net_conn_v4_t *net_details,
+                                                                    u16 family);
+static __always_inline int get_local_net_id_from_network_details_v6(struct sock *sk,
+                                                                    net_id_t *connect_id,
+                                                                    net_conn_v6_t *net_details,
+                                                                    u16 family);
+
+// IMPLEMENTATIONS -----------------------------------------------------------------------------------
+
 //
 // Regular events related to network
 //

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -74,10 +74,13 @@
 #endif
 
 #undef container_of
+
+
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
 #include <bpf/bpf_endian.h>
+#include "tracee.bpf.h"
 #include "maps.h"
 #include "types.h"
 #include "common/arch.h"
@@ -2751,14 +2754,6 @@ static __always_inline bool should_submit_io_event(u32 event_id, program_data_t 
             should_submit(event_id, p->event));
 }
 
-/** do_file_io_operation - generic file IO (read and write) event creator.
- *
- * @ctx:            the state of the registers prior the hook.
- * @event_id:       the ID of the event to be created.
- * @tail_call_id:   the ID of the tail call to be called before function return.
- * @is_read:        true if the operation is read. False if write.
- * @is_buf:         true if the non-file side of the operation is a buffer. False if io_vector.
- */
 static __always_inline int
 do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool is_read, bool is_buf)
 {
@@ -2829,10 +2824,6 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
     return 0;
 }
 
-// Capture file write
-// Will only capture if:
-// 1. File write capture was configured
-// 2. File matches the filters given
 static __always_inline int capture_file_write(struct pt_regs *ctx, u32 event_id)
 {
     program_data_t p = {};
@@ -3384,8 +3375,6 @@ int BPF_KPROBE(trace_security_bpf)
     }
     return 0;
 }
-
-// arm_kprobe can't be hooked in arm64 architecture, use enable logic instead
 
 static __always_inline int arm_kprobe_handler(struct pt_regs *ctx)
 {

--- a/pkg/ebpf/c/tracee.bpf.h
+++ b/pkg/ebpf/c/tracee.bpf.h
@@ -1,0 +1,167 @@
+#ifndef __TRACEE_BPF_H__
+#define __TRACEE_BPF_H__
+
+#ifndef CORE
+    #include <missing_noncore_definitions.h>
+#else
+    #include <missing_definitions.h>
+    #include <vmlinux.h>
+#endif
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_endian.h>
+
+#include "types.h"
+#include "common/network.h"
+
+static __always_inline int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd);
+
+// Populate all the modules to an efficient query-able hash map.
+static __always_inline bool init_shown_modules();
+
+static __always_inline bool is_hidden(u64 mod);
+
+static __always_inline bool find_modules_from_module_kset_list(program_data_t *p);
+
+#ifdef CORE // in non CORE builds it's already defined
+static __always_inline struct latch_tree_node *__lt_from_rb(struct rb_node *node, int idx);
+#endif
+
+static __always_inline bool walk_mod_tree(program_data_t *p, struct rb_node *root, int idx);
+
+static __always_inline bool find_modules_from_mod_tree(program_data_t *p);
+
+static __always_inline bool check_is_proc_modules_hooked(program_data_t *p);
+
+static __always_inline bool kern_ver_below_min_lkm(struct pt_regs *ctx);
+
+static __always_inline struct trace_kprobe *get_trace_kprobe_from_trace_probe(void *tracep);
+
+static __always_inline struct trace_uprobe *get_trace_uprobe_from_trace_probe(void *tracep);
+
+// This function returns a pointer to struct trace_probe from struct trace_event_call.
+static __always_inline void *get_trace_probe_from_trace_event_call(struct trace_event_call *call);
+
+// Inspired by bpf_get_perf_event_info() kernel func.
+// https://elixir.bootlin.com/linux/v5.19.2/source/kernel/trace/bpf_trace.c#L2123
+static __always_inline int
+send_bpf_attach(program_data_t *p, struct file *bpf_prog_file, struct file *perf_event_file);
+
+static __always_inline u32 tail_call_send_bin(void *ctx,
+                                              program_data_t *p,
+                                              bin_args_t *bin_args,
+                                              int tail_call);
+
+static __always_inline u32 send_bin_helper(void *ctx, void *prog_array, int tail_call);
+
+static __always_inline int
+submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data, u32 bytes_written);
+
+static __always_inline bool should_submit_io_event(u32 event_id, program_data_t *p);
+
+/** do_file_io_operation - generic file IO (read and write) event creator.
+ *
+ * @ctx:            the state of the registers prior the hook.
+ * @event_id:       the ID of the event to be created.
+ * @tail_call_id:   the ID of the tail call to be called before function return.
+ * @is_read:        true if the operation is read. False if write.
+ * @is_buf:         true if the non-file side of the operation is a buffer. False if io_vector.
+ */
+static __always_inline int
+do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool is_read, bool is_buf);
+
+// Capture file write
+// Will only capture if:
+// 1. File write capture was configured
+// 2. File matches the filters given
+static __always_inline int capture_file_write(struct pt_regs *ctx, u32 event_id);
+
+// Check (CORE || (!CORE && kernel >= 5.7)) to compile successfully.
+// (compiler will try to compile the func even if no execution path leads to it).
+#if defined(CORE) || (!defined(CORE) && (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0)))
+static __always_inline int do_check_bpf_link(program_data_t *p, union bpf_attr *attr, int cmd);
+#endif
+
+static __always_inline int check_bpf_link(program_data_t *p, union bpf_attr *attr, int cmd);
+
+// arm_kprobe can't be hooked in arm64 architecture, use enable logic instead
+static __always_inline int arm_kprobe_handler(struct pt_regs *ctx);
+
+static __always_inline int handle_bpf_helper_func_id(u32 host_tid, int func_id);
+
+static __always_inline struct pipe_buffer *get_last_write_pipe_buffer(struct pipe_inode_info *pipe);
+
+static __always_inline int common_utimes(struct pt_regs *ctx);
+
+static __always_inline int common_file_modification_ent(struct pt_regs *ctx);
+
+static __always_inline int common_file_modification_ret(struct pt_regs *ctx);
+
+// Network Packets (works from ~5.2 and beyond)
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(5, 1, 0) || defined(CORE)) || defined(RHEL_RELEASE_CODE)
+
+// To track ingress/egress traffic we always need to link a flow to its related
+// task (particularly when hooking ingress skb bpf programs, where the current
+// task is typically a kernel thread).
+
+// In older kernels, managing cgroup skb programs can be more difficult due to
+// the lack of bpf helpers and buggy/incomplete verifier. To deal with this,
+// this approach uses a technique of kprobing the function responsible for
+// calling the cgroup/skb programs.
+
+// Tracee utilizes a technique of kprobing the function responsible for calling
+// the cgroup/skb programs in order to perform the tasks which cgroup skb
+// programs would usually accomplish. Through this method, all the data needed
+// by the cgroup/skb programs is already stored in a map.
+
+// Unfortunately this approach has some cons: the kprobe to cgroup/skb execution
+// flow does not have preemption disabled, so the map used in between all the
+// hooks need to use as a key something that is available to all the hooks
+// context (the packet contents themselves: e.g. L3 header fields).
+
+// At the end, the logic is simple: every time a socket is created an inode is
+// also created. The task owning the socket is indexed by the socket inode so
+// everytime this socket is used we know which task it belongs to (specially
+// during ingress hook, executed from the softirq context within a kthread).
+
+//
+// network helper functions
+//
+
+static __always_inline bool is_family_supported(struct socket *sock);
+
+static __always_inline bool is_socket_supported(struct socket *sock);
+
+//
+// Support functions for network code
+//
+
+static __always_inline u64 sizeof_net_event_context_t(void);
+
+static __always_inline void set_net_task_context(event_data_t *event, net_task_context_t *netctx);
+
+static __always_inline int should_submit_net_event(net_event_context_t *neteventctx,
+                                                   net_packet_t packet_type);
+
+static __always_inline int should_capture_net_event(net_event_context_t *neteventctx,
+                                                    net_packet_t packet_type);
+
+static __always_inline u32 cgroup_skb_submit(void *map,
+                                             struct __sk_buff *ctx,
+                                             net_event_context_t *neteventctx,
+                                             u32 event_type,
+                                             u32 size);
+
+
+static __always_inline u32 cgroup_skb_capture_event(struct __sk_buff *ctx,
+                                                    net_event_context_t *neteventctx,
+                                                    u32 event_type);
+
+static __always_inline u32 update_net_inodemap(struct socket *sock, event_data_t *event);
+
+static __always_inline u32 cgroup_skb_generic(struct __sk_buff *ctx, void *cgrpctxmap);
+
+static __always_inline int net_l7_is_http(struct __sk_buff *skb, u32 l7_off);
+
+#endif // Network Packets
+
+#endif


### PR DESCRIPTION
Add functions declaration for C files if there is enough logic in them. The tracee.bpf.c file declarations are exported to a header file.

### 1. Explain what the PR does

pkg/ebpf: add declarations for C functions
Add functions declaration for C files if there is enough logic in them.
The tracee.bpf.c file declarations are exported to a header file.

fix #2359

### 3. Other comments

I implemented this PR without creating header files, to reduce files in the project.
@yanivagman and @rafaeldtinoco tell me what you think of it.
We should probably add documentation to exposed function, and reorder to expose important functions prior to internal ones as well.