### PR TITLE
[v0.17.0] fix(ebpf): size of mntns/pidns filters key holders (#3337)

### DIFF
--- a/pkg/ebpf/c/common/filtering.h
+++ b/pkg/ebpf/c/common/filtering.h
@@ -239,14 +239,14 @@ statfunc u64 compute_scopes(program_data_t *p)
     if (p->config->mnt_ns_filter_enabled_scopes) {
         u64 filter_out_scopes = p->config->mnt_ns_filter_out_scopes;
         u64 mask = ~p->config->mnt_ns_filter_enabled_scopes;
-        u32 mnt_id = context->mnt_id;
+        u64 mnt_id = context->mnt_id;
         res &= equality_filter_matches(filter_out_scopes, &mnt_ns_filter, &mnt_id) | mask;
     }
 
     if (p->config->pid_ns_filter_enabled_scopes) {
         u64 filter_out_scopes = p->config->pid_ns_filter_out_scopes;
         u64 mask = ~p->config->pid_ns_filter_enabled_scopes;
-        u32 pid_id = context->pid_id;
+        u64 pid_id = context->pid_id;
         res &= equality_filter_matches(filter_out_scopes, &pid_ns_filter, &pid_id) | mask;
     }
 

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
 	"github.com/aquasecurity/tracee/pkg/config"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	uproc "github.com/aquasecurity/tracee/pkg/utils/proc"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -229,4 +231,14 @@ func assureIsRoot(t *testing.T) {
 	if syscall.Geteuid() != 0 {
 		t.Skipf("***** %s must be run as ROOT *****", t.Name())
 	}
+}
+
+func getProcNS(nsName string) string {
+	pid := syscall.Getpid()
+	nsID, err := uproc.GetProcNS(uint(pid), nsName)
+	if err != nil {
+		panic(err)
+	}
+
+	return strconv.Itoa(nsID)
 }


### PR DESCRIPTION
### 1. Explain what the PR does

32ff32e26 **fix(ebpf): size of mntns/pidns filters key holders (#3337)** _<sub>(2023/jul/25) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
Even though the namespace id is a 32-bit integer, the key size for the
mntns/pidns filters has been set to 64-bit. This caused these filters to
not work correctly as their key value was being read beyond limits.

Chore: Add integration tests for mntns/pidns filters.

commit: bb8c4c8 (main), cherry-pick
```

### 2. Explain how to test it


### 3. Other comments
