### PR TITLE
refactor: add broadcast printer

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -177,17 +177,15 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Container information printer flag
 
+	// TODO: set this on the printer config creation
 	containerMode := cmd.GetContainerMode(cfg)
-	printers := make([]printer.EventPrinter, 0, len(output.PrinterConfigs))
 	for _, pConfig := range output.PrinterConfigs {
 		pConfig.ContainerMode = containerMode
+	}
 
-		p, err := printer.New(pConfig)
-		if err != nil {
-			return runner, err
-		}
-
-		printers = append(printers, p)
+	broadcast, err := printer.NewBroadcast(output.PrinterConfigs)
+	if err != nil {
+		return runner, err
 	}
 
 	// Check kernel lockdown
@@ -244,7 +242,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	runner.Server = httpServer
 	runner.TraceeConfig = cfg
-	runner.Printers = printers
+	runner.Printer = broadcast
 
 	// parse arguments must be enabled if the rule engine is part of the pipeline
 	runner.TraceeConfig.Output.ParseArguments = true

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -115,16 +115,13 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	// Container information printer flag
 	containerMode := cmd.GetContainerMode(cfg)
-	printers := make([]printer.EventPrinter, 0, len(output.PrinterConfigs))
 	for _, pConfig := range output.PrinterConfigs {
 		pConfig.ContainerMode = containerMode
+	}
 
-		p, err := printer.New(pConfig)
-		if err != nil {
-			return runner, err
-		}
-
-		printers = append(printers, p)
+	broadcast, err := printer.NewBroadcast(output.PrinterConfigs)
+	if err != nil {
+		return runner, err
 	}
 
 	// Check kernel lockdown
@@ -180,7 +177,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	runner.Server = httpServer
 	runner.TraceeConfig = cfg
-	runner.Printers = printers
+	runner.Printer = broadcast
 
 	return runner, nil
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR refactors the broadcast to be a printer. The idea of refactoring is to simplify the interface of the Runner, exposing only one printer to the outside, keeping the whole logic of printers creation inside the `pkg/cmd` and `flags`, with this refactor in place, a follow-up PR will be created to add a printer which is policy aware for policies' actions (webhook, and fluentd), the new printer will route events where it is appropriate instead of broadcast for all printers.

Part of -> https://github.com/aquasecurity/tracee/issues/2975

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
