### PR TITLE
cli: don't sort flags in help/usage messages

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -284,6 +284,8 @@ func initCmd() error {
 		return errfmt.WrapError(err)
 	}
 
+	rootCmd.Flags().SortFlags = false
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

After moving to cobra, flags are automatically sorted alphabetically. This, however, is not the desired behavior since we want the most useful flags to show first in the help message.
Disable this automatic sorting behavior.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

`./dist/tracee -h`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
