### PR TITLE
make print_mem_dump reprint on kernel module load

### DIFF
--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -333,7 +333,7 @@ func (t *Tracee) processDoInitModule(event *trace.Event) error {
 	_, okProcFops := t.events[events.HookedProcFops]
 	_, okMemDump := t.events[events.PrintMemDump]
 
-	if okSyscalls || okSeqOps || okProcFops {
+	if okSyscalls || okSeqOps || okProcFops || okMemDump {
 		err := capabilities.GetInstance().EBPF(
 			func() error {
 				return t.UpdateKallsyms()

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -6260,6 +6260,11 @@ var Definitions = eventDefinitions{
 					{EventID: DoInitModule},
 				},
 				KSymbols: &[]kSymbolDependency{},
+				Capabilities: capDependency{
+					capabilities.Base: []cap.Value{
+						cap.SYSLOG, // read /proc/kallsyms
+					},
+				},
 			},
 		},
 		VfsRead: {


### PR DESCRIPTION
fix #3071

### 1. Explain what the PR does

commit 6edd49a5041601c7c6ece7bc38ad13ceb2e804b0 (HEAD -> fix_print_mem, origin/fix_print_mem)
Author: AsafEitani <eitaniasaf@gmail.com>
Date:   Wed May 3 14:09:55 2023 +0300

    make print_mem_dump reprint on kernel module load
    
    fix #3071

### 2. Explain how to test it

`sudo dist/tracee-ebpf -f e=print_mem_dump -f print_mem_dump.args.symbol_name=execve,kill`

load a kernel module and see 2 new events being printed.
