### PR TITLE
fix: derived event not triggering if base filtered

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -510,16 +510,16 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (
 					t.handleError(err)
 				}
 
-				for i, derivative := range derivatives {
+				for i := range derivatives {
 					// Skip events that dont work with filtering due to missing types being handled.
 					// https://github.com/aquasecurity/tracee/issues/2486
-					switch events.ID(derivative.EventID) {
+					switch events.ID(derivatives[i].EventID) {
 					case events.SymbolsLoaded:
 					case events.SharedObjectLoaded:
 					case events.PrintMemDump:
 					default:
 						// Derived events might need filtering as well
-						if t.matchPolicies(&derivative) == 0 {
+						if t.matchPolicies(&derivatives[i]) == 0 {
 							_ = t.stats.EventsFiltered.Increment()
 							continue
 						}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3279

The bug happens because we pass a different event to [`matchPolicies`](https://github.com/aquasecurity/tracee/blob/main/pkg/ebpf/events_pipeline.go#L522) inside the for, instead of passing the [event that goes down the pipeline](https://github.com/aquasecurity/tracee/blob/main/pkg/ebpf/events_pipeline.go#L531), so the logic of [changing the bitmap](https://github.com/aquasecurity/tracee/blob/main/pkg/ebpf/events_pipeline.go#L366) is lost, because it happened on different events.

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
name: pol1
description: general policy
scope:
  - global
defaultActions: 
  - log
rules:
  - event: cgroup_mkdir
    filters:
      - args.cgroup_path!=/system.slice*
  - event: container_create
```

```
./dist/tracee -p policy.yaml
```

```
docker run ubuntu:latest ls
```

The `container_created` should be triggered but not the `cgroup_mkdir`. 

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
