### PR TITLE
ebpf: pipeline: reduce iteration over policies

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -282,7 +282,7 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 }
 
 // matchPolicies does the userland filtering (policy matching) for events. It iterates through all
-// existing policies, that were set by the kernel in the event bitmask. Some of those policies might
+// existing policies, that were set by the kernel in the event bitmap. Some of those policies might
 // not match the event after userland filters are applied. In those cases, the policy bit is cleared
 // (so the event is "filtered" for that policy).
 // This may be called in different stages of the pipeline (decode, derive, engine).
@@ -435,7 +435,7 @@ func (t *Tracee) processEvents(ctx context.Context, in <-chan *trace.Event) (
 				continue
 			}
 
-			// Get a bitmask with all policies containing container filters
+			// Get a bitmap with all policies containing container filters
 			policiesWithContainerFilter := t.config.Policies.ContainerFilterEnabled()
 
 			// Filter out events that don't have a container ID from all the policies that have

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -291,12 +291,12 @@ func (t *Tracee) matchPolicies(event *trace.Event) uint64 {
 	bitmap := event.MatchedPoliciesKernel
 
 	// Short circuit if there are no policies in userland that need filtering.
-	if bitmap&t.config.Policies.FilterableInUserSpace() == 0 {
+	if bitmap&t.config.Policies.FilterableInUserland() == 0 {
 		event.MatchedPoliciesUser = bitmap // store untoched bitmap to be used in sink stage
 		return bitmap
 	}
 
-	for p := range t.config.Policies.FilterableInUserSpaceMap() { // range through each userland filterable policy
+	for p := range t.config.Policies.FilterableInUserlandMap() { // range through each userland filterable policy
 		// Policy ID is the bit offset in the bitmap.
 		bitOffset := uint(p.ID)
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -746,7 +746,7 @@ func (t *Tracee) computeConfigValues() []byte {
 		byteIndex := p.ID / 8
 		bitOffset := p.ID % 8
 
-		// filter enabled policies bitmask
+		// filter enabled policies bitmap
 		if p.UIDFilter.Enabled() {
 			// uid_filter_enabled_scopes
 			configVal[16+byteIndex] |= 1 << bitOffset
@@ -800,7 +800,7 @@ func (t *Tracee) computeConfigValues() []byte {
 			configVal[112+byteIndex] |= 1 << bitOffset
 		}
 
-		// filter out scopes bitmask
+		// filter out scopes bitmap
 		if p.UIDFilter.FilterOut() {
 			// uid_filter_out_scopes
 			configVal[120+byteIndex] |= 1 << bitOffset

--- a/pkg/filters/containers.go
+++ b/pkg/filters/containers.go
@@ -50,7 +50,7 @@ func (f *ContainerFilter) UpdateBPF(bpfModule *bpf.Module, cts *containers.Conta
 			equalitySetInPolicies = binary.LittleEndian.Uint64(curVal[8:16])
 		}
 
-		// filterNotEqual == 0, so clear n bitmask bit
+		// filterNotEqual == 0, so clear n bitmap bit
 		utils.ClearBit(&equalInPolicies, policyID)
 		utils.SetBit(&equalitySetInPolicies, policyID)
 
@@ -78,7 +78,7 @@ func (f *ContainerFilter) UpdateBPF(bpfModule *bpf.Module, cts *containers.Conta
 			equalitySetInPolicies = binary.LittleEndian.Uint64(curVal[8:16])
 		}
 
-		// filterEqual == 1, so set n bitmask bit
+		// filterEqual == 1, so set n bitmap bit
 		utils.SetBit(&equalInPolicies, policyID)
 		utils.SetBit(&equalitySetInPolicies, policyID)
 

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -259,7 +259,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, policyID uint) e
 			equalitySetInPolicies = binary.LittleEndian.Uint64(curVal[8:16])
 		}
 
-		// filterNotEqual == 0, so clear n bitmask bit
+		// filterNotEqual == 0, so clear n bitmap bit
 		utils.ClearBit(&equalInPolicies, policyID)
 		utils.SetBit(&equalitySetInPolicies, policyID)
 
@@ -282,7 +282,7 @@ func (filter *BPFStringFilter) UpdateBPF(bpfModule *bpf.Module, policyID uint) e
 			equalitySetInPolicies = binary.LittleEndian.Uint64(curVal[8:16])
 		}
 
-		// filterEqual == 1, so set n bitmask bit
+		// filterEqual == 1, so set n bitmap bit
 		utils.SetBit(&equalInPolicies, policyID)
 		utils.SetBit(&equalitySetInPolicies, policyID)
 

--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -262,7 +262,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, policyID uint) 
 			equalitySetInPolicies = binary.LittleEndian.Uint64(curVal[8:16])
 		}
 
-		// filterNotEqual == 0, so clear n bitmask bit
+		// filterNotEqual == 0, so clear n bitmap bit
 		utils.ClearBit(&equalInPolicies, policyID)
 		utils.SetBit(&equalitySetInPolicies, policyID)
 
@@ -290,7 +290,7 @@ func (filter *BPFUIntFilter[T]) UpdateBPF(bpfModule *bpf.Module, policyID uint) 
 			equalitySetInPolicies = binary.LittleEndian.Uint64(curVal[8:16])
 		}
 
-		// filterEqual == 1, so set n bitmask bit
+		// filterEqual == 1, so set n bitmap bit
 		utils.SetBit(&equalInPolicies, policyID)
 		utils.SetBit(&equalitySetInPolicies, policyID)
 

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -68,9 +68,11 @@ func (ps *Policies) PIDFilterableInUserSpace() bool {
 	return ps.pidFilterableInUserSpace
 }
 
-// ContainerFilterEnabled returns a bitmask of policies that have at least one container filter type
-// enabled. TODO: make sure the stores are also atomic (an atomic load is only protecting the read
-// from context switches, not from CPU cache coherency issues).
+// ContainerFilterEnabled returns a bitmap of policies that have at least
+// one container filter type enabled.
+//
+// TODO: make sure the stores are also atomic (an atomic load is only protecting
+// the read from context switches, not from CPU cache coherency issues).
 func (ps *Policies) ContainerFilterEnabled() uint64 {
 	return atomic.LoadUint64(&ps.containerFiltersEnabled)
 }
@@ -187,7 +189,7 @@ func (ps *Policies) Lookup(id int) (*Policy, error) {
 }
 
 // MatchedNames returns a list of matched policies names based on
-// the given matched bitmask.
+// the given matched bitmap.
 func (ps *Policies) MatchedNames(matched uint64) []string {
 	names := []string{}
 


### PR DESCRIPTION
### 1. Explain what the PR does

5bce4837 **policies: replace "userspace" with "userland"** _(2023/jun/08) <Geyslan Gregório>_

```
```

0a015810 **docs: change "bitmask" mentions to "bitmap"** _(2023/jun/07) <Geyslan Gregório>_

```
```

229ce1c9 **ebpf: pipeline: reduce iteration over policies** _(2023/jun/07) <Geyslan Gregório>_

```
This creates a policy bitmap with filters that need to be checked in the
userland. This bitmap is used to avoid iterating the entire map when
there is no policy match in the kernel that requires userland filtering.

When there is a policy that requires userland filtering, the iteration
must be done using FilterableInUserSpaceMap(), which returns a possible
reduced map of policies.
```


### 2. Explain how to test it


### 3. Other comments

