### PR TITLE
fix: send init events to pipeline

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -425,6 +425,9 @@ func (t *Tracee) processEvents(ctx context.Context, in <-chan *trace.Event) (
 	out := make(chan *trace.Event, 10000)
 	errc := make(chan error, 1)
 
+	// Some "informational" events are started here (TODO: API server?)
+	t.invokeInitEvents(out)
+
 	go func() {
 		defer close(out)
 		defer close(errc)


### PR DESCRIPTION
### 1. Explain what the PR does

Fix: #3267

218c6e04 **fix: send init events to pipeline** _<sub>(2023/jun/26) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
This commit fixes the issue where init events were sent to printer
directly instead of being sent to the pipeline.
```

### 2. Explain how to test it

`sudo ./dist/tracee -f e=init_namespaces -o json`

### 3. Other comments
