### PR TITLE
tests: fix event MatchedPoliciesUser check

### DIFF
--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1603,7 +1603,7 @@ func ExpectAllEqualTo(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, 
 					assert.Equal(t, expEvt.EventID, actEvt.EventID, "event id")
 				}
 				if checkPolicy {
-					assert.Equal(t, expEvt.MatchedPolicies, actEvt.MatchedPolicies, "matched policies")
+					assert.Equal(t, expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser, "matched policies")
 				}
 				if checkPolicyName {
 					assertUnorderedStringSlicesEqual(t, expEvt.MatchedPolicies, actEvt.MatchedPolicies)
@@ -1684,7 +1684,7 @@ func ExpectAllInOrder(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, 
 				assert.Equal(t, expEvt.EventID, actEvt.EventID, "event id")
 			}
 			if checkPolicy {
-				assert.Equal(t, expEvt.MatchedPolicies, actEvt.MatchedPolicies, "matched policies")
+				assert.Equal(t, expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser, "matched policies")
 			}
 			if checkPolicyName {
 				assertUnorderedStringSlicesEqual(t, expEvt.MatchedPolicies, actEvt.MatchedPolicies)


### PR DESCRIPTION
### 1. Explain what the PR does

Fix: #3219

f393a556 **tests: fix event MatchedPoliciesUser check** _<sub>(2023/jun/08) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
For matched policies bitmap, it was wrongly checking for the
MatchedPolicies field, which is now the matched policies' names.

This commit fixes the check to use the MatchedPoliciesUser (bitmap)
field instead.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
