### PR TITLE
ebpf: fix mem_prot_alert anonymous file info

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3180,12 +3180,15 @@ int BPF_KPROBE(trace_mmap_alert)
     if ((prot & (VM_WRITE | VM_EXEC)) == (VM_WRITE | VM_EXEC) &&
         should_submit(MEM_PROT_ALERT, p.event)) {
         u32 alert = ALERT_MMAP_W_X;
-        int fd = sys->args.args[5];
+        int fd = sys->args.args[4];
         void *addr = (void *) sys->args.args[0];
         size_t len = sys->args.args[1];
-        struct file *file = get_struct_file_from_fd(fd);
         int prev_prot = 0;
-        file_info_t file_info = get_file_info(file);
+        file_info_t file_info = {.pathname_p = NULL};
+        if (fd >= 0) {
+            struct file *file = get_struct_file_from_fd(fd);
+            file_info = get_file_info(file);
+        }
         submit_mem_prot_alert_event(p.event, alert, addr, len, prot, prev_prot, file_info);
     }
 


### PR DESCRIPTION
### 1. Explain what the PR does

Anonymous files in `mmap` triggering `mem_prot_alert` got an incorrect file info, because it was not checked.
Fix it so there won't be file info in this case.

fix #3217

### 2. Explain how to test it

Ran it using the following script:

```
#include <stdio.h>
#include <stdlib.h>
#include <sys/mman.h>

int main() {
    size_t size = 4096; // Size of memory to allocate (in bytes)
    void* addr = NULL;  // Address at which to create the mapping

    // Allocate anonymous memory with write and execute permissions
    void* ptr = mmap(addr, size, PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
    if (ptr == MAP_FAILED) {
        perror("mmap");
        exit(1);
    }

    if (munmap(ptr, size) == -1) {
        perror("munmap");
        exit(1);
    }

    return 0;
}
```c
