### PR TITLE
fix: data source registration after NewEngine

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -156,7 +156,11 @@ func main() {
 				c.Bool(server.PProfEndpointFlag),
 				c.Bool(server.PyroscopeAgentFlag),
 			)
+			if err != nil {
+				return err
+			}
 
+			err = e.Init()
 			if err != nil {
 				return err
 			}

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -357,9 +357,11 @@ func TestEngine_ConsumeSources(t *testing.T) {
 
 			e, err := NewEngine(tc.config, inputs, outputChan)
 			require.NoError(t, err, "constructing engine")
-			go func() {
-				e.Start(ctx)
-			}()
+
+			err = e.Init()
+			require.NoError(t, err, "initializing engine")
+
+			go e.Start(ctx)
 
 			// send a test event
 			e.inputs.Tracee <- tc.inputEvent
@@ -419,6 +421,10 @@ func TestEngine_GetSelectedEvents(t *testing.T) {
 	config := Config{Signatures: sigs}
 	e, err := NewEngine(config, EventSources{Tracee: make(chan protocol.Event)}, make(chan detect.Finding))
 	require.NoError(t, err, "constructing engine")
+
+	err = e.Init()
+	require.NoError(t, err, "initializing engine")
+
 	se := e.GetSelectedEvents()
 	expected := []detect.SignatureEventSelector{
 		{


### PR DESCRIPTION
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Wed Jul 26 15:03:21 2023 +0000

chore (engine): split Init from NewEngine

Previously data sources could not be registered after the NewEngine call
call and be used in signatures, due to the Init calls being made in
NewEngine.

Fix by moving the loadSignature and initial data source registers to
a new Init method from NewEngine.

In addition, export a method in tracee to prepare the builtin data
sources provided out of the box.
```

Fix #3341

Needs backport into v0.16.0 and v0.17.0