### PR TITLE
tracee: signatures-dir accept multiple values

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -54,10 +54,15 @@ func main() {
 				return fmt.Errorf("invalid target specified: %s", strings.ToLower(c.String("rego-runtime-target")))
 			}
 
+			var rulesDir []string
+			if c.String("rules-dir") != "" {
+				rulesDir = []string{c.String("rules-dir")}
+			}
+
 			sigs, err := signature.Find(
 				target,
 				c.Bool("rego-partial-eval"),
-				c.String("rules-dir"),
+				rulesDir,
 				c.StringSlice("rules"),
 				c.Bool("rego-aio"),
 			)

--- a/cmd/tracee/cmd/list.go
+++ b/cmd/tracee/cmd/list.go
@@ -15,10 +15,10 @@ import (
 
 func init() {
 	rootCmd.AddCommand(listCmd)
-	listCmd.Flags().String(
+	listCmd.Flags().StringArray(
 		"signatures-dir",
-		"",
-		"Directory where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats",
+		[]string{},
+		"Directories where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats",
 	)
 }
 
@@ -30,7 +30,7 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get signatures to update event list
 
-		sigsDir, err := cmd.Flags().GetString("signatures-dir")
+		sigsDir, err := cmd.Flags().GetStringArray("signatures-dir")
 		if err != nil {
 			logger.Fatalw("Failed to get signatures-dir flag", "err", err)
 			os.Exit(1)

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -148,10 +148,10 @@ func initCmd() error {
 
 	// Signature flags
 
-	rootCmd.Flags().String(
+	rootCmd.Flags().StringArray(
 		"signatures-dir",
-		"",
-		"Directory where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats",
+		[]string{},
+		"Directories where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats",
 	)
 	err = viper.BindPFlag("signatures-dir", rootCmd.Flags().Lookup("signatures-dir"))
 	if err != nil {

--- a/docs/docs/events/custom/overview.md
+++ b/docs/docs/events/custom/overview.md
@@ -14,6 +14,10 @@ tracee --signatures-dir=/tmp/myevents
 !!! Tip
     Tracee also uses the custom events to add a few events, if you pass your own directory
     for `signatures-dir` you will not load the tracee [Behaviour events](../builtin/signatures.md), 
-    to avoid such problems, place your own events under the same directory of the tracee custom events. 
+    to avoid such problems, you can either place your own events under the same directory of the tracee custom events,
+    or pass multiple directories for example:
+    ```
+    tracee --signatures-dir=/tmp/myevents --signatures-dir=./dist/signatures
+    ```
 
 👈 Please use the side-navigation on the left in order to browse the different topics.

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -48,7 +48,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	sigs, err := signature.Find(
 		rego.RuntimeTarget,
 		rego.PartialEval,
-		viper.GetString("signatures-dir"),
+		viper.GetStringSlice("signatures-dir"),
 		nil,
 		rego.AIO,
 	)

--- a/pkg/signatures/signature/signature_test.go
+++ b/pkg/signatures/signature/signature_test.go
@@ -20,7 +20,7 @@ const (
 )
 
 func TestFindByEventName(t *testing.T) {
-	sigs, err := Find(compile.TargetRego, false, exampleRulesDir, []string{"anti_debugging"}, false)
+	sigs, err := Find(compile.TargetRego, false, []string{exampleRulesDir}, []string{"anti_debugging"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sigs))
 
@@ -41,7 +41,7 @@ func TestFindByEventName(t *testing.T) {
 }
 
 func TestFindByRuleID(t *testing.T) {
-	sigs, err := Find(compile.TargetRego, false, exampleRulesDir, []string{"TRC-2"}, false)
+	sigs, err := Find(compile.TargetRego, false, []string{exampleRulesDir}, []string{"TRC-2"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sigs))
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3179

```
Author: Jose Donizetti <jdbjunior@gmail.com>
Date:   Wed Jun 14 20:48:42 2023 -0300

    feat: signatures-dir accept multiple values
```

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

 The tracee-rules binary should be working as before:

```
mkdir /tmp/test

./dist/tracee-rules --help # should still only support one dir
./dist/tracee-rules --list 
./dist/tracee-rules --list --rules-dir=/tmp # should find no signatures
```

The unified binary should now support multiple directories:

```
mkdir /tmp/test

./dist/tracee list
./dist/tracee list --signatures-dir=/tmp/test # should not find any signatures
./dist/tracee list --signatures-dir=/tmp/test --signatures-dir=./dist/signatures # should find normal signatures

./dist/tracee --signatures-dir=/tmp/test -f e=anti_debugging # should fail because it can't find the signatures
./dist/tracee --signatures-dir=/tmp/test --signatures-dir=./dist/signatures  -f e=anti_debugging # should work normally
```


<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
