### PR TITLE
docs: Fix incorrect flags and usage documentation for unlinkat

### DIFF
--- a/docs/docs/events/builtin/syscalls/unlinkat.md
+++ b/docs/docs/events/builtin/syscalls/unlinkat.md
@@ -9,12 +9,10 @@ unlinkat is a system call that deletes a file name, relative to an open director
 
 Unlinkat also allows a user to delete links without traversing whole directory hierarchies, by providing the location of the file (directory) and its name as two separate arguments.
 
-Unlinkat also provides the option to not traverse symbolic links with the **O_NOFOLLOW** flag. This allows users to delete symbolic links more securely.
-
 ## Arguments
 * `dirfd`:`int`[K] - an open file descriptor referring to a directory.
 * `pathname`:`const char*`[KU] - a string containing the name of the file to be deleted, relative to the directory referred to by dirfd.
-* `flags`:`int`[K] - optional flags that can include **O_NOFOLLOW**, **AT_REMOVEDIR**, or **AT_SYMLINK_NOFOLLOW**.
+* `flags`:`int`[K] - optional flags that can include **AT_REMOVEDIR**.
 
 ### Available Tags
 * K - Originated from kernel-space.
@@ -33,7 +31,7 @@ To monitor file deletions.
 Finding malicious file deletions.
 
 ## Issues
-unlinkat is vulnerable to TOCTOU (time of check, time of use) attacks if the **O_NOFOLLOW** flag is not included.
+unlinkat is vulnerable to TOCTOU (time of check, time of use) attacks.
 
 ## Related Events
 unlink(), remove(), readlinkat(), openat()


### PR DESCRIPTION


<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

unlinkat(2) does *not* accept any flags other than AT_REMOVEDIR. It cannot unlink files without following symlinks. This fixes the documentation accordingly.

### 2. Explain how to test it

N/A

### 3. Other comments

Man page: https://linux.die.net/man/2/unlinkat
Kernel implementation: https://github.com/torvalds/linux/blob/66d8fc0539b0d49941f313c9509a8384e4245ac1/fs/namei.c#L4433

I came across this documentation on Google and noticed that it was incorrectly generated by ChatGPT. It might be worth reconsidering this documentation strategy as potentially misleading content can get indexed.