### PR TITLE
remove --help, fix help command for flags

### DIFF
--- a/builder/Makefile.tracee-container
+++ b/builder/Makefile.tracee-container
@@ -75,7 +75,7 @@ help:
 	@echo ""
 	@echo "    $$ make -f builder/Makefile.tracee-container build-tracee"
 	@echo ""
-	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee ARG=\"--help\""
+	@echo "    $$ make -f builder/Makefile.tracee-container run-tracee ARG=\"help\""
 	@echo ""
 	@echo "    > This will run tracee using provided arguments."
 	@echo ""

--- a/cmd/tracee/cmd/analyze.go
+++ b/cmd/tracee/cmd/analyze.go
@@ -27,25 +27,6 @@ import (
 func init() {
 	rootCmd.AddCommand(analyze)
 
-	hfFallback := rootCmd.HelpFunc()
-	// Override default help function to support help for flags.
-	// Since for commands the usage is tracee help <command>, for flags
-	// the usage is tracee --help <flag>.
-	// e.g. tracee analyze --help rego
-	//      tracee analyze -h rego
-	analyze.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if len(args) > 2 && (args[1] == "--help" || args[1] == "-h") {
-			flagHelp := flags.GetHelpString(args[2], true)
-			if flagHelp != "" {
-				fmt.Fprintf(os.Stdout, "%s\n", flagHelp)
-				os.Exit(0)
-			}
-		}
-
-		// If flag help was not found, fallback to default help function
-		hfFallback(cmd, args)
-	})
-
 	// flags
 
 	// events

--- a/cmd/tracee/cmd/help.go
+++ b/cmd/tracee/cmd/help.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+func init() {
+	// override the default help command
+	rootCmd.SetHelpCommand(helpCmd)
+	// use custom usage template
+	rootCmd.SetUsageTemplate(customUsageTemplate)
+}
+
+var customUsageTemplate = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use:
+  "{{.CommandPath}} [command] --help" for more information about a command.
+  "{{.CommandPath}} help [command|flag]" for more information about a command or flag.{{end}}
+`
+
+var helpCmd = &cobra.Command{
+	Use:    "help [command|flag]",
+	Short:  "Help about any command or flag",
+	Hidden: false,
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			// check if the argument is a flag
+			if flagHelp := flags.GetHelpString(args[0], true); flagHelp != "" {
+				fmt.Fprintf(os.Stdout, "%s\n", flagHelp)
+				return
+			}
+
+			// check if the argument is a command
+			for _, cmd := range rootCmd.Commands() {
+				if cmd.Name() == args[0] {
+					if err := cmd.Help(); err != nil {
+						logger.Errorw("failed to print help for command", "command", cmd.Name(), "error", err)
+						os.Exit(1)
+					}
+					return
+				}
+			}
+		}
+
+		// use the default help function
+		cmd.Root().HelpFunc()(cmd.Root(), args)
+	},
+}

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/viper"
 
 	cmdcobra "github.com/aquasecurity/tracee/pkg/cmd/cobra"
-	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -55,25 +54,6 @@ func initCmd() error {
 	rootCmd.SetErr(os.Stderr)
 
 	cobra.OnInitialize(initConfig)
-
-	hfFallback := rootCmd.HelpFunc()
-	// Override default help function to support help for flags.
-	// Since for commands the usage is tracee help <command>, for flags
-	// the usage is tracee --help <flag>.
-	// e.g. tracee --help filter
-	//      tracee -h filter
-	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 && (args[0] == "--help" || args[0] == "-h") {
-			flagHelp := flags.GetHelpString(args[1], true)
-			if flagHelp != "" {
-				fmt.Fprintf(os.Stdout, "%s\n", flagHelp)
-				os.Exit(0)
-			}
-		}
-
-		// If flag help was not found, fallback to default help function
-		hfFallback(cmd, args)
-	})
 
 	// Filter/Policy flags
 

--- a/docs/contributing/building/containers.md
+++ b/docs/contributing/building/containers.md
@@ -76,5 +76,5 @@ the "run" targets:
     !!! note
         Tracee arguments are passed through the `ARG` variable:
         ```console
