### PR TITLE
containers: trim mountpoint from stored paths

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -159,6 +159,9 @@ func (c *Containers) populate() error {
 // saving container information in Containers CgroupInfo map.
 // NOTE: ALL given cgroup dir paths are stored in CgroupInfo map.
 func (c *Containers) CgroupUpdate(cgroupId uint64, path string, ctime time.Time) (CgroupInfo, error) {
+	// Cgroup paths should be stored and evaluated relative to the mountpoint,
+	// trim it from the path.
+	path = strings.TrimPrefix(path, c.cgroups.GetDefaultCgroup().GetMountPoint())
 	containerId, containerRuntime, isRoot := getContainerIdFromCgroup(path)
 	container := cruntime.ContainerMetadata{
 		ContainerId: containerId,


### PR DESCRIPTION
This ensures that only the cgroup subpath is evaluated for a container id.
This resolves the case where container mounting the cgroup fs through kubernetes may have their container id as part of the mountpoint. Then, events on the host would be evaluated with respect to that mountpoint, including its container id.