### PR TITLE
tracee: add engine field to tracee object

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -169,6 +169,7 @@ type Tracee struct {
 	running   atomic.Bool
 	outDir    *os.File // use utils.XXX functions to access this file
 	stats     metrics.Stats
+	sigEngine *engine.Engine
 	// Events
 	events           map[events.ID]eventConfig
 	eventsSorter     *sorting.EventsChronologicalSorter

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -70,25 +70,6 @@ func NewEngine(config Config, sources EventSources, output chan detect.Finding) 
 	return &engine, nil
 }
 
-// StartPipeline receives an input channel, and returns an output channel
-// allowing the signatures engine to be used in the events pipeline
-func StartPipeline(ctx context.Context, cfg Config, input chan protocol.Event) <-chan detect.Finding {
-	output := make(chan detect.Finding)
-
-	source := EventSources{Tracee: input}
-	engine, err := NewEngine(cfg, source, output)
-	if err != nil {
-		logger.Fatalw("Error creating engine: " + err.Error())
-	}
-
-	go func() {
-		defer close(output)
-		engine.Start(ctx)
-	}()
-
-	return output
-}
-
 // signatureStart is the signature handling business logics.
 func signatureStart(signature detect.Signature, c chan protocol.Event, wg *sync.WaitGroup) {
 	wg.Add(1)


### PR DESCRIPTION
This change allows managing the signature engine directly from tracee when running in "everything is an event" mode.
This allows access to engine methods from tracee itself.

Due to the following change, the engine.PipelineStart method was removed as the encapsulation was no longer relevant to the purpose of this change.

Tested by:
1. Sanity checking anti_debugging_ptrace signature and making sure it still triggers

This change is necessary to resolve #3007, and will allow further future developments of direct interactions between tracee and the signature engine.