-        make -f builder/Makefile.tracee-container run-tracee ARG="--help"
+        make -f builder/Makefile.tracee-container run-tracee ARG="help"
         ```

--- a/docs/docs/deep-dive/caching-events.md
+++ b/docs/docs/deep-dive/caching-events.md
@@ -4,7 +4,7 @@ Tracee has an events caching (in-memory) mechanism. In order to check latest
 caching options you may execute:
 
 ```console
-./dist/tracee --help cache
+./dist/tracee help cache
 ```
 
 !!! Read Important

--- a/docs/docs/deep-dive/dropping-capabilities.md
+++ b/docs/docs/deep-dive/dropping-capabilities.md
@@ -50,7 +50,7 @@ does is through different "execution protection rings":
 You may see all available capabilities in the running environment by running:
 
 ```console
---help capabilities
+help capabilities
 ```
 
 command line flag.

--- a/docs/docs/filters/filtering.md
+++ b/docs/docs/filters/filtering.md
@@ -1,7 +1,7 @@
 # Tracing Event Filtering
 
 ```console
-sudo ./dist/tracee --help filter
+sudo ./dist/tracee help filter
 sudo ./dist/tracee --filter xxx
 ```
 

--- a/docs/docs/forensics/index.md
+++ b/docs/docs/forensics/index.md
@@ -4,7 +4,7 @@ Tracee has a unique feature that lets you capture interesting artifacts from
 running applications, using the `--capture` flag.
 
 ```console
