### PR TITLE
eBPF control plane signals

### DIFF
--- a/pkg/bufferdecoder/decoder_test.go
+++ b/pkg/bufferdecoder/decoder_test.go
@@ -30,7 +30,6 @@ func TestDecodeContext(t *testing.T) {
 		EventID:     0,
 		Retval:      0,
 		StackID:     0,
-		Argnum:      0,
 	}
 	err := binary.Write(buf, binary.LittleEndian, ctxExpected)
 	assert.Equal(t, nil, err)

--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -49,9 +49,9 @@ const (
 	boolT
 )
 
-// ReadArgFromBuff read the next argument from the buffer.
+// readArgFromBuff read the next argument from the buffer.
 // Return the index of the argument and the parsed argument.
-func ReadArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.ArgMeta,
+func readArgFromBuff(id events.ID, ebpfMsgDecoder *EbpfDecoder, params []trace.ArgMeta,
 ) (
 	uint, trace.Argument, error,
 ) {

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -166,7 +166,7 @@ func TestReadArgFromBuff(t *testing.T) {
 
 	for _, tc := range testCases {
 		decoder := New(tc.input)
-		_, actual, err := ReadArgFromBuff(0, decoder, tc.params)
+		_, actual, err := readArgFromBuff(0, decoder, tc.params)
 
 		if tc.expectedError != nil {
 			assert.ErrorContains(t, err, tc.expectedError.Error())

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -44,12 +44,12 @@ type Context struct {
 	Retval          int64
 	StackID         uint32
 	ProcessorId     uint16
+	_               [2]byte // padding
 	Argnum          uint8
-	_               [1]byte // padding
 }
 
-func (Context) GetSizeBytes() uint32 {
-	return 128
+func (Context) GetSizeBytes() int {
+	return 129
 }
 
 type ChunkMeta struct {

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -45,11 +45,10 @@ type Context struct {
 	StackID         uint32
 	ProcessorId     uint16
 	_               [2]byte // padding
-	Argnum          uint8
 }
 
 func (Context) GetSizeBytes() int {
-	return 129
+	return 128
 }
 
 type ChunkMeta struct {

--- a/pkg/bufferdecoder/protocol_test.go
+++ b/pkg/bufferdecoder/protocol_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Note: because of memory alignment, unsafe.Sizeof doesn't return the sum of byte size of each fields.
-// Thus, in order to the test to be appropriate (and fail if any change to the struct is done without updating GetSizeBytes), we need
+// Thus, for the test to work and fail if any change to the struct is done without updating GetSizeBytes, we need
 // to find a function that relates GetSizeBytes and the actual size of the struct calculated with unsafe.Sizeof.
 
 // If the test is failing then this means you added/moved the fields inside in the type of variable v.
@@ -17,7 +17,7 @@ import (
 func TestContextSize(t *testing.T) {
 	var v Context
 	size := int(unsafe.Sizeof(v))
-	assert.Equal(t, size, int(v.GetSizeBytes()))
+	assert.Equal(t, size-7, int(v.GetSizeBytes()))
 }
 func TestChunkMetaSize(t *testing.T) {
 	var v ChunkMeta

--- a/pkg/bufferdecoder/protocol_test.go
+++ b/pkg/bufferdecoder/protocol_test.go
@@ -17,7 +17,7 @@ import (
 func TestContextSize(t *testing.T) {
 	var v Context
 	size := int(unsafe.Sizeof(v))
-	assert.Equal(t, size-7, int(v.GetSizeBytes()))
+	assert.Equal(t, size, int(v.GetSizeBytes()))
 }
 func TestChunkMetaSize(t *testing.T) {
 	var v ChunkMeta

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -205,6 +205,11 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 		return metadata, errfmt.Errorf("no containerId")
 	}
 
+	if info.Container.Image != "" {
+		// If already enriched (from control plane) - short circuit and return
+		return info.Container, nil
+	}
+
 	// There might be a performance overhead with the cancel
 	// But, I think it will be negligible since this code path shouldn't be reached too frequently
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -55,7 +55,6 @@ init_context(void *ctx, event_context_t *context, struct task_struct *task, u32 
     }
 
     context->ts = bpf_ktime_get_ns();
-    context->argnum = 0;
 
     // Clean Stack Trace ID
     context->stack_id = 0;
@@ -132,7 +131,8 @@ statfunc int init_program_data(program_data_t *p, void *ctx)
     }
 
     p->ctx = ctx;
-    p->event->buf_off = 0;
+    p->event->args_buf.offset = 0;
+    p->event->args_buf.argnum = 0;
 
     bool container_lookup_required = true;
 
@@ -215,8 +215,8 @@ statfunc int init_tailcall_program_data(program_data_t *p, void *ctx)
 // use this function for programs that send more than one event
 statfunc void reset_event_args(program_data_t *p)
 {
-    p->event->buf_off = 0;
-    p->event->context.argnum = 0;
+    p->event->args_buf.offset = 0;
+    p->event->args_buf.argnum = 0;
 }
 
 #endif

--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -58,6 +58,7 @@ typedef struct net_event_contextmd {
 
 typedef struct net_event_context {
     event_context_t eventctx;
+    u8 argnum;
     struct { // event arguments (needs packing), use anonymous struct to ...
         u8 index0;
         u32 bytes;

--- a/pkg/ebpf/c/common/signal.h
+++ b/pkg/ebpf/c/common/signal.h
@@ -1,7 +1,21 @@
 #ifndef __COMMON_SIGNAL_H__
 #define __COMMON_SIGNAL_H__
 
-typedef struct signal {
-} signal_t;
+#include <vmlinux.h>
 
-#endif __COMMON_SIGNAL_H__
+#include <types.h>
+#include <common/common.h>
+
+statfunc controlplane_signal_t *init_controlplane_signal()
+{
+    int zero = 0;
+    controlplane_signal_t *signal = bpf_map_lookup_elem(&signal_data_map, &zero);
+    if (unlikely(signal == NULL))
+        return NULL;
+
+    signal->args_buf.argnum = 0;
+    signal->args_buf.offset = 0;
+    return signal;
+}
+
+#endif

--- a/pkg/ebpf/c/common/signal.h
+++ b/pkg/ebpf/c/common/signal.h
@@ -1,0 +1,7 @@
+#ifndef __COMMON_SIGNAL_H__
+#define __COMMON_SIGNAL_H__
+
+typedef struct signal {
+} signal_t;
+
+#endif __COMMON_SIGNAL_H__

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -112,6 +112,7 @@ BPF_LRU_HASH(bpf_attach_map, u32, bpf_used_helpers_t, 1024);       // holds bpf 
 BPF_LRU_HASH(bpf_attach_tmp_map, u32, bpf_used_helpers_t, 1024);   // temporarily hold bpf_used_helpers_t
 BPF_LRU_HASH(bpf_prog_load_map, u32, void *, 1024);                // store bpf prog aux pointer between bpf_check and security_bpf_prog
 BPF_PERCPU_ARRAY(event_data_map, event_data_t, 1);                 // persist event related data
+BPF_PERCPU_ARRAY(signal_data_map, controlplane_signal_t, 1);       // signal scratch map
 BPF_HASH(logs_count, bpf_log_t, bpf_log_count_t, 4096);            // logs count
 BPF_PERCPU_ARRAY(scratch_map, scratch_t, 1);                       // scratch space to avoid allocating stuff on the stack
 BPF_LRU_HASH(file_modification_map, file_mod_key_t, int, 10240);   // hold file data to decide if should submit file modification event
@@ -122,6 +123,6 @@ BPF_LRU_HASH(io_file_path_cache_map, file_id_t, path_buf_t, 5);    // store cach
 BPF_PERF_OUTPUT(logs, 1024);        // logs submission
 BPF_PERF_OUTPUT(events, 1024);      // events submission
 BPF_PERF_OUTPUT(file_writes, 1024); // file writes events submission
-BPF_PERF_OUTPUT(signals, 1024);
+BPF_PERF_OUTPUT(signals, 1024);     // control plane signals submissions
 
 #endif /* __MAPS_H__ */

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -122,5 +122,6 @@ BPF_LRU_HASH(io_file_path_cache_map, file_id_t, path_buf_t, 5);    // store cach
 BPF_PERF_OUTPUT(logs, 1024);        // logs submission
 BPF_PERF_OUTPUT(events, 1024);      // events submission
 BPF_PERF_OUTPUT(file_writes, 1024); // file writes events submission
+BPF_PERF_OUTPUT(signals, 1024);
 
 #endif /* __MAPS_H__ */

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -33,7 +33,6 @@ typedef struct event_context {
     s64 retval;
     u32 stack_id;
     u16 processor_id; // The ID of the processor which processed the event
-    u8 argnum;
 } event_context_t;
 
 enum event_id_e
@@ -341,10 +340,15 @@ typedef struct netconfig_entry {
     u32 capture_length;  // amount of network packet payload to capture (pcap)
 } netconfig_entry_t;
 
+typedef struct args_buffer {
+    u8 argnum;
+    char args[ARGS_BUF_SIZE];
+    u32 offset;
+} args_buffer_t;
+
 typedef struct event_data {
     event_context_t context;
-    char args[ARGS_BUF_SIZE];
-    u32 buf_off;
+    args_buffer_t args_buf;
     struct task_struct *task;
     u64 param_types;
 } event_data_t;

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -353,7 +353,20 @@ typedef struct event_data {
     u64 param_types;
 } event_data_t;
 
-#define MAX_EVENT_SIZE sizeof(event_context_t) + ARGS_BUF_SIZE
+// A control plane signal - sent to indicate some critical event which should be processed
+// with priority.
+//
+// Signals currently consist of shortened events sent only with their arguments.
+// As such, they consist of an event id and an argument buffer.
+// If we ever require a signal independent of an event, the event_id field should change
+// accordingly.
+typedef struct controlplane_signal {
+    u32 event_id;
+    args_buffer_t args_buf;
+} controlplane_signal_t;
+
+#define MAX_EVENT_SIZE  sizeof(event_context_t) + sizeof(u8) + ARGS_BUF_SIZE
+#define MAX_SIGNAL_SIZE sizeof(u32) + sizeof(u8) + ARGS_BUF_SIZE
 
 #define BPF_MAX_LOG_FILE_LEN 72
 

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -1,0 +1,185 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aquasecurity/libbpfgo"
+
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+const pollTimeout int = 300 // from tracee.go (move to a consts package?)
+
+// Control Plane probe handles
+const (
+	cgroupMkdirControlProbe probes.Handle = iota
+	cgroupRmdirControlProbe
+)
+
+type Controller struct {
+	ctx            context.Context
+	signalChan     chan []byte
+	lostSignalChan chan uint64
+	bpfModule      *libbpfgo.Module
+	probeGroup     *probes.ProbeGroup
+	signalBuffer   *libbpfgo.PerfBuffer
+	cgroupManager  *containers.Containers
+	enrichEnabled  bool
+}
+
+func NewController(bpfModule *libbpfgo.Module, cgroupManager *containers.Containers, enrichEnabled bool) (*Controller, error) {
+	var err error
+	p := &Controller{
+		signalChan:     make(chan []byte, 100),
+		lostSignalChan: make(chan uint64),
+		bpfModule:      bpfModule,
+		cgroupManager:  cgroupManager,
+	}
+	p.signalBuffer, err = bpfModule.InitPerfBuf("signals", p.signalChan, p.lostSignalChan, 1024)
+	if err != nil {
+		return nil, err
+	}
+
+	p.probeGroup = probes.NewProbeGroup(bpfModule, map[probes.Handle]probes.Probe{
+		cgroupMkdirControlProbe: probes.NewTraceProbe(
+			probes.RawTracepoint,
+			"cgroup:cgroup_mkdir",
+			"cgroup_mkdir_signal",
+		),
+		cgroupRmdirControlProbe: probes.NewTraceProbe(
+			probes.RawTracepoint,
+			"cgroup:cgroup_rmdir",
+			"cgroup_rmdir_signal",
+		),
+	})
+
+	return p, nil
+}
+
+func (p *Controller) Attach() error {
+	err := p.probeGroup.Attach(cgroupMkdirControlProbe)
+	if err != nil {
+		return fmt.Errorf("failed to attach cgroup_mkdir probe in control plane: %v", err)
+	}
+	err = p.probeGroup.Attach(cgroupRmdirControlProbe)
+	if err != nil {
+		return fmt.Errorf("failed to attach cgroup_rmdir probe in control plane: %v", err)
+	}
+	return nil
+}
+
+func (p *Controller) Start() error {
+	p.signalBuffer.Poll(pollTimeout)
+	return nil
+}
+
+func (p *Controller) Run(ctx context.Context) {
+	p.ctx = ctx
+	go func() {
+		for {
+			select {
+			case signalData := <-p.signalChan:
+				signal := signal{}
+				err := signal.Unmarshal(signalData)
+				if err != nil {
+					logger.Errorw("error unmarshaling signal ebpf buffer", "error", err)
+					continue
+				}
+				err = p.processSignal(signal)
+				if err != nil {
+					logger.Errorw("error processing control plane signal", "error", err)
+				}
+			case lost := <-p.lostSignalChan:
+				logger.Warnw(fmt.Sprintf("Lost %d control plane signals", lost))
+			case <-p.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (p *Controller) Stop() error {
+	p.signalBuffer.Stop()
+	return p.probeGroup.DetachAll()
+}
+
+func (p *Controller) processSignal(signal signal) error {
+	switch signal.eventID {
+	case events.CgroupMkdir:
+		return p.processCgroupMkdir(signal.args)
+	case events.CgroupRmdir:
+		return p.processCgroupRmdir(signal.args)
+	}
+	return nil
+}
+
+func (p *Controller) processCgroupMkdir(args []trace.Argument) error {
+	cgroupId, err := parse.ArgVal[uint64](args, "cgroup_id")
+	if err != nil {
+		return errfmt.Errorf("error parsing cgroup_mkdir signal args: %v", err)
+	}
+	path, err := parse.ArgVal[string](args, "cgroup_path")
+	if err != nil {
+		return errfmt.Errorf("error parsing cgroup_mkdir signal args: %v", err)
+	}
+	hId, err := parse.ArgVal[uint32](args, "hierarchy_id")
+	if err != nil {
+		return errfmt.Errorf("error parsing cgroup_mkdir signal args: %v", err)
+	}
+	info, err := p.cgroupManager.CgroupMkdir(cgroupId, path, hId)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+	if info.Container.ContainerId == "" {
+		// If cgroupId is from a regular cgroup directory, and not the
+		// container base directory (from known runtimes), it should be
+		// removed from the containers bpf map.
+		err := capabilities.GetInstance().EBPF(
+			func() error {
+				return p.cgroupManager.RemoveFromBpfMap(p.bpfModule, cgroupId, hId)
+			},
+		)
+		if err != nil {
+			// If the cgroupId was not found in bpf map, this could mean that
+			// it is not a container cgroup and, as a systemd cgroup, could have been
+			// created and removed very quickly.
+			// In this case, we don't want to return an error.
+			logger.Debugw("Failed to remove entry from containers bpf map", "error", err)
+		}
+		return errfmt.WrapError(err)
+	}
+
+	if p.enrichEnabled {
+		// If cgroupId belongs to a container, enrich now (in a goroutine)
+		go func() {
+			_, err = p.cgroupManager.EnrichCgroupInfo(cgroupId)
+			if err != nil {
+				logger.Errorw("error triggering container enrich in control plane", "error", err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+func (p *Controller) processCgroupRmdir(args []trace.Argument) error {
+	cgroupId, err := parse.ArgVal[uint64](args, "cgroup_id")
+	if err != nil {
+		return errfmt.Errorf("error parsing cgroup_rmdir args: %v", err)
+	}
+
+	hId, err := parse.ArgVal[uint32](args, "hierarchy_id")
+	if err != nil {
+		return errfmt.Errorf("error parsing cgroup_rmdir args: %v", err)
+	}
+	p.cgroupManager.CgroupRemove(cgroupId, hId)
+	return nil
+}

--- a/pkg/ebpf/controlplane/signal.go
+++ b/pkg/ebpf/controlplane/signal.go
@@ -1,0 +1,41 @@
+package controlplane
+
+import (
+	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type signal struct {
+	eventID events.ID
+	args    []trace.Argument
+}
+
+func (sig *signal) Unmarshal(buffer []byte) error {
+	ebpfDecoder := bufferdecoder.New(buffer)
+	var eventIdUint32 uint32
+	err := ebpfDecoder.DecodeUint32(&eventIdUint32)
+	if err != nil {
+		return errfmt.Errorf("failed to decode signal event ID: %v", err)
+	}
+	sig.eventID = events.ID(eventIdUint32)
+	var argnum uint8
+	err = ebpfDecoder.DecodeUint8(&argnum)
+	if err != nil {
+		return errfmt.Errorf("failed to decode signal argnum: %v", err)
+	}
+
+	eventDefinition, ok := events.Definitions.GetSafe(sig.eventID)
+	if !ok {
+		return errfmt.Errorf("failed to get configuration of event %d", sig.eventID)
+	}
+
+	sig.args = make([]trace.Argument, len(eventDefinition.Params))
+	err = ebpfDecoder.DecodeArguments(sig.args, int(argnum), eventDefinition, sig.eventID)
+	if err != nil {
+		return errfmt.Errorf("failed to decode signal arguments: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/ebpf/events_enrich.go
+++ b/pkg/ebpf/events_enrich.go
@@ -89,7 +89,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 				cgroupId := uint64(event.CgroupID)
 				// CgroupMkdir: pick EventID from the event itself
 				if eventID == events.CgroupMkdir {
-					cgroupId, _ = parse.ArgVal[uint64](event, "cgroup_id")
+					cgroupId, _ = parse.ArgVal[uint64](event.Args, "cgroup_id")
 				}
 				// CgroupRmdir: clean up remaining events and maps
 				if eventID == events.CgroupRmdir {
@@ -165,7 +165,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 			select {
 			case event := <-queueClean:
 				bLock.Lock()
-				cgroupId, _ := parse.ArgVal[uint64](event, "cgroup_id")
+				cgroupId, _ := parse.ArgVal[uint64](event.Args, "cgroup_id")
 				if queue, ok := queues[cgroupId]; ok {
 					// if queue is still full reschedule cleanup
 					if len(queue) > 0 {

--- a/pkg/ebpf/events_enrich.go
+++ b/pkg/ebpf/events_enrich.go
@@ -192,6 +192,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 
 func enrichEvent(evt *trace.Event, enrichData runtime.ContainerMetadata) {
 	evt.Container = trace.Container{
+		ID:          enrichData.ContainerId,
 		ImageName:   enrichData.Image,
 		ImageDigest: enrichData.ImageDigest,
 		Name:        enrichData.Name,

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -158,34 +158,22 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 				t.handleError(err)
 				continue
 			}
+			var argnum uint8
+			if err := ebpfMsgDecoder.DecodeUint8(&argnum); err != nil {
+				t.handleError(err)
+				continue
+			}
 			eventId := events.ID(ctx.EventID)
 			eventDefinition, ok := events.Definitions.GetSafe(eventId)
 			if !ok {
 				t.handleError(errfmt.Errorf("failed to get configuration of event %d", eventId))
 				continue
 			}
-
 			args := make([]trace.Argument, len(eventDefinition.Params))
-			for i := 0; i < int(ctx.Argnum); i++ {
-				idx, arg, err := bufferdecoder.ReadArgFromBuff(
-					eventId,
-					ebpfMsgDecoder,
-					eventDefinition.Params,
-				)
-				if err != nil {
-					t.handleError(errfmt.Errorf("failed to read argument %d of event %s: %v", i, eventDefinition.Name, err))
-					continue
-				}
-				if args[idx].Value != nil {
-					t.handleError(errfmt.Errorf("read more than one instance of argument %s of event %s. Saved value: %v. New value: %v", arg.Name, eventDefinition.Name, args[idx].Value, arg.Value))
-				}
-				args[idx] = arg
-			}
-			// Fill missing arguments metadata
-			for i := 0; i < len(eventDefinition.Params); i++ {
-				if args[i].Value == nil {
-					args[i].ArgMeta = eventDefinition.Params[i]
-				}
+			err := ebpfMsgDecoder.DecodeArguments(args, int(argnum), eventDefinition, eventId)
+			if err != nil {
+				t.handleError(err)
+				continue
 			}
 
 			// Add stack trace if needed
@@ -252,7 +240,7 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 				EventID:               int(ctx.EventID),
 				EventName:             eventDefinition.Name,
 				MatchedPoliciesKernel: ctx.MatchedPolicies,
-				ArgsNum:               int(ctx.Argnum),
+				ArgsNum:               int(argnum),
 				ReturnValue:           int(ctx.Retval),
 				Args:                  args,
 				StackAddresses:        stackAddresses,

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -98,8 +98,6 @@ func (t *Tracee) registerEventProcessors() {
 	t.RegisterEventProcessor(events.KernelWrite, t.processWriteEvent)
 	t.RegisterEventProcessor(events.SchedProcessExec, t.processSchedProcessExec)
 	t.RegisterEventProcessor(events.SchedProcessFork, t.processSchedProcessFork)
-	t.RegisterEventProcessor(events.CgroupMkdir, t.processCgroupMkdir)
-	t.RegisterEventProcessor(events.CgroupRmdir, t.processCgroupRmdir)
 	t.RegisterEventProcessor(events.DoInitModule, t.processDoInitModule)
 	t.RegisterEventProcessor(events.HookedProcFops, t.processHookedProcFops)
 	t.RegisterEventProcessor(events.PrintNetSeqOps, t.processTriggeredEvent)

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -131,7 +131,7 @@ func (t *Tracee) processWriteEvent(event *trace.Event) error {
 	if !t.config.Capture.FileWrite.Capture {
 		return nil
 	}
-	filePath, err := parse.ArgVal[string](event, "pathname")
+	filePath, err := parse.ArgVal[string](event.Args, "pathname")
 	if err != nil {
 		return errfmt.Errorf("error parsing vfs_write args: %v", err)
 	}
@@ -139,11 +139,11 @@ func (t *Tracee) processWriteEvent(event *trace.Event) error {
 	if filePath == "" || filePath[0] != '/' {
 		return nil
 	}
-	dev, err := parse.ArgVal[uint32](event, "dev")
+	dev, err := parse.ArgVal[uint32](event.Args, "dev")
 	if err != nil {
 		return errfmt.Errorf("error parsing vfs_write args: %v", err)
 	}
-	inode, err := parse.ArgVal[uint64](event, "inode")
+	inode, err := parse.ArgVal[uint64](event.Args, "inode")
 	if err != nil {
 		return errfmt.Errorf("error parsing vfs_write args: %v", err)
 	}
@@ -169,7 +169,7 @@ func (t *Tracee) processReadEvent(event *trace.Event) error {
 	if !t.config.Capture.FileRead.Capture {
 		return nil
 	}
-	filePath, err := parse.ArgVal[string](event, "pathname")
+	filePath, err := parse.ArgVal[string](event.Args, "pathname")
 	if err != nil {
 		return fmt.Errorf("error parsing vfs_read args: %v", err)
 	}
@@ -177,11 +177,11 @@ func (t *Tracee) processReadEvent(event *trace.Event) error {
 	if filePath == "" || filePath[0] != '/' {
 		return nil
 	}
-	dev, err := parse.ArgVal[uint32](event, "dev")
+	dev, err := parse.ArgVal[uint32](event.Args, "dev")
 	if err != nil {
 		return fmt.Errorf("error parsing vfs_write args: %v", err)
 	}
-	inode, err := parse.ArgVal[uint64](event, "inode")
+	inode, err := parse.ArgVal[uint64](event.Args, "inode")
 	if err != nil {
 		return fmt.Errorf("error parsing vfs_write args: %v", err)
 	}
@@ -211,7 +211,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 	}
 	// capture executed files
 	if t.config.Capture.Exec || t.config.Output.ExecHash {
-		filePath, err := parse.ArgVal[string](event, "pathname")
+		filePath, err := parse.ArgVal[string](event.Args, "pathname")
 		if err != nil {
 			return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
 		}
@@ -226,7 +226,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 		for _, pid := range pids { // will break on success
 			err = nil
 			sourceFilePath := fmt.Sprintf("/proc/%s/root%s", strconv.Itoa(int(pid)), filePath)
-			sourceFileCtime, err := parse.ArgVal[uint64](event, "ctime")
+			sourceFileCtime, err := parse.ArgVal[uint64](event.Args, "ctime")
 			if err != nil {
 				return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
 			}
@@ -312,15 +312,15 @@ func (t *Tracee) processSchedProcessFork(event *trace.Event) error {
 }
 
 func (t *Tracee) processCgroupMkdir(event *trace.Event) error {
-	cgroupId, err := parse.ArgVal[uint64](event, "cgroup_id")
+	cgroupId, err := parse.ArgVal[uint64](event.Args, "cgroup_id")
 	if err != nil {
 		return errfmt.Errorf("error parsing cgroup_mkdir args: %v", err)
 	}
-	path, err := parse.ArgVal[string](event, "cgroup_path")
+	path, err := parse.ArgVal[string](event.Args, "cgroup_path")
 	if err != nil {
 		return errfmt.Errorf("error parsing cgroup_mkdir args: %v", err)
 	}
-	hId, err := parse.ArgVal[uint32](event, "hierarchy_id")
+	hId, err := parse.ArgVal[uint32](event.Args, "hierarchy_id")
 	if err != nil {
 		return errfmt.Errorf("error parsing cgroup_mkdir args: %v", err)
 	}
@@ -346,12 +346,12 @@ func (t *Tracee) processCgroupMkdir(event *trace.Event) error {
 }
 
 func (t *Tracee) processCgroupRmdir(event *trace.Event) error {
-	cgroupId, err := parse.ArgVal[uint64](event, "cgroup_id")
+	cgroupId, err := parse.ArgVal[uint64](event.Args, "cgroup_id")
 	if err != nil {
 		return errfmt.Errorf("error parsing cgroup_rmdir args: %v", err)
 	}
 
-	hId, err := parse.ArgVal[uint32](event, "hierarchy_id")
+	hId, err := parse.ArgVal[uint32](event.Args, "hierarchy_id")
 	if err != nil {
 		return errfmt.Errorf("error parsing cgroup_mkdir args: %v", err)
 	}
@@ -401,7 +401,7 @@ func (t *Tracee) processDoInitModule(event *trace.Event) error {
 }
 
 func (t *Tracee) processHookedProcFops(event *trace.Event) error {
-	fopsAddresses, err := parse.ArgVal[[]uint64](event, "hooked_fops_pointers")
+	fopsAddresses, err := parse.ArgVal[[]uint64](event.Args, "hooked_fops_pointers")
 	if err != nil || fopsAddresses == nil {
 		return errfmt.Errorf("error parsing hooked_proc_fops args: %v", err)
 	}
@@ -529,7 +529,7 @@ func processKernelReadFile(event *trace.Event) error {
 }
 
 func (t *Tracee) processPrintMemDump(event *trace.Event) error {
-	address, err := parse.ArgVal[uintptr](event, "address")
+	address, err := parse.ArgVal[uintptr](event.Args, "address")
 	if err != nil || address == 0 {
 		return errfmt.Errorf("error parsing print_mem_dump args: %v", err)
 	}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/cgroup"
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/ebpf/controlplane"
 	"github.com/aquasecurity/tracee/pkg/ebpf/initialization"
 	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -111,6 +112,8 @@ type Tracee struct {
 	containers        *containers.Containers
 	contPathResolver  *containers.ContainerPathResolver
 	contSymbolsLoader *sharedobjs.ContainersSymbolsLoader
+	// Control Plane
+	controlPlane *controlplane.Controller
 	// Specific Events Needs
 	triggerContexts trigger.Context
 	readyCallback   func(gocontext.Context)
@@ -127,8 +130,6 @@ func GetEssentialEventsList() map[events.ID]eventConfig {
 		events.SchedProcessExec: {},
 		events.SchedProcessExit: {},
 		events.SchedProcessFork: {},
-		events.CgroupMkdir:      {submit: 0xFFFFFFFFFFFFFFFF},
-		events.CgroupRmdir:      {submit: 0xFFFFFFFFFFFFFFFF},
 	}
 }
 
@@ -1234,6 +1235,12 @@ func (t *Tracee) GetTailCalls() ([]*events.TailCall, error) {
 func (t *Tracee) attachProbes() error {
 	var err error
 
+	// attach control plane probes first
+	err = t.controlPlane.Attach()
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+
 	// attach selected tracing events probes
 
 	for tr := range t.events {
@@ -1301,6 +1308,12 @@ func (t *Tracee) initBPF() error {
 	// Populate eBPF maps with initial data
 
 	err = t.populateBPFMaps()
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+
+	// Initialize control plane
+	t.controlPlane, err = controlplane.NewController(t.bpfModule, t.containers, t.config.ContainersEnrich)
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
@@ -1405,6 +1418,13 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 
 	go t.lkmSeekerRoutine(ctx)
 
+	// Start control plane
+	err = t.controlPlane.Start()
+	if err != nil {
+		return err
+	}
+	go t.controlPlane.Run(ctx)
+
 	// Main event loop (polling events perf buffer)
 
 	t.eventsPerfMap.Poll(pollTimeout)
@@ -1507,6 +1527,12 @@ func (t *Tracee) Close() {
 		err := t.probes.DetachAll()
 		if err != nil {
 			logger.Errorw("failed to detach probes when closing tracee", "err", err)
+		}
+	}
+	if t.controlPlane != nil {
+		err := t.controlPlane.Stop()
+		if err != nil {
+			logger.Errorw("failed to stop control plane when closing tracee", "err", err)
 		}
 	}
 	if t.bpfModule != nil {

--- a/pkg/events/derive/container_create.go
+++ b/pkg/events/derive/container_create.go
@@ -21,7 +21,7 @@ func deriveContainerCreateArgs(cts *containers.Containers) func(event trace.Even
 		if check, err := isCgroupEventInHid(&event, cts); !check {
 			return nil, errfmt.WrapError(err)
 		}
-		cgroupId, err := parse.ArgVal[uint64](&event, "cgroup_id")
+		cgroupId, err := parse.ArgVal[uint64](event.Args, "cgroup_id")
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
@@ -51,7 +51,7 @@ func isCgroupEventInHid(event *trace.Event, cts *containers.Containers) (bool, e
 	if cts.GetCgroupVersion() == cgroup.CgroupVersion2 {
 		return true, nil
 	}
-	hierarchyID, err := parse.ArgVal[uint32](event, "hierarchy_id")
+	hierarchyID, err := parse.ArgVal[uint32](event.Args, "hierarchy_id")
 	if err != nil {
 		return false, errfmt.WrapError(err)
 	}

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -20,7 +20,7 @@ func deriveContainerRemoveArgs(cts *containers.Containers) deriveArgsFunction {
 		if check, err := isCgroupEventInHid(&event, cts); !check {
 			return nil, errfmt.WrapError(err)
 		}
-		cgroupId, err := parse.ArgVal[uint64](&event, "cgroup_id")
+		cgroupId, err := parse.ArgVal[uint64](event.Args, "cgroup_id")
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}

--- a/pkg/events/derive/hidden_kernel_module.go
+++ b/pkg/events/derive/hidden_kernel_module.go
@@ -52,7 +52,7 @@ func HiddenKernelModule() DeriveFunction {
 
 func deriveHiddenKernelModulesArgs() deriveArgsFunction {
 	return func(event trace.Event) ([]interface{}, error) {
-		address, err := parse.ArgVal[uint64](&event, "address")
+		address, err := parse.ArgVal[uint64](event.Args, "address")
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func deriveHiddenKernelModulesArgs() deriveArgsFunction {
 			return nil, nil // event in cache: already reported.
 		}
 
-		flags, err := parse.ArgVal[uint32](&event, "flags")
+		flags, err := parse.ArgVal[uint32](event.Args, "flags")
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +88,7 @@ func deriveHiddenKernelModulesArgs() deriveArgsFunction {
 		// Parse module name if possible
 
 		var name string
-		nameBytes, err := parse.ArgVal[[]byte](&event, "name")
+		nameBytes, err := parse.ArgVal[[]byte](event.Args, "name")
 		if err != nil {
 			name = ""
 			// Don't fail hard, submit it without a name!
@@ -101,7 +101,7 @@ func deriveHiddenKernelModulesArgs() deriveArgsFunction {
 		// Parse module srcversion if possible
 
 		var srcversion string
-		srcversionBytes, err := parse.ArgVal[[]byte](&event, "srcversion")
+		srcversionBytes, err := parse.ArgVal[[]byte](event.Args, "srcversion")
 		if err != nil {
 			srcversion = ""
 			// Don't fail hard, submit it without a srcversion!

--- a/pkg/events/derive/hooked_seq_ops.go
+++ b/pkg/events/derive/hooked_seq_ops.go
@@ -34,7 +34,7 @@ func HookedSeqOps(kernelSymbols helpers.KernelSymbolTable) DeriveFunction {
 
 func deriveHookedSeqOpsArgs(kernelSymbols helpers.KernelSymbolTable) deriveArgsFunction {
 	return func(event trace.Event) ([]interface{}, error) {
-		seqOpsArr, err := parse.ArgVal[[]uint64](&event, "net_seq_ops")
+		seqOpsArr, err := parse.ArgVal[[]uint64](event.Args, "net_seq_ops")
 		if err != nil || len(seqOpsArr) < 1 {
 			return nil, errfmt.WrapError(err)
 		}

--- a/pkg/events/derive/hooked_syscall.go
+++ b/pkg/events/derive/hooked_syscall.go
@@ -21,7 +21,7 @@ func DetectHookedSyscall(kernelSymbols helpers.KernelSymbolTable) DeriveFunction
 
 func deriveDetectHookedSyscallArgs(kernelSymbols helpers.KernelSymbolTable) deriveArgsFunction {
 	return func(event trace.Event) ([]interface{}, error) {
-		syscallAddresses, err := parse.ArgVal[[]uint64](&event, "syscalls_addresses")
+		syscallAddresses, err := parse.ArgVal[[]uint64](event.Args, "syscalls_addresses")
 		if err != nil {
 			return nil, errfmt.Errorf("error parsing syscalls_numbers arg: %v", err)
 		}

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -504,14 +504,14 @@ func TestSymbolsCollision(t *testing.T) {
 					found := false
 					for _, event := range colEvents {
 						require.Len(t, event.Args, 3)
-						loadingSOPath, err := parse.ArgVal[string](&event, "loaded_path")
+						loadingSOPath, err := parse.ArgVal[string](event.Args, "loaded_path")
 						require.NoError(t, err)
 						assert.Equal(t, testCase.loadingSO.Path, loadingSOPath)
-						collidedSOPath, err := parse.ArgVal[string](&event, "collision_path")
+						collidedSOPath, err := parse.ArgVal[string](event.Args, "collision_path")
 						require.NoError(t, err)
 						require.IsType(t, "", collidedSOPath)
 						if collidedSOPath == lso.so.Path {
-							col, err := parse.ArgVal[[]string](&event, "symbols")
+							col, err := parse.ArgVal[[]string](event.Args, "symbols")
 							require.NoError(t, err)
 							assert.ElementsMatch(t, col, lso.expectedCollisions)
 							found = true

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -200,19 +200,19 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) getSymbolsFromCache(id shared
 func getSharedObjectInfo(event trace.Event) (sharedobjs.ObjInfo, error) {
 	var objInfo sharedobjs.ObjInfo
 
-	loadedObjectInode, err := parse.ArgVal[uint64](&event, "inode")
+	loadedObjectInode, err := parse.ArgVal[uint64](event.Args, "inode")
 	if err != nil {
 		return objInfo, errfmt.WrapError(err)
 	}
-	loadedObjectDevice, err := parse.ArgVal[uint32](&event, "dev")
+	loadedObjectDevice, err := parse.ArgVal[uint32](event.Args, "dev")
 	if err != nil {
 		return objInfo, errfmt.WrapError(err)
 	}
-	loadedObjectCtime, err := parse.ArgVal[uint64](&event, "ctime")
+	loadedObjectCtime, err := parse.ArgVal[uint64](event.Args, "ctime")
 	if err != nil {
 		return objInfo, errfmt.WrapError(err)
 	}
-	loadedObjectPath, err := parse.ArgVal[string](&event, "pathname")
+	loadedObjectPath, err := parse.ArgVal[string](event.Args, "pathname")
 	if err != nil {
 		return objInfo, errfmt.WrapError(err)
 	}

--- a/pkg/events/parse/params.go
+++ b/pkg/events/parse/params.go
@@ -5,8 +5,8 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
-func ArgVal[T any](event *trace.Event, argName string) (T, error) {
-	for _, arg := range event.Args {
+func ArgVal[T any](args []trace.Argument, argName string) (T, error) {
+	for _, arg := range args {
 		if arg.Name == argName {
 			val, ok := arg.Value.(T)
 			if !ok {

--- a/pkg/events/parse/params_test.go
+++ b/pkg/events/parse/params_test.go
@@ -54,7 +54,7 @@ func TestArgVal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
-				val, err := ArgVal[int32](&e, tt.name)
+				val, err := ArgVal[int32](e.Args, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), tt.errorMessage)
@@ -111,7 +111,7 @@ func TestArgVal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
-				val, err := ArgVal[string](&e, tt.name)
+				val, err := ArgVal[string](e.Args, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), tt.errorMessage)
@@ -168,7 +168,7 @@ func TestArgVal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
-				val, err := ArgVal[uint64](&e, tt.name)
+				val, err := ArgVal[uint64](e.Args, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), tt.errorMessage)
@@ -225,7 +225,7 @@ func TestArgVal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
-				val, err := ArgVal[uint32](&e, tt.name)
+				val, err := ArgVal[uint32](e.Args, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), tt.errorMessage)
@@ -282,7 +282,7 @@ func TestArgVal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
-				val, err := ArgVal[[]string](&e, tt.name)
+				val, err := ArgVal[[]string](e.Args, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), tt.errorMessage)
@@ -339,7 +339,7 @@ func TestArgVal(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
-				val, err := ArgVal[[]uint64](&e, tt.name)
+				val, err := ArgVal[[]uint64](e.Args, tt.name)
 				if tt.errorMessage != "" {
 					assert.Error(t, err)
 					assert.Contains(t, err.Error(), tt.errorMessage)

--- a/pkg/events/trigger/context.go
+++ b/pkg/events/trigger/context.go
@@ -55,7 +55,7 @@ func (store *context) Get(id uint64) (trace.Event, bool) {
 }
 
 func (store *context) Apply(event trace.Event) (trace.Event, error) {
-	contextID, err := parse.ArgVal[uint64](&event, ContextArgName)
+	contextID, err := parse.ArgVal[uint64](event.Args, ContextArgName)
 	if err != nil {
 		return trace.Event{}, errfmt.Errorf("error parsing caller_context_id arg: %v", err)
 	}


### PR DESCRIPTION
Add a control plane package which attaches specialized shorter eBPF probes to guarantee lifecycle events reach tracee.
Currently, only container lifecycle events are handled.

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Sun Jun 4 09:04:16 2023 +0000

    ebpf: refactor arg buffer to type
```

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Jun 7 12:14:55 2023 +0000

    bufferdecoder: add DecodeArguments method
```

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Jun 7 12:29:37 2023 +0000

    events/parse: refactor parse.ArgVal
    
    Take arguments array directly instead of the entire event.
```

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Jun 7 12:31:05 2023 +0000

    ebpf: add control plane
    
    The Control Plane's intention is to process "signal programs" which
    would previously depend on the event submission success.
    
    Instead, a separate buffer and slimmer type is used for these critical
    event processes.
```

Resolve #3086