### PR TITLE
cmd: cobra: fix parsing for multiple values

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -78,7 +78,7 @@ func initCmd() error {
 	// Filter/Policy flags
 
 	// filter is not bound to viper
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"filter",
 		"f",
 		[]string{},
@@ -86,7 +86,7 @@ func initCmd() error {
 	)
 
 	// policy is not bound to viper
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"policy",
 		"p",
 		[]string{},
@@ -95,7 +95,7 @@ func initCmd() error {
 
 	// Output flags
 
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"output",
 		"o",
 		[]string{"table"},
@@ -107,7 +107,7 @@ func initCmd() error {
 	}
 
 	// capture is not bound to viper
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"capture",
 		"c",
 		[]string{},
@@ -136,7 +136,7 @@ func initCmd() error {
 		return errfmt.WrapError(err)
 	}
 
-	rootCmd.Flags().StringSlice(
+	rootCmd.Flags().StringArray(
 		"crs",
 		[]string{},
 		"Define connected container runtimes",
@@ -158,7 +158,7 @@ func initCmd() error {
 		return errfmt.WrapError(err)
 	}
 
-	rootCmd.Flags().StringSlice(
+	rootCmd.Flags().StringArray(
 		"rego",
 		[]string{},
 		"Control event rego settings",
@@ -191,7 +191,7 @@ func initCmd() error {
 		return errfmt.WrapError(err)
 	}
 
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"cache",
 		"a",
 		[]string{"none"},
@@ -258,7 +258,7 @@ func initCmd() error {
 
 	// Other flags
 
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"capabilities",
 		"C",
 		[]string{},
@@ -279,7 +279,7 @@ func initCmd() error {
 		return errfmt.WrapError(err)
 	}
 
-	rootCmd.Flags().StringSliceP(
+	rootCmd.Flags().StringArrayP(
 		"log",
 		"l",
 		[]string{"info"},

--- a/docs/docs/config/overview.md
+++ b/docs/docs/config/overview.md
@@ -23,7 +23,7 @@ sudo ./dist/tracee --config ./examples/global_config.yaml --log info
 
 ## Configuration File Format
 
-The configuration file can be in any format supported by the [viper](https://github.com/spf13/viper) library, which includes YAML, JSON, TOML, INI, HCL and Java properties. The configuration file should contain a mapping of flag names to their values. For example, to output aggregated debug level logs every default seconds `--log debug,aggregate`, you would add the following to your configuration file:
+The configuration file can be in any format supported by the [viper](https://github.com/spf13/viper) library, which includes YAML, JSON, TOML, INI, HCL and Java properties. The configuration file should contain a mapping of flag names to their values. For example, to output aggregated debug level logs every default seconds `--log debug --log aggregate`, you would add the following to your configuration file:
 
 ```yaml
 log:

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -112,7 +112,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Capture command line flags - via cobra flag
 
-	captureFlags, err := c.Flags().GetStringSlice("capture")
+	captureFlags, err := c.Flags().GetStringArray("capture")
 	if err != nil {
 		return runner, err
 	}
@@ -133,12 +133,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Policy/Filter command line flags - via cobra flag
 
-	policyFlags, err := c.Flags().GetStringSlice("policy")
+	policyFlags, err := c.Flags().GetStringArray("policy")
 	if err != nil {
 		return runner, err
 	}
 
-	filterFlags, err := c.Flags().GetStringSlice("filter")
+	filterFlags, err := c.Flags().GetStringArray("filter")
 	if err != nil {
 		return runner, err
 	}


### PR DESCRIPTION
### 1. Explain what the PR does

The previous implementation was making use of StringSlice which parses the input as a comma separated list. This is not what we want, we want to be able to pass multiple values to the same flag, letting the parsing of the values to the Prepare function.

### 2. Explain how to test it

```
❯ sudo ./dist/tracee --filter event=openat,close --filter comm=ls --filter comm=uname,who                                      
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
07:38:27:474415  1000   ls               830292  830292  3                openat                    dirfd: -100, pathname: /etc/ld.so.cache, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:27:474447  1000   ls               830292  830292  0                close                     fd: 3
07:38:27:474479  1000   ls               830292  830292  3                openat                    dirfd: -100, pathname: /usr/lib/libcap.so.2, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:27:474569  1000   ls               830292  830292  0                close                     fd: 3
07:38:27:474579  1000   ls               830292  830292  3                openat                    dirfd: -100, pathname: /usr/lib/libc.so.6, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:27:474668  1000   ls               830292  830292  0                close                     fd: 3
07:38:27:474990  1000   ls               830292  830292  3                openat                    dirfd: -100, pathname: /usr/lib/locale/locale-archive, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:27:475033  1000   ls               830292  830292  0                close                     fd: 3
07:38:27:475294  1000   ls               830292  830292  3                openat                    dirfd: -100, pathname: ., flags: O_RDONLY|O_NONBLOCK|O_DIRECTORY|O_CLOEXEC, mode: 0
07:38:27:475429  1000   ls               830292  830292  0                close                     fd: 3
07:38:27:475540  1000   ls               830292  830292  0                close                     fd: 1
07:38:27:475545  1000   ls               830292  830292  0                close                     fd: 2
07:38:29:973627  1000   uname            830335  830335  3                openat                    dirfd: -100, pathname: /etc/ld.so.cache, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:29:973667  1000   uname            830335  830335  0                close                     fd: 3
07:38:29:973693  1000   uname            830335  830335  3                openat                    dirfd: -100, pathname: /usr/lib/libc.so.6, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:29:973793  1000   uname            830335  830335  0                close                     fd: 3
07:38:29:974028  1000   uname            830335  830335  3                openat                    dirfd: -100, pathname: /usr/lib/locale/locale-archive, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:29:974058  1000   uname            830335  830335  0                close                     fd: 3
07:38:29:974136  1000   uname            830335  830335  0                close                     fd: 1
07:38:29:974142  1000   uname            830335  830335  0                close                     fd: 2
07:38:30:590124  1000   who              830355  830355  3                openat                    dirfd: -100, pathname: /etc/ld.so.cache, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:30:590136  1000   who              830355  830355  0                close                     fd: 3
07:38:30:590146  1000   who              830355  830355  3                openat                    dirfd: -100, pathname: /usr/lib/libc.so.6, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:30:590178  1000   who              830355  830355  0                close                     fd: 3
07:38:30:590287  1000   who              830355  830355  3                openat                    dirfd: -100, pathname: /usr/lib/locale/locale-archive, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:30:590297  1000   who              830355  830355  0                close                     fd: 3
07:38:30:590322  1000   who              830355  830355  3                openat                    dirfd: -100, pathname: /var/run/utmp, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:30:590335  1000   who              830355  830355  0                close                     fd: 3
07:38:30:590346  1000   who              830355  830355  3                openat                    dirfd: -100, pathname: /etc/localtime, flags: O_RDONLY|O_CLOEXEC, mode: 0
07:38:30:590354  1000   who              830355  830355  0                close                     fd: 3
07:38:30:590369  1000   who              830355  830355  0                close                     fd: 1
07:38:30:590370  1000   who              830355  830355  0                close                     fd: 2
```


### 3. Other comments

Fix #3033
