### PR TITLE
fix(pkg/events): fix tailcall dependencies race issues

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -517,7 +517,7 @@ func (t *Tracee) initTailCall(tailCall *events.TailCall) error {
 	}
 
 	// Attach internal syscall probes if needed.
-	for _, index := range tailCall.GetMapIndexes() {
+	for _, index := range tailCall.GetIndexes() {
 		def := events.Definitions.Get(events.ID(index))
 		if def.Syscall {
 			err := t.probes.Attach(probes.SyscallEnter__Internal)
@@ -1179,10 +1179,10 @@ func getTailCalls(eventConfigs map[events.ID]eventConfig) ([]*events.TailCall, e
 		def := events.Definitions.Get(e)
 
 		for _, tailCall := range def.Dependencies.TailCalls {
-			if tailCall.GetMapIndexesLen() == 0 {
+			if tailCall.GetIndexesLen() == 0 {
 				continue // skip if tailcall has no indexes defined
 			}
-			for _, index := range tailCall.GetMapIndexes() {
+			for _, index := range tailCall.GetIndexes() {
 				if index >= uint32(events.MaxCommonID) {
 					logger.Debugw(
 						"Removing index from tail call (over max event id)",

--- a/pkg/ebpf/tracee_test.go
+++ b/pkg/ebpf/tracee_test.go
@@ -1,11 +1,9 @@
 package ebpf
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/tracee/pkg/events"
 )
@@ -114,29 +112,8 @@ func Test_getTailCalls(t *testing.T) {
 		t.Run(tc.name,
 			func(t *testing.T) {
 				tailCalls, err := getTailCalls(tc.events)
-				if tc.expectedErr != nil {
-					assert.ErrorIs(t, err, tc.expectedErr)
-					return
-				}
-				require.NoError(t, err)
-				for i := 0; i < len(tailCalls); i++ {
-					found := false
-					for j := 0; j < len(tc.expectedTailCalls); j++ {
-						if tailCalls[i].GetMapName() != tc.expectedTailCalls[j].GetMapName() {
-							continue
-						}
-						if tailCalls[i].GetProgName() != tc.expectedTailCalls[j].GetProgName() {
-							continue
-						}
-						if !reflect.DeepEqual(tailCalls[i].GetMapIndexes(),
-							tc.expectedTailCalls[j].GetMapIndexes(),
-						) {
-							continue
-						}
-						found = true
-					}
-					assert.True(t, found)
-				}
+				assert.NoError(t, err)
+				assert.ElementsMatch(t, tc.expectedTailCalls, tailCalls)
 			},
 		)
 	}


### PR DESCRIPTION
This was supposed to enter together with https://github.com/aquasecurity/tracee/pull/3252 (the full event definition instances) but, because of the release, this fix has to be applied before that can be merged.

This fixes race issues with the tailcall dependency instance (already merged into main before that PR).

NOTE: This code is fully tested against thread-safety but the tests will be merged altogether in that PR.