### PR TITLE
chore: restore old ContainerID field

### DIFF
--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -227,9 +227,10 @@ func TestOutputTemplates(t *testing.T) {
 					},
 				},
 				Event: trace.Event{
-					ProcessID: 21312,
-					Timestamp: 1321321,
-					UserID:    0,
+					ProcessID:   21312,
+					Timestamp:   1321321,
+					UserID:      0,
+					ContainerID: "abbc123",
 					Container: trace.Container{
 						ID: "abbc123",
 					},
@@ -255,7 +256,7 @@ func TestOutputTemplates(t *testing.T) {
 					"a":123,"b":"c","d":true,"f":{"123":"456","foo":"bar"}
 				},
 				"Context":{
-					"timestamp":1321321,"processorId":0,"processId":21312,"threadId":0,"threadStartTime":0,"parentProcessId":0,"hostProcessId":0,"hostThreadId":0,"hostParentProcessId":0,"userId":0,"mountNamespace":0,"pidNamespace":0,"processName":"","hostName":"","cgroupId":0,"container":{"id":"abbc123"},"kubernetes":{},"eventId":"0","eventName":"execve","argsNum":0,"returnValue":0,"syscall":"execve","stackAddresses":null,"args":null,"contextFlags":{"containerStarted":true,"isCompat":false}
+					"timestamp":1321321,"processorId":0,"processId":21312,"threadId":0,"threadStartTime":0,"parentProcessId":0,"hostProcessId":0,"hostThreadId":0,"hostParentProcessId":0,"userId":0,"mountNamespace":0,"pidNamespace":0,"processName":"","hostName":"","cgroupId":0,"containerId":"abbc123","container":{"id":"abbc123"},"kubernetes":{},"eventId":"0","eventName":"execve","argsNum":0,"returnValue":0,"syscall":"execve","stackAddresses":null,"args":null,"contextFlags":{"containerStarted":true,"isCompat":false}
 				},
 				"SigMetadata":{
 					"ID":"TRC-1","EventName": "stdio","Version":"0.1.0","Name":"Standard Input/Output Over Socket","Description":"Redirection of process's standard input/output to socket","Tags":["linux","container"],"Properties":{"MITRE ATT\u0026CK":"Persistence: Server Software Component","Severity":3}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230525195705-4707c7022ac4
+	github.com/aquasecurity/tracee/types v0.0.0-20230529103208-c134a2b7369a
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible
 	github.com/golang/protobuf v1.5.3
@@ -162,7 +162,7 @@ require (
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.68 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -69,10 +69,8 @@ github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e6
 github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
-github.com/aquasecurity/tracee/types v0.0.0-20230509064557-880c7642f59f h1:9zdf+kWasQkycgJ9KNP/GXeKBXZrVCEEOpBCr7HKeUI=
-github.com/aquasecurity/tracee/types v0.0.0-20230509064557-880c7642f59f/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
-github.com/aquasecurity/tracee/types v0.0.0-20230525195705-4707c7022ac4 h1:Eb6z+G+pI/DB5sYU1mLFQquKSbqrbAwECoMkBACSUW8=
-github.com/aquasecurity/tracee/types v0.0.0-20230525195705-4707c7022ac4/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
+github.com/aquasecurity/tracee/types v0.0.0-20230529103208-c134a2b7369a h1:3XI2XimnuYGeB/lMKC6VX9zoVjb3Ky1VK0fuNYS3z8s=
+github.com/aquasecurity/tracee/types v0.0.0-20230529103208-c134a2b7369a/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -248,6 +248,7 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 				ProcessName:         string(bytes.TrimRight(ctx.Comm[:], "\x00")),
 				HostName:            string(bytes.TrimRight(ctx.UtsName[:], "\x00")),
 				CgroupID:            uint(ctx.CgroupID),
+				ContainerID:         containerData.ID,
 				Container:           containerData,
 				Kubernetes:          kubernetesData,
 				EventID:             int(ctx.EventID),

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -186,7 +186,7 @@ func checkNewContainers(t *testing.T, gotOutput *eventOutput) {
 	containerIds := []string{}
 	output := gotOutput.getEventsCopy()
 	for _, evt := range output {
-		containerIds = append(containerIds, evt.Container.ID)
+		containerIds = append(containerIds, evt.Container.ID, evt.ContainerID)
 	}
 	for _, id := range containerIds {
 		assert.Equal(t, containerId, id)


### PR DESCRIPTION
## Change 

The PR reintroduces the `ContainerID` field into the `trace.Event` type.
It should be equivalent to using the new `.Container.ID` field.
This was done because the field change back in v0.13 has broken some json consumers of tracee.
We've decided to duplicate this field in it's original format until we make the event type overhaul in v0.16 to let consumers have more time to prepare migrations.

## Testing

Run `tracee -o json -f c`
Start a container `docker run --rm ubuntu`
Confirm that both the `"containerId"` field and `"container": "id"` field are populated the same way.
