### PR TITLE
ebpf: fix socket_accept event

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -6460,6 +6460,11 @@ var Definitions = eventDefinitions{
 						"syscall__accept4",
 						[]uint32{uint32(Accept), uint32(Accept4)},
 					),
+					NewTailCall(
+						"sys_exit_init_tail",
+						"sys_exit_init",
+						[]uint32{uint32(Accept), uint32(Accept4)},
+					),
 				},
 			},
 			Sets: []string{},


### PR DESCRIPTION
commit a68570d2c97b
```
    ebpf: simplify socket_accept tailcall
    
    Use the existing sockaddr buffer submit helper, instead of manually
    parsing and submitting.
```
commit 5d843b0c548bf8b0ed8a7c
```
    ebpf: fix socket_accept event
    
    1. Event definition was missing a tail call register for the accept
    syscalls in the sys_exit_init program.
    2. The sockfd argument was not saved into the argument buffer.
```

Fix #3229