### PR TITLE
k8s: enrichment enabled by default

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -33,6 +33,7 @@ spec:
           args:
             - --filter set=signatures
             - --output json
+            - --containers
           {{- if .Values.postee.enabled }}
             - --output webhook:{{ .Values.postee.webhook }}
           {{- end }}
@@ -46,6 +47,18 @@ spec:
               mountPath: /tmp/tracee
             - name: etc-os-release
               mountPath: /etc/os-release-host
+              readOnly: true
+            - mountPath: /var/run/containerd/containerd.sock
+              name: containerd-sock
+              readOnly: true
+            - mountPath: /var/run/crio/crio.sock
+              name: crio-sock
+              readOnly: true
+            - mountPath: /var/run/docker.sock
+              name: docker-sock
+              readOnly: true
+            - mountPath: /var/run/podman/podman.sock
+              name: podman-sock
               readOnly: true
             {{- if .Values.signatures.config }}
             - name: tracee-config
@@ -74,6 +87,18 @@ spec:
         - name: etc-os-release
           hostPath:
             path: /etc/os-release
+        - name: containerd-sock
+          hostPath:
+            path: /var/run/containerd/containerd.sock
+        - name: crio-sock
+          hostPath:
+            path: /var/run/crio/crio.sock
+        - name: podman-sock
+          hostPath:
+            path: /var/run/podman/podman.sock
+        - name: docker-sock
+          hostPath:
+            path: /var/run/docker.sock
         {{- if .Values.signatures.config }}
         - name: tracee-config
           configMap:

--- a/deploy/kubernetes/kustomize/base/tracee.yaml
+++ b/deploy/kubernetes/kustomize/base/tracee.yaml
@@ -24,16 +24,29 @@ spec:
         args:
           - --filter set=signatures
           - --output json
+          - --containers
         env:
           - name: LIBBPFGO_OSRELEASE_FILE
             value: /etc/os-release-host
         securityContext:
           privileged: true
         volumeMounts:
-        - name: tmp-tracee
-          mountPath: /tmp/tracee
-        - name: etc-os-release
-          mountPath: /etc/os-release-host
+        - mountPath: /tmp/tracee
+          name: tmp-tracee
+        - mountPath: /etc/os-release-host
+          name: etc-os-release
+          readOnly: true
+        - mountPath: /var/run/containerd/containerd.sock
+          name: containerd-sock
+          readOnly: true
+        - mountPath: /var/run/crio/crio.sock
+          name: crio-sock
+          readOnly: true
+        - mountPath: /var/run/docker.sock
+          name: docker-sock
+          readOnly: true
+        - mountPath: /var/run/podman/podman.sock
+          name: podman-sock
           readOnly: true
         # NOTE: Resource consumption will vary between different use cases and
         # workload characteristics. User should monitor tracee for resource
@@ -55,9 +68,21 @@ spec:
         - effect: NoExecute
           operator: Exists
       volumes:
-      - hostPath:
+      - name: tmp-tracee
+        hostPath:
           path: /tmp/tracee
-        name: tmp-tracee
-      - hostPath:
+      - name: etc-os-release
+        hostPath:
           path: /etc/os-release
-        name: etc-os-release
+      - name: containerd-sock
+        hostPath:
+          path: /var/run/containerd/containerd.sock
+      - name: crio-sock
+        hostPath:
+          path: /var/run/crio/crio.sock
+      - name: podman-sock
+        hostPath:
+          path: /var/run/podman/podman.sock
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock

--- a/deploy/kubernetes/tracee-postee/tracee.yaml
+++ b/deploy/kubernetes/tracee-postee/tracee.yaml
@@ -21,6 +21,7 @@ spec:
         - --filter set=signatures
         - --output json
         - --output webhook:http://postee-svc:8082
+        - --containers
         env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host
@@ -35,6 +36,18 @@ spec:
         - mountPath: /etc/os-release-host
           name: etc-os-release
           readOnly: true
+        - mountPath: /var/run/containerd/containerd.sock
+          name: containerd-sock
+          readOnly: true
+        - mountPath: /var/run/crio/crio.sock
+          name: crio-sock
+          readOnly: true
+        - mountPath: /var/run/docker.sock
+          name: docker-sock
+          readOnly: true
+        - mountPath: /var/run/podman/podman.sock
+          name: podman-sock
+          readOnly: true
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -47,3 +60,15 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: etc-os-release
+      - hostPath:
+          path: /var/run/containerd/containerd.sock
+        name: containerd-sock
+      - hostPath:
+          path: /var/run/crio/crio.sock
+        name: crio-sock
+      - hostPath:
+          path: /var/run/podman/podman.sock
+        name: podman-sock
+      - hostPath:
+          path: /var/run/docker.sock
+        name: docker-sock

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -20,6 +20,7 @@ spec:
       - args:
         - --filter set=signatures
         - --output json
+        - --containers
         env:
         - name: LIBBPFGO_OSRELEASE_FILE
           value: /etc/os-release-host
@@ -34,6 +35,18 @@ spec:
         - mountPath: /etc/os-release-host
           name: etc-os-release
           readOnly: true
+        - mountPath: /var/run/containerd/containerd.sock
+          name: containerd-sock
+          readOnly: true
+        - mountPath: /var/run/crio/crio.sock
+          name: crio-sock
+          readOnly: true
+        - mountPath: /var/run/docker.sock
+          name: docker-sock
+          readOnly: true
+        - mountPath: /var/run/podman/podman.sock
+          name: podman-sock
+          readOnly: true
       tolerations:
       - effect: NoSchedule
         operator: Exists
@@ -46,3 +59,15 @@ spec:
       - hostPath:
           path: /etc/os-release
         name: etc-os-release
+      - hostPath:
+          path: /var/run/containerd/containerd.sock
+        name: containerd-sock
+      - hostPath:
+          path: /var/run/crio/crio.sock
+        name: crio-sock
+      - hostPath:
+          path: /var/run/podman/podman.sock
+        name: podman-sock
+      - hostPath:
+          path: /var/run/docker.sock
+        name: docker-sock


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/2731

The PR maps the paths for tracee runtime autodiscovery, and enables enrichment by default. This might not cover all cases, see https://github.com/aquasecurity/tracee/issues/1864, but it was tested and worked on kind, minikube, azure, digital ocean and google kubernetes engine, so it is a good start. 

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it


```
# install tracee with: 
kubectl apply -f deploy/kubernetes/tracee/tracee.yaml

# or

helm repo add aqua https://aquasecurity.github.io/helm-charts/
helm dependency update ./deploy/helm/tracee
helm install tracee ./deploy/helm/tracee \
        --namespace tracee-system --create-namespace \
        --set hostPID=true

# create a simple container to trigger a signatures
kubectl run test --image=ubuntu:latest -- tail -f /dev/null

kubectl exec -ti test -- apt update -y && apt install -y strace  && strace ls
```


<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
