### PR TITLE
fix: validate policy names are rfc 1123

### DIFF
--- a/deploy/helm/tracee/templates/tracee-policies.yaml
+++ b/deploy/helm/tracee/templates/tracee-policies.yaml
@@ -10,7 +10,7 @@ data:
     apiVersion: aquasecurity.github.io/v1beta1
     kind: TraceePolicy
     metadata:
-      name: signature_events
+      name: signature-events
       annotations:
         description: traces all signature events
     spec:

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -12,7 +12,7 @@ data:
     apiVersion: aquasecurity.github.io/v1beta1
     kind: TraceePolicy
     metadata:
-      name: signature_events
+      name: signature-events
       annotations:
         description: traces all signature events
     spec:

--- a/docs/docs/events/overview.md
+++ b/docs/docs/events/overview.md
@@ -21,7 +21,7 @@ cat <<EOF >sample_policy.yaml
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-	name: sample policy
+	name: sample-policy
 	annotations:
 		description: traces execve events
 spec:

--- a/docs/docs/policies/index.md
+++ b/docs/docs/policies/index.md
@@ -13,7 +13,7 @@ Following is a sample policy:
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-	name: overview policy
+	name: overview-policy
 	annotations:
 		description: sample overview policy
 spec:

--- a/docs/docs/policies/rules.md
+++ b/docs/docs/policies/rules.md
@@ -15,7 +15,7 @@ Context is data which is collected along the event. They can be filtered like:
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-	name: sample_context_filter
+	name: sample-context-filter
 	annotations:
 		description: sample context filter
 spec:
@@ -190,7 +190,7 @@ Events have arguments, which can be filtered.
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-	name: sample_argument_filter
+	name: sample-argument-filter
 	annotations:
 		description: sample argument filter
 spec:
@@ -220,7 +220,7 @@ Return values can also be filtered.
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-	name: sample_return_value
+	name: sample-return-value
 	annotations:
 		description: sample return value
 spec:

--- a/docs/tutorials/k8s-policies.md
+++ b/docs/tutorials/k8s-policies.md
@@ -59,7 +59,7 @@ signatures.yaml:
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-	name: signature_events
+	name: signature-events
 	annotations:
 		description: traces all signature events
 spec:
@@ -115,7 +115,7 @@ events.yaml: |-
   apiVersion: aquasecurity.github.io/v1beta1
   kind: TraceePolicy
   metadata:
-	  name: execve_event
+	  name: execve-event
 	  annotations:
 	  	description: traces all signature events
   spec:

--- a/examples/policies/container_dns_events.yaml
+++ b/examples/policies/container_dns_events.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: container_dns_events
+  name: container-dns-events
   annotations:
     description: traces dns events from containers
 spec:

--- a/examples/policies/context_comm.yaml
+++ b/examples/policies/context_comm.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: context_comm
+  name: context-comm
   annotations:
     description: traces openat done by ls
 spec:

--- a/examples/policies/new_containers.yaml
+++ b/examples/policies/new_containers.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: new_containers
+  name: new-containers
   annotations:
     description: traces events container_created and security_file_open only for new container
 spec:

--- a/examples/policies/new_pids.yaml
+++ b/examples/policies/new_pids.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: new_pids
+  name: new-pids
   annotations:
     description: traces openat and security_file_open for new pids
 spec:

--- a/examples/policies/not_containers.yaml
+++ b/examples/policies/not_containers.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: not_containers
+  name: not-containers
   annotations:
     description: traces anti_debugging in the host
 spec:

