### PR TITLE
fix: signature event not triggering if base filtered

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -249,11 +249,14 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 			}
 
 			// If there aren't any policies that need filtering in userland, tracee **may** skip
-			// this event, as long as there aren't any derivatives that depend on it. Some base
-			// events (for derivative ones) might not have set related policy bit, thus the need
-			// to continue with those within the pipeline.
+			// this event, as long as there aren't any derivatives or signatures that depend on it.
+			// Some base events (derivative and signatures) might not have set related policy bit,
+			// thus the need to continue with those within the pipeline.
 			if t.matchPolicies(&evt) == 0 {
-				if _, ok := t.eventDerivations[eventId]; !ok {
+				_, hasDerivation := t.eventDerivations[eventId]
+				_, hasSignature := t.eventSignatures[eventId]
+
+				if !hasDerivation && !hasSignature {
 					_ = t.stats.EventsFiltered.Increment()
 					continue
 				}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -185,11 +185,9 @@ type Event struct {
 	Params       []trace.ArgMeta
 }
 
-func (e *Event) IsASignatureEvent() bool {
-	for _, s := range e.Sets {
-		if s == "signatures" {
-			return true
-		}
+func IsASignatureEvent(id ID) bool {
+	if id >= StartSignatureID && id <= MaxSignatureID {
+		return true
 	}
 
 	return false

--- a/pkg/filters/args.go
+++ b/pkg/filters/args.go
@@ -106,7 +106,7 @@ func (filter *ArgFilter) Parse(filterName string, operatorAndValues string, even
 	}
 
 	// if the event is a signature event, we allow filtering on dynamic argument
-	if !argFound && !eventDefinition.IsASignatureEvent() {
+	if !argFound && !events.IsASignatureEvent(id) {
 		return InvalidEventArgument(argName)
 	}
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
Fix https://github.com/aquasecurity/tracee/issues/3207

This PR builds a map between a base event and its signatures, allowing us to check after the `decode` stage if the event should be passed down the pipeline because there is a signature depending on it, or in case the userland filter out the event, ignore it and continue. 

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```

name: signature_events
description: traces all signature events
defaultActions: 
  - log
scope:
  - global
rules:
  - event: ptrace
    filters:
      - userId=1000
  - event: anti_debugging
```

```
./dist/tracee -p policy.yaml
```

```
sudo strace ls
```

The `anti_debugging` signature should be triggered even though we are filtering the `ptrace` event for the uid 1000.

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
