### PR TITLE
policy: add not-equal operator parsing

### DIFF
--- a/pkg/policy/policy_file.go
+++ b/pkg/policy/policy_file.go
@@ -232,7 +232,11 @@ func validateEvent(policyName, eventName string) error {
 }
 
 func validateEventArg(policyName, eventName, argName string) error {
-	s := strings.Split(argName, "=")
+	s := strings.Split(argName, "!=")
+
+	if len(s) == 1 {
+		s = strings.Split(argName, "=")
+	}
 
 	if len(s) == 1 {
 		return errfmt.Errorf("policy %s, arg %s value can't be empty", policyName, s[0])

--- a/pkg/policy/policy_file_test.go
+++ b/pkg/policy/policy_file_test.go
@@ -340,6 +340,24 @@ func TestPolicyValidate(t *testing.T) {
 			expectedError: errors.New("policy.validateEventArg: policy empty_arg_value, arg pathname value can't be empty"),
 		},
 		{
+			testName: "empty arg value",
+			policy: PolicyFile{
+				Name:          "empty_arg_value",
+				Description:   "empty arg value",
+				Scope:         []string{"global"},
+				DefaultAction: "log",
+				Rules: []Rule{
+					{
+						Event: "openat",
+						Filter: []string{
+							"args.pathname!=",
+						},
+					},
+				},
+			},
+			expectedError: errors.New("policy.validateEventArg: policy empty_arg_value, arg pathname value can't be empty"),
+		},
+		{
 			testName: "signature filter arg",
 			policy: PolicyFile{
 				Name:          "signature_filter_arg",
@@ -351,6 +369,7 @@ func TestPolicyValidate(t *testing.T) {
 						Event: "fake_signature",
 						Filter: []string{
 							"args.lala=lala",
+							"args.lele!=lele",
 						},
 					},
 				},


### PR DESCRIPTION
### 1. Explain what the PR does

    policy: add not-equal operator parsing
    
    This adds the not-equal operator check to the policy parser. It also
    adds test cases for the not-equal operator.

### 2. Explain how to test it

`sudo ./dist/tracee -p ./not_equal.yaml`

```yaml
name: test policy
description: test symbols_loaded filter
scope:
  - global
defaultAction: log
rules:
  - event: symbols_loaded
    filter:
      - args.symbols=fopen
      - args.library_path!=libc
```

### 3. Other comments

Fix: #3166 
