### PR TITLE
fix for kernels v6.3 and mitigation for tracee.pid in tests

### DIFF
--- a/.github/workflows/debug-shell.yaml
+++ b/.github/workflows/debug-shell.yaml
@@ -252,7 +252,7 @@ jobs:
           submodules: true
       - name: "Executing Debug Shell"
         run: ./tests/remotessh.sh
-  jammy6127-core:
+  jammy6127:
     if: ${{ github.event.inputs.distro == 'jammy6127' }}
     runs-on:
       [
@@ -265,7 +265,7 @@ jobs:
           submodules: true
       - name: "Executing Debug Shell"
         run: ./tests/remotessh.sh
-  jammy6301-core:
+  jammy6301:
     if: ${{ github.event.inputs.distro == 'jammy6301' }}
     runs-on:
       [

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -678,67 +678,67 @@ jobs:
       - name: "Instrumentation"
         run: |
           ./tests/e2e-instrumentation-test.sh
-  # #
-  # # JAMMY v6.1
-  # #
-  # jammy6127-core:
-  #   name: Jammy 6.1.27 X64
-  #   needs:
-  #     - unit-tests
-  #     - verify-signatures
-  #     - verify-tools
-  #   env:
-  #     HOME: "/tmp/root"
-  #     GOPATH: "/tmp/go"
-  #     GOCACHE: "/tmp/go-cache"
-  #     GOROOT: "/usr/local/go"
-  #   runs-on:
-  #     [
-  #       "github-self-hosted_ami-0469948ef83c039e9_${{ github.event.number }}-${{ github.run_id }}_x64c",
-  #     ]
-  #   steps:
-  #     - name: "Checkout"
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: true
-  #     - name: "Kernel"
-  #       run: |
-  #         ./tests/kerneltest.sh
-  #     - name: "Network"
-  #       run: |
-  #         ./tests/e2e-net-test.sh
-  #     - name: "Instrumentation"
-  #       run: |
-  #         ./tests/e2e-instrumentation-test.sh
-  # #
-  # # JAMMY v6.3
-  # #
-  # jammy6301-core:
-  #   name: Jammy 6.3.1 X64
-  #   needs:
-  #     - unit-tests
-  #     - verify-signatures
-  #     - verify-tools
-  #   env:
-  #     HOME: "/tmp/root"
-  #     GOPATH: "/tmp/go"
-  #     GOCACHE: "/tmp/go-cache"
-  #     GOROOT: "/usr/local/go"
-  #   runs-on:
-  #     [
-  #       "github-self-hosted_ami-05bc39f8670e0c226_${{ github.event.number }}-${{ github.run_id }}_x64c",
-  #     ]
-  #   steps:
-  #     - name: "Checkout"
-  #       uses: actions/checkout@v3
-  #       with:
-  #         submodules: true
-  #     - name: "Kernel"
-  #       run: |
-  #         ./tests/kerneltest.sh
-  #     - name: "Network"
-  #       run: |
-  #         ./tests/e2e-net-test.sh
-  #     - name: "Instrumentation"
-  #       run: |
-  #         ./tests/e2e-instrumentation-test.sh
+  #
+  # JAMMY v6.1
+  #
+  jammy6127-core:
+    name: Jammy 6.1.27 X64
+    needs:
+      - unit-tests
+      - verify-signatures
+      - verify-tools
+    env:
+      HOME: "/tmp/root"
+      GOPATH: "/tmp/go"
+      GOCACHE: "/tmp/go-cache"
+      GOROOT: "/usr/local/go"
+    runs-on:
+      [
+        "github-self-hosted_ami-0469948ef83c039e9_${{ github.event.number }}-${{ github.run_id }}_x64c",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Kernel"
+        run: |
+          ./tests/kerneltest.sh
+      - name: "Network"
+        run: |
+          ./tests/e2e-net-test.sh
+      - name: "Instrumentation"
+        run: |
+          ./tests/e2e-instrumentation-test.sh
+  #
+  # JAMMY v6.3
+  #
+  jammy6301-core:
+    name: Jammy 6.3.1 X64
+    needs:
+      - unit-tests
+      - verify-signatures
+      - verify-tools
+    env:
+      HOME: "/tmp/root"
+      GOPATH: "/tmp/go"
+      GOCACHE: "/tmp/go-cache"
+      GOROOT: "/usr/local/go"
+    runs-on:
+      [
+        "github-self-hosted_ami-05bc39f8670e0c226_${{ github.event.number }}-${{ github.run_id }}_x64c",
+      ]
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: "Kernel"
+        run: |
+          ./tests/kerneltest.sh
+      - name: "Network"
+        run: |
+          ./tests/e2e-net-test.sh
+      - name: "Instrumentation"
+        run: |
+          ./tests/e2e-instrumentation-test.sh

--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -49,7 +49,6 @@ func main() {
 
 			return runner.Run(ctx)
 		},
-		SliceFlagSeparator: " ",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "list",

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	github.com/urfave/cli/v2 v2.25.3
+	github.com/urfave/cli/v2 v2.3.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sys v0.8.0
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1
@@ -74,7 +74,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	go.opentelemetry.io/otel v1.15.1 // indirect
 	go.opentelemetry.io/otel/trace v1.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,7 @@ github.com/containerd/ttrpc v1.2.1 h1:VWv/Rzx023TBLv4WQ+9WPXlBG/s3rsRjY3i9AJ2BJd
 github.com/containerd/ttrpc v1.2.1/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
 github.com/containerd/typeurl/v2 v2.1.0 h1:yNAhJvbNEANt7ck48IlEGOxP7YAp6LLpGn5jZACDNIE=
 github.com/containerd/typeurl/v2 v2.1.0/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -370,6 +371,7 @@ github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqn
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sashabaranov/go-gpt3 v1.4.0 h1:UqHYdXgJNtNvTtbzDnnQgkQ9TgTnHtCXx966uFTYXvU=
@@ -379,6 +381,7 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
@@ -423,8 +426,8 @@ github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+Kd
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.6.0 h1:kebhY2Qt+3U6RNK7UqpYNA+tJ23IBEGKkB7JQBfDYms=
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
-github.com/urfave/cli/v2 v2.25.3 h1:VJkt6wvEBOoSjPFQvOkv6iWIrsJyCrKGtCtxXWwmGeY=
-github.com/urfave/cli/v2 v2.25.3/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -433,8 +436,6 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yashtewari/glob-intersection v0.1.0 h1:6gJvMYQlTDOL3dMsPF6J0+26vwX9MB8/1q3uAdhmTrg=
 github.com/yashtewari/glob-intersection v0.1.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/ebpf/c/common/capabilities.h
+++ b/pkg/ebpf/c/common/capabilities.h
@@ -1,0 +1,36 @@
+#ifndef __COMMON_CAPABILITIES_H__
+#define __COMMON_CAPABILITIES_H__
+
+#include <vmlinux.h>
+#include <vmlinux_flavors.h>
+
+#include <common/common.h>
+
+// BEFORE: Currently, (2021), there are ~40 capabilities in the Linux kernel
+// which are stored in an u32 array of length 2. This might change in the (not
+// so near) future as more capabilities will be added. For now, we use u64 to
+// store this array in one piece
+//
+// NEW NOTE: Recently, (2023), kernel has started using an u64 for all
+// capabilities, instead of using variable u32 array. Use type flavors to
+// deal with that.
+//
+
+static __always_inline u64 credcap_to_slimcap(void *from)
+{
+    kernel_cap_t___older to = {0};
+
+    if (bpf_core_field_exists(to.cap)) {
+        bpf_core_read(&to, bpf_core_type_size(kernel_cap_t___older), from);
+        return ((to.cap[1] + 0ULL) << 32) + to.cap[0];
+
+    } else {
+        kernel_cap_t newto = {0};
+        bpf_core_read(&newto, bpf_core_type_size(kernel_cap_t), from);
+        return newto.val;
+    }
+
+    return 0;
+}
+
+#endif

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -297,11 +297,9 @@ typedef struct {
     gid_t val;
 } kgid_t;
 
-struct kernel_cap_struct {
-    __u32 cap[2];
-};
-
-typedef struct kernel_cap_struct kernel_cap_t;
+typedef struct {
+    u64 val;
+} kernel_cap_t;
 
 struct cred {
     kuid_t uid;

--- a/pkg/ebpf/c/vmlinux_flavors.h
+++ b/pkg/ebpf/c/vmlinux_flavors.h
@@ -77,6 +77,14 @@ struct trace_probe___v53 {
     struct trace_event_call call;
 };
 
+// kernel >= 6.1 kernel_cap_t type change
+
+struct kernel_cap_struct___older {
+    __u32 cap[2];
+};
+
+typedef struct kernel_cap_struct___older kernel_cap_t___older;
+
 #pragma clang attribute pop
 
 #endif

--- a/tests/e2e-instrumentation-test.sh
+++ b/tests/e2e-instrumentation-test.sh
@@ -169,6 +169,9 @@ for TEST in $TESTS; do
 
     # give a little break for OS noise to reduce
     sleep 3
+
+    # cleanup leftovers
+    rm -rf $TRACEE_TMP_DIR
 done
 
 info

--- a/tests/e2e-instrumentation-test.sh
+++ b/tests/e2e-instrumentation-test.sh
@@ -17,7 +17,7 @@ if [[ $KERNEL_MAJ -lt 5 && "$KERNEL" != *"el8"* ]]; then
     info_exit "skip test in kernels < 5.0 (and not RHEL)"
 fi
 
-TRACEE_STARTUP_TIMEOUT=5
+TRACEE_STARTUP_TIMEOUT=30
 SCRIPT_TMP_DIR=/tmp
 TRACEE_TMP_DIR=/tmp/tracee
 

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -177,6 +177,9 @@ for TEST in $TESTS; do
 
     # give a little break for OS noise to reduce
     sleep 3
+
+    # cleanup leftovers
+    rm -rf $TRACEE_TMP_DIR
 done
 
 info

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -17,7 +17,7 @@ if [[ $KERNEL_MAJ -lt 5 && "$KERNEL" != *"el8"* ]]; then
     info_exit "skip test in kernels < 5.0 (and not RHEL)"
 fi
 
-TRACEE_STARTUP_TIMEOUT=5
+TRACEE_STARTUP_TIMEOUT=30
 SCRIPT_TMP_DIR=/tmp
 TRACEE_TMP_DIR=/tmp/tracee
 

--- a/tests/kerneltest.sh
+++ b/tests/kerneltest.sh
@@ -167,6 +167,9 @@ for TEST in $TESTS; do
     # make sure tracee is exited with SIGKILL
     kill -9 $rules_pid >/dev/null 2>&1
     kill -9 $tracee_pid >/dev/null 2>&1
+
+    # cleanup leftovers
+    rm -rf $TRACEE_TMP_DIR
 done
 
 info


### PR DESCRIPTION
commit cea89a66 (HEAD -> include-v6, rafaeldtinoco/include-v6)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Mon May 8 23:45:33 2023

    workflow: enable v6.1 and v6.3 tests after fix

commit f45cc1ba
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Mon May 8 23:42:07 2023

    ebpf: CO-RE: deal with new kernel_cap_t type

commit 57520600
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Mon May 8 12:54:31 2023

    workflow: fix debug-shell job name

commit 6aee7293
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Mon May 8 12:53:06 2023

    tests: cleanup tracee.pid in case not cleaned

----

The only change that isn't chore is the change that fixes v6.3 kernels (commit f45cc1ba) and the way to test it:

#### test case

```console
#### command 01

$ sudo ./dist/tracee --output json --filter event=com
mit_creds --filter comm=capsh

#### command 02

$ sudo capsh --drop=cap_sys_admin -- -c 'sleep 1000'

#### command 03

$ sudo cat /proc/$(pidof sleep)/status | grep ^Cap
CapInh: 0000000000000000
CapPrm: 000001ffffdfffff
CapEff: 000001ffffdfffff
CapBnd: 000001ffffdfffff
CapAmb: 0000000000000000
```

#### in a v6.3.1 kernel (vanilla upstream)
```json
{"timestamp":1683599572209837155,"threadStartTime":1683599572207592072,"processorId":12,"processId":1645572,"cgroupId":6255,"threadId":1645572,"parentProcessId":1645571,"hostProcessId":1645572,"hostThreadId":1645572,"hostParentProcessId":1645571,"userId":0,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"capsh","hostName":"fujitsu","container":{},"kubernetes":{},"eventId":"723","eventName":"commit_creds","matchedPolicies":[""],"argsNum":2,"returnValue":0,"syscall":"prctl","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"args":[{"name":"old_cred","type":"slim_cred_t","value":{"Uid":0,"Gid":0,"Suid":0,"Sgid":0,"Euid":0,"Egid":0,"Fsuid":0,"Fsgid":0,"UserNamespace":4026531837,"SecureBits":0,"CapInheritable":0,"CapPermitted":2199023255551,"CapEffective":2199023255551,"CapBounding":2199023255551,"CapAmbient":0}},{"name":"new_cred","type":"slim_cred_t","value":{"Uid":0,"Gid":0,"Suid":0,"Sgid":0,"Euid":0,"Egid":0,"Fsuid":0,"Fsgid":0,"UserNamespace":4026531837,"SecureBits":0,"CapInheritable":0,"CapPermitted":2199023255551,"CapEffective":2199023255551,"CapBounding":2199021158399,"CapAmbient":0}}]}
```

#### in a 5.15.0-69-generic kernel (ubuntu flavored)

```json
{"timestamp":1683599381252829883,"threadStartTime":1683599381250171936,"processorId":5,"processId":2981,"cgroupId":4098,"threadId":2981,"parentProcessId":2980,"hostProcessId":2981,"hostThreadId":2981,"hostParentProcessId":2980,"userId":0,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"capsh","hostName":"e2etests","container":{},"kubernetes":{},"eventId":"723","eventName":"commit_creds","matchedPolicies":[""],"argsNum":2,"returnValue":0,"syscall":"prctl","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"args":[{"name":"old_cred","type":"slim_cred_t","value":{"Uid":0,"Gid":0,"Suid":0,"Sgid":0,"Euid":0,"Egid":0,"Fsuid":0,"Fsgid":0,"UserNamespace":4026531837,"SecureBits":0,"CapInheritable":0,"CapPermitted":2199023255551,"CapEffective":2199023255551,"CapBounding":2199023255551,"CapAmbient":0}},{"name":"new_cred","type":"slim_cred_t","value":{"Uid":0,"Gid":0,"Suid":0,"Sgid":0,"Euid":0,"Egid":0,"Fsuid":0,"Fsgid":0,"UserNamespace":4026531837,"SecureBits":0,"CapInheritable":0,"CapPermitted":2199023255551,"CapEffective":2199023255551,"CapBounding":2199021158399,"CapAmbient":0}}]}
```