### PR TITLE
btfhub: fix tracee container image with btfhub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
-./dist/*
-./3rdparty/btfhub
-./3rdparty/btfhub/*
-./3rdparty/btfhub-archive
-./3rdparty/btfhub-archive/*
-./tests/distro-tester/*
+dist/*
+3rdparty/btfhub
+3rdparty/btfhub/*
+3rdparty/btfhub-archive
+3rdparty/btfhub-archive/*
+tests/distro-tester/*

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -63,10 +63,10 @@ WORKDIR /tracee
 COPY . /tracee
 
 RUN make clean && \
+    BTFHUB=$BTFHUB make tracee && \
     BTFHUB=$BTFHUB make tracee-ebpf && \
     make tracee-rules && \
     make signatures && \
-    make tracee && \
     rm -rf ./3rdparty/btfhub/ && \
     rm -rf ./3rdparty/btfhub-archive/
 

--- a/pkg/cmd/initialize/bpfobject.go
+++ b/pkg/cmd/initialize/bpfobject.go
@@ -43,6 +43,8 @@ func BpfObject(config *tracee.Config, kConfig *helpers.KernelConfig, osInfo *hel
 		if err == nil {
 			logger.Debugw("BTF: btfhub embedded BTF file", "file", unpackBTFFile)
 			config.BTFObjPath = unpackBTFFile
+		} else {
+			logger.Debugw("BTF: error unpacking embedded BTFHUB file", "error", err)
 		}
 	}
 


### PR DESCRIPTION
Currently, after the single binary was added to the official container image, I believe BTFHUB support has not been included in the binaries of the docker images. This needs fixing asap as this is what allows tracee to be fully portable.

This is an important fix if you want to run tracee in older kernels.

@ShiraCohen33 FYI. I'll be merging this fix and doing a new release of v0.14 (to v0.14.3). You can cherry-pick/backport the fix if it solves your issue.

@josedonizetti FYIO, the single binary didn't have BTFHUB support, so I added.