### PR TITLE
fix deadlocks triggered by cancelled ctx

### DIFF
--- a/pkg/cmd/printer/broadcast.go
+++ b/pkg/cmd/printer/broadcast.go
@@ -1,19 +1,19 @@
 package printer
 
 import (
-	"context"
-
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
 // Broadcast is a printer that broadcasts events to multiple printers
 type Broadcast struct {
 	eventsChan []chan trace.Event
+	done       chan struct{}
 }
 
 // NewBroadcast creates a new Broadcast printer
-func NewBroadcast(ctx context.Context, printers []EventPrinter) *Broadcast {
+func NewBroadcast(printers []EventPrinter) *Broadcast {
 	eventsChan := make([]chan trace.Event, 0, len(printers))
+	done := make(chan struct{})
 
 	for _, printer := range printers {
 		// we use a buffered channel to avoid blocking the event channel,
@@ -21,10 +21,13 @@ func NewBroadcast(ctx context.Context, printers []EventPrinter) *Broadcast {
 		eventChan := make(chan trace.Event, 1000)
 		eventsChan = append(eventsChan, eventChan)
 
-		go startPrinter(ctx, eventChan, printer)
+		go startPrinter(done, eventChan, printer)
 	}
 
-	return &Broadcast{eventsChan: eventsChan}
+	return &Broadcast{
+		eventsChan: eventsChan,
+		done:       done,
+	}
 }
 
 // Print broadcasts the event to all printers
@@ -35,16 +38,21 @@ func (b *Broadcast) Print(event trace.Event) {
 	}
 }
 
-func startPrinter(ctx context.Context, c chan trace.Event, p EventPrinter) {
+// Close closes Broadcast printer
+func (b *Broadcast) Close() {
+	close(b.done)
+}
+
+func startPrinter(done chan struct{}, c chan trace.Event, p EventPrinter) {
 	// Print the preamble and start event channel reception
 	p.Preamble()
 
 	for {
 		select {
+		case <-done:
+			return
 		case event := <-c:
 			p.Print(event)
-		case <-ctx.Done():
-			return
 		}
 	}
 }

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -57,7 +57,7 @@ func (r Runner) Run(ctx context.Context) error {
 		return errfmt.Errorf("error initializing Tracee: %v", err)
 	}
 
-	broadcast := printer.NewBroadcast(ctx, r.Printers)
+	broadcast := printer.NewBroadcast(r.Printers)
 
 	// Start event channel reception
 	go func() {
@@ -80,6 +80,7 @@ func (r Runner) Run(ctx context.Context) error {
 		case event := <-r.TraceeConfig.ChanEvents:
 			broadcast.Print(event)
 		default:
+			broadcast.Close()
 			return err
 		}
 	}

--- a/pkg/ebpf/bpf_log.go
+++ b/pkg/ebpf/bpf_log.go
@@ -160,8 +160,8 @@ func (b *BPFLog) Decode(rawBuffer []byte) error {
 }
 
 func (t *Tracee) processBPFLogs(ctx context.Context) {
-	logger.Debugw("Starting processBPFLogs go routine")
-	defer logger.Debugw("Stopped processBPFLogs go routine")
+	logger.Debugw("Starting processBPFLogs goroutine")
+	defer logger.Debugw("Stopped processBPFLogs goroutine")
 
 	for {
 		select {

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -25,6 +25,9 @@ const noSyscall int32 = -1
 
 // handleEvents is a high-level function that starts all operations related to events processing
 func (t *Tracee) handleEvents(ctx context.Context) {
+	logger.Debugw("Starting handleEvents goroutine")
+	defer logger.Debugw("Stopped handleEvents goroutine")
+
 	var errcList []<-chan error
 
 	// Source pipeline stage.

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -2,7 +2,6 @@ package ebpf
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -33,7 +32,7 @@ func init() {
 	initKernelReadFileTypes()
 }
 
-func (t *Tracee) processLostEvents(ctx context.Context) {
+func (t *Tracee) processLostEvents() {
 	logger.Debugw("Starting processLostEvents go routine")
 	defer logger.Debugw("Stopped processLostEvents go routine")
 
@@ -49,7 +48,8 @@ func (t *Tracee) processLostEvents(ctx context.Context) {
 				}
 				logger.Warnw(fmt.Sprintf("Lost %d events", lost))
 			}
-		case <-ctx.Done():
+		// Since this is an end-state go routine, it should be terminated only when Tracee done channel is closed.
+		case <-t.done:
 			return
 		}
 	}

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -33,8 +33,8 @@ func init() {
 }
 
 func (t *Tracee) processLostEvents() {
-	logger.Debugw("Starting processLostEvents go routine")
-	defer logger.Debugw("Stopped processLostEvents go routine")
+	logger.Debugw("Starting processLostEvents goroutine")
+	defer logger.Debugw("Stopped processLostEvents goroutine")
 
 	for {
 		select {
@@ -48,7 +48,7 @@ func (t *Tracee) processLostEvents() {
 				}
 				logger.Warnw(fmt.Sprintf("Lost %d events", lost))
 			}
-		// Since this is an end-state go routine, it should be terminated only when Tracee done channel is closed.
+		// Since this is an end-state goroutine, it should be terminated only when Tracee done channel is closed.
 		case <-t.done:
 			return
 		}

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -30,8 +30,8 @@ const (
 )
 
 func (t *Tracee) processNetCaptureEvents(ctx context.Context) {
-	logger.Debugw("Starting processNetCaptureEvents go routine")
-	defer logger.Debugw("Stopped processNetCaptureEvents go routine")
+	logger.Debugw("Starting processNetCaptureEvents goroutine")
+	defer logger.Debugw("Stopped processNetCaptureEvents goroutine")
 
 	var errChanList []<-chan error
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1440,8 +1440,9 @@ func (t *Tracee) initBPF() error {
 }
 
 func (t *Tracee) lkmSeekerRoutine(ctx gocontext.Context) {
-	logger.Debugw("Starting lkmSeekerRoutine go routine")
-	defer logger.Debugw("Stopped lkmSeekerRoutine go routine")
+	logger.Debugw("Starting lkmSeekerRoutine goroutine")
+	defer logger.Debugw("Stopped lkmSeekerRoutine goroutine")
+
 	if t.events[events.HiddenKernelModule].emit == 0 {
 		return
 	}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1437,7 +1437,9 @@ func (t *Tracee) initBPF() error {
 	return errfmt.WrapError(err)
 }
 
-func (t *Tracee) lkmSeekerRoutine() {
+func (t *Tracee) lkmSeekerRoutine(ctx gocontext.Context) {
+	logger.Debugw("Starting lkmSeekerRoutine go routine")
+	defer logger.Debugw("Stopped lkmSeekerRoutine go routine")
 	if t.events[events.HiddenKernelModule].emit == 0 {
 		return
 	}
@@ -1454,6 +1456,15 @@ func (t *Tracee) lkmSeekerRoutine() {
 		return
 	}
 
+	// randomDuration returns a random duration between min and max, inclusive
+	randomDuration := func(min, max int) time.Duration {
+		randDuration := time.Duration(rand.Intn(max-min+1)+min) * time.Second
+		return randDuration
+	}
+
+	// get a random duration between 10 and 310 seconds
+	waitDuration := randomDuration(10, 310)
+
 	for {
 		derive.ClearModulesState(modsMap)
 		err = derive.FillModulesFromProcFs(t.kernelSymbols, modsMap)
@@ -1464,8 +1475,15 @@ func (t *Tracee) lkmSeekerRoutine() {
 
 		t.triggerKernelModuleSeeker()
 
-		r := rand.Intn(300) + 10 // min 10 seconds sleep
-		time.Sleep(time.Duration(r) * time.Second)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(waitDuration):
+			// continue
+		}
+
+		// renew wait duration
+		waitDuration = randomDuration(10, 310)
 	}
 }
 
@@ -1481,10 +1499,11 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 		logger.Warnw("Memory dump", "error", err)
 	}
 
-	go t.lkmSeekerRoutine()
+	go t.lkmSeekerRoutine(ctx)
 
 	t.eventsPerfMap.Poll(pollTimeout)
 	go t.processLostEvents(ctx)
+
 	go t.handleEvents(ctx)
 	if t.config.BlobPerfBufferSize > 0 {
 		t.fileWrPerfMap.Poll(pollTimeout)

--- a/pkg/ebpf/write_capture.go
+++ b/pkg/ebpf/write_capture.go
@@ -16,8 +16,8 @@ import (
 )
 
 func (t *Tracee) processFileWrites(ctx context.Context) {
-	logger.Debugw("Starting processFileWrites go routine")
-	defer logger.Debugw("Stopped processFileWrites go routine")
+	logger.Debugw("Starting processFileWrites goroutine")
+	defer logger.Debugw("Stopped processFileWrites goroutine")
 
 	const (
 		// stat_S_IFMT uint32 = 0170000 // bit mask for the file type bit field

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,8 +52,8 @@ func (s *Server) Start(ctx context.Context) {
 	defer srvCancel()
 
 	go func() {
-		logger.Debugw("Starting serving metrics endpoint go routine", "address", s.hs.Addr)
-		defer logger.Debugw("Stopped serving metrics endpoint")
+		logger.Debugw("Starting serving metrics endpoint goroutine", "address", s.hs.Addr)
+		defer logger.Debugw("Stopped serving metrics endpoint goroutine")
 
 		if err := s.hs.ListenAndServe(); err != http.ErrServerClosed {
 			logger.Errorw("Serving metrics endpoint", "error", err)


### PR DESCRIPTION
### 1. Explain what the PR does

commit 502db312fdb975e44d2e5419e6da8b1e4d33c581

    cosmetics

commit 47399fff525a2a9d663e967ba84b879ea2dd3dcb

    tracee: add done channel to Tracee struct
    
    This is an end-stage channel that will be used to signal the last
    processing goroutines to stop. This is needed to avoid a deadlock in
    processLostEvents().

commit c94cbcd41cd47e496328fa8ff454a1cfcc62024a

    add ctx to lkmSeekerRoutine
    
    This make lkmSeekerRoutine goroutine safe by adding a context to it.

commit f9e442f19aa6ed6652bf54a6703e18cfc7c8fbac

    tracee: add done channel to Broadcast struct
    
    This add a done channel to Broadcast struct, and closes it by calling
    Close() method. This way, the printer goroutine can be stopped by
    closing the channel in a late stage of the program execution instead of
    using the main ctx that is cancelled first.


### 2. Explain how to test it

Set a filter `set` (or a combination of events) which captures a lot of events, wait a few seconds (10-20 to be sure) and terminate tracee with `CTRL+C`.

It should terminate smoothly.

E.g.:

```
sudo ./dist/tracee -f set=syscalls
...
^C
...
18:03:08:669970  1000   gnome-shell      2550    2550    -11              recvmsg                   sockfd: 6, msg: 0x7ffd00f63480, flags: 0
18:03:08:669972  1000   gnome-shell      2550    2550    -11              recvmsg                   sockfd: 6, msg: 0x7ffd00f63490, flags: 0
18:03:08:669976  1000   gnome-shell      2550    2550    -11              recvmsg                   sockfd: 31, msg: 0x7ffd00f63460, flags: 0
18:03:08:669982  1000   gnome-shell      2550    2550    1                poll                      fds: 0x5593b2c32310, nfds: 43, timeout: 0

End of events stream
Stats: {EventCount:883491 EventsFiltered:0 NetCapCount:0 BPFLogsCount:0 ErrorCount:0 LostEvCount:2223808 LostWrCount:0 LostNtCapCount:0 LostBPFLogsCount:0}
```


### 3. Other comments

Fix: #3039

- #3039