-sudo ./dist/tracee --help capture
+sudo ./dist/tracee help capture
 sudo ./dist/tracee --capture xxx
 ```
 

--- a/docs/docs/integrating/prometheus.md
+++ b/docs/docs/integrating/prometheus.md
@@ -11,7 +11,7 @@ through the following URLs:
 **tracee** can be scraped through `:3366/metrics`
 
 > Metrics addresses can be changed through **tracee** command line
-> arguments `metrics` and `listen-addr`, check `--help` for more information.
+> arguments `metrics` and `listen-addr`, check `help` for more information.
 
 !!! Tip
     Check [this tutorial] for more information as well.

--- a/docs/docs/outputs/output-formats.md
+++ b/docs/docs/outputs/output-formats.md
@@ -1,6 +1,6 @@
 # Tracing Output Formats
 
-The `--output` flag controls where and how Tracee will output events, by specifying `--output <format>:<destination>`.  You can use the `--output` flag multiple times to output events in multiple ways. To see all output options you can run `tracee --help output`.
+The `--output` flag controls where and how Tracee will output events, by specifying `--output <format>:<destination>`.  You can use the `--output` flag multiple times to output events in multiple ways. To see all output options you can run `tracee help output`.
 
 The following output formats are supported:
 

--- a/docs/docs/outputs/output-options.md
+++ b/docs/docs/outputs/output-options.md
@@ -1,6 +1,6 @@
 # Tracing Output Options
 
-Tracee supports different output options for customizing the way events are printed. For a complete list of available options, run `tracee --help output`.
+Tracee supports different output options for customizing the way events are printed. For a complete list of available options, run `tracee help output`.
 
 Available options:
 

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -190,7 +190,7 @@ func PrepareCapture(captureSlice []string, newBinary bool) (config.CaptureConfig
 			}
 		} else {
 			if newBinary {
-				return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--help capture' for more info")
+				return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use 'help capture' for more info")
 			}
 
 			return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--capture help' for more info")

--- a/pkg/cmd/flags/errors.go
+++ b/pkg/cmd/flags/errors.go
@@ -18,7 +18,7 @@ func InvalidEventExcludeError(event string) error {
 
 func InvalidFilterOptionError(expr string, newBinary bool) error {
 	if newBinary {
-		return fmt.Errorf("invalid filter option specified (%s), use '--help filter' for more info", expr)
+		return fmt.Errorf("invalid filter option specified (%s), use 'help filter' for more info", expr)
 	}
 
 	return fmt.Errorf("invalid filter option specified (%s), use '--filter help' for more info", expr)

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -50,7 +50,7 @@ func invalidLogOption(err error, opt string, newBinary bool) error {
 	}
 
 	if newBinary {
-		return errfmt.Errorf("invalid log option: %s, %s, use '--help log' for more info", opt, err)
+		return errfmt.Errorf("invalid log option: %s, %s, use 'help log' for more info", opt, err)
 	}
 
 	return errfmt.Errorf("invalid log option: %s, %s, use '--log help' for more info", opt, err)
@@ -63,7 +63,7 @@ func invalidLogOptionValue(err error, opt string, newBinary bool) error {
 	}
 
 	if newBinary {
-		return errfmt.Errorf("invalid log option value: %s, %s, use '--help log' for more info", opt, err)
+		return errfmt.Errorf("invalid log option value: %s, %s, use 'help log' for more info", opt, err)
 	}
 
 	return errfmt.Errorf("invalid log option value: %s, %s, use '--log help' for more info", opt, err)

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -83,7 +83,7 @@ func PrepareOutput(outputSlice []string, newBinary bool) (PrepareOutputResult, e
 		case "none":
 			if len(outputParts) > 1 {
 				if newBinary {
-					return outConfig, errors.New("none output does not support path. Use '--help output' for more info")
+					return outConfig, errors.New("none output does not support path. Use 'help output' for more info")
 				}
 
 				return outConfig, errors.New("none output does not support path. Use '--output help' for more info")
@@ -115,7 +115,7 @@ func PrepareOutput(outputSlice []string, newBinary bool) (PrepareOutputResult, e
 			}
 		default:
 			if newBinary {
-				return outConfig, fmt.Errorf("invalid output flag: %s, use '--help output' for more info", outputParts[0])
+				return outConfig, fmt.Errorf("invalid output flag: %s, use 'help output' for more info", outputParts[0])
 			}
 
 			return outConfig, fmt.Errorf("invalid output flag: %s, use '--output help' for more info", outputParts[0])
@@ -158,7 +158,7 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 		cfg.EventsSorting = true
 	default:
 		if newBinary {
-			return errfmt.Errorf("invalid output option: %s, use '--help output' for more info", option)
+			return errfmt.Errorf("invalid output option: %s, use 'help output' for more info", option)
 		}
 
 		return errfmt.Errorf("invalid output option: %s, use '--output help' for more info", option)
@@ -209,7 +209,7 @@ func parseFormat(outputParts []string, printerMap map[string]string, newBinary b
 	for _, outPath := range strings.Split(outputParts[1], ",") {
 		if outPath == "" {
 			if newBinary {
-				return errfmt.Errorf("format flag can't be empty, use '--help output' for more info")
+				return errfmt.Errorf("format flag can't be empty, use 'help output' for more info")
 			}
 
 			return errfmt.Errorf("format flag can't be empty, use '--output help' for more info")
@@ -217,7 +217,7 @@ func parseFormat(outputParts []string, printerMap map[string]string, newBinary b
 
 		if _, ok := printerMap[outPath]; ok {
 			if newBinary {
-				return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use '--help output' for more info", outPath)
+				return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use 'help output' for more info", outPath)
 			}
 
 			return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use '--output help' for more info", outPath)
@@ -232,7 +232,7 @@ func parseFormat(outputParts []string, printerMap map[string]string, newBinary b
 func parseOption(outputParts []string, traceeConfig *config.OutputConfig, newBinary bool) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
 		if newBinary {
-			return errfmt.Errorf("option flag can't be empty, use '--help output' for more info")
+			return errfmt.Errorf("option flag can't be empty, use 'help output' for more info")
 		}
 
 		return errfmt.Errorf("option flag can't be empty, use '--output help' for more info")
@@ -272,7 +272,7 @@ func createFile(path string) (*os.File, error) {
 func validateURL(outputParts []string, flag string, newBinary bool) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
 		if newBinary {
-			return errfmt.Errorf("%s flag can't be empty, use '--help output' for more info", flag)
+			return errfmt.Errorf("%s flag can't be empty, use 'help output' for more info", flag)
 		}
 
 		return errfmt.Errorf("%s flag can't be empty, use '--output help' for more info", flag)
@@ -282,7 +282,7 @@ func validateURL(outputParts []string, flag string, newBinary bool) error {
 
 	if err != nil {
 		if newBinary {
-			return errfmt.Errorf("invalid uri for %s output %q. Use '--help output' for more info", flag, outputParts[1])
+			return errfmt.Errorf("invalid uri for %s output %q. Use 'help output' for more info", flag, outputParts[1])
 		}
 
 		return errfmt.Errorf("invalid uri for %s output %q. Use '--output help' for more info", flag, outputParts[1])

--- a/pkg/cmd/flags/rego.go
+++ b/pkg/cmd/flags/rego.go
@@ -40,7 +40,7 @@ func PrepareRego(regoSlice []string) (rego.Config, error) {
 		case "aio":
 			c.AIO = true
 		default:
-			return rego.Config{}, errfmt.Errorf("invalid rego option specified, use '--help rego' for more info")
+			return rego.Config{}, errfmt.Errorf("invalid rego option specified, use 'help rego' for more info")
 		}
 	}
 


### PR DESCRIPTION
Close #3299

### 1. Explain what the PR does

b54909374 **fix(flags)!: remove --help, fix help command** _<sub>(2023/jul/06) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
The --help workaround for flags is removed, and the help command is
fixed to work as expected for both commands and flags.

BREAKING CHANGE: --help is no longer supported for flags. Use:
 - "tracee [command] --help" for more information about a command.
 - "tracee help [command|flag]" for more information about a command or
    flag.
```

