### PR TITLE
bpf: fix int truncation in address holder

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -1522,7 +1522,7 @@ int uprobe_syscall_trigger(struct pt_regs *ctx)
         return 0;
 
     u64 idx;
-    u32 syscall_addr = 0;
+    u64 syscall_addr = 0;
     u64 syscall_address[NUMBER_OF_SYSCALLS_TO_CHECK];
 
 #pragma unroll
@@ -1536,7 +1536,7 @@ int uprobe_syscall_trigger(struct pt_regs *ctx)
             continue;
         }
 
-        bpf_core_read(&syscall_addr, sizeof(u32), &syscall_table_addr[*syscall_num_p]);
+        bpf_core_read(&syscall_addr, sizeof(u64), &syscall_table_addr[*syscall_num_p]);
         if (syscall_addr == 0) {
             return 0;
         }


### PR DESCRIPTION
### 1. Explain what the PR does

    bpf: fix int truncation in address holder

### 2. Explain how to test it

Running `sudo ./dist/tracee -f comm=uname -o json | jq` on this PR, should not (falsely) detect syscall hooks.

Running on main:

`sudo ./dist/tracee -f comm=uname -o json | jq`

```json
{
  "timestamp": 0,
  "threadStartTime": 0,
  "processorId": 0,
  "processId": 0,
  "cgroupId": 0,
  "threadId": 0,
  "parentProcessId": 0,
  "hostProcessId": 0,
  "hostThreadId": 0,
  "hostParentProcessId": 0,
  "userId": 0,
  "mountNamespace": 0,
  "pidNamespace": 0,
  "processName": "",
  "hostName": "",
  "containerId": "",
  "container": {},
  "kubernetes": {},
  "eventId": "6028",
  "eventName": "syscall_hooking",
  "matchedPolicies": [
    ""
  ],
  "argsNum": 1,
  "returnValue": 0,
  "syscall": "",
  "stackAddresses": [
    0
  ],
  "contextFlags": {
    "containerStarted": false,
    "isCompat": false
  },
  "args": [
    {
      "name": "Hooked syscalls",
      "type": "unknown",
      "value": [
        {
          "SymbolName": "read",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "write",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "open",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "close",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "ioctl",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "socket",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "sendto",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "recvfrom",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "sendmsg",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "recvmsg",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "execve",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "kill",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "getdents",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "ptrace",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "getdents64",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "openat",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "bpf",
          "ModuleOwner": "hidden"
        },
        {
          "SymbolName": "execveat",
          "ModuleOwner": "hidden"
        }
      ]
    }
  ],
  "metadata": {
    "Version": "1",
    "Description": "Syscall table hooking detected. Syscalls (system calls) are the interface between user applications and the kernel. By hooking the syscall table an adversary gains control on certain system function, such as file writing and reading or other basic function performed by the operation system. The adversary may also hijack the execution flow and execute it's own code. Syscall table hooking is considered a malicious behavior that is performed by rootkits and may indicate that the host's kernel has been compromised. Hidden modules are marked as hidden symbol owners and indicate further malicious activity of an adversary.",
    "Tags": null,
    "Properties": {
      "Category": "defense-evasion",
      "Kubernetes_Technique": "",
      "Severity": 3,
      "Technique": "Rootkit",
      "external_id": "T1014",
      "id": "attack-pattern--0f20e3cb-245b-4a61-8a91-2d93f7cb0e9b",
      "signatureID": "TRC-1030",
      "signatureName": "Syscall table hooking detected"
    }
  }
}
```

### 3. Other comments

