### PR TITLE
enrich: fixes post control plane

### DIFF
--- a/pkg/containers/datasource.go
+++ b/pkg/containers/datasource.go
@@ -21,8 +21,8 @@ func (ctx SignaturesDataSource) Get(key interface{}) (map[string]interface{}, er
 	if !ok {
 		return nil, detect.ErrKeyNotSupported
 	}
-	ctx.containers.mtx.RLock()
-	defer ctx.containers.mtx.RUnlock()
+	ctx.containers.cgroupsMutex.RLock()
+	defer ctx.containers.cgroupsMutex.RUnlock()
 	for _, cgroup := range ctx.containers.cgroupsMap {
 		if cgroup.Container.ContainerId == containerId {
 			containerData := cgroup.Container

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -143,7 +143,7 @@ func (p *Controller) processCgroupMkdir(args []trace.Argument) error {
 		// removed from the containers bpf map.
 		err := capabilities.GetInstance().EBPF(
 			func() error {
-				return p.cgroupManager.RemoveFromBpfMap(p.bpfModule, cgroupId, hId)
+				return p.cgroupManager.RemoveFromBPFMap(p.bpfModule, cgroupId, hId)
 			},
 		)
 		if err != nil {

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -42,6 +42,7 @@ func NewController(bpfModule *libbpfgo.Module, cgroupManager *containers.Contain
 		lostSignalChan: make(chan uint64),
 		bpfModule:      bpfModule,
 		cgroupManager:  cgroupManager,
+		enrichEnabled:  enrichEnabled,
 	}
 	p.signalBuffer, err = bpfModule.InitPerfBuf("signals", p.signalChan, p.lostSignalChan, 1024)
 	if err != nil {
@@ -83,27 +84,25 @@ func (p *Controller) Start() error {
 
 func (p *Controller) Run(ctx context.Context) {
 	p.ctx = ctx
-	go func() {
-		for {
-			select {
-			case signalData := <-p.signalChan:
-				signal := signal{}
-				err := signal.Unmarshal(signalData)
-				if err != nil {
-					logger.Errorw("error unmarshaling signal ebpf buffer", "error", err)
-					continue
-				}
-				err = p.processSignal(signal)
-				if err != nil {
-					logger.Errorw("error processing control plane signal", "error", err)
-				}
-			case lost := <-p.lostSignalChan:
-				logger.Warnw(fmt.Sprintf("Lost %d control plane signals", lost))
-			case <-p.ctx.Done():
-				return
+	for {
+		select {
+		case signalData := <-p.signalChan:
+			signal := signal{}
+			err := signal.Unmarshal(signalData)
+			if err != nil {
+				logger.Errorw("error unmarshaling signal ebpf buffer", "error", err)
+				continue
 			}
+			err = p.processSignal(signal)
+			if err != nil {
+				logger.Errorw("error processing control plane signal", "error", err)
+			}
+		case lost := <-p.lostSignalChan:
+			logger.Warnw(fmt.Sprintf("Lost %d control plane signals", lost))
+		case <-p.ctx.Done():
+			return
 		}
-	}()
+	}
 }
 
 func (p *Controller) Stop() error {
@@ -160,7 +159,7 @@ func (p *Controller) processCgroupMkdir(args []trace.Argument) error {
 	if p.enrichEnabled {
 		// If cgroupId belongs to a container, enrich now (in a goroutine)
 		go func() {
-			_, err = p.cgroupManager.EnrichCgroupInfo(cgroupId)
+			_, err := p.cgroupManager.EnrichCgroupInfo(cgroupId)
 			if err != nil {
 				logger.Errorw("error triggering container enrich in control plane", "error", err)
 			}


### PR DESCRIPTION
The `container_create` argument enrichment was broken due to a race in context switching between the control plane and the ebpf event pipeline.
As such the control plane would trigger but a context switch could cause the pipeline continue instead. Then when enrichment for the `cgroup_mkdir` event would trigger, the cgroup info would be missing in the `Containers` struct, since now the control plane populates it.

The root cause is that the locking scheme in `Containers` is non transactional. Now that we have multiple pipelines writing to the `Containers` struct, locking should align with the situation. This PR does that.

```
    containers: change locking scheme
    
    Locks in the container package were as short as possible.
    This caused transaction issues once a few actors interacted with it.
    
    Changed the locking scheme to be more "transactional" with large locks,
    instead of combining read locks and write locks in the same transaction.
```
```
    controlplane: chore fixes
    
    1. Initialize enrichEnabled field
    2. Run started a go routine internally, which was redundant.
```

Fix #3282