### PR TITLE
Add policy printer

### DIFF
--- a/docs/docs/policies/actions.md
+++ b/docs/docs/policies/actions.md
@@ -1,13 +1,47 @@
 # Actions
 
-Actions are taken when there is an event match. Currently the only action supported is `log`. 
+## DefaultAction
+Every policy must have a `defaultAction`. Actions are taken when there is match on some rule declared at the policy. 
+The following actions are currently supported:
+
+- `log` - output events in json format. The default path to file is stdout.
+- `forward:http://url/fluent` - send events in json format using the Forward protocol to a Fluent receiver
+- `webhook:http://url/webhook` - send events in json format to the webhook url
+
+## Examples
+
+### Log action
 
 ```yaml
-name: overview policy
-description: sample overview policy
+name: log_sample_policy
+description: log sample policy
 scope:
   - global
 defaultAction: log
+rules:
+  - event: dropped_executable
+```
+
+### Webhook action
+
+```yaml
+name: webhook_sample_policy
+description: webhook_sample_policy
+scope:
+  - global
+defaultAction: webhook:http://localhost:8080
+rules:
+  - event: dropped_executable
+```
+
+### Fluentd action
+
+```yaml
+name: webhook_sample_policy
+description: webhook_sample_policy
+scope:
+  - global
+defaultAction: forward:tcp://localhost:24224
 rules:
   - event: dropped_executable
 ```

--- a/pkg/cmd/cobra/helper.go
+++ b/pkg/cmd/cobra/helper.go
@@ -1,0 +1,128 @@
+package cobra
+
+import (
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/cmd"
+	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/cmd/printer"
+	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/policy"
+)
+
+func getConfigAndPrinterFromPoliciesFlags(cfg tracee.Config, policyFlags, outputFlags []string) (tracee.Config, printer.EventPrinter, error) {
+	policyFiles, err := policy.PoliciesFromPaths(policyFlags)
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	filterMap, err := flags.PrepareFilterMapFromPolicies(policyFiles)
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	policies, err := flags.CreatePolicies(filterMap, true)
+	if err != nil {
+		return cfg, nil, err
+	}
+	cfg.Policies = policies
+
+	// we ignore printers passed in the flags if you using policies,
+	// though we still need the output options
+	// TODO: extract output options from --output flag
+	outputFlags = getOutputOptions(outputFlags)
+	outputFlags = append(outputFlags, getOutputFlagsFromPolicies(policyFiles)...)
+
+	// Output command line flags
+	output, err := flags.PrepareOutput(outputFlags, true)
+	if err != nil {
+		return cfg, nil, err
+	}
+	cfg.Output = output.TraceeConfig
+
+	// The policy printer routes the event to the printer specified in the policy,
+	// or an the event inside the policy
+	p, err := printer.NewPolicyEventPrinter(output.PrinterConfigs, policyFiles, cmd.GetContainerMode(cfg))
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	return cfg, p, err
+}
+
+func getConfigAndPrinterFromFilterFlags(cfg tracee.Config, filterFlags, outputFlags []string) (tracee.Config, printer.EventPrinter, error) {
+	filterMap, err := flags.PrepareFilterMapFromFlags(filterFlags)
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	policies, err := flags.CreatePolicies(filterMap, true)
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	cfg.Policies = policies
+
+	// Output command line flags
+	output, err := flags.PrepareOutput(outputFlags, true)
+	if err != nil {
+		return cfg, nil, err
+	}
+	cfg.Output = output.TraceeConfig
+
+	// Create printer
+	p, err := printer.NewBroadcast(output.PrinterConfigs, cmd.GetContainerMode(cfg))
+	if err != nil {
+		return cfg, nil, err
+	}
+
+	return cfg, p, err
+}
+
+// getOutputOptions returns a slice of output options from the output flags
+func getOutputOptions(outputFlags []string) []string {
+	options := make([]string, 0)
+
+	for _, f := range outputFlags {
+		if strings.HasPrefix(f, "option:") {
+			options = append(options, f)
+		}
+	}
+
+	return options
+}
+
+// getOutputFlagsFromPolicies returns a slice of output flags that are used in the policies' actions
+func getOutputFlagsFromPolicies(policies []policy.PolicyFile) []string {
+	m := make(map[string]bool)
+	for _, p := range policies {
+		key := strings.TrimSpace(p.DefaultAction)
+
+		// log action translates to json:stdout
+		if key == "log" {
+			key = "json"
+		}
+
+		m[key] = true
+
+		for _, r := range p.Rules {
+			if r.Action != "" {
+				key = strings.TrimSpace(r.Action)
+
+				// log action translates to json:stdout
+				if key == "log" {
+					key = "json"
+				}
+
+				m[key] = true
+			}
+		}
+	}
+
+	outputSlice := make([]string, 0)
+	for k := range m {
+		outputSlice = append(outputSlice, k)
+	}
+
+	return outputSlice
+}

