### PR TITLE
workflow: fix contents permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         "github-self-hosted_ami-0f4881c8d69684001_${{ github.event.number }}-${{ github.run_id }}",
       ]
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     steps:
@@ -73,7 +73,7 @@ jobs:
         "github-self-hosted_ami-03217ce7c37572c4d_${{ github.event.number }}-${{ github.run_id }}",
       ]
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     steps:


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix permission to write contents for the release workflow.

```
./dist/signatures/builtin.so

[7660](https://github.com/aquasecurity/tracee/actions/runs/5198242348/jobs/9374109061#step:6:7661)HTTP 403: Resource not accessible by integration (https://api.github.com/repos/aquasecurity/tracee/releases)

[7661](https://github.com/aquasecurity/tracee/actions/runs/5198242348/jobs/9374109061#step:6:7662)make: *** [builder/Makefile.release:161: release] Error 1

[7662](https://github.com/aquasecurity/tracee/actions/runs/5198242348/jobs/9374109061#step:6:7663)Error: Process completed with exit code 2.
```

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
