### PR TITLE
docs: remove old trace subcommand

### DIFF
--- a/docs/docs/integrating/container-engines.md
+++ b/docs/docs/integrating/container-engines.md
@@ -69,7 +69,7 @@ As a user, when container enrichment is enabled the event output will include en
         -v /etc/os-release:/etc/os-release-host:ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         aquasec/tracee:{{ git.tag }} \
-        trace --output json --containers
+        --output json --containers
     ```
 
 2. Running in container filtering mode and with enrichment enabled will add the image name to the table printer
@@ -81,5 +81,5 @@ As a user, when container enrichment is enabled the event output will include en
         -v /etc/os-release:/etc/os-release-host:ro \
         -v /var/run/containerd:/var/run/containerd \
         aquasec/tracee:{{ git.tag }} \
-        trace --filter container --containers
+        --filter container --containers
     ```


### PR DESCRIPTION
### 1. Explain what the PR does

1eeeeb25 **docs: remove old trace subcommand** _<sub>(2023/jun/14) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
```

### 2. Explain how to test it

### 3. Other comments

Mentioned in https://github.com/aquasecurity/tracee/pull/3226#discussion_r1229179145

Detected via regex search: `docker run[\s\S\n]+?trace`