### PR TITLE
policy: fix output options

### DIFF
--- a/pkg/cmd/cobra/helper.go
+++ b/pkg/cmd/cobra/helper.go
@@ -105,11 +105,11 @@ func getOutputFlagsFromPolicies(outputFlags []string, policies []policy.PolicyFi
 		switch outputParts[0] {
 		case "forward", "webhook":
 			actionsMap[outputParts[0]] = true
-			outputSlice = append(outputSlice, o)
 		case "table", "table-verbose", "json", "gob":
 			actionsMap["log"] = true
-			outputSlice = append(outputSlice, o)
 		}
+
+		outputSlice = append(outputSlice, o)
 	}
 
 	// if printer was not defined for action log, return default to table:stdout

--- a/pkg/cmd/cobra/helper_test.go
+++ b/pkg/cmd/cobra/helper_test.go
@@ -18,7 +18,7 @@ func Test_getOutputFlagsFromPolicies(t *testing.T) {
 	}{
 		{
 			name:        "no output flags, with action log",
-			outputFlags: []string{""},
+			outputFlags: []string{},
 			policyFiles: []policy.PolicyFile{
 				{
 					Name:          "test",
@@ -29,6 +29,37 @@ func Test_getOutputFlagsFromPolicies(t *testing.T) {
 				},
 			},
 			expectedOutputFlags: []string{"table:stdout"},
+		},
+		{
+			name: "output options",
+			outputFlags: []string{
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+			},
+			policyFiles: []policy.PolicyFile{
+				{
+					Name:          "test",
+					DefaultAction: "log",
+					Rules: []policy.Rule{
+						{Event: "test"},
+					},
+				},
+			},
+			expectedOutputFlags: []string{
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+				"table:stdout",
+			},
 		},
 		{
 			name:        "no output flags, with action webhook",


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3191

`--output option*` were getting ignore when using policies.

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
name: test
description: test
scope:
  - comm=ping
defaultAction: log
rules:
  - event: sched_process_exec
```

```
sudo ./dist/tracee -p policy.yml --output option:exec-env --output json
```

env should not be empty

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
