### PR TITLE
fix(pkg/counter): finish making counter atomic (#3276)

### DIFF
--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -12,73 +12,86 @@ type Counter struct {
 	value uint64
 }
 
-// NewCounter creates a new counter with the given initial value.
 func NewCounter(initialValue uint64) Counter {
 	return Counter{value: initialValue}
 }
 
-// Increase increases the counter by the given value (thread-safe).
-func (c *Counter) Increase(values ...uint64) error {
-	_, err := c.IncreaseAndRead(values...)
+// Increment
+
+// Increment increments counter by given value (default: 1, thread-safe).
+func (c *Counter) Increment(x ...uint64) error {
+	var err error
+
+	val := uint64(1)
+	if len(x) != 0 {
+		for _, v := range x {
+			val += v
+		}
+		val-- // initial 1
+	}
+
+	// NOTE: checking if val > 0 adds ~200ns/op in benchmarking: not worth if
+	//       not proved that amount of times Increment(0) is called makes it
+	//       worth it.
+	_, err = c.IncrementValueAndRead(val)
+
 	return err
 }
 
-// IncreaseAndRead increases the counter by the given value (thread-safe) and returns the new value.
-func (c *Counter) IncreaseAndRead(values ...uint64) (uint64, error) {
-	if len(values) == 0 {
-		values = append(values, 1)
+// IncrementValueAndRead increments counter by given value and returns the new value (thread-safe).
+func (c *Counter) IncrementValueAndRead(x uint64) (uint64, error) {
+	var err error
+
+	n := atomic.AddUint64(&c.value, x)
+	if n < x {
+		err = errors.New("counter overflow")
 	}
 
-	var n uint64
-
-	for _, value := range values {
-		n = atomic.AddUint64(&c.value, value)
-		if n < value {
-			return n, errors.New("counter overflow")
-		}
-	}
-
-	return n, nil // return last known value (atomically incremented)
+	return n, err
 }
 
-// Decrease decreases the counter by the given value (thread-safe).
-func (c *Counter) Decrease(values ...uint64) error {
-	_, err := c.DecreaseAndRead(values...)
+// Decrement
+
+// Decrement decrements counter by given value (default: 1, thread-safe).
+func (c *Counter) Decrement(x ...uint64) error {
+	val := uint64(1)
+	if len(x) != 0 {
+		for _, v := range x {
+			val += v
+		}
+		val-- // initial 1
+	}
+
+	// NOTE: checking if val > 0 adds ~200ns/op in benchmarking: not worth if
+	//       not proved that amount of times Decrement(0) is called makes it
+	//       worth it.
+	_, err := c.DecrementValueAndRead(val)
+
 	return err
 }
 
-// DecreaseAndRead decreases the counter by the given value (thread-safe) and returns the new value.
-func (c *Counter) DecreaseAndRead(values ...uint64) (uint64, error) {
-	if len(values) == 0 {
-		values = append(values, 1)
+// DecrementValueAndRead decrements counter by given value and returns the new value (thread-safe).
+func (c *Counter) DecrementValueAndRead(x uint64) (uint64, error) {
+	var err error
+
+	n := atomic.AddUint64(&c.value, ^uint64(x-1))
+	if n > math.MaxUint64-x {
+		err = errors.New("counter underflow")
 	}
 
-	var n uint64
-
-	for _, value := range values {
-		if value == 0 {
-			continue
-		}
-		n = atomic.AddUint64(&c.value, ^uint64(value-1))
-		if n == math.MaxUint64 {
-			return n, errors.New("counter underflow")
-		}
-	}
-
-	return n, nil // return last known value (atomically decremented)
+	return n, err
 }
 
-// Read returns the current value of the counter (thread-safe).
-func (c *Counter) Read() uint64 {
-	return atomic.LoadUint64(&c.value)
-}
+// Setters and Getters
 
-// Set sets the counter to the given value (thread-safe).
 func (c *Counter) Set(value uint64) {
 	atomic.StoreUint64(&c.value, value)
 }
 
-// Format implements fmt.Formatter (thread-safe).
+func (c *Counter) Get() uint64 {
+	return atomic.LoadUint64(&c.value)
+}
+
 func (c *Counter) Format(f fmt.State, r rune) {
-	f.Write([]byte(strconv.FormatUint(c.Read(), 10)))
+	f.Write([]byte(strconv.FormatUint(c.Get(), 10)))
 }

--- a/pkg/counter/counter_bench_test.go
+++ b/pkg/counter/counter_bench_test.go
@@ -1,0 +1,121 @@
+package counter
+
+import "testing"
+
+// Increment
+
+func BenchmarkIncrement(b *testing.B) {
+	c := NewCounter(0)
+
+	for i := 0; i < b.N; i++ {
+		err := c.Increment()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIncrementWithValue(b *testing.B) {
+	c := NewCounter(0)
+
+	for i := 0; i < b.N; i++ {
+		err := c.Increment(1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIncrementWithMultipleValue(b *testing.B) {
+	c := NewCounter(0)
+
+	for i := 0; i < b.N; i += 3 {
+		err := c.Increment(1, 1, 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// Note: Looping 1/3 of times in this case
+}
+
+func BenchmarkZeroedIncrementWithValue(b *testing.B) {
+	c := NewCounter(0)
+
+	for i := 0; i < b.N; i++ {
+		err := c.Increment(0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkZeroedIncrementWithMultipleValue(b *testing.B) {
+	c := NewCounter(0)
+
+	for i := 0; i < b.N; i++ {
+		err := c.Increment(0, 0, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Decrement
+
+func BenchmarkDecrement(b *testing.B) {
+	c := NewCounter(uint64(b.N))
+
+	for i := b.N; i > 0; i-- {
+		err := c.Decrement()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecrementWithValue(b *testing.B) {
+	c := NewCounter(uint64(b.N))
+
+	for i := b.N; i > 0; i-- {
+		err := c.Decrement(1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecrementWithMultipleValue(b *testing.B) {
+	c := NewCounter(uint64(b.N))
+
+	for i := b.N; i > 3; i -= 3 {
+		err := c.Decrement(1, 1, 1)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// Note: Looping 1/3 of times in this case
+}
+
+func BenchmarkZeroedDecrementWithValue(b *testing.B) {
+	c := NewCounter(uint64(b.N))
+
+	for i := b.N; i > 0; i-- {
+		err := c.Decrement(0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkZeroedDecrementWithMultipleValue(b *testing.B) {
+	c := NewCounter(uint64(b.N))
+
+	for i := b.N; i > 0; i-- {
+		err := c.Decrement(0, 0, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/ebpf/bpf_log.go
+++ b/pkg/ebpf/bpf_log.go
@@ -187,7 +187,7 @@ func (t *Tracee) processBPFLogs(ctx context.Context) {
 				"line", bpfLog.Line(),
 				"count", bpfLog.Count(),
 			)
-			if err := t.stats.BPFLogsCount.Increase(uint64(bpfLog.Count())); err != nil {
+			if err := t.stats.BPFLogsCount.Increment(uint64(bpfLog.Count())); err != nil {
 				logger.Errorw("Incrementing BPF logs count", "error", err)
 			}
 
@@ -196,7 +196,7 @@ func (t *Tracee) processBPFLogs(ctx context.Context) {
 			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
 			// https://github.com/aquasecurity/libbpfgo/issues/122
 			if lost > 0 {
-				if err := t.stats.LostBPFLogsCount.Increase(lost); err != nil {
+				if err := t.stats.LostBPFLogsCount.Increment(lost); err != nil {
 					logger.Errorw("Incrementing lost BPF logs count", "error", err)
 				}
 				logger.Warnw(fmt.Sprintf("Lost %d ebpf logs events", lost))

--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -218,7 +218,7 @@ func (t *Tracee) processFileCaptures(ctx context.Context) {
 			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
 			// https://github.com/aquasecurity/libbpfgo/issues/122
 			if lost > 0 {
-				if err := t.stats.LostWrCount.Increase(lost); err != nil {
+				if err := t.stats.LostWrCount.Increment(lost); err != nil {
 					logger.Errorw("Incrementing lost capture count", "error", err)
 				}
 				logger.Warnw(fmt.Sprintf("Lost %d capture events", lost))

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -254,7 +254,7 @@ func (t *Tracee) decodeEvents(outerCtx context.Context, sourceChan chan []byte) 
 			// to continue with those within the pipeline.
 			if t.matchPolicies(&evt) == 0 {
 				if _, ok := t.eventDerivations[eventId]; !ok {
-					_ = t.stats.EventsFiltered.Increase()
+					_ = t.stats.EventsFiltered.Increment()
 					continue
 				}
 			}
@@ -520,7 +520,7 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (
 					default:
 						// Derived events might need filtering as well
 						if t.matchPolicies(&derivative) == 0 {
-							_ = t.stats.EventsFiltered.Increase()
+							_ = t.stats.EventsFiltered.Increment()
 							continue
 						}
 					}
@@ -571,7 +571,7 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 			// Send the event to the printers.
 			select {
 			case t.config.ChanEvents <- *event:
-				_ = t.stats.EventCount.Increase()
+				_ = t.stats.EventCount.Increment()
 				event = nil
 			case <-ctx.Done():
 				return
@@ -653,7 +653,7 @@ func MergeErrors(cs ...<-chan error) <-chan error {
 }
 
 func (t *Tracee) handleError(err error) {
-	_ = t.stats.ErrorCount.Increase()
+	_ = t.stats.ErrorCount.Increment()
 	logger.Errorw("Tracee encountered an error", "error", err)
 }
 

--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -43,7 +43,7 @@ func (t *Tracee) processLostEvents() {
 			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
 			// https://github.com/aquasecurity/libbpfgo/issues/122
 			if lost > 0 {
-				if err := t.stats.LostEvCount.Increase(lost); err != nil {
+				if err := t.stats.LostEvCount.Increment(lost); err != nil {
 					logger.Errorw("Incrementing lost event count", "error", err)
 				}
 				logger.Warnw(fmt.Sprintf("Lost %d events", lost))

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -59,12 +59,12 @@ func (t *Tracee) processNetCapEvents(ctx context.Context, in <-chan *trace.Event
 			select {
 			case event := <-in:
 				t.processNetCapEvent(event)
-				_ = t.stats.NetCapCount.Increase()
+				_ = t.stats.NetCapCount.Increment()
 
 			case lost := <-t.lostNetCapChannel:
 				if lost > 0 {
 					// https://github.com/aquasecurity/libbpfgo/issues/122
-					if err := t.stats.LostNtCapCount.Increase(lost); err != nil {
+					if err := t.stats.LostNtCapCount.Increment(lost); err != nil {
 						logger.Errorw("Incrementing lost network events count", "error", err)
 					}
 					logger.Warnw(fmt.Sprintf("Lost %d network capture events", lost))

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -97,7 +97,7 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 				}
 
 				if t.matchPolicies(event) == 0 {
-					_ = t.stats.EventsFiltered.Increase()
+					_ = t.stats.EventsFiltered.Increment()
 					continue
 				}
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1606,7 +1606,7 @@ func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
 		systemInfoEvent := events.InitNamespacesEvent()
 		setMatchedPolicies(&systemInfoEvent, emit)
 		out <- &systemInfoEvent
-		_ = t.stats.EventCount.Increase()
+		_ = t.stats.EventCount.Increment()
 	}
 
 	emit = t.events[events.ExistingContainer].emit
@@ -1614,7 +1614,7 @@ func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
 		for _, e := range events.ExistingContainersEvents(t.containers, t.config.ContainersEnrich) {
 			setMatchedPolicies(&e, emit)
 			out <- &e
-			_ = t.stats.EventCount.Increase()
+			_ = t.stats.EventCount.Increment()
 		}
 	}
 }

--- a/pkg/events/trigger/context.go
+++ b/pkg/events/trigger/context.go
@@ -40,7 +40,7 @@ func (store *context) Store(event trace.Event) uint64 {
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
 
-	id, err := store.counter.IncreaseAndRead()
+	id, err := store.counter.IncrementValueAndRead(1)
 	if err != nil {
 		logger.Debugw("failed to increase context counter", "error", err)
 	}

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -26,7 +26,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "events_total",
 		Help:      "events collected by tracee-ebpf",
-	}, func() float64 { return float64(stats.EventCount.Read()) }))
+	}, func() float64 { return float64(stats.EventCount.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -36,7 +36,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "events_filtered",
 		Help:      "events filtered by tracee-ebpf in userspace",
-	}, func() float64 { return float64(stats.EventsFiltered.Read()) }))
+	}, func() float64 { return float64(stats.EventsFiltered.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -46,7 +46,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "network_capture_events_total",
 		Help:      "network capture events collected by tracee-ebpf",
-	}, func() float64 { return float64(stats.NetCapCount.Read()) }))
+	}, func() float64 { return float64(stats.NetCapCount.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -56,7 +56,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "lostevents_total",
 		Help:      "events lost in the submission buffer",
-	}, func() float64 { return float64(stats.LostEvCount.Read()) }))
+	}, func() float64 { return float64(stats.LostEvCount.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -66,7 +66,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "write_lostevents_total",
 		Help:      "events lost in the write buffer",
-	}, func() float64 { return float64(stats.LostWrCount.Read()) }))
+	}, func() float64 { return float64(stats.LostWrCount.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -76,7 +76,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "network_capture_lostevents_total",
 		Help:      "network capture lost events in network capture buffer",
-	}, func() float64 { return float64(stats.LostNtCapCount.Read()) }))
+	}, func() float64 { return float64(stats.LostNtCapCount.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -86,7 +86,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "bpf_logs_total",
 		Help:      "logs collected by tracee-ebpf during ebpf execution",
-	}, func() float64 { return float64(stats.BPFLogsCount.Read()) }))
+	}, func() float64 { return float64(stats.BPFLogsCount.Get()) }))
 
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -96,7 +96,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_ebpf",
 		Name:      "errors_total",
 		Help:      "errors accumulated by tracee-ebpf",
-	}, func() float64 { return float64(stats.ErrorCount.Read()) }))
+	}, func() float64 { return float64(stats.ErrorCount.Get()) }))
 
 	return errfmt.WrapError(err)
 }

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -125,7 +125,7 @@ func (engine *Engine) unloadAllSignatures() {
 
 // matchHandler is a function that runs when a signature is matched
 func (engine *Engine) matchHandler(res detect.Finding) {
-	_ = engine.stats.Detections.Increase()
+	_ = engine.stats.Detections.Increment()
 	engine.output <- res
 }
 
@@ -149,7 +149,7 @@ func (engine *Engine) processEvent(event protocol.Event) {
 		Name:   event.Headers.Selector.Name,
 		Origin: event.Headers.Selector.Origin,
 	}
-	_ = engine.stats.Events.Increase()
+	_ = engine.stats.Events.Increment()
 
 	// Check the selector for every case and partial case
 
@@ -310,7 +310,7 @@ func (engine *Engine) loadSignature(signature detect.Signature) (string, error) 
 		}
 	}
 
-	_ = engine.stats.Signatures.Increase()
+	_ = engine.stats.Signatures.Increment()
 	return metadata.ID, nil
 }
 
@@ -340,7 +340,7 @@ func (engine *Engine) UnloadSignature(signatureId string) error {
 	if ok {
 		delete(engine.signatures, signature)
 		defer func() {
-			_ = engine.stats.Signatures.Decrease()
+			_ = engine.stats.Signatures.Decrement()
 		}()
 		defer signature.Close()
 		defer close(c)

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -478,7 +478,7 @@ func TestEngine_LoadSignature(t *testing.T) {
 			}
 
 			// check that signature stats were correctly incremented
-			assert.Equal(t, tc.expectedCount, int(engine.Stats().Signatures.Read()))
+			assert.Equal(t, tc.expectedCount, int(engine.Stats().Signatures.Get()))
 			close(input)
 		})
 	}

--- a/pkg/signatures/metrics/stats.go
+++ b/pkg/signatures/metrics/stats.go
@@ -19,7 +19,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_rules",
 		Name:      "events_total",
 		Help:      "events ingested by tracee-rules",
-	}, func() float64 { return float64(stats.Events.Read()) }))
+	}, func() float64 { return float64(stats.Events.Get()) }))
 
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_rules",
 		Name:      "detections_total",
 		Help:      "detections made by tracee-rules",
-	}, func() float64 { return float64(stats.Detections.Read()) }))
+	}, func() float64 { return float64(stats.Detections.Get()) }))
 
 	if err != nil {
 		return err
@@ -39,7 +39,7 @@ func (stats *Stats) RegisterPrometheus() error {
 		Namespace: "tracee_rules",
 		Name:      "signatures_total",
 		Help:      "signatures loaded",
-	}, func() float64 { return float64(stats.Signatures.Read()) }))
+	}, func() float64 { return float64(stats.Signatures.Get()) }))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Last changes renamed Increment/Decrement to Increase/Decrease. This was reverted after discussions.

With this new approach:

- Overflow is detected in both cases (and proved by test).
- Thread safety is guaranteed by atomic Add/Sub operations.
- Unit tests prove all assumptions and thread safety for all cases.
- Benchmark tests can be used to test other approaches in the future.
- Overflow of a sum of all given arguments isn't detected (avoid overhead).

NOTE: The issue is now fully fixed...

Originally, the bug was only about reading counter value in parallel to atomic operation (multiple LOAD/STORE simultaneously, and some not protected by atomics).

Previous fix, made by commit 1e54ce292, fixed data race but overflow errors could be reported more than once. It also had atomic operations for each given argument (if multiple arguments).

This version addresses all concerns.

commit: 0b97409c5 (main), cherry-pick
