### PR TITLE
pkg/containers: fix deadlock

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -380,6 +380,8 @@ func (c *Containers) GetCgroupInfo(cgroupId uint64) CgroupInfo {
 		// cgroupInfo in the Containers struct. An empty subPath will make
 		// getCgroupPath() to walk all cgroupfs directories until it finds the
 		// directory of given cgroupId.
+		var cgroupInfo CgroupInfo
+
 		c.cgroupsMutex.Lock()
 		defer c.cgroupsMutex.Unlock()
 
@@ -387,12 +389,14 @@ func (c *Containers) GetCgroupInfo(cgroupId uint64) CgroupInfo {
 		if err == nil {
 			var stat syscall.Stat_t
 			if err = syscall.Stat(path, &stat); err == nil {
-				info, err := c.cgroupUpdate(cgroupId, path, time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec))
-				if err == nil {
-					return info
+				cgroupInfo, err = c.cgroupUpdate(cgroupId, path, time.Unix(stat.Ctim.Sec, stat.Ctim.Nsec))
+				if err != nil {
+					logger.Errorw("cgroupUpdate", "error", err)
 				}
 			}
 		}
+
+		return cgroupInfo
 	}
 
 	c.cgroupsMutex.RLock()


### PR DESCRIPTION
The write Lock() is not getting released because of the defer, blocking the read RLock(), and the pipeline.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3310

We had a deadlock introduced on the last release on the PR https://github.com/aquasecurity/tracee/pull/3285

The write [`Lock()`](https://github.com/aquasecurity/tracee/blob/main/pkg/containers/containers.go#L383) isn't getting release due to the [`defer`](https://github.com/aquasecurity/tracee/blob/main/pkg/containers/containers.go#L384), which blocks the read [`RLock`](https://github.com/aquasecurity/tracee/blob/main/pkg/containers/containers.go#L398) and the pipeline.

To fix it, I remove the defer and did the lock() and unlock() on the critical path, also removed the `return`, we only update the cgroupMap inside the if logic, then move on to get the cgroupInfo and return. There are other ways of fixing it, let me know if you think it should be different.

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

The simplest to simulate the bug is to run tracee into kind or minukube.

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
