### PR TITLE
workflow: add 6.1 and 6.3 kernels

### DIFF
--- a/.github/workflows/debug-shell.yaml
+++ b/.github/workflows/debug-shell.yaml
@@ -25,6 +25,8 @@ on:
           - jammy519-arm64
           - focal419
           - focal419-arm64
+          - jammy6127
+          - jammy6301
 jobs:
   alma418:
     if: ${{ github.event.inputs.distro == 'alma418' }}
@@ -243,6 +245,32 @@ jobs:
         "github-self-hosted_ami-07271263d87a0e883_${{ github.event.number }}-${{ github.run_id }}_arm64c",
       ]
     timeout-minutes: 50400
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  jammy6127-core:
+    if: ${{ github.event.inputs.distro == 'jammy6127' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-0469948ef83c039e9_${{ github.event.number }}-${{ github.run_id }}_x64c",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Executing Debug Shell"
+        run: ./tests/remotessh.sh
+  jammy6301-core:
+    if: ${{ github.event.inputs.distro == 'jammy6301' }}
+    runs-on:
+      [
+        "github-self-hosted_ami-05bc39f8670e0c226_${{ github.event.number }}-${{ github.run_id }}_x64c",
+      ]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -678,3 +678,67 @@ jobs:
       - name: "Instrumentation"
         run: |
           ./tests/e2e-instrumentation-test.sh
+  # #
+  # # JAMMY v6.1
+  # #
+  # jammy6127-core:
+  #   name: Jammy 6.1.27 X64
+  #   needs:
+  #     - unit-tests
+  #     - verify-signatures
+  #     - verify-tools
+  #   env:
+  #     HOME: "/tmp/root"
+  #     GOPATH: "/tmp/go"
+  #     GOCACHE: "/tmp/go-cache"
+  #     GOROOT: "/usr/local/go"
+  #   runs-on:
+  #     [
+  #       "github-self-hosted_ami-0469948ef83c039e9_${{ github.event.number }}-${{ github.run_id }}_x64c",
+  #     ]
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #     - name: "Kernel"
+  #       run: |
+  #         ./tests/kerneltest.sh
+  #     - name: "Network"
+  #       run: |
+  #         ./tests/e2e-net-test.sh
+  #     - name: "Instrumentation"
+  #       run: |
+  #         ./tests/e2e-instrumentation-test.sh
+  # #
+  # # JAMMY v6.3
+  # #
+  # jammy6301-core:
+  #   name: Jammy 6.3.1 X64
+  #   needs:
+  #     - unit-tests
+  #     - verify-signatures
+  #     - verify-tools
+  #   env:
+  #     HOME: "/tmp/root"
+  #     GOPATH: "/tmp/go"
+  #     GOCACHE: "/tmp/go-cache"
+  #     GOROOT: "/usr/local/go"
+  #   runs-on:
+  #     [
+  #       "github-self-hosted_ami-05bc39f8670e0c226_${{ github.event.number }}-${{ github.run_id }}_x64c",
+  #     ]
+  #   steps:
+  #     - name: "Checkout"
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #     - name: "Kernel"
+  #       run: |
+  #         ./tests/kerneltest.sh
+  #     - name: "Network"
+  #       run: |
+  #         ./tests/e2e-net-test.sh
+  #     - name: "Instrumentation"
+  #       run: |
+  #         ./tests/e2e-instrumentation-test.sh


### PR DESCRIPTION
@yanivagman FYI, IMO would be good to have those included (and any issue fixed, like https://github.com/aquasecurity/tracee/pull/3067, before the 0.14.1).

These are 6.1 and 6.3 kernels from the upstream stable tree, being used in Ubuntu Jammy, and using the same kconfig values as Ubuntu does for 5.19 kernels (this way we can test upstream trees before Ubuntu releases them).