### PR TITLE
workflow: guarantee release has needed tags

### DIFF
--- a/.github/workflows/release-arm64-only.yaml
+++ b/.github/workflows/release-arm64-only.yaml
@@ -21,6 +21,9 @@ jobs:
       - name: AWS Environment
         run: |
           dmidecode
+      - name: Fetch all tags for sure
+        run: |
+          git fetch --tags
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -27,6 +27,9 @@ jobs:
       - name: AWS Environment
         run: |
           dmidecode
+      - name: Fetch all tags for sure
+        run: |
+          git fetch --tags
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:
@@ -61,6 +64,9 @@ jobs:
       - name: AWS Environment
         run: |
           dmidecode
+      - name: Fetch all tags for sure
+        run: |
+          git fetch --tags
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ jobs:
       - name: AWS Environment
         run: |
           dmidecode
+      - name: Fetch all tags for sure
+        run: |
+          git fetch --tags
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:
@@ -65,6 +68,9 @@ jobs:
       - name: AWS Environment
         run: |
           dmidecode
+      - name: Fetch all tags for sure
+        run: |
+          git fetch --tags
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
The git checkout might be a shallow clone and not have all needed tags in order for "git describe" to work, knowing the exact version to be released.