### PR TITLE
docs: updating link to tracee docs for search results

### DIFF
--- a/cmd/tracee-rules/readme.md
+++ b/cmd/tracee-rules/readme.md
@@ -1,6 +1,5 @@
 # Documentation
 
-The full documentation of Tracee-Rules is available at
-[https://aquasecurity.github.io/tracee/dev/docs/detecting/](https://aquasecurity.github.io/tracee/dev/docs/detecting/).
-You can use the version selector on top to view documentation for a specific
-version of Tracee.
+**Important**
+Tracee has no a new design.
+For more details, please take a look at the up-to-date [documentation.](https://aquasecurity.github.io/tracee/latest)

--- a/cmd/tracee-rules/readme.md
+++ b/cmd/tracee-rules/readme.md
@@ -1,5 +1,5 @@
 # Documentation
 
 **Important**
-Tracee has no a new design.
+Tracee has a new design.
 For more details, please take a look at the up-to-date [documentation.](https://aquasecurity.github.io/tracee/latest)


### PR DESCRIPTION
The tracee rules docs site in the repo is one of the links that shows up when searching for Tracee. I just want to make sure people then get easily to the right information.