### PR TITLE
ebpf: bitwise should_submit_net_event return

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4994,7 +4994,7 @@ statfunc int should_submit_net_event(net_event_context_t *neteventctx,
         return 0;
 
     // Any policy matched is enough to submit the net event
-    return evt_config->submit_for_policies;
+    return evt_config->submit_for_policies & neteventctx->eventctx.matched_policies;
 }
 
 #pragma clang diagnostic pop


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

commit 77cf072129e749139c7e1e2325a019d90ca98347 (HEAD -> 3184-net-return, origin/3184-net-return)
Author: Geyslan Gregório <geyslan@gmail.com>
Date:   Fri Jun 2 16:08:15 2023 -0300

    ebpf: bitwise should_submit_net_event return
    
    This is the continuation of #3184, fixing should_submit_net_event()
    return.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
