### PR TITLE
feat: support running tracee from pid ns

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -835,9 +835,9 @@ int uprobe_lkm_seeker(struct pt_regs *ctx)
     p.event->context.syscall = NO_SYSCALL;
     p.event->context.matched_policies = ULLONG_MAX;
 
-    u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
     // uprobe was triggered from other tracee instance
-    if (p.config->tracee_pid != trigger_pid) {
+    if (p.config->tracee_pid != p.task_info->context.pid &&
+        p.config->tracee_pid != p.task_info->context.host_pid) {
         return 0;
     }
 
@@ -1286,7 +1286,6 @@ SEC("uprobe/trigger_syscall_event")
 int uprobe_syscall_trigger(struct pt_regs *ctx)
 {
     u64 caller_ctx_id = 0;
-    u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
 
     // clang-format off
     //
@@ -1323,7 +1322,8 @@ int uprobe_syscall_trigger(struct pt_regs *ctx)
     p.event->context.matched_policies = ULLONG_MAX;
 
     // uprobe was triggered from other tracee instance
-    if (p.config->tracee_pid != trigger_pid)
+    if (p.config->tracee_pid != p.task_info->context.pid &&
+        p.config->tracee_pid != p.task_info->context.host_pid)
         return 0;
 
     int key = 0;
@@ -1380,7 +1380,6 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
     u64 caller_ctx_id = 0;
     u64 *address_array = NULL;
     u64 struct_address;
-    u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
 
     // clang-format off
     //
@@ -1420,7 +1419,8 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
     p.event->context.matched_policies = ULLONG_MAX;
 
     // uprobe was triggered from other tracee instance
-    if (p.config->tracee_pid != trigger_pid)
+    if (p.config->tracee_pid != p.task_info->context.pid &&
+        p.config->tracee_pid != p.task_info->context.host_pid)
         return 0;
 
     void *stext_addr = get_stext_addr();
@@ -1478,7 +1478,6 @@ int uprobe_mem_dump_trigger(struct pt_regs *ctx)
     u64 address = 0;
     u64 size = 0;
     u64 caller_ctx_id = 0;
-    u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
 
 #if defined(bpf_target_x86)
     address = ctx->bx;       // 1st arg
@@ -1501,7 +1500,8 @@ int uprobe_mem_dump_trigger(struct pt_regs *ctx)
     p.event->context.matched_policies = ULLONG_MAX;
 
     // uprobe was triggered from other tracee instance
-    if (p.config->tracee_pid != trigger_pid)
+    if (p.config->tracee_pid != p.task_info->context.pid &&
+        p.config->tracee_pid != p.task_info->context.host_pid)
         return 0;
 
     if (size <= 0)


### PR DESCRIPTION
issue: #3036

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste your very well written git logs -->

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Wed May 3 17:33:53 2023 +0300

    feat: support running tracee from pid ns

    in triggered events, check the pid and host_pid of the triggering
    process against tracee_pid to allow running tracee from non-host pid ns
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

run tracee inside WSL
command: `./dist/tracee-ebpf -f e=print_mem_dump -f print_mem_dump.args.symbol_name=security_bprm_check`

upon tracee startup you should get `print_mem_dump` event.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
