### PR TITLE
cmd: log only after tracee.Run()

### DIFF
--- a/cmd/tracee/main.go
+++ b/cmd/tracee/main.go
@@ -1,17 +1,9 @@
 package main
 
 import (
-	"os"
-
 	"github.com/aquasecurity/tracee/cmd/tracee/cmd"
-	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
 func main() {
-	logger.Init(logger.NewDefaultLoggingConfig())
-
-	if err := cmd.Execute(); err != nil {
-		logger.Fatalw("Execution", "error", err)
-		os.Exit(1)
-	}
+	cmd.Execute()
 }


### PR DESCRIPTION
### 1. Explain what the PR does

While tracee doesn't reach the Run() function, we don't want to log anything, just print possible errors to stderr.

### 2. Explain how to test it

### 3. Other comments

Fix: #3044