### PR TITLE
pipeline memory efficiency using pool

### DIFF
--- a/pkg/ebpf/events_pipeline_bench_test.go
+++ b/pkg/ebpf/events_pipeline_bench_test.go
@@ -1,0 +1,331 @@
+package ebpf
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+const (
+	decodeEvts  = 1000
+	processEvts = decodeEvts
+	deriveEvts  = processEvts / 4
+	engineEvts  = processEvts / 4
+	sinkEvts    = processEvts + deriveEvts + engineEvts
+)
+
+// BenchmarkGetEventFromPool is a benchmark of using a sync.Pool for Event objects,
+// which simulates, with caveats, the way the pipeline works.
+func BenchmarkGetEventFromPool(b *testing.B) {
+	evtPool := sync.Pool{
+		New: func() interface{} {
+			return &trace.Event{}
+		},
+	}
+	// warm up the pool
+	for i := 0; i < decodeEvts; i++ {
+		evtPool.Put(evtPool.New())
+	}
+
+	ctx := bufferdecoder.Context{}
+	containerData := trace.Container{}
+	kubernetesData := trace.Kubernetes{}
+	eventDefinition := events.Event{}
+	args := []trace.Argument{}
+	stackAddresses := []uint64{}
+	flags := trace.ContextFlags{}
+	syscall := ""
+	argnum := uint8(0)
+
+	decodeChan := make(chan *bufferdecoder.Context, 10000)
+	processChan := make(chan *trace.Event, 10000)
+	deriveChan := make(chan *trace.Event)
+	engineChan := make(chan *trace.Event)
+	sinkChan := make(chan *trace.Event)
+
+	var wg sync.WaitGroup
+
+	b.ResetTimer()
+
+	// decode stage 1
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < decodeEvts; j++ {
+				decodeChan <- &ctx
+			}
+		}
+	}()
+
+	// decode stage 2
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < decodeEvts; j++ {
+				ctx := <-decodeChan
+				evt := evtPool.Get().(*trace.Event)
+
+				evt.Timestamp = int(ctx.Ts)
+				evt.ThreadStartTime = int(ctx.StartTime)
+				evt.ProcessorID = int(ctx.ProcessorId)
+				evt.ProcessID = int(ctx.Pid)
+				evt.ThreadID = int(ctx.Tid)
+				evt.ParentProcessID = int(ctx.Ppid)
+				evt.HostProcessID = int(ctx.HostPid)
+				evt.HostThreadID = int(ctx.HostTid)
+				evt.HostParentProcessID = int(ctx.HostPpid)
+				evt.UserID = int(ctx.Uid)
+				evt.MountNS = int(ctx.MntID)
+				evt.PIDNS = int(ctx.PidID)
+				evt.ProcessName = string(bytes.TrimRight(ctx.Comm[:], "\x00"))
+				evt.HostName = string(bytes.TrimRight(ctx.UtsName[:], "\x00"))
+				evt.CgroupID = uint(ctx.CgroupID)
+				evt.ContainerID = containerData.ID
+				evt.Container = containerData
+				evt.Kubernetes = kubernetesData
+				evt.EventID = int(ctx.EventID)
+				evt.EventName = eventDefinition.Name
+				evt.MatchedPoliciesKernel = ctx.MatchedPolicies
+				evt.MatchedPoliciesUser = 0
+				evt.MatchedPolicies = []string{}
+				evt.ArgsNum = int(argnum)
+				evt.ReturnValue = int(ctx.Retval)
+				evt.Args = args
+				evt.StackAddresses = stackAddresses
+				evt.ContextFlags = flags
+				evt.Syscall = syscall
+				evt.Metadata = nil
+
+				processChan <- evt
+			}
+		}
+	}()
+
+	// process stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < processEvts; j++ {
+				evt := <-processChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				// get an event from the pool, fill it with data and
+				// pass it to the other stages
+				evtCopy := evtPool.Get().(*trace.Event)
+				*evtCopy = *evt // shallow copy
+				sinkChan <- evt
+				if j < deriveEvts {
+					deriveChan <- evtCopy
+				}
+				if j < engineEvts {
+					engineChan <- evtCopy
+				}
+			}
+		}
+	}()
+
+	// derive stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < deriveEvts; j++ {
+				evt := <-deriveChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				sinkChan <- evt
+			}
+		}
+	}()
+
+	// engine stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < engineEvts; j++ {
+				evt := <-engineChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				sinkChan <- evt
+			}
+		}
+	}()
+
+	// sink stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < sinkEvts; j++ {
+				evt := <-sinkChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				_ = evt
+				evtPool.Put(evt) // return the event to the pool
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// BenchmarkNewEventObject is a benchmark of using a new Event object for each event,
+// which simulates, with caveats, the way the pipeline works.
+func BenchmarkNewEventObject(b *testing.B) {
+	ctx := bufferdecoder.Context{}
+	containerData := trace.Container{}
+	kubernetesData := trace.Kubernetes{}
+	eventDefinition := events.Event{}
+	args := []trace.Argument{}
+	stackAddresses := []uint64{}
+	flags := trace.ContextFlags{}
+	syscall := ""
+	argnum := uint8(0)
+
+	decodeChan := make(chan *bufferdecoder.Context, 10000)
+	processChan := make(chan *trace.Event, 10000)
+	deriveChan := make(chan *trace.Event)
+	engineChan := make(chan *trace.Event)
+	sinkChan := make(chan *trace.Event)
+
+	var wg sync.WaitGroup
+
+	b.ResetTimer()
+
+	// decode stage 1
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < decodeEvts; j++ {
+				decodeChan <- &ctx
+			}
+		}
+	}()
+
+	// decode stage 2
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < decodeEvts; j++ {
+				ctx := <-decodeChan
+
+				evt := trace.Event{
+					Timestamp:             int(ctx.Ts),
+					ThreadStartTime:       int(ctx.StartTime),
+					ProcessorID:           int(ctx.ProcessorId),
+					ProcessID:             int(ctx.Pid),
+					ThreadID:              int(ctx.Tid),
+					ParentProcessID:       int(ctx.Ppid),
+					HostProcessID:         int(ctx.HostPid),
+					HostThreadID:          int(ctx.HostTid),
+					HostParentProcessID:   int(ctx.HostPpid),
+					UserID:                int(ctx.Uid),
+					MountNS:               int(ctx.MntID),
+					PIDNS:                 int(ctx.PidID),
+					ProcessName:           string(bytes.TrimRight(ctx.Comm[:], "\x00")),
+					HostName:              string(bytes.TrimRight(ctx.UtsName[:], "\x00")),
+					CgroupID:              uint(ctx.CgroupID),
+					ContainerID:           containerData.ID,
+					Container:             containerData,
+					Kubernetes:            kubernetesData,
+					EventID:               int(ctx.EventID),
+					EventName:             eventDefinition.Name,
+					MatchedPoliciesKernel: ctx.MatchedPolicies,
+					ArgsNum:               int(argnum),
+					ReturnValue:           int(ctx.Retval),
+					Args:                  args,
+					StackAddresses:        stackAddresses,
+					ContextFlags:          flags,
+					Syscall:               syscall,
+				}
+
+				processChan <- &evt
+			}
+		}
+	}()
+
+	// process stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < processEvts; j++ {
+				evt := <-processChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				evtCopy := *evt
+				sinkChan <- evt
+				if j < deriveEvts {
+					deriveChan <- &evtCopy
+				}
+				if j < engineEvts {
+					engineChan <- &evtCopy
+				}
+			}
+		}
+	}()
+
+	// derive stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < deriveEvts; j++ {
+				evt := <-deriveChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				sinkChan <- evt
+			}
+		}
+	}()
+
+	// engine stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < engineEvts; j++ {
+				evt := <-engineChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				sinkChan <- evt
+			}
+		}
+	}()
+
+	// sink stage
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < sinkEvts; j++ {
+				evt := <-sinkChan
+				// simulate some work through the pipeline
+				time.Sleep(1 * time.Millisecond)
+
+				_ = evt
+				evt = nil // release the reference to the event
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
### 1. Explain what the PR does

04bf8534f **perf:(pipeline) memory efficiency using pool** _<sub>(2023/jul/01) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
This commit employs sync.Pool to bolster memory performance in event
handling. The benchmarking file, events_pipeline_bench_test.go,
simulates the pipeline execution and measures sync.Pool's effectiveness.

Benchmark command:

go test \
  -benchmem -benchtime=100x \
  -run=^$ -bench ^(BenchmarkGetEventFromPool|BenchmarkNewEventObject)$ \
  github.com/aquasecurity/tracee/pkg/ebpf

Findings:

Environment:
- OS: Linux
- Arch: amd64
- Package: github.com/aquasecurity/tracee/pkg/ebpf
- CPU: Intel Core i7-12700H

Benchmarking Results:

BenchmarkGetEventFromPool (with pooling):
- Time per Op: 1740.88 ms
- Memory per Op: 243.5 KB
- Allocations per Op: 543

BenchmarkNewEventObject (without pooling):
- Time per Op: 1754.69 ms
- Memory per Op: 896.2 KB
- Allocations per Op: 2001

Using object pooling reduces memory allocation and allocation count
by ~3.7x.

In conclusion, sync.Pool results in remarkable memory optimization
without substantial impact on runtime. This efficiency is critical in
the pipeline that must have high throughput, as it can facilitate
garbage collection and promote resource efficiency.

For more information, see the benchmarking results of tracee actually
running on #3297.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