### 2. Explain how to test it

Ask for a command help `list` (generated by cobra):

`./dist/tracee help list`

```
List traceable events

Usage:
  tracee list

Aliases:
  list, l

Flags:
      --signatures-dir stringArray   Directories where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats
```

Ask for a flag help `--config` (our own text, since cobra doesn't provide help cmd for flags):

`./dist/tracee help config`

```
The --config flag allows you to define global configuration options (flags)
for tracee, by providing a file in YAML or JSON format between others (see documentation).

All flags can be set in the config file, except for the following, which are reserved only
for the CLI:
  --config (this flag)
  --capture
  --policy

The --filter flag also cannot be set in the config file since it's reserved for the CLI
and the policy file loading mechanism (via the --policy flag).
```

Ask for a general help (generated by cobra based on specified template):

`./dist/tracee help`

```
Tracee uses eBPF technology to tap into your system and give you
access to hundreds of events that help you understand how your system behaves.

Usage:
  tracee [flags]
  tracee [command]

Available Commands:
  analyze     Analyze past events with signature events [Experimental]
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command or flag
  list        List traceable events
  version     Print the version number of Tracee

Flags:
  -f, --filter stringArray           Select events to trace by defining filter expressions
  -p, --policy stringArray           Path to a policy or directory with policies
  -o, --output stringArray           Control how and where output is printed (default [table])
  -c, --capture stringArray          Capture artifacts that were written, executed or found to be suspicious
      --config string                Global config file (yaml, json between others - see documentation)
      --containers                   Enable container info enrichment to events. This feature is experimental and may cause unexpected behavior in the pipeline
      --crs stringArray              Define connected container runtimes
      --signatures-dir stringArray   Directories where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats
      --rego stringArray             Control event rego settings
  -b, --perf-buffer-size int         Size, in pages, of the internal perf ring buffer used to submit events from the kernel (default 1024)
      --blob-perf-buffer-size int    Size, in pages, of the internal perf ring buffer used to send blobs from the kernel (default 1024)
  -a, --cache stringArray            Control event caching queues (default [none])
      --metrics                      Enable metrics endpoint
      --healthz                      Enable healthz endpoint
      --pprof                        Enable pprof endpoints
      --pyroscope                    Enable pyroscope agent
      --listen-addr string           Listening address of the metrics endpoint server (default ":3366")
  -C, --capabilities stringArray     Define capabilities for tracee to run with
      --install-path string          Path where tracee will install or lookup it's resources (default "/tmp/tracee")
  -l, --log stringArray              Logger options (default [info])

Use:
  "tracee [command] --help" for more information about a command.
  "tracee help [command|flag]" for more information about a command or flag.
```

### 3. Other comments

It's important to note that `--help` continues to function as a flag for commands.
