### PR TITLE
feature(k8s): add default events to k8s policies

### DIFF
--- a/deploy/helm/tracee/templates/tracee-policies.yaml
+++ b/deploy/helm/tracee/templates/tracee-policies.yaml
@@ -6,6 +6,52 @@ metadata:
   labels:
     {{- include "tracee.labels" . | nindent 4 }}
 data:
+  default_events.yaml: |-
+    name: default_events
+    description: tracee default events
+    scope:
+      - global
+    rules:
+      - event: creat
+      - event: chmod
+      - event: fchmod
+      - event: chown
+      - event: fchown
+      - event: lchown
+      - event: ptrace
+      - event: setuid
+      - event: setgid
+      - event: setpgid
+      - event: setsid
+      - event: setreuid
+      - event: setregid
+      - event: setresuid
+      - event: setresgid
+      - event: setfsuid
+      - event: setfsgid
+      - event: init_module
+      - event: fchownat
+      - event: fchmodat
+      - event: setns
+      - event: process_vm_readv
+      - event: process_vm_writev
+      - event: finit_module
+      - event: memfd_create
+      - event: move_mount
+      - event: sched_process_exec
+      - event: security_inode_unlink
+      - event: security_socket_connect
+      - event: security_socket_accept
+      - event: security_socket_bind
+      - event: security_sb_mount
+      - event: container_create
+      - event: container_remove
+      - event: net_packet_icmp
+      - event: net_packet_icmpv6
+      - event: net_packet_dns_request
+      - event: net_packet_dns_response
+      - event: net_packet_http_request
+      - event: net_packet_http_response
   signatures.yaml: |-
     name: signature_events
     description: traces all signature events

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -8,9 +8,55 @@ metadata:
     app.kubernetes.io/part-of: tracee
   name: tracee-policies
 data:
+  default_events.yaml: |-
+    name: default_events
+    description: tracee default events
+    scope:
+      - global
+    rules:
+      - event: creat
+      - event: chmod
+      - event: fchmod
+      - event: chown
+      - event: fchown
+      - event: lchown
+      - event: ptrace
+      - event: setuid
+      - event: setgid
+      - event: setpgid
+      - event: setsid
+      - event: setreuid
+      - event: setregid
+      - event: setresuid
+      - event: setresgid
+      - event: setfsuid
+      - event: setfsgid
+      - event: init_module
+      - event: fchownat
+      - event: fchmodat
+      - event: setns
+      - event: process_vm_readv
+      - event: process_vm_writev
+      - event: finit_module
+      - event: memfd_create
+      - event: move_mount
+      - event: sched_process_exec
+      - event: security_inode_unlink
+      - event: security_socket_connect
+      - event: security_socket_accept
+      - event: security_socket_bind
+      - event: security_sb_mount
+      - event: container_create
+      - event: container_remove
+      - event: net_packet_icmp
+      - event: net_packet_icmpv6
+      - event: net_packet_dns_request
+      - event: net_packet_dns_response
+      - event: net_packet_http_request
+      - event: net_packet_http_response
   signatures.yaml: |-
     name: signature_events
-    description: traces all signature events
+    description: tracee default signature events
     scope:
       - global
     rules:


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3323

Adds a new policy to have all default events collected by default into kubernetes. 

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

```
# create a k8s cluster
minikube start

# deploy tracee
helm install tracee ./deploy/helm/tracee

# check it is running
kubectl get pods
kubectl logs -f ds/tracee
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