--- a/pkg/cmd/printer/broadcast.go
+++ b/pkg/cmd/printer/broadcast.go
@@ -14,11 +14,12 @@ type Broadcast struct {
 	wg             *sync.WaitGroup
 	eventsChan     []chan trace.Event
 	done           chan struct{}
+	containerMode  ContainerMode
 }
 
 // NewBroadcast creates a new Broadcast printer
-func NewBroadcast(printerConfigs []Config) (*Broadcast, error) {
-	b := &Broadcast{PrinterConfigs: printerConfigs}
+func NewBroadcast(printerConfigs []Config, containerMode ContainerMode) (*Broadcast, error) {
+	b := &Broadcast{PrinterConfigs: printerConfigs, containerMode: containerMode}
 	return b, b.Init()
 }
 
@@ -27,6 +28,8 @@ func (b *Broadcast) Init() error {
 	wg := &sync.WaitGroup{}
 
 	for _, pConfig := range b.PrinterConfigs {
+		pConfig.ContainerMode = b.containerMode
+
 		p, err := New(pConfig)
 		if err != nil {
 			return err

--- a/pkg/cmd/printer/policy.go
+++ b/pkg/cmd/printer/policy.go
@@ -1,0 +1,160 @@
+package printer
+
+import (
+	"sync"
+
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/metrics"
+	"github.com/aquasecurity/tracee/pkg/policy"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+// PolicyEventPrinter is an EventPrinter that prints events based on a policy
+// Each policy can define a global action or action per events.
+// A map is created between policy:event or policy to printerName
+// which is used to send events to the correct printer
+type PolicyEventPrinter struct {
+	printerConfigs []Config
+	policies       []policy.PolicyFile
+	printers       []EventPrinter
+	printerMap     map[string]chan trace.Event
+	policyMap      map[string]string
+	wg             *sync.WaitGroup
+	done           chan struct{}
+	containerMode  ContainerMode
+}
+
+// NewPolicyEventPrinter creates a new PolicyEventPrinter
+func NewPolicyEventPrinter(pConfigs []Config, policies []policy.PolicyFile, containerMode ContainerMode) (*PolicyEventPrinter, error) {
+	p := &PolicyEventPrinter{
+		printerConfigs: pConfigs,
+		policies:       policies,
+		containerMode:  containerMode,
+	}
+	return p, p.Init()
+}
+
+// Init serves as the initializer method for every event Printer type
+func (pp *PolicyEventPrinter) Init() error {
+	printerMap := make(map[string]chan trace.Event)
+	done := make(chan struct{})
+	wg := &sync.WaitGroup{}
+
+	printers := make([]EventPrinter, 0, len(pp.printerConfigs))
+	for _, pConfig := range pp.printerConfigs {
+		pConfig.ContainerMode = pp.containerMode
+
+		p, err := New(pConfig)
+		if err != nil {
+			return err
+		}
+
+		err = p.Init()
+		if err != nil {
+			return err
+		}
+
+		printers = append(printers, p)
+
+		eventChan := make(chan trace.Event, 1000)
+		wg.Add(1)
+		go startPrinter(wg, done, eventChan, p)
+
+		printerName := pConfig.Kind + ":" + pConfig.OutPath
+		printerMap[printerName] = eventChan
+	}
+
+	// key -> policy:event, or policy
+	// val -> printerName
+	// eg:
+	// 	"policy1:open" -> "webhook:https://webhook.site/..."
+	// 	"policy1" -> "json:stdout"
+	policyMap := make(map[string]string)
+
+	for _, p := range pp.policies {
+		for _, rule := range p.Rules {
+			if rule.Action == "" {
+				continue
+			}
+
+			// action for this specif event at this policy
+			key := p.Name + ":" + rule.Event
+			policyMap[key] = getAction(rule.Action)
+		}
+
+		// default action for this policy
+		policyMap[p.Name] = getAction(p.DefaultAction)
+	}
+
+	pp.printerMap = printerMap
+	pp.policyMap = policyMap
+	pp.wg = wg
+	pp.printers = printers
+	pp.done = done
+
+	return nil
+}
+
+// Preamble prints something before event printing begins (one time)
+func (pp *PolicyEventPrinter) Preamble() {
+	for _, printer := range pp.printers {
+		printer.Preamble()
+	}
+}
+
+// Epilogue prints something after event printing ends (one time)
+func (pp *PolicyEventPrinter) Epilogue(stats metrics.Stats) {
+	// if you execute epilogue no other events should be sent to the printers,
+	// so we finish the events goroutines
+	close(pp.done)
+
+	pp.wg.Wait()
+	for _, printer := range pp.printers {
+		printer.Epilogue(stats)
+	}
+}
+
+// Print prints a single event
+func (pp *PolicyEventPrinter) Print(event trace.Event) {
+	for _, policyName := range event.MatchedPoliciesNames {
+		// if the event overrides the default action
+		key := policyName + ":" + event.EventName
+		if printerName, ok := pp.policyMap[key]; ok {
+			c, ok := pp.printerMap[printerName]
+			if !ok {
+				logger.Fatalw("printer not found", "printerName", printerName)
+			}
+			c <- event
+			continue
+		}
+
+		// policy default action
+		key = policyName
+		if printerName, ok := pp.policyMap[key]; ok {
+			c, ok := pp.printerMap[printerName]
+			if !ok {
+				logger.Fatalw("printer not found", "printerName", printerName)
+			}
+			c <- event
+			continue
+		}
+	}
+}
+
+// dispose of resources
+func (pp *PolicyEventPrinter) Close() {
+	for _, printer := range pp.printers {
+		printer.Close()
+	}
+}
+
+func getKey(policyName, eventName string) string {
+	return policyName + ":" + eventName
+}
+
+func getAction(action string) string {
+	if action == "log" {
+		return "json:stdout"
+	}
+	return action
+}

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -113,13 +113,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 
 	cfg.Policies = policies
 
-	// Container information printer flag
-	containerMode := cmd.GetContainerMode(cfg)
-	for _, pConfig := range output.PrinterConfigs {
-		pConfig.ContainerMode = containerMode
-	}
-
-	broadcast, err := printer.NewBroadcast(output.PrinterConfigs)
+	broadcast, err := printer.NewBroadcast(output.PrinterConfigs, cmd.GetContainerMode(cfg))
 	if err != nil {
 		return runner, err
 	}

--- a/pkg/policy/policy_file.go
+++ b/pkg/policy/policy_file.go
@@ -66,10 +66,12 @@ func (p PolicyFile) validateDefaultAction() error {
 func validateAction(policyName, a string) error {
 	actions := []string{
 		"log",
+		"webhook:",
+		"forward:",
 	}
 
 	for _, action := range actions {
-		if a == action {
+		if strings.HasPrefix(a, action) {
 			return nil
 		}
 	}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Adds a printer for policy actions. The printer creates a map where a policy event can point to a specific printer, if it was overriding on the policy declaration, or if not, uses the default action. 

Fix https://github.com/aquasecurity/tracee/issues/2975

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it


```
name: dig
description: traces dns events from the dig binary
scope:
  - global
defaultAction: log
rules:
  - event: ptrace
  - event: net_packet_dns_request
    action: webhook:http://localhost:8080
  - event: net_packet_dns_response
    action: webhook:http://localhost:8081
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments
