### PR TITLE
fix: file_modification not triggered in newer kernels

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4376,8 +4376,7 @@ int BPF_KPROBE(trace_file_modified)
      * this is because on older kernels the file_modified() function calls the file_update_time()
      * function. in those cases, we don't need this probe active.
      */
-    struct file *file = (struct file *) PT_REGS_PARM1(ctx);
-    if (bpf_core_field_exists(file->f_iocb_flags)) {
+    if (bpf_core_field_exists(((struct file *) 0)->f_iocb_flags)) {
         /* kernel version >= 6 */
         return common_file_modification_ent(ctx);
     }
@@ -4393,14 +4392,9 @@ int BPF_KPROBE(trace_ret_file_modified)
      * this is because on older kernels the file_modified() function calls the file_update_time()
      * function. in those cases, we don't need this probe active.
      */
-    args_t saved_args;
-    if (load_args(&saved_args, FILE_MODIFICATION) != 0)
-        return 0;
-
-    struct file *file = (struct file *) saved_args.args[0];
-    if (bpf_core_field_exists(file->f_iocb_flags)) {
+    if (bpf_core_field_exists(((struct file *) 0)->f_iocb_flags)) {
         /* kernel version >= 6 */
-        return common_file_modification_ent(ctx);
+        return common_file_modification_ret(ctx);
     }
 
     return 0;


### PR DESCRIPTION
fixes: #3077

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste your very well written git logs -->

```
Author: RoiKol <roi.kol@aquasec.com>
Date:   Sun May 21 16:55:33 2023 +0300

    fix: file_modification not triggered in newer kernels
    
    file_modification event was not triggered properly in kernels 6.*
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

command: `./dist/tracee -f e=file_modification`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