--- a/examples/policies/openat_args_pahtname.yaml
+++ b/examples/policies/openat_args_pahtname.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: openat_args_pathname
+  name: openat-args-pathname
   annotations:
     description: traces openat under /tmp/*
 spec:

--- a/examples/policies/pid_equal.yaml
+++ b/examples/policies/pid_equal.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: pid_equal
+  name: pid-equal
   annotations:
     description: traces read and write syscalls for pids 1000, and 2000
 spec:

--- a/examples/policies/scope_comm.yaml
+++ b/examples/policies/scope_comm.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: comm_strace
+  name: comm-strace
   annotations:
     description: traces sched_process_exec and sched_process_exit for the command strace
 spec:

--- a/examples/policies/signature_events.yaml
+++ b/examples/policies/signature_events.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: signature_events
+  name: signature-events
   annotations:
     description: traces all signature events
 spec:

--- a/examples/policies/uid_higher_than_or_equal_to_zero.yaml
+++ b/examples/policies/uid_higher_than_or_equal_to_zero.yaml
@@ -1,7 +1,7 @@
 apiVersion: aquasecurity.github.io/v1beta1
 kind: TraceePolicy
 metadata:
-  name: uid_higher_than_or_equal_to_zero
+  name: uid-higher-than-or-equal-to-zero
   annotations:
     description: traces read and write syscall for uids higher than or equal to 0
 spec:

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/yaml.v2 v2.4.0
 	gotest.tools v2.2.0+incompatible
+	k8s.io/apimachinery v0.27.1
 	kernel.org/pub/linux/libs/security/libcap/cap v1.2.68
 )
 
@@ -89,7 +90,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gotest.tools/v3 v3.4.0 // indirect
 	k8s.io/api v0.27.1 // indirect
-	k8s.io/apimachinery v0.27.1 // indirect
 	k8s.io/client-go v0.27.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -40,7 +40,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "global scope - single event",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name:        "global_scope_single_event",
+					Name:        "global-scope-single-event",
 					Annotations: description,
 				},
 				Spec: v1beta1.PolicySpec{
@@ -53,13 +53,13 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "global_scope_single_event",
+					policyName: "global-scope-single-event",
 					scopeFlags: []scopeFlag{},
 				},
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "global_scope_single_event",
+					policyName: "global-scope-single-event",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -70,7 +70,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "global scope - multiple events",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "global_scope_multiple_events",
+					Name: "global-scope-multiple-events",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -83,13 +83,13 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "global_scope_multiple_events",
+					policyName: "global-scope-multiple-events",
 					scopeFlags: []scopeFlag{},
 				},
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "global_scope_multiple_events",
+					policyName: "global-scope-multiple-events",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						readEvtFlag,
@@ -101,7 +101,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "uid scope",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "uid_scope",
+					Name: "uid-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"uid>=1000"},
@@ -113,7 +113,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "uid_scope",
+					policyName: "uid-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "uid>=1000",
@@ -125,7 +125,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "uid_scope",
+					policyName: "uid-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -136,7 +136,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "pid scope",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "pid_scope",
+					Name: "pid-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"pid<=10"},
@@ -148,7 +148,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "pid_scope",
+					policyName: "pid-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "pid<=10",
@@ -160,7 +160,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "pid_scope",
+					policyName: "pid-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -206,7 +206,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "pidns scope",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "pidns_scope",
+					Name: "pidns-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"pidns!=4026531836"},
@@ -218,7 +218,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "pidns_scope",
+					policyName: "pidns-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "pidns!=4026531836",
@@ -230,7 +230,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "pidns_scope",
+					policyName: "pidns-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -241,7 +241,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "uts scope",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "uts_scope",
+					Name: "uts-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"uts!=ab356bc4dd554"},
@@ -253,7 +253,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "uts_scope",
+					policyName: "uts-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "uts!=ab356bc4dd554",
@@ -265,7 +265,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "uts_scope",
+					policyName: "uts-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -276,7 +276,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "comm=bash",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "comm_scope",
+					Name: "comm-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"comm=bash"},
@@ -288,7 +288,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "comm_scope",
+					policyName: "comm-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "comm=bash",
@@ -300,7 +300,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "comm_scope",
+					policyName: "comm-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -311,7 +311,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "container=new",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "container_scope",
+					Name: "container-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"container=new"},
@@ -323,7 +323,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "container_scope",
+					policyName: "container-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "container=new",
@@ -335,7 +335,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "container_scope",
+					policyName: "container-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -346,7 +346,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "!container",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "!container_scope",
+					Name: "!container-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"!container"},
@@ -358,7 +358,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "!container_scope",
+					policyName: "!container-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "!container",
@@ -370,7 +370,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "!container_scope",
+					policyName: "!container-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -381,7 +381,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "container",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "container_scope",
+					Name: "container-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"container"},
@@ -393,7 +393,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "container_scope",
+					policyName: "container-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "container",
@@ -405,7 +405,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "container_scope",
+					policyName: "container-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -416,7 +416,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "tree=3213,5200",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "tree_scope",
+					Name: "tree-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"tree=3213,5200"},
@@ -428,7 +428,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "tree_scope",
+					policyName: "tree-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "tree=3213,5200",
@@ -440,7 +440,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "tree_scope",
+					policyName: "tree-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -451,7 +451,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "scope with space",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "scope_with_space",
+					Name: "scope-with-space",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"tree = 3213"},
@@ -463,7 +463,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "scope_with_space",
+					policyName: "scope-with-space",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "tree=3213",
@@ -475,7 +475,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "scope_with_space",
+					policyName: "scope-with-space",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -486,7 +486,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "binary=host:/usr/bin/ls",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "binary_scope",
+					Name: "binary-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"binary=host:/usr/bin/ls"},
@@ -498,7 +498,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "binary_scope",
+					policyName: "binary-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "binary=host:/usr/bin/ls",
@@ -510,7 +510,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "binary_scope",
+					policyName: "binary-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -522,7 +522,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "bin=4026532448:/usr/bin/ls",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "bin_scope",
+					Name: "bin-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"bin=4026532448:/usr/bin/ls"},
@@ -534,7 +534,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "bin_scope",
+					policyName: "bin-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "bin=4026532448:/usr/bin/ls",
@@ -546,7 +546,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "bin_scope",
+					policyName: "bin-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -557,7 +557,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "follow",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "follow_scope",
+					Name: "follow-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"follow"},
@@ -569,7 +569,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "follow_scope",
+					policyName: "follow-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "follow",
@@ -581,7 +581,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "follow_scope",
+					policyName: "follow-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -592,7 +592,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "multiple scopes",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "multiple_scope",
+					Name: "multiple-scope",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"comm=bash", "follow", "!container", "uid=1000"},
@@ -604,7 +604,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyScopeMap: PolicyScopeMap{
 				0: {
-					policyName: "multiple_scope",
+					policyName: "multiple-scope",
 					scopeFlags: []scopeFlag{
 						{
 							full:              "comm=bash",
@@ -631,7 +631,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "multiple_scope",
+					policyName: "multiple-scope",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 					},
@@ -648,7 +648,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "args filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "args_filter",
+					Name: "args-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -664,7 +664,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "args_filter",
+					policyName: "args-filter",
 					eventFlags: []eventFlag{
 						{
 							full:              "security_file_open",
@@ -686,7 +686,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "return filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "return_filter",
+					Name: "return-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -702,7 +702,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "return_filter",
+					policyName: "return-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -720,7 +720,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "timestamp filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "timestamp_filter",
+					Name: "timestamp-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -736,7 +736,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "timestamp_filter",
+					policyName: "timestamp-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -753,7 +753,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "processorId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "processorId_filter",
+					Name: "processorId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -769,7 +769,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "processorId_filter",
+					policyName: "processorId-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -786,7 +786,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "p filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "p_filter",
+					Name: "p-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -802,7 +802,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "p_filter",
+					policyName: "p-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -819,7 +819,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "pid filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "pid_filter",
+					Name: "pid-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -835,7 +835,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "pid_filter",
+					policyName: "pid-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -852,7 +852,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "processId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "processId_filter",
+					Name: "processId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -868,7 +868,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "processId_filter",
+					policyName: "processId-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -885,7 +885,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "tid filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "tid_filter",
+					Name: "tid-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -901,7 +901,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "tid_filter",
+					policyName: "tid-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -918,7 +918,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "threadId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "threadId_filter",
+					Name: "threadId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -934,7 +934,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "threadId_filter",
+					policyName: "threadId-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -984,7 +984,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "parentProcessId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "parentProcessId_filter",
+					Name: "parentProcessId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1000,7 +1000,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "parentProcessId_filter",
+					policyName: "parentProcessId-filter",
 					eventFlags: []eventFlag{
 						writeEvtFlag,
 						{
@@ -1017,7 +1017,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "hostTid filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "hostTid_filter",
+					Name: "hostTid-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1033,7 +1033,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "hostTid_filter",
+					policyName: "hostTid-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1050,7 +1050,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "hostThreadId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "hostThreadId_filter",
+					Name: "hostThreadId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1066,7 +1066,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "hostThreadId_filter",
+					policyName: "hostThreadId-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1083,7 +1083,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "hostPid filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "hostPid_filter",
+					Name: "hostPid-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1099,7 +1099,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "hostPid_filter",
+					policyName: "hostPid-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1116,7 +1116,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "hostParentProcessID filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "hostParentProcessId_filter",
+					Name: "hostParentProcessId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1132,7 +1132,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "hostParentProcessId_filter",
+					policyName: "hostParentProcessId-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1149,7 +1149,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "userId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "userId_filter",
+					Name: "userId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1165,7 +1165,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "userId_filter",
+					policyName: "userId-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1182,7 +1182,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "mntns filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "mntns_filter",
+					Name: "mntns-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1198,7 +1198,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "mntns_filter",
+					policyName: "mntns-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1215,7 +1215,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "mountNamespace filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "mountNamespace_filter",
+					Name: "mountNamespace-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1231,7 +1231,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "mountNamespace_filter",
+					policyName: "mountNamespace-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1248,7 +1248,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "pidns filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "pidns_filter",
+					Name: "pidns-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1264,7 +1264,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "pidns_filter",
+					policyName: "pidns-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1281,7 +1281,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "pidNamespace filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "pidNamespace_filter",
+					Name: "pidNamespace-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1297,7 +1297,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "pidNamespace_filter",
+					policyName: "pidNamespace-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1314,7 +1314,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "processName filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "processName_filter",
+					Name: "processName-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1330,7 +1330,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "processName_filter",
+					policyName: "processName-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1347,7 +1347,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "comm filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "comm_filter",
+					Name: "comm-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1363,7 +1363,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "comm_filter",
+					policyName: "comm-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1380,7 +1380,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "hostName filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "hostName_filter",
+					Name: "hostName-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1396,7 +1396,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "hostName_filter",
+					policyName: "hostName-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1479,7 +1479,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "container filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "container_filter",
+					Name: "container-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1495,7 +1495,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "container_filter",
+					policyName: "container-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1512,7 +1512,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "containerId filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "containerId_filter",
+					Name: "containerId-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1528,7 +1528,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "containerId_filter",
+					policyName: "containerId-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1545,7 +1545,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "containerImage filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "containerImage_filter",
+					Name: "containerImage-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1561,7 +1561,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "containerImage_filter",
+					policyName: "containerImage-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1578,7 +1578,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "containerName filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "containerName_filter",
+					Name: "containerName-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1594,7 +1594,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "containerName_filter",
+					policyName: "containerName-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1611,7 +1611,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "podName filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "podName_filter",
+					Name: "podName-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1627,7 +1627,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "podName_filter",
+					policyName: "podName-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1644,7 +1644,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "podNamespace filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "podNamespace_filter",
+					Name: "podNamespace-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1660,7 +1660,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "podNamespace_filter",
+					policyName: "podNamespace-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{
@@ -1677,7 +1677,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			testName: "podUid filter",
 			policy: v1beta1.PolicyFile{
 				Metadata: v1beta1.Metadata{
-					Name: "podUid_filter",
+					Name: "podUid-filter",
 				},
 				Spec: v1beta1.PolicySpec{
 					Scope:          []string{"global"},
@@ -1693,7 +1693,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 			expPolicyScopeMap: PolicyScopeMap{},
 			expPolicyEventMap: PolicyEventMap{
 				0: {
-					policyName: "podUid_filter",
+					policyName: "podUid-filter",
 					eventFlags: []eventFlag{
 						readEvtFlag,
 						{

--- a/pkg/policy/v1beta1/policy_file.go
+++ b/pkg/policy/v1beta1/policy_file.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
@@ -67,8 +68,8 @@ func (p PolicyFile) Rules() []Rule {
 }
 
 func (p PolicyFile) Validate() error {
-	if p.Name() == "" {
-		return errfmt.Errorf("policy name cannot be empty")
+	if err := validation.IsDNS1123Subdomain(p.Name()); err != nil {
+		return errfmt.Errorf("policy name %s is invalid: %s", p.Name(), err)
 	}
 
 	if p.APIVersion != "aquasecurity.github.io/v1beta1" {

--- a/pkg/policy/v1beta1/policy_file_test.go
+++ b/pkg/policy/v1beta1/policy_file_test.go
@@ -22,44 +22,37 @@ func TestPolicyValidate(t *testing.T) {
 		expectedPolicyError bool
 	}{
 		{
-			testName: "empty name",
-			policy: PolicyFile{
-				Metadata: Metadata{Name: ""},
-			},
-			expectedError: errors.New("policy name cannot be empty"),
-		},
-		{
 			testName: "empty API",
 			policy: PolicyFile{
 				APIVersion: "",
-				Metadata:   Metadata{Name: "emptyAPI"},
+				Metadata:   Metadata{Name: "empty-api"},
 			},
-			expectedError: errors.New("policy emptyAPI, apiVersion not supported"),
+			expectedError: errors.New("policy empty-api, apiVersion not supported"),
 		},
 		{
 			testName: "invalid API",
 			policy: PolicyFile{
 				APIVersion: "aquasecurity.github.io/test",
-				Metadata:   Metadata{Name: "invalidAPI"},
+				Metadata:   Metadata{Name: "invalid-api"},
 			},
-			expectedError: errors.New("policy invalidAPI, apiVersion not supported"),
+			expectedError: errors.New("policy invalid-api, apiVersion not supported"),
 		},
 		{
 			testName: "empty Kind",
 			policy: PolicyFile{
 				APIVersion: "aquasecurity.github.io/v1beta1",
-				Metadata:   Metadata{Name: "emptyKind"},
+				Metadata:   Metadata{Name: "empty-kind"},
 			},
-			expectedError: errors.New("policy emptyKind, kind not supported"),
+			expectedError: errors.New("policy empty-kind, kind not supported"),
 		},
 		{
 			testName: "invalid Kind",
 			policy: PolicyFile{
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "Policy",
-				Metadata:   Metadata{Name: "invalidKind"},
+				Metadata:   Metadata{Name: "invalid-kind"},
 			},
-			expectedError: errors.New("policy invalidKind, kind not supported"),
+			expectedError: errors.New("policy invalid-kind, kind not supported"),
 		},
 		{
 			testName: "empty scope",
@@ -67,14 +60,14 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_scope",
+					Name: "empty-scope",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{},
 					DefaultActions: []string{"log"},
 				},
 			},
-			expectedError: errors.New("policy empty_scope, scope cannot be empty"),
+			expectedError: errors.New("policy empty-scope, scope cannot be empty"),
 		},
 		{
 			testName: "empty rules",
@@ -82,7 +75,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_rules",
+					Name: "empty-rules",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -90,7 +83,7 @@ func TestPolicyValidate(t *testing.T) {
 					Rules:          []Rule{},
 				},
 			},
-			expectedError: errors.New("policy empty_rules, rules cannot be empty"),
+			expectedError: errors.New("policy empty-rules, rules cannot be empty"),
 		},
 		{
 			testName: "empty event name",
@@ -98,7 +91,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_event_name",
+					Name: "empty-event-name",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -108,7 +101,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.validateEvent: policy empty_event_name, event cannot be empty"),
+			expectedError: errors.New("v1beta1.validateEvent: policy empty-event-name, event cannot be empty"),
 		},
 		{
 			testName: "invalid event name",
@@ -116,7 +109,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_event_name",
+					Name: "invalid-event-name",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -126,7 +119,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.validateEvent: policy invalid_event_name, event non_existing_event is not valid"),
+			expectedError: errors.New("v1beta1.validateEvent: policy invalid-event-name, event non_existing_event is not valid"),
 		},
 		{
 			testName: "invalid_scope_operator",
@@ -134,7 +127,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_scope_operator",
+					Name: "invalid-scope-operator",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"random"},
@@ -144,7 +137,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.parseScope: policy invalid_scope_operator, scope random is not valid"),
+			expectedError: errors.New("v1beta1.parseScope: policy invalid-scope-operator, scope random is not valid"),
 		},
 		{
 			testName: "invalid_scope",
@@ -152,7 +145,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_scope",
+					Name: "invalid-scope",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"random!=0"},
@@ -162,7 +155,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateScope: policy invalid_scope, scope random is not valid"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateScope: policy invalid-scope, scope random is not valid"),
 		},
 		{
 			testName: "global scope must be unique",
@@ -170,7 +163,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "global_scope_must_be_unique",
+					Name: "global-scope-must-be-unique",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global", "uid=1000"},
@@ -180,7 +173,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("policy global_scope_must_be_unique, global scope must be unique"),
+			expectedError: errors.New("policy global-scope-must-be-unique, global scope must be unique"),
 		},
 		{
 			testName: "duplicated event",
@@ -188,7 +181,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "duplicated_event",
+					Name: "duplicated-event",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -199,7 +192,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("policy duplicated_event, event write is duplicated"),
+			expectedError: errors.New("policy duplicated-event, event write is duplicated"),
 		},
 		{
 			testName: "invalid filter operator",
@@ -207,7 +200,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_filter_operator",
+					Name: "invalid-filter-operator",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -222,7 +215,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy invalid_filter_operator, invalid filter operator: random"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy invalid-filter-operator, invalid filter operator: random"),
 		},
 		{
 			testName: "invalid policy action",
@@ -230,7 +223,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_policy_action",
+					Name: "invalid-policy-action",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -240,7 +233,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.validateActions: policy invalid_policy_action, action audit is not valid"),
+			expectedError: errors.New("v1beta1.validateActions: policy invalid-policy-action, action audit is not valid"),
 		},
 		{
 			testName: "invalid retval",
@@ -248,7 +241,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_retval",
+					Name: "invalid-retval",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -263,7 +256,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy invalid_retval, invalid filter operator: retval"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy invalid-retval, invalid filter operator: retval"),
 		},
 		{
 			testName: "empty retval",
@@ -271,7 +264,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_retval",
+					Name: "empty-retval",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -286,7 +279,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty_retval, retval cannot be empty"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty-retval, retval cannot be empty"),
 		},
 		{
 			testName: "retval not an integer",
@@ -294,7 +287,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "retval_not_an_integer",
+					Name: "retval-not-an-integer",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -309,7 +302,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy retval_not_an_integer, retval must be an integer: lala"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy retval-not-an-integer, retval must be an integer: lala"),
 		},
 		{
 			testName: "empty arg name 1",
@@ -317,7 +310,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_filter_arg_1",
+					Name: "empty-filter-arg-1",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -332,7 +325,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty_filter_arg_1, invalid filter operator: args"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty-filter-arg-1, invalid filter operator: args"),
 		},
 		{
 			testName: "empty arg name 3",
@@ -340,7 +333,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_filter_arg_3",
+					Name: "empty-filter-arg-3",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -355,7 +348,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty_filter_arg_3, arg name can't be empty"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty-filter-arg-3, arg name can't be empty"),
 		},
 		{
 			testName: "empty arg name 4",
@@ -363,7 +356,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_filter_arg_4",
+					Name: "empty-filter-arg-4",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -378,7 +371,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty_filter_arg_4, arg name can't be empty"),
+			expectedError: errors.New("v1beta1.PolicyFile.validateRules: policy empty-filter-arg-4, arg name can't be empty"),
 		},
 		{
 			testName: "invalid arg",
@@ -386,7 +379,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "invalid_arg",
+					Name: "invalid-arg",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -401,7 +394,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.validateEventArg: policy invalid_arg, event openat does not have argument lala"),
+			expectedError: errors.New("v1beta1.validateEventArg: policy invalid-arg, event openat does not have argument lala"),
 		},
 		{
 			testName: "empty arg value",
@@ -409,7 +402,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_arg_value",
+					Name: "empty-arg-value",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -424,7 +417,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.validateEventArg: policy empty_arg_value, arg pathname value can't be empty"),
+			expectedError: errors.New("v1beta1.validateEventArg: policy empty-arg-value, arg pathname value can't be empty"),
 		},
 		{
 			testName: "empty arg value",
@@ -432,7 +425,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "empty_arg_value",
+					Name: "empty-arg-value",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},
@@ -447,7 +440,7 @@ func TestPolicyValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("v1beta1.validateEventArg: policy empty_arg_value, arg pathname value can't be empty"),
+			expectedError: errors.New("v1beta1.validateEventArg: policy empty-arg-value, arg pathname value can't be empty"),
 		},
 		{
 			testName: "signature filter arg",
@@ -455,7 +448,7 @@ func TestPolicyValidate(t *testing.T) {
 				APIVersion: "aquasecurity.github.io/v1beta1",
 				Kind:       "TraceePolicy",
 				Metadata: Metadata{
-					Name: "signature_filter_arg",
+					Name: "signature-filter-arg",
 				},
 				Spec: PolicySpec{
 					Scope:          []string{"global"},

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -43,7 +43,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "container_event",
+							Name: "container-event",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -69,7 +69,7 @@ func Test_EventFilters(t *testing.T) {
 					"docker run -d --rm hello-world",
 					10*time.Second, // give some time for the container to start (possibly downloading the image)
 					[]trace.Event{
-						expectEvent(anyHost, "hello", anyProcessorID, 1, 0, events.SchedProcessExec, orPolNames("container_event"), orPolIDs(1)),
+						expectEvent(anyHost, "hello", anyProcessorID, 1, 0, events.SchedProcessExec, orPolNames("container-event"), orPolIDs(1)),
 					},
 					[]string{}, // no sets
 				),
@@ -84,7 +84,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event",
+							Name: "comm-event",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -110,8 +110,8 @@ func Test_EventFilters(t *testing.T) {
 					"ping -c1 0.0.0.0",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm_event"), orPolIDs(1)),
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm_event"), orPolIDs(1)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm-event"), orPolIDs(1)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm-event"), orPolIDs(1)),
 					},
 					[]string{},
 				),
@@ -126,7 +126,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 5,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event",
+							Name: "comm-event",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -148,8 +148,8 @@ func Test_EventFilters(t *testing.T) {
 					"ping -c1 0.0.0.0",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event"), orPolIDs(5)),
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event"), orPolIDs(5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event"), orPolIDs(5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event"), orPolIDs(5)),
 					},
 					[]string{},
 				),
@@ -164,7 +164,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "event_args",
+							Name: "event-args",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -189,7 +189,7 @@ func Test_EventFilters(t *testing.T) {
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "integration.tes", // note that comm name is from the go test binary that runs the command
-							testutils.CPUForTests, anyPID, 0, events.Execve, orPolNames("event_args"), orPolIDs(42), expectArg("pathname", "*ls")),
+							testutils.CPUForTests, anyPID, 0, events.Execve, orPolNames("event-args"), orPolIDs(42), expectArg("pathname", "*ls")),
 					},
 					[]string{},
 				),
@@ -204,7 +204,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "event_args",
+							Name: "event-args",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -239,7 +239,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_args",
+							Name: "comm-event-args",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -263,7 +263,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("comm_event_args"), orPolIDs(42), expectArg("pathname", "*integration")),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("comm-event-args"), orPolIDs(42), expectArg("pathname", "*integration")),
 					},
 					[]string{},
 				),
@@ -278,7 +278,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 4,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_4",
+							Name: "comm-event-4",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -298,7 +298,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 2,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_2",
+							Name: "comm-event-2",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -319,14 +319,14 @@ func Test_EventFilters(t *testing.T) {
 				newCmdEvents("ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm_event_4"), orPolIDs(4)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm-event-4"), orPolIDs(4)),
 					},
 					[]string{},
 				),
 				newCmdEvents("uname",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "uname", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm_event_2"), orPolIDs(2)),
+						expectEvent(anyHost, "uname", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm-event-2"), orPolIDs(2)),
 					},
 					[]string{},
 				),
@@ -341,7 +341,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "bin_event_1",
+							Name: "bin-event-1",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -361,7 +361,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 2,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "bin_event_2",
+							Name: "bin-event-2",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -382,14 +382,14 @@ func Test_EventFilters(t *testing.T) {
 				newCmdEvents("who",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("bin_event_1"), orPolIDs(1)),
+						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("bin-event-1"), orPolIDs(1)),
 					},
 					[]string{},
 				),
 				newCmdEvents("uname",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "uname", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("bin_event_2"), orPolIDs(2)),
+						expectEvent(anyHost, "uname", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("bin-event-2"), orPolIDs(2)),
 					},
 					[]string{},
 				),
@@ -406,7 +406,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "pid_0_event_args",
+							Name: "pid-0-event-args",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -430,8 +430,8 @@ func Test_EventFilters(t *testing.T) {
 					"kill -SIGHUP 1", // reloads the complete daemon configuration
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid_0_event_args"), orPolIDs(1), expectArg("next_comm", "systemd")),
-						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid_0_event_args"), orPolIDs(1), expectArg("next_comm", "init")),
+						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-args"), orPolIDs(1), expectArg("next_comm", "systemd")),
+						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-args"), orPolIDs(1), expectArg("next_comm", "init")),
 					},
 					[]string{},
 				),
@@ -446,7 +446,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "pid_1",
+							Name: "pid-1",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -463,8 +463,8 @@ func Test_EventFilters(t *testing.T) {
 					"kill -SIGHUP 1", // reloads the complete daemon configuration
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "init", anyProcessorID, 1, 0, anyEventID, orPolNames("pid_1"), orPolIDs(1)),
-						expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, anyEventID, orPolNames("pid_1"), orPolIDs(1)),
+						expectEvent(anyHost, "init", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
+						expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
 					},
 					[]string{},
 				),
@@ -479,7 +479,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "uid_0_comm",
+							Name: "uid-0-comm",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -497,7 +497,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("uid_0_comm"), orPolIDs(1)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("uid-0-comm"), orPolIDs(1)),
 					},
 					[]string{},
 				),
@@ -512,7 +512,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "uid_0_comm",
+							Name: "uid-0-comm",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -543,7 +543,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "event_fs",
+							Name: "event-fs",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -565,7 +565,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("event_fs"), orPolIDs(1)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("event-fs"), orPolIDs(1)),
 					},
 					[]string{"fs"},
 				),
@@ -580,7 +580,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "bin_event",
+							Name: "bin-event",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -603,7 +603,7 @@ func Test_EventFilters(t *testing.T) {
 					10*time.Second, // give some time for the container to start (possibly downloading the image)
 					[]trace.Event{
 						// using anyComm as some versions of dockerd may result in e.g. "dockerd" or "exe"
-						expectEvent(anyHost, anyComm, anyProcessorID, anyPID, 0, events.Setns, orPolNames("bin_event"), orPolIDs(1)),
+						expectEvent(anyHost, anyComm, anyProcessorID, anyPID, 0, events.Setns, orPolNames("bin-event"), orPolIDs(1)),
 					},
 					[]string{},
 				),
@@ -618,7 +618,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "pid_new",
+							Name: "pid-new",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -649,7 +649,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_64",
+							Name: "comm-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -666,7 +666,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_64"), orPolIDs(64)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64"), orPolIDs(64)),
 					},
 					[]string{},
 				),
@@ -681,7 +681,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_64",
+							Name: "comm-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -697,7 +697,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_42",
+							Name: "comm-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -714,7 +714,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_64"), orPolIDs(64)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64"), orPolIDs(64)),
 					},
 					[]string{},
 				),
@@ -729,7 +729,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_64",
+							Name: "comm-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -744,7 +744,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_42",
+							Name: "comm-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -761,7 +761,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_64"), orPolIDs(64)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64"), orPolIDs(64)),
 					},
 					[]string{},
 				),
@@ -769,7 +769,7 @@ func Test_EventFilters(t *testing.T) {
 					"who",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_42"), orPolIDs(42)),
+						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-42"), orPolIDs(42)),
 					},
 					[]string{},
 				),
@@ -784,7 +784,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "event_args_context",
+							Name: "event-args-context",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -810,7 +810,7 @@ func Test_EventFilters(t *testing.T) {
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "bash", // note that comm name is from the runner
-							testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("event_args_context"), orPolIDs(42), expectArg("pathname", "*ls")),
+							testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("event-args-context"), orPolIDs(42), expectArg("pathname", "*ls")),
 					},
 					[]string{},
 				),
@@ -825,7 +825,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event",
+							Name: "comm-event",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -847,7 +847,7 @@ func Test_EventFilters(t *testing.T) {
 					"bash -c '/usr/bin/tee /tmp/magic_write_test < <(echo 42)'",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "tee", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("comm_event"), orPolIDs(42)),
+						expectEvent(anyHost, "tee", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("comm-event"), orPolIDs(42)),
 					},
 					[]string{},
 				),
@@ -865,7 +865,7 @@ func Test_EventFilters(t *testing.T) {
 		// 		{
 		// 			id: 3,
 		// 			policyFile: v1beta1.PolicyFile{
-		// 				Name:          "comm_event",
+		// 				Name:          "comm-event",
 		// 				Scope:         []string{"comm=ping"},
 		// 				DefaultActions: []string{"log"},
 		// 				Rules: []v1beta1.Rule{
@@ -879,7 +879,7 @@ func Test_EventFilters(t *testing.T) {
 		// 		{
 		// 			id: 5,
 		// 			policyFile: v1beta1.PolicyFile{
-		// 				Name:          "event_args",
+		// 				Name:          "event-args",
 		// 				Scope:         []string{},
 		// 				DefaultActions: []string{"log"},
 		// 				Rules: []v1beta1.Rule{
@@ -910,7 +910,7 @@ func Test_EventFilters(t *testing.T) {
 		// 			"ping -c1 0.0.0.0",
 		// 			1*time.Second,
 		// 			[]trace.Event{
-		// 				expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event"), orPolIDs(3)),
+		// 				expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event"), orPolIDs(3)),
 		// 			},
 		// 			[]string{},
 		// 		),
@@ -918,7 +918,7 @@ func Test_EventFilters(t *testing.T) {
 		// 			"strace ls",
 		// 			1*time.Second,
 		// 			[]trace.Event{
-		// 				expectEvent(anyHost, "strace", testutils.CPUForTests, anyPID, 0, events.Ptrace, orPolNames("event_args"), orPolIDs(5)),
+		// 				expectEvent(anyHost, "strace", testutils.CPUForTests, anyPID, 0, events.Ptrace, orPolNames("event-args"), orPolIDs(5)),
 		// 				expectEvent(anyHost, "strace", testutils.CPUForTests, anyPID, 0, events.anti_debugging, orPolNames("sign"), orPolIDs(9)),
 		// 			},
 		// 			[]string{},
@@ -936,7 +936,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 3,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_3",
+							Name: "comm-event-3",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -956,7 +956,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 5,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_5",
+							Name: "comm-event-5",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -978,8 +978,8 @@ func Test_EventFilters(t *testing.T) {
 					"ping -c1 0.0.0.0",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event_3", "comm_event_5"), orPolIDs(3, 5)),
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event_3", "comm_event_5"), orPolIDs(3, 5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
 					},
 					[]string{},
 				),
@@ -994,7 +994,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 3,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_3",
+							Name: "comm-event-3",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1014,7 +1014,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 5,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_5",
+							Name: "comm-event-5",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1040,10 +1040,10 @@ func Test_EventFilters(t *testing.T) {
 					"ping -c1 0.0.0.0",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.Setuid, orPolNames("comm_event_5"), orPolIDs(5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.Setuid, orPolNames("comm-event-5"), orPolIDs(5)),
 
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event_3", "comm_event_5"), orPolIDs(3, 5)),
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event_3", "comm_event_5"), orPolIDs(3, 5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
 					},
 					[]string{},
 				),
@@ -1058,7 +1058,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 3,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_3",
+							Name: "comm-event-3",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1078,7 +1078,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 5,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_5",
+							Name: "comm-event-5",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1098,7 +1098,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 7,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_7",
+							Name: "comm-event-7",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1118,7 +1118,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 9,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_9",
+							Name: "comm-event-9",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1144,12 +1144,12 @@ func Test_EventFilters(t *testing.T) {
 					"ping -c1 0.0.0.0",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm_event_7", "comm_event_9"), orPolIDs(7, 9)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm-event-7", "comm-event-9"), orPolIDs(7, 9)),
 
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SecuritySocketConnect, orPolNames("comm_event_9"), orPolIDs(9)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SecuritySocketConnect, orPolNames("comm-event-9"), orPolIDs(9)),
 
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event_3", "comm_event_5"), orPolIDs(3, 5)),
-						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm_event_3", "comm_event_5"), orPolIDs(3, 5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
+						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
 					},
 					[]string{},
 				),
@@ -1164,7 +1164,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_64",
+							Name: "comm-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1179,7 +1179,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_42",
+							Name: "comm-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1197,7 +1197,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_64", "comm_42"), orPolIDs(64, 42)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64", "comm-42"), orPolIDs(64, 42)),
 					},
 					[]string{},
 				),
@@ -1205,7 +1205,7 @@ func Test_EventFilters(t *testing.T) {
 					"who",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_42"), orPolIDs(42)),
+						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-42"), orPolIDs(42)),
 					},
 					[]string{},
 				),
@@ -1220,7 +1220,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_64",
+							Name: "comm-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1235,7 +1235,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_42",
+							Name: "comm-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1252,7 +1252,7 @@ func Test_EventFilters(t *testing.T) {
 					"ls",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_64", "comm_42"), orPolIDs(64, 42)),
+						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64", "comm-42"), orPolIDs(64, 42)),
 					},
 					[]string{},
 				),
@@ -1260,7 +1260,7 @@ func Test_EventFilters(t *testing.T) {
 					"who",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm_42"), orPolIDs(42)),
+						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-42"), orPolIDs(42)),
 					},
 					[]string{},
 				),
@@ -1281,7 +1281,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 1,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event",
+							Name: "comm-event",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1307,8 +1307,8 @@ func Test_EventFilters(t *testing.T) {
 					"fakeprog1",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Read, orPolNames("comm_event"), orPolIDs(1)),
-						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Write, orPolNames("comm_event"), orPolIDs(1)),
+						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Read, orPolNames("comm-event"), orPolIDs(1)),
+						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Write, orPolNames("comm-event"), orPolIDs(1)),
 					},
 					[]string{},
 				),
@@ -1323,7 +1323,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "event_pol_42",
+							Name: "event-pol-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope:          []string{"global"},
@@ -1343,7 +1343,7 @@ func Test_EventFilters(t *testing.T) {
 					"fakeprog1",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Execve, orPolNames("event_pol_42"), orPolIDs(42)),
+						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Execve, orPolNames("event-pol-42"), orPolIDs(42)),
 					},
 					[]string{},
 				),
@@ -1358,7 +1358,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_args_64",
+							Name: "comm-event-args-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1382,7 +1382,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_args_42",
+							Name: "comm-event-args-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1407,7 +1407,7 @@ func Test_EventFilters(t *testing.T) {
 					"fakeprog1",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Openat, orPolNames("comm_event_args_64"), orPolIDs(64),
+						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Openat, orPolNames("comm-event-args-64"), orPolIDs(64),
 							expectArg("dirfd", int32(0)),
 							expectArg("flags", int32(0)),
 							expectArg("mode", uint32(0)),
@@ -1419,7 +1419,7 @@ func Test_EventFilters(t *testing.T) {
 					"fakeprog2",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "fakeprog2", testutils.CPUForTests, anyPID, 0, events.Open, orPolNames("comm_event_args_42"), orPolIDs(42),
+						expectEvent(anyHost, "fakeprog2", testutils.CPUForTests, anyPID, 0, events.Open, orPolNames("comm-event-args-42"), orPolIDs(42),
 							expectArg("flags", int32(0)),
 							expectArg("mode", uint32(0)),
 						),
@@ -1437,7 +1437,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 64,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_retval_64",
+							Name: "comm-event-retval-64",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1460,7 +1460,7 @@ func Test_EventFilters(t *testing.T) {
 					id: 42,
 					policyFile: v1beta1.PolicyFile{
 						Metadata: v1beta1.Metadata{
-							Name: "comm_event_retval_42",
+							Name: "comm-event-retval-42",
 						},
 						Spec: v1beta1.PolicySpec{
 							Scope: []string{
@@ -1484,7 +1484,7 @@ func Test_EventFilters(t *testing.T) {
 					"fakeprog1",
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Openat, orPolNames("comm_event_retval_64"), orPolIDs(64),
+						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Openat, orPolNames("comm-event-retval-64"), orPolIDs(64),
 							expectArg("dirfd", int32(0)),
 							expectArg("flags", int32(0)),
 							expectArg("mode", uint32(0)),


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3333

Policy names must be k8s compatible, which means defined as [RFC 1123](https://tools.ietf.org/html/rfc1123). 
So the name must:

contain no more than 63 characters
contain only lowercase alphanumeric characters, '-' or '.'
start with an alphanumeric character
end with an alphanumeric character

https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

<!-- Best advice is to put copy & paste your very well written git logs -->

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
