### PR TITLE
tracee: clean up untraced signatures

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -240,6 +240,25 @@ func New(cfg Config) (*Tracee, error) {
 		}
 	}
 
+	// Clean up signatures not chosen for tracing
+	// Looping from the back to avoid bounds checking
+	for i := len(t.config.EngineConfig.Signatures) - 1; i > 0; i-- {
+		sig := t.config.EngineConfig.Signatures[i]
+		md, _ := sig.GetMetadata()
+		sigEventName := md.EventName
+		sigEventId, ok := events.Definitions.GetID(sigEventName)
+		if !ok {
+			logger.Debugw("removing signature from events to trace", "signature", sigEventName, "reason", "ID does not exist in definitions")
+			t.config.EngineConfig.Signatures = append(t.config.EngineConfig.Signatures[:i], t.config.EngineConfig.Signatures[i+1:]...)
+			continue
+		}
+		_, ok = t.events[sigEventId]
+		if !ok {
+			logger.Debugw("removing signature from events to trace", "signature", sigEventName, "reason", "was not requested for tracing")
+			t.config.EngineConfig.Signatures = append(t.config.EngineConfig.Signatures[:i], t.config.EngineConfig.Signatures[i+1:]...)
+		}
+	}
+
 	// Handle all essential events dependencies
 
 	for id, evt := range t.events {


### PR DESCRIPTION
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Thu Jun 1 15:21:15 2023 +0000

    tracee: clean up untraced signatures
    
    Up to this commit, all signatures would be loaded to the engine even if
    tracing them was not requested. This would consume runtime resources.
    
    Fix this by verifying they were actually requested for tracing and
    removing those that weren't.
```
Fix #3190