### PR TITLE
chore: migrate to golang-lru v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/cel-go v0.15.1
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/kubernetes/cri-api v0.27.1
 	github.com/open-policy-agent/opa v0.52.0
 	github.com/prometheus/client_golang v1.15.1
@@ -168,3 +169,5 @@ require (
 )
 
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0
+
+replace github.com/aquasecurity/tracee/types => ./types

--- a/go.sum
+++ b/go.sum
@@ -69,10 +69,6 @@ github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e6
 github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
-github.com/aquasecurity/tracee/types v0.0.0-20230529103208-c134a2b7369a h1:3XI2XimnuYGeB/lMKC6VX9zoVjb3Ky1VK0fuNYS3z8s=
-github.com/aquasecurity/tracee/types v0.0.0-20230529103208-c134a2b7369a/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
-github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf h1:bSWqjqjFPGyn+thqof/rph4A5jSqd2d7xWJK5MGMb0I=
-github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -262,6 +258,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.2 h1:Dwmkdr5Nc/oBiXgJS3CDHNhJtIHkuZ3DZF5twqnfBdU=
+github.com/hashicorp/golang-lru/v2 v2.0.2/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -270,10 +270,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 			if t.config.Output.ExecHash {
 				var hashInfoObj fileExecInfo
 				var currentHash string
-				hashInfoInterface, ok := t.fileHashes.Get(capturedFileID)
-				if ok {
-					hashInfoObj = hashInfoInterface.(fileExecInfo)
-				}
+				hashInfoObj, ok := t.fileHashes.Get(capturedFileID)
 				// check if cache can be used
 				if ok && hashInfoObj.LastCtime == castedSourceFileCtime {
 					currentHash = hashInfoObj.Hash

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sys/unix"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
@@ -76,7 +76,7 @@ type Tracee struct {
 	eventProcessor   map[events.ID][]func(evt *trace.Event) error
 	eventDerivations derive.Table
 	// Artifacts
-	fileHashes     *lru.Cache
+	fileHashes     *lru.Cache[string, fileExecInfo]
 	capturedFiles  map[string]int64
 	writtenFiles   map[string]string
 	netCapturePcap *pcaps.Pcaps
@@ -408,7 +408,7 @@ func (t *Tracee) Init() error {
 
 	// Initialize hashes for files
 
-	t.fileHashes, err = lru.New(1024)
+	t.fileHashes, err = lru.New[string, fileExecInfo](1024)
 	if err != nil {
 		t.Close()
 		return errfmt.WrapError(err)

--- a/pkg/events/derive/hidden_kernel_module.go
+++ b/pkg/events/derive/hidden_kernel_module.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"unsafe"
 
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/aquasecurity/libbpfgo/helpers"
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	foundHiddenKernModsCache *lru.Cache
+	foundHiddenKernModsCache *lru.Cache[uint64, struct{}]
 	allModsMap               *bpf.BPFMap
 	newModuleOnlyMap         *bpf.BPFMap
 	recentDeletedModulesMap  *bpf.BPFMap
@@ -194,10 +194,7 @@ func InitHiddenKernelModules(
 	recentInsertedModulesMap = insertedModMap
 
 	var err error
-	foundHiddenKernModsCache, err = lru.New(2048)
-	if err != nil {
-		logger.Errorw("Error occurred initializing kernel hidden modules: " + err.Error())
-	}
+	foundHiddenKernModsCache, err = lru.New[uint64, struct{}](2048)
 	return err
 }
 

--- a/pkg/pcaps/common.go
+++ b/pkg/pcaps/common.go
@@ -55,12 +55,12 @@ func initializeGlobalVars(output *os.File) {
 
 // getItemIndexFromEvent returns correct trace.Event variable according to
 // given PcapType
-func getItemIndexFromEvent(event *trace.Event, itemType PcapType) interface{} {
+func getItemIndexFromEvent(event *trace.Event, itemType PcapType) string {
 	switch itemType {
 	case Single:
 		return itemType.String()
 	case Process:
-		return event.HostThreadID
+		return fmt.Sprint(event.HostThreadID)
 	case Container:
 		return event.Container.ID
 	case Command:
@@ -71,7 +71,7 @@ func getItemIndexFromEvent(event *trace.Event, itemType PcapType) interface{} {
 		return ret
 	}
 
-	return new(interface{})
+	return ""
 }
 
 // getPcapFileName returns a string used to create a pcap file under the


### PR DESCRIPTION
Upgrade `hashicorp/golang-lru` to v2.
This includes generics and further optimizations and fixes.

TODO: add pcaps tests to make sure it doesn't break.