### PR TITLE
v0.14.1: about to be released

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -25,16 +25,21 @@ run_tracee() {
 
     echo "INFO: starting tracee..."
 
-    $TRACEE_EXE \
-        --metrics \
-        --output=option:parse-arguments \
-        --cache cache-type=mem \
-        --cache mem-cache-size=512 \
-        --containers=$CONTAINERS_ENRICHMENT \
-        --capabilities bypass=$CAPABILITIES_BYPASS \
-        --capabilities add=$CAPABILITIES_ADD \
-        --capabilities drop=$CAPABILITIES_DROP \
-        $@
+    if [[ $# -ne 0 ]]; then
+        # no default arguments, just given ones
+        $TRACEE_EXE $@
+    else
+        # default arguments
+        $TRACEE_EXE \
+            --metrics \
+            --output=option:parse-arguments \
+            --cache cache-type=mem \
+            --cache mem-cache-size=512 \
+            --containers=$CONTAINERS_ENRICHMENT \
+            --capabilities bypass=$CAPABILITIES_BYPASS \
+            --capabilities add=$CAPABILITIES_ADD \
+            --capabilities drop=$CAPABILITIES_DROP
+    fi
 
     tracee_ret=$?
 }

--- a/deploy/helm/tracee/Chart.yaml
+++ b/deploy/helm/tracee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tracee
 description: Linux Runtime Security and Forensics using eBPF
-home: https://aquasecurity.github.io/tracee/v0.14.0/
+home: https://aquasecurity.github.io/tracee/v0.14.1/
 sources:
   - https://github.com/aquasecurity/tracee
 
@@ -18,13 +18,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.14.0"
+version: "0.14.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 
 dependencies:
   - name: postee

--- a/deploy/kubernetes/kustomize/base/tracee.yaml
+++ b/deploy/kubernetes/kustomize/base/tracee.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: tracee
-        image: docker.io/aquasec/tracee:0.14.0
+        image: docker.io/aquasec/tracee:0.14.1
         imagePullPolicy: IfNotPresent
         args:
           - --filter set=signatures

--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -24,7 +24,7 @@ spec:
         env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host
-        image: docker.io/aquasec/tracee:0.14.0
+        image: docker.io/aquasec/tracee:0.14.1
         imagePullPolicy: IfNotPresent
         name: tracee
         securityContext:

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -23,7 +23,7 @@ spec:
         env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host
-        image: docker.io/aquasec/tracee:0.14.0
+        image: docker.io/aquasec/tracee:0.14.1
         imagePullPolicy: IfNotPresent
         name: tracee
         securityContext:


### PR DESCRIPTION
commit 8564f2cd (HEAD -> about-to-be-released, rafaeldtinoco/about-to-be-released)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 9 23:46:27 2023

    k8s: update tags for about to be released version

commit 62d8b3ac
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 9 23:44:42 2023

    types: update to latest types

commit 1c59f8a2
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue May 9 23:33:34 2023

    entrypoint: fix container image arguments

    Currently the docker image given arguments were put at the end of an
    already set cmdline with some arguments before. With that, it is
    currently impossible to give a simple "help" or "list" argument to
    the container image.

    This commit fixes the issue by replacing ALL "tracee" command line
    with a given command line IF there is one. If not, then a default
    command line is executed.

    Fixes: #3082