### PR TITLE
libbpfgo: trim suffix newline from libbpf message

### DIFF
--- a/pkg/cmd/initialize/callbacks.go
+++ b/pkg/cmd/initialize/callbacks.go
@@ -2,6 +2,7 @@ package initialize
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/aquasecurity/libbpfgo"
 
@@ -58,6 +59,7 @@ func SetLibbpfgoCallbacks() {
 				lvl = logger.DebugLevel
 			}
 
+			msg = strings.TrimSuffix(msg, "\n")
 			logger.Log(lvl, false, msg)
 		},
 		LogFilters: []func(libLevel int, msg string) bool{


### PR DESCRIPTION
### 1. Explain what the PR does

After https://github.com/aquasecurity/libbpfgo/commit/6d17d1ac71918fcf13379ffecfbccff607204b9b, the libbpf message is passed as it is to the callback function. This causes the message to be printed with an additional newline.

So this commit trims the suffix newline from the message.

### 2. Explain how to test it

### 3. Other comments

Fix: #2950 