### PR TITLE
chore: move syscaller to dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ compile_commands.json
 
 # binaries and build files
 dist
-tests/integration/syscaller/cmd/syscaller
 
 # release files
 release_notes.txt

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ CMD_STATICCHECK ?= staticcheck
 CMD_STRIP ?= llvm-strip
 CMD_TOUCH ?= touch
 CMD_TR ?= tr
-CMD_SYSCALLER ?= ./tests/integration/syscaller/cmd/syscaller
 
 .check_%:
 #
@@ -732,18 +731,18 @@ test-types: \
 # syscaller (required for integration tests)
 #
 
-.PHONY: $(CMD_SYSCALLER)
-$(CMD_SYSCALLER): \
+.PHONY: $(OUTPUT_DIR)/syscaller
+$(OUTPUT_DIR)/syscaller: \
 	$(OUTPUT_DIR)/libbpf/libbpf.a \
 	| .check_$(CMD_GO)
 #
 	$(GO_ENV_EBPF) \
-	$(CMD_GO) build -o $(CMD_SYSCALLER) $(dir $(CMD_SYSCALLER))
+	$(CMD_GO) build -o $(OUTPUT_DIR)/syscaller ./tests/integration/syscaller/cmd
 
 .PHONY: test-integration
 test-integration: \
 	.checkver_$(CMD_GO) \
-	$(CMD_SYSCALLER) \
+	$(OUTPUT_DIR)/syscaller \
 	tracee-ebpf
 #
 	$(GO_ENV_EBPF) \
@@ -866,4 +865,3 @@ clean:
 	$(CMD_RM) -f .*.md5
 	$(CMD_RM) -f .check*
 	$(CMD_RM) -f .*-pkgs*
-	$(CMD_RM) -f $(CMD_SYSCALLER)

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -25,6 +26,8 @@ import (
 // Test_EventFilters tests a variety of trace event filters
 // with different combinations of policies
 func Test_EventFilters(t *testing.T) {
+	assureIsRoot(t)
+
 	// Make sure we don't leak any goroutines since we run Tracee many times in this test.
 	// If a test case fails, ignore the leak since it's probably caused by the aborted test.
 	defer goleak.VerifyNone(t)
@@ -1218,7 +1221,9 @@ func runCmds(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscal
 
 // formatCmdEvents formats given commands to be executed by syscaller helper tool
 func formatCmdEvents(cmd *cmdEvents) {
-	cmd.runCmd = fmt.Sprintf("./syscaller/cmd/syscaller %s", cmd.runCmd)
+	syscallerAbsPath := filepath.Join("..", "..", "dist", "syscaller")
+	cmd.runCmd = fmt.Sprintf("%s %s", syscallerAbsPath, cmd.runCmd)
+
 	for _, evt := range cmd.evts {
 		cmd.runCmd = fmt.Sprintf("%s %d", cmd.runCmd, evt.EventID)
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_InitNamespacesEvent(t *testing.T) {
+	assureIsRoot(t)
+
 	procNamespaces := [...]string{"mnt", "cgroup", "pid", "pid_for_children", "time", "time_for_children", "user", "ipc", "net", "uts"}
 	evts := events.InitNamespacesEvent()
 	initNamespaces := make(map[string]uint32)

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -219,5 +220,12 @@ func waitForTraceeOutputEvents(t *testing.T, actual *eventBuffer, now time.Time,
 			}
 			return
 		}
+	}
+}
+
+// assureIsRoot skips the test if it is not run as root
+func assureIsRoot(t *testing.T) {
+	if syscall.Geteuid() != 0 {
+		t.Skipf("***** %s must be run as ROOT *****", t.Name())
 	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

dc068334 **chore: move syscaller to dist** _<sub>(2023/jun/26) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
This commit moves syscaller to dist.

This also makes integration tests don't fail if not run as root. Now,
they will just skip the tests that require root privileges.
```

### 2. Explain how to test it

`make integration-test`
`sudo make integration-test`

### 3. Other comments
