### PR TITLE
fix: correct list of bpf helpers

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3513,12 +3513,13 @@ int BPF_KPROBE(trace_check_helper_call)
 
     int func_id;
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0))
-    func_id = (int) PT_REGS_PARM2(ctx);
-#else
-    struct bpf_insn *insn = (struct bpf_insn *) PT_REGS_PARM2(ctx);
-    func_id = READ_KERN(insn->imm);
-#endif
+    if (!bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_for_each_map_elem)) {
+        // if BPF_FUNC_for_each_map_elem doesn't exist under bpf_func_id - kernel version < 5.13
+        func_id = (int) PT_REGS_PARM2(ctx);
+    } else {
+        struct bpf_insn *insn = (struct bpf_insn *) PT_REGS_PARM2(ctx);
+        func_id = READ_KERN(insn->imm);
+    }
 
     return handle_bpf_helper_func_id(p.event->context.task.host_tid, func_id);
 }

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -676,6 +676,7 @@ enum bpf_func_id
     BPF_FUNC_override_return = 58,
     BPF_FUNC_sk_storage_get = 107,
     BPF_FUNC_copy_from_user = 148,
+    BPF_FUNC_for_each_map_elem = 164,
 };
 
 #define MODULE_NAME_LEN (64 - sizeof(unsigned long))


### PR DESCRIPTION
fixes: #3063

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/next" label if you want it in the next milestone.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste your very well written git logs -->

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Sun May 7 14:39:10 2023 +0300

    fix: correct list of bpf helpers

    get correct kernel version when getting bpf helpers list for
    bpf_attach and security_bpf_prog events
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

in kernel version >= 5.13 : 

terminal 1: `./dist/tracee-ebpf -f e=bpf_attach`
terminal 2: `./dist/tracee-ebpf -f e=security_socket_bind`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
