### PR TITLE
[v0.16.0] chore: bump k8s tag to 0.16.2

### DIFF
--- a/deploy/helm/tracee/Chart.yaml
+++ b/deploy/helm/tracee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tracee
 description: Linux Runtime Security and Forensics using eBPF
-home: https://aquasecurity.github.io/tracee/v0.16.1/
+home: https://aquasecurity.github.io/tracee/v0.16.2/
 sources:
   - https://github.com/aquasecurity/tracee
 
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.16.1"
+version: "0.16.2"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.16.1"
+appVersion: "0.16.2"

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
       - name: tracee
-        image: docker.io/aquasec/tracee:0.16.1
+        image: docker.io/aquasec/tracee:0.16.2
         imagePullPolicy: IfNotPresent
         command: 
           - /tracee/tracee


### PR DESCRIPTION
Backport https://github.com/aquasecurity/tracee/pull/3331