### PR TITLE
fix (cgroups): already dead edge case

### DIFF
--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -137,7 +137,7 @@ func (p *Controller) processCgroupMkdir(args []trace.Argument) error {
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
-	if info.Container.ContainerId == "" {
+	if info.Container.ContainerId == "" && !info.Dead {
 		// If cgroupId is from a regular cgroup directory, and not the
 		// container base directory (from known runtimes), it should be
 		// removed from the containers bpf map.


### PR DESCRIPTION
```
commit b3d043c558b50526fef1c7e65c8d89db8f984d28
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Tue Jul 18 14:59:12 2023 +0000

    fix (cgroups): already dead edge case
    
    Certain kubernetes version make use of short lived cgroups for various
    tasks (for example log rotation). These cgroups will generate events and
    a very quick cgroup_rmdir event.
    As such, many related events to the cgroup will attempt to query its
    directory through the recursive path and not find it.
    
    Commit adds a "Dead" field to the cgroup info to indicate a cgroup which
    has already been removed. Various logical sections can refer to it if
    its relevant to them, and more importantly, additional queries will not
    be attempted.
    
    Bonus: optimize away additional Stat syscall in containers by returning
    the directory ctime in cgroup.GetCgroupPath.
```

Fix #3324

@rafaeldtinoco I want to backport this to v0.16.0 branch if that's ok with you.