### PR TITLE
tracee: move metrics register to tracee

### DIFF
--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -25,6 +25,13 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 	}
 	t.sigEngine = sigEngine
 
+	if t.config.MetricsEnabled {
+		err := t.sigEngine.Stats().RegisterPrometheus()
+		if err != nil {
+			logger.Errorw("Registering signature engine prometheus metrics", "error", err)
+		}
+	}
+
 	go t.sigEngine.Start(ctx)
 
 	// TODO: in the upcoming releases, the rule engine should be changed to receive trace.Event,

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -72,6 +72,7 @@ type Config struct {
 	Sockets            runtime.Sockets
 	ContainersEnrich   bool
 	EngineConfig       engine.Config
+	MetricsEnabled     bool
 }
 
 type CaptureConfig struct {
@@ -387,6 +388,15 @@ func New(cfg Config) (*Tracee, error) {
 	// Start event triggering logic context
 
 	t.triggerContexts = trigger.NewContext()
+
+	// Export metrics to prometheus if enabled
+
+	if t.config.MetricsEnabled {
+		err := t.Stats().RegisterPrometheus()
+		if err != nil {
+			logger.Errorw("Registering prometheus metrics", "error", err)
+		}
+	}
 
 	return t, nil
 }


### PR DESCRIPTION
Adds a new config field MetricsEnabled, which is used to register tracee and the rule engine's (in everything is an event) stats, instead of relying on doing in the runner when the flag is enabled from the server (which now informs the config field instead).

Fix #3007 
