### PR TITLE
ebpf: events: set policies for init events

### DIFF
--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -170,6 +170,20 @@ func (ps *Policies) Lookup(id int) (*Policy, error) {
 	return p, nil
 }
 
+// MatchedNames returns a list of matched policies names based on
+// the given matched bitmask.
+func (ps *Policies) MatchedNames(matched uint64) []string {
+	names := []string{}
+
+	for p := range ps.Map() {
+		if utils.HasBit(matched, uint(p.ID)) {
+			names = append(names, p.Name)
+		}
+	}
+
+	return names
+}
+
 func (ps *Policies) Map() map[*Policy]int {
 	return ps.filterEnabledPoliciesMap
 }


### PR DESCRIPTION
### 1. Explain what the PR does

    ebpf: events: set policies for init events
    
    This sets the policies for the init events, populating matchedPolicies
    names in the event by using setMatchedPolicies().

### 2. Explain how to test it

`sudo ./dist/tracee -f e=init_namespaces -o json`

```json
{"timestamp":1685388723975242360,"threadStartTime":0,"processorId":0,"processId":0,"cgroupId":0,"threadId":0,"parentProcessId":0,"hostProcessId":0,"hostThreadId":0,"hostParentProcessId":0,"userId":0,"mountNamespace":0,"pidNamespace":0,"processName":"tracee-ebpf","hostName":"","containerId":"","container":{},"kubernetes":{},"eventId":"2013","eventName":"init_namespaces","matchedPolicies":[""],"argsNum":10,"returnValue":0,"syscall":"","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"args":[{"name":"cgroup","type":"u32","value":4026531835},{"name":"ipc","type":"u32","value":4026531839},{"name":"mnt","type":"u32","value":4026531841},{"name":"net","type":"u32","value":4026531840},{"name":"pid","type":"u32","value":4026531836},{"name":"pid_for_children","type":"u32","value":4026531836},{"name":"time","type":"u32","value":4026531834},{"name":"time_for_children","type":"u32","value":4026531834},{"name":"user","type":"u32","value":4026531837},{"name":"uts","type":"u32","value":4026531838}]}
```

`sudo ./dist/tracee -p ./pol2.yaml -p ./pol3.yaml`
`sudo ./dist/tracee -p ./pol1.yaml -p ./pol3.yaml`

```yaml
name: pol1
description: general policy
scope:
  - global
defaultAction: log
rules:
  - event: init_namespaces
```

```yaml
name: pol2
description: general policy
scope:
  - global
defaultAction: log
rules:
  - event: init_namespaces
```

```yaml
name: pol3
description: general policy
scope:
  - global
defaultAction: log
rules:
  - event: socket_dup
```

### 3. Other comments

Fix: #3108 
