### PR TITLE
add .gitmessage template and git hook

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,48 @@
+
+# Use the following conventions <https://www.conventionalcommits.org/en/v1.0.0>
+#
+# <type>(scope): <description>
+#
+# (optional body)
+#
+# (optional footer(s))
+#
+# Type can be:
+#	feat:     A new feature
+#	fix:      A bug fix
+#	docs:     Documentation changes
+#	style:    Code style changes (formatting, indentation, etc.)
+#	refactor: Code restructuring that neither fixes a bug nor adds a feature
+#	perf:     Performance improvements
+#	test:     Adding or modifying tests
+#	build:    Changes to the build system or dependencies
+#	chore:    Other changes that don't modify src or test files
+#	revert:   Reverts a previous commit
+#
+# Scope can be anything specifying place of the commit change.
+#
+# Add "!" immediately after the type and scope, and before the colon, 
+# to draw attention to a breaking change.
+#
+# Description should be a concise explanation of the changes.
+#
+# The body should be a more detailed explanation of the changes.
+#
+# The footer should contain any additional information such as:
+# - "BREAKING CHANGE" to signal a breaking change.
+# - "Closes #123" to reference an issue.
+# - If to be pushed to a release branch:
+#   * "commit: 0b97409 (main), cherry-pick" to reference a commit cherry-picked
+#     from main branch.
+#   * "commit: 00f71ab (main), back-port" to reference a commit back-ported from
+#     main branch.
+#
+# Example:
+# chore(cmd/flags)!: change flags name
+#
+# Standardize naming.
+#
+# BREAKING CHANGE: change --flags to --flag.
+# Closes #123
+# commit: caf3b4b (main), cherry-pick
+#

--- a/git-hooks/prepare-commit-msg
+++ b/git-hooks/prepare-commit-msg
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2
+
+# Define the template
+TEMPLATE=".gitmessage"
+
+# Check if the commit message is already populated (e.g. by 'git commit -m "message"')
+if [ -z "$COMMIT_SOURCE" ]; then
+    # If not, append the template
+    cat "$TEMPLATE" >> "$COMMIT_MSG_FILE"
+fi


### PR DESCRIPTION
### 1. Explain what the PR does

25e4800a **chore(git): add .gitmessage template and git hook** _<sub>(2023/jun/28) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
To use this template, after a fresh clone, create a symlink:
  ln -s ../../git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
```

### 2. Explain how to test it

`git commit` shows default commit msg appended with `.gitmessage` template.


### 3. Other comments

