### PR TITLE
cmd: adjust cobra cmdline parsing for comma

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -24,8 +24,7 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "tracee",
 		Short: "Trace OS events and syscalls using eBPF",
-		Long: `Tracee uses eBPF technology to tap into your system and give you
-access to hundreds of events that help you understand how your system behaves.`,
+		Long:  `Tracee uses eBPF technology to tap into your system and give you access to hundreds of events that help you understand how your system behaves.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			logger.Init(logger.NewDefaultLoggingConfig())
 			initialize.SetLibbpfgoCallbacks()

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -160,7 +160,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 			return runner, err
 		}
 	} else {
-		filterMap, err = flags.PrepareFilterMapFromFlags(filterFlags)
+		filterMap, err = flags.PrepareFilterMapFromCobraFlags(filterFlags)
 		if err != nil {
 			return runner, err
 		}


### PR DESCRIPTION
### 1. Explain what the PR does

Create PrepareFilterMapFromCobraFlags() in order to concatenate values from the same filter type, per operator index, so it can be used by the same filter parsering logic.

Fixes: #3033

### 2. Explain how to test it

```
sudo ./dist/tracee --filter event=one,two --filter event=three --filter comm=cmd01 --filter event!=four,five,six --filter comm=cmd02,cmd03
```

### 3. Other comments

