### PR TITLE
events: update syscall_pathname for security_file_open

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -1974,9 +1974,12 @@ int BPF_KPROBE(trace_security_file_open)
     if (syscall_traced) {
         sys = &p.task_info->syscall_data;
         switch (sys->id) {
+            case SYSCALL_EXECVE:
             case SYSCALL_OPEN:
                 syscall_pathname = (void *) sys->args.args[0];
                 break;
+
+            case SYSCALL_EXECVEAT:
             case SYSCALL_OPENAT:
             case SYSCALL_OPENAT2:
                 syscall_pathname = (void *) sys->args.args[1];


### PR DESCRIPTION
### 1. Explain what the PR does

syscall_pathname was fetched only for open(at) syscalls, thus was empty for security_file_open originated from execve(at) syscall


### 2. Explain how to test it

./tracee -f e=security_file_open


