### PR TITLE
[v0.17.0] fix(flags)!: del help cmd, add md files for flags (#3321)

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -31,7 +31,7 @@ func main() {
 			// Logger Setup
 			logger.Init(logger.NewDefaultLoggingConfig())
 
-			flags.PrintAndExitIfHelp(c, false)
+			flags.PrintAndExitIfHelp(c)
 
 			if c.Bool("list") {
 				cmd.PrintEventList(false) // list events

--- a/cmd/tracee/cmd/analyze.go
+++ b/cmd/tracee/cmd/analyze.go
@@ -27,25 +27,6 @@ import (
 func init() {
 	rootCmd.AddCommand(analyze)
 
-	hfFallback := rootCmd.HelpFunc()
-	// Override default help function to support help for flags.
-	// Since for commands the usage is tracee help <command>, for flags
-	// the usage is tracee --help <flag>.
-	// e.g. tracee analyze --help rego
-	//      tracee analyze -h rego
-	analyze.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if len(args) > 2 && (args[1] == "--help" || args[1] == "-h") {
-			flagHelp := flags.GetHelpString(args[2], true)
-			if flagHelp != "" {
-				fmt.Fprintf(os.Stdout, "%s\n", flagHelp)
-				os.Exit(0)
-			}
-		}
-
-		// If flag help was not found, fallback to default help function
-		hfFallback(cmd, args)
-	})
-
 	// flags
 
 	// events

--- a/cmd/tracee/cmd/list.go
+++ b/cmd/tracee/cmd/list.go
@@ -29,7 +29,6 @@ var listCmd = &cobra.Command{
 	Long:    ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get signatures to update event list
-
 		sigsDir, err := cmd.Flags().GetStringArray("signatures-dir")
 		if err != nil {
 			logger.Fatalw("Failed to get signatures-dir flag", "err", err)

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/viper"
 
 	cmdcobra "github.com/aquasecurity/tracee/pkg/cmd/cobra"
-	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -26,6 +25,26 @@ var (
 		Short: "Trace OS events and syscalls using eBPF",
 		Long: `Tracee uses eBPF technology to tap into your system and give you
 access to hundreds of events that help you understand how your system behaves.`,
+		DisableFlagParsing: true, // in order to have fine grained control over flags parsing
+		PreRun: func(cmd *cobra.Command, args []string) {
+			if len(args) > 0 {
+				// parse --help, -h flags as the first argument
+				if len(args) == 1 && (args[0] == "--help" || args[0] == "-h") {
+					if err := cmd.Help(); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+						os.Exit(1)
+					}
+					os.Exit(0)
+				}
+
+				// parse all other flags
+				if err := cmd.Flags().Parse(args); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+					fmt.Fprintf(os.Stderr, "Run 'tracee --help' for usage.\n")
+					os.Exit(1)
+				}
+			}
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			logger.Init(logger.NewDefaultLoggingConfig())
 			initialize.SetLibbpfgoCallbacks()
@@ -56,24 +75,8 @@ func initCmd() error {
 
 	cobra.OnInitialize(initConfig)
 
-	hfFallback := rootCmd.HelpFunc()
-	// Override default help function to support help for flags.
-	// Since for commands the usage is tracee help <command>, for flags
-	// the usage is tracee --help <flag>.
-	// e.g. tracee --help filter
-	//      tracee -h filter
-	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 && (args[0] == "--help" || args[0] == "-h") {
-			flagHelp := flags.GetHelpString(args[1], true)
-			if flagHelp != "" {
-				fmt.Fprintf(os.Stdout, "%s\n", flagHelp)
-				os.Exit(0)
-			}
-		}
-
-		// If flag help was not found, fallback to default help function
-		hfFallback(cmd, args)
-	})
+	// disable default help command (./tracee help) overriding it with an empty command
+	rootCmd.SetHelpCommand(&cobra.Command{})
 
 	// Scope/Event/Policy flags
 
@@ -82,7 +85,7 @@ func initCmd() error {
 		"scope",
 		"s",
 		[]string{},
-		"Select workloads to trace by defining filter expressions",
+		"[uid|comm|container...]\t\tSelect workloads to trace by defining filter expressions",
 	)
 
 	// events is not bound to viper
@@ -90,7 +93,7 @@ func initCmd() error {
 		"events",
 		"e",
 		[]string{},
-		"Select events to trace and event filters",
+		"[name|name.args.pathname...]\tSelect events to trace and event filters",
 	)
 
 	// policy is not bound to viper
@@ -98,7 +101,7 @@ func initCmd() error {
 		"policy",
 		"p",
 		[]string{},
-		"Path to a policy or directory with policies",
+		"[file|dir]\t\t\t\tPath to a policy or directory with policies",
 	)
 
 	// Output flags
@@ -107,7 +110,7 @@ func initCmd() error {
 		"output",
 		"o",
 		[]string{"table"},
-		"Control how and where output is printed",
+		"[json|none|webhook...]\t\tControl how and where output is printed",
 	)
 	err := viper.BindPFlag("output", rootCmd.Flags().Lookup("output"))
 	if err != nil {
@@ -119,7 +122,7 @@ func initCmd() error {
 		"capture",
 		"c",
 		[]string{},
-		"Capture artifacts that were written, executed or found to be suspicious",
+		"[write|exec|network...]\t\tCapture artifacts that were written, executed or found to be suspicious",
 	)
 
 	// Config flag
@@ -129,7 +132,7 @@ func initCmd() error {
 		&cfgFile,
 		"config",
 		"",
-		"Global config file (yaml, json between others - see documentation)",
+		"<file>\t\t\t\tGlobal config file (yaml, json between others - see documentation)",
 	)
 
 	// Container flags
@@ -137,7 +140,7 @@ func initCmd() error {
 	rootCmd.Flags().Bool(
 		"containers",
 		false,
-		"Enable container info enrichment to events. This feature is experimental and may cause unexpected behavior in the pipeline",
+		"\t\t\t\t\tEnable container info enrichment to events. This feature is experimental and may cause unexpected behavior in the pipeline",
 	)
 	err = viper.BindPFlag("containers", rootCmd.Flags().Lookup("containers"))
 	if err != nil {
@@ -147,7 +150,7 @@ func initCmd() error {
 	rootCmd.Flags().StringArray(
 		"crs",
 		[]string{},
-		"Define connected container runtimes",
+		"<runtime:socket>\t\t\tDefine connected container runtimes",
 	)
 	err = viper.BindPFlag("crs", rootCmd.Flags().Lookup("crs"))
 	if err != nil {
@@ -159,7 +162,7 @@ func initCmd() error {
 	rootCmd.Flags().StringArray(
 		"signatures-dir",
 		[]string{},
-		"Directories where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats",
+		"<dir>\t\t\t\tDirectories where to search for signatures in CEL (.yaml), OPA (.rego), and Go plugin (.so) formats",
 	)
 	err = viper.BindPFlag("signatures-dir", rootCmd.Flags().Lookup("signatures-dir"))
 	if err != nil {
@@ -169,7 +172,7 @@ func initCmd() error {
 	rootCmd.Flags().StringArray(
 		"rego",
 		[]string{},
-		"Control event rego settings",
+		"[partial-eval|aio]\t\t\tControl event rego settings",
 	)
 	err = viper.BindPFlag("rego", rootCmd.Flags().Lookup("rego"))
 	if err != nil {
@@ -182,7 +185,7 @@ func initCmd() error {
 		"perf-buffer-size",
 		"b",
 		1024, // 4 MB of contiguous pages
-		"Size, in pages, of the internal perf ring buffer used to submit events from the kernel",
+		"<size>\t\t\t\tSize, in pages, of the internal perf ring buffer used to submit events from the kernel",
 	)
 	err = viper.BindPFlag("perf-buffer-size", rootCmd.Flags().Lookup("perf-buffer-size"))
 	if err != nil {
@@ -192,7 +195,7 @@ func initCmd() error {
 	rootCmd.Flags().Int(
 		"blob-perf-buffer-size",
 		1024, // 4 MB of contiguous pages
-		"Size, in pages, of the internal perf ring buffer used to send blobs from the kernel",
+		"<size>\t\t\t\tSize, in pages, of the internal perf ring buffer used to send blobs from the kernel",
 	)
 	err = viper.BindPFlag("blob-perf-buffer-size", rootCmd.Flags().Lookup("blob-perf-buffer-size"))
 	if err != nil {
@@ -203,7 +206,7 @@ func initCmd() error {
 		"cache",
 		"a",
 		[]string{"none"},
-		"Control event caching queues",
+		"[type|mem-cache-size]\t\tControl event caching queues",
 	)
 	err = viper.BindPFlag("cache", rootCmd.Flags().Lookup("cache"))
 	if err != nil {
@@ -215,7 +218,7 @@ func initCmd() error {
 	rootCmd.Flags().Bool(
 		server.MetricsEndpointFlag,
 		false,
-		"Enable metrics endpoint",
+		"\t\t\t\t\tEnable metrics endpoint",
 	)
 	err = viper.BindPFlag(server.MetricsEndpointFlag, rootCmd.Flags().Lookup(server.MetricsEndpointFlag))
 	if err != nil {
@@ -225,7 +228,7 @@ func initCmd() error {
 	rootCmd.Flags().Bool(
 		server.HealthzEndpointFlag,
 		false,
-		"Enable healthz endpoint",
+		"\t\t\t\t\tEnable healthz endpoint",
 	)
 	err = viper.BindPFlag(server.HealthzEndpointFlag, rootCmd.Flags().Lookup(server.HealthzEndpointFlag))
 	if err != nil {
@@ -235,7 +238,7 @@ func initCmd() error {
 	rootCmd.Flags().Bool(
 		server.PProfEndpointFlag,
 		false,
-		"Enable pprof endpoints",
+		"\t\t\t\t\tEnable pprof endpoints",
 	)
 	err = viper.BindPFlag(server.PProfEndpointFlag, rootCmd.Flags().Lookup(server.PProfEndpointFlag))
 	if err != nil {
@@ -245,7 +248,7 @@ func initCmd() error {
 	rootCmd.Flags().Bool(
 		server.PyroscopeAgentFlag,
 		false,
-		"Enable pyroscope agent",
+		"\t\t\t\t\tEnable pyroscope agent",
 	)
 	err = viper.BindPFlag(server.PyroscopeAgentFlag, rootCmd.Flags().Lookup(server.PyroscopeAgentFlag))
 	if err != nil {
@@ -255,7 +258,7 @@ func initCmd() error {
 	rootCmd.Flags().String(
 		server.ListenEndpointFlag,
 		":3366",
-		"Listening address of the metrics endpoint server",
+		"<url:port>\t\t\t\tListening address of the metrics endpoint server",
 	)
 	err = viper.BindPFlag(server.ListenEndpointFlag, rootCmd.Flags().Lookup(server.ListenEndpointFlag))
 	if err != nil {
@@ -268,7 +271,7 @@ func initCmd() error {
 		"capabilities",
 		"C",
 		[]string{},
-		"Define capabilities for tracee to run with",
+		"[bypass|add|drop]\t\t\tDefine capabilities for tracee to run with",
 	)
 	err = viper.BindPFlag("capabilities", rootCmd.Flags().Lookup("capabilities"))
 	if err != nil {
@@ -278,7 +281,7 @@ func initCmd() error {
 	rootCmd.Flags().String(
 		"install-path",
 		"/tmp/tracee",
-		"Path where tracee will install or lookup it's resources",
+		"<dir>\t\t\t\tPath where tracee will install or lookup it's resources",
 	)
 	err = viper.BindPFlag("install-path", rootCmd.Flags().Lookup("install-path"))
 	if err != nil {
@@ -289,7 +292,7 @@ func initCmd() error {
 		"log",
 		"l",
 		[]string{"info"},
-		"Logger options",
+		"[debug|info|warn...]\t\tLogger options",
 	)
 	err = viper.BindPFlag("log", rootCmd.Flags().Lookup("log"))
 	if err != nil {

--- a/docs/docs/deep-dive/caching-events.md
+++ b/docs/docs/deep-dive/caching-events.md
@@ -3,9 +3,10 @@
 Tracee has an events caching (in-memory) mechanism. In order to check latest
 caching options you may execute:
 
-```console
-./dist/tracee --help cache
-```
+<!-- TODO: build man page -->
+<!-- ```console
+man tracee-cache
+``` -->
 
 !!! Read Important
     Before continuing, please read the [architecture page], in order to

--- a/docs/docs/deep-dive/dropping-capabilities.md
+++ b/docs/docs/deep-dive/dropping-capabilities.md
@@ -49,9 +49,10 @@ does is through different "execution protection rings":
 
 You may see all available capabilities in the running environment by running:
 
-```console
---help capabilities
-```
+<!-- TODO: build man page -->
+<!-- ```console
+man tracee-capabilities
+``` -->
 
 command line flag.
 

--- a/docs/docs/flags/cache.md
+++ b/docs/docs/flags/cache.md
@@ -1,0 +1,38 @@
+## NAME
+
+tracee **--cache** - Select different cache types for the event pipeline queueing
+
+## SYNOPSIS
+
+tracee **--cache** [none|cache-type=\<type\>] [**--cache** mem-cache-size=\<size\>]
+
+## DESCRIPTION
+
+The **--cache** flag allows you to select different cache types for the event pipeline queueing.
+
+Possible options for **cache-type** are:
+
+- **none**: No event caching in the pipeline (default) - similar to **--cache none**.
+- **mem**: Enables caching events in memory.
+
+If **cache-type=mem** is chosen, you can also set the memory cache size in megabytes (MB) using the **mem-cache-size** option. This option only works when **cache-type=mem**.
+
+## EXAMPLES
+
+- To cache events in memory using the default values, use the following flag:
+
+  ```console
+  --cache cache-type=mem
+  ```
+
+- To cache events in memory and set the memory cache size to 1024 MB, use the following flag:
+
+  ```console
+  --cache cache-type=mem --cache mem-cache-size=1024
+  ```
+
+- To disable event caching in the pipeline, use the following flag:
+
+  ```console
+  --cache none
+  ```

--- a/docs/docs/flags/capabilities.md
+++ b/docs/docs/flags/capabilities.md
@@ -1,0 +1,41 @@
+## NAME
+
+tracee **--capabilities** - Opt out from dropping capabilities by default or set specific ones
+
+## SYNOPSIS
+
+tracee **--capabilities** [\<bypass=[true|false]\> | \<add=cap1(,cap2...)\> | \<drop=cap1(,cap2...)\>] ... [**--capabilities** \[<add=cap1(,cap2...)\> | \<drop=cap1(,cap2...)\>] ...]
+
+## DESCRIPTION
+
+The **--capabilities** flag allows you to control the dropping of capabilities during execution time or set specific capabilities.
+
+Possible options:
+
+- **bypass=[true|false]**: Keep all capabilities during execution time. Setting **bypass=true** will opt out from dropping any capabilities.
+- **add=cap1(,cap2...)**: Add specific capabilities to the "required" capabilities ring. You can provide multiple capability names separated by commas.
+- **drop=cap1(,cap2...)**: Drop specific capabilities from the "required" capabilities ring. You can specify multiple capability names separated by commas.
+
+Please note that the available capabilities will depend on the running system. For the list of capabilities available on your system, see the **list-caps** command.
+
+## EXAMPLES
+
+- To keep all capabilities during execution time, use the following flag:
+
+  ```console
+  --capabilities bypass=true
+  ```
+
+- To add specific capabilities (e.g., cap_kill and cap_syslog) to the "required" capabilities ring, use the following flag:
+
+  ```console
+  --capabilities add=cap_kill,cap_syslog
+  ```
+
+- To drop a specific capability (e.g., cap_chown) from the "required" capabilities ring, use the following flag:
+
+  ```console
+  --capabilities drop=cap_chown
+  ```
+
+Please refer to the [documentation](../deep-dive/dropping-capabilities.md) for more information on environment capabilities.

--- a/docs/docs/flags/capture.md
+++ b/docs/docs/flags/capture.md
@@ -1,0 +1,110 @@
+## NAME
+
+tracee **--capture** - Capture artifacts that were written, executed, or found to be suspicious
+
+## SYNOPSIS
+
+tracee **--capture** \<[artifact:]capture-option[=value]\> ...
+
+tracee **--capture** \<network\> [**--capture** [pcap:option1(,option2...)|pcap-options:option|pcap-snaplen:size]] ...
+
+## DESCRIPTION
+
+The **--capture** flag allows you to capture artifacts that were written, executed, or found to be suspicious during the execution of Tracee. The captured artifacts will appear in the 'output-path' directory.
+
+Possible capture options:
+
+- **[artifact:]write[=/path/prefix\*]**: Capture written files. You can provide a filter to only capture file writes whose path starts with a certain prefix (up to 50 characters). Up to 3 filters can be given.
+- **[artifact:]read[=/path/prefix\*]**: Capture read files. You can provide a filter to only capture file reads whose path starts with a certain prefix (up to 50 characters). Up to 3 filters can be given.
+- **[artifact:]exec**: Capture executed files.
+- **[artifact:]module**: Capture loaded kernel modules.
+- **[artifact:]bpf**: Capture loaded BPF programs bytecode.
+- **[artifact:]mem**: Capture memory regions that had write+execute (w+x) protection and then changed to execute (x) only.
+- **[artifact:]network**: Capture network traffic. Only TCP/UDP/ICMP protocols are currently supported.
+
+### File Capture Filters
+
+Files captured upon read/write can be filtered to catch only specific IO operations. The different filter types have a logical 'AND' between them but a logical 'OR' between filters of the same type. The filter format is as follows: \<read/write\>:\<filter-type\>=\<filter-value\>
+
+Filter types:
+
+- **path**: A filter for the file path prefix (up to 50 characters). Up to 3 filters can be given. Identical to using '\<read/write\>=/path/prefix\*'.
+- **type**: A file type from the following options: 'regular', 'pipe', and 'socket'.
+- **fd**: The file descriptor of the file. Can be one of the three standards: 'stdin', 'stdout', and 'stderr'.
+
+### Network Capture Notes
+
+- Pcap Files:
+  - If you only specify **--capture network**, you will have a single file with all network traffic.
+  - You can use **pcap:xxx,yyy** to have more than one pcap file, split by different means.
+
+- Pcap Options:
+  - If you do not specify **pcap-options** (or set to none), you will capture ALL network traffic into your pcap files.
+  - If you specify **pcap-options:filtered**, events being traced will define what network traffic will be captured.
+
+- Snap Length:
+  - If you do not specify a snaplen, the default is headers only (incomplete packets in tcpdump).
+  - If you specify **max** as snaplen, you will get the full contents of each packet (pcap files will be large).
+  - If you specify **headers** as snaplen, you will only get L2/L3 headers in captured packets.
+  - If you specify **headers** but trace for **net_packet_dns** events, the L4 DNS header will be captured.
+  - If you specify **headers** but trace for **net_packet_http** events, only L2/L3 headers will be captured.
+
+## EXAMPLES
+
+### File capture
+
+- To capture executed files into the default output directory, use the following flag:
+
+  ```console
+  --capture exec
+  ```
+
+- To capture executed files into a specific directory, clear the directory before starting, use the following flags:
+
+  ```console
+  --capture exec --capture dir:/my/dir --capture clear-dir
+  ```
+
+- To capture files that were written into anywhere under /usr/bin/ or /etc/, use the following flags:
+
+  ```console
+  --capture write=/usr/bin/* --capture write=/etc/*
+  ```
+
+- To capture file writes to socket files that are the 'stdout' of the writing process, use the following flag:
+
+  ```console
+  --capture write:type=socket --capture write:fd=stdout
+  ```
+
+### Network Capture
+
+- To capture network traffic, use the following flag:
+
+  ```console
+  --capture network
+  ```
+
+- To capture network traffic and save separate pcap files for processes and commands, use the following flag:
+
+  ```console
+  --capture network --capture pcap:process,command
+  ```
+
+- To capture network traffic and save pcap files containing only traced/filtered packets, use the following flag:
+
+  ```console
+  --capture network --capture pcap-options:filtered
+  ```
+
+- To capture network traffic and set the captured payload from each packet to 1KB, use the following flag:
+
+  ```console
+  --capture network --capture pcap-snaplen:1kb
+  ```
+
+- To capture network traffic and save pcap files for containers and commands, use the following flag:
+
+  ```console
+  --capture network --capture pcap:container,command
+  ```

--- a/docs/docs/flags/config.md
+++ b/docs/docs/flags/config.md
@@ -1,0 +1,21 @@
+## NAME
+
+tracee **--config** - Define global configuration options for tracee
+
+## SYNOPSIS
+
+tracee **--config** \<file\>
+
+## DESCRIPTION
+
+The **--config** flag allows you to define global configuration options (flags) for tracee. It expects a file in YAML or JSON format, among others (see [documentation](../config/overview.md)).
+
+All flags can be set in the config file, except for the following, which are reserved only for the CLI:
+
+- **--config**: This flag itself is reserved for the CLI and should not be set in the config file.
+- **--capture**
+- **--policy**
+- **--scope**
+- **--event**
+
+Please refer to the [documentation](../config/overview.md) for more information on the file format and available configuration options.

--- a/docs/docs/flags/containers.md
+++ b/docs/docs/flags/containers.md
@@ -1,0 +1,35 @@
+## NAME
+
+tracee **--crs** - Select container runtimes to connect to for container events enrichment
+
+## SYNOPSIS
+
+tracee **--crs** \<[crio|containerd|docker|podman]:socket\> [**--crs** ...] ...
+
+## DESCRIPTION
+
+By default, if no flag is passed, Tracee will automatically detect installed runtimes by going through known runtime socket paths, looking for the following paths:
+
+1. **Docker**:     `/var/run/docker.sock`
+2. **Containerd**: `/var/run/containerd/containerd.sock`
+3. **CRI-O**:      `/var/run/crio/crio.sock`
+4. **Podman**:     `/var/run/podman/podman.sock`
+
+If runtimes are specified using the **--crs** flag, only the ones passed through the flags will be connected to through the provided socket file path.
+
+Supported runtimes are:
+
+1. **CRI-O** (crio, cri-o)
+2. **Containerd** (containerd)
+3. **Docker** (docker)
+4. **Podman** (podman)
+
+## EXAMPLE
+
+- To connect to CRI-O using the socket file path `/var/run/crio/crio.sock`, use the following flag:
+
+  ```console
+  --crs crio:/var/run/crio/crio.sock
+  ```
+
+Please refer to the [documentation](../integrating/container-engines.md) for more information on container events enrichment.

--- a/docs/docs/flags/events.md
+++ b/docs/docs/flags/events.md
@@ -1,0 +1,128 @@
+## NAME
+
+tracee **--events** - Select which events to trace
+
+## SYNOPSIS
+
+tracee **--events** [\<event-name1(,[-]event-name2...)\> | \<[-]event-name1(,set1...)\> | \<set1(,[-]event-name1,[-]event-name2...)\> | \<event1.args.arg-field[=|!=]value\> | \<event1.retval[=|!=|\<|\>|\<=|\>=]value\> | \<event1.context.context-field[=|!=|\<|\>|\<=|\>=]value\> | \<event.context.container\>] ...
+
+## DESCRIPTION
+
+The **--events** flag allows you to select which events to trace by defining filters.
+
+## FILTERS
+
+- Event or set name: Select specific events using 'event-name1,event-name2...' or predefined event sets using 'event_set_name1,event_set_name2...'. To exclude events, prepend the event name with a dash '-': '-event-name'.
+
+- Event arguments: Filter events based on their arguments using 'event-name.args.event_arg'. The event argument expression follows the syntax of a string expression.
+
+- Event return value: Filter events based on their return value using 'event-name.retval'. The event return value expression follows the syntax of a numerical expression.
+
+- Event context fields: Filter events based on the non-argument fields defined in the trace.Event struct using 'event-name.context.field'. Refer to the json tags in the trace.Event struct located in the types/trace package for the correct field names, and the event filtering section in the documentation for a full list.
+
+## FILTER EXPRESSION
+
+Filter expressions can be defined to operate on event options or process metadata. Only events that match all filter expressions will be traced.
+
+Multiple flags are combined with AND logic, while multiple values within a single flag are combined with OR logic when using the equals operator '='. Multiple values can be specified using ','.
+
+### NUMERICAL EXPRESSION OPERATORS
+
+'=', '!=', '\<', '\>', '\<=', '\>='
+
+Available for:
+
+- return value
+- context fields
+
+NOTE: Expressions containing '\<' or '\>' tokens must be escaped!
+
+### STRING EXPRESSION OPERATORS
+
+'=', '!='
+
+Available for:
+
+- event arguments
+- return value
+- context fields
+
+Strings can be compared as a prefix if ending with '\*', or as a suffix if starting with '\*'.
+
+NOTE: Expressions containing '\*' token must be escaped!
+
+### EXCLUSION OPERATOR (PREPENDED)
+
+'-'
+
+Available only for:
+
+- event names
+
+## EXAMPLES
+
+- To trace only 'execve' and 'open' events, use the following flag:
+
+  ```console
+  --events execve,open
+  ```
+
+- To trace only events prefixed by "open", use the following flag:
+
+  ```console
+  --events 'open*'
+  ```
+
+- To exclude events prefixed by "open" or "dup", use the following flag:
+
+  ```console
+  --events '-open*,-dup*'
+  ```
+
+- To trace all file-system related events, use the following flag:
+
+  ```console
+  --events fs
+  ```
+
+- To trace all file-system related events, but not 'open' or 'openat', use the following flag:
+
+  ```console
+  --events fs --events '-open,-openat'
+  ```
+
+- To trace only 'close' events that have 'fd' equal to 5, use the following flag:
+
+  ```console
+  --events close.args.fd=5
+  ```
+
+- To trace only 'openat' events that have 'pathname' prefixed by '/tmp', use the following flag:
+
+  ```console
+  --events openat.args.pathname='/tmp*'
+  ```
+
+- To trace only 'openat' events that have 'pathname' suffixed by 'shadow', use the following flag:
+
+  ```console
+  --events openat.args.pathname='*shadow'
+  ```
+
+- To exclude 'openat' events that have 'pathname' equal to '/tmp/1' or '/bin/ls', use the following flag:
+
+  ```console
+  --events openat.args.pathname!=/tmp/1,/bin/ls
+  ```
+
+- To trace only 'openat' events that have 'processName' equal to 'ls', use the following flag:
+
+  ```console
+  --events openat.context.processName=ls
+  ```
+
+- To trace only 'security_file_open' events coming from a container, use the following flag:
+
+  ```console
+  --events security_file_open.context.container
+  ```

--- a/docs/docs/flags/log.md
+++ b/docs/docs/flags/log.md
@@ -1,0 +1,99 @@
+## NAME
+
+tracee **--log** - Control logger options - aggregation and level priority
+
+## SYNOPSIS
+
+tracee **--log** aggregate[:interval] | \<debug|info|warn|error|panic\> | file:/path/to/file | filter:[msg=\<value,...\>;regex=\<value,...\>;pkg=\<value,...\>;file=\<value,...\>;lvl=\<value,...\>;libbpf] | filter-out:[msg=\<value,...\>;regex=\<value,...\>;pkg=\<value,...\>;file=\<value,...\>;lvl=\<value,...\>;libbpf]
+
+## DESCRIPTION
+
+The **--log** flag allows you to control logger options for the tool.
+
+Possible log options:
+
+- **aggregate[:interval]**: Turns log aggregation on, delaying output with an optional interval. The default interval is off. The interval can be specified in seconds (s) or minutes (m).
+
+- **\<debug|info|warn|error|panic\>**: Sets the log level. The default log level is 'info'.
+
+- **file:/path/to/file**: Writes the logs to the specified file. If the file exists, it will be created or trimmed.
+
+- **filter:**\<option;...\>: Filters in logs that match the specified option values. Multiple filter options can be provided, separated by semicolons.
+
+- **filter-out:**\<option;...\>: Filters out logs that match the specified option values. Multiple filter options can be provided, separated by semicolons.
+
+Filter options:
+
+- **msg=\<value,...\>**: Filters logs that have the message containing any of the specified values.
+
+- **regex=\<value,...\>**: Filters logs that match the specified regular expression in the message.
+
+- **pkg=\<value,...\>**: Filters logs that originate from the specified package.
+
+- **file=\<value,...\>**: Filters logs that originate from the specified file.
+
+- **lvl=\<value,...\>**: Filters logs that are of the specified level.
+
+- **libbpf**: Filters logs that originate from libbpf.
+
+## EXAMPLES
+
+- To output debug level logs, use the following flag:
+
+  ```console
+  --log debug
+  ```
+
+- To output aggregated debug level logs every 3 seconds (default), use the following flag:
+
+  ```console
+  --log debug --log aggregate
+  ```
+
+- To output aggregated logs every 5 seconds, use the following flag:
+
+  ```console
+  --log aggregate:5s
+  ```
+
+- To output debug level logs to `/tmp/tracee.log`, use the following flag:
+
+  ```console
+  --log debug --log file:/tmp/tracee.log
+  ```
+
+- To filter in logs that have either 'foo' or 'bar' in the message, are from the 'core' package, and are of 'error' level, use the following flag:
+
+  ```console
+  --log filter:'msg=foo,bar;pkg=core;lvl=error'
+  ```
+
+- To filter out logs that have either 'foo' or 'bar' in the message, are from the 'core' package, and are of 'error' level, use the following flag:
+
+  ```console
+  --log filter-out:'msg=foo,bar;pkg=core;lvl=error'
+  ```
+
+- To filter in logs that have either 'foo' or 'bar' in the message and, based on that result, filter out logs that are from the 'core' package, use the following flag:
+
+  ```console
+  --log filter:msg=foo,bar --log filter-out:pkg=core
+  ```
+
+- To filter out logs that originate from the '/pkg/cmd/flags/logger.go' file, use the following flag:
+
+  ```console
+  --log filter-out:file=/pkg/cmd/flags/logger.go
+  ```
+
+- To filter in logs that have messages matching the regex '^foo', use the following flag:
+
+  ```console
+  --log filter:regex='^foo'
+  ```
+
+- To filter in logs that originate from libbpf, use the following flag:
+
+  ```console
+  --log filter:libbpf
+  ```

--- a/docs/docs/flags/output.md
+++ b/docs/docs/flags/output.md
@@ -1,0 +1,114 @@
+## NAME
+
+tracee **--output** - Control how and where output is printed
+
+## SYNOPSIS
+
+tracee **--output** \<format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,parse-arguments-fds,sort-events} ...
+
+
+## DESCRIPTION
+
+The **--output** flag allows you to control how and where the output is printed.
+
+Format options:
+
+- **table[:/path/to/file,...]**: Output events in table format. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
+
+- **table-verbose[:/path/to/file,...]**: Output events in table format with extra fields per event. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
+
+- **json[:/path/to/file,...]**: Output events in JSON format. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
+
+- **gob[:/path/to/file,...]**: Output events in gob format. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
+
+- **gotemplate=/path/to/template[:/path/to/file,...]**: Output events formatted using a given Go template file. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
+
+- **none**: Ignore the stream of events output. This is usually used with the **--capture** flag.
+
+Fluent Forward options:
+
+- **forward:url**: Send events in JSON format using the Forward protocol to a Fluent receiver. Specify the URL of the Fluent receiver.
+
+Webhook options:
+
+- **webhook:url**: Send events in JSON format to the specified webhook URL.
+
+Other options:
+
+- **option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-events}**: Augment output according to the given options. The default is none. Multiple options can be specified, separated by commas.
+
+  - **stack-addresses**: Include stack memory addresses for each event.
+  - **exec-env**: When tracing execve/execveat, show the environment variables that were used for execution.
+  - **relative-time**: Use relative timestamp instead of wall timestamp for events.
+  - **exec-hash**: When tracing sched_process_exec, show the file hash (sha256) and ctime.
+  - **parse-arguments**: Do not show raw machine-readable values for event arguments. Instead, parse them into human-readable strings.
+  - **parse-arguments-fds**: Enable parse-arguments and enrich file descriptors (fds) with their file path translation. This can cause pipeline slowdowns.
+  - **sort-events**: Enable sorting events before passing them to the output. This may decrease the overall program efficiency.
+
+## EXAMPLES
+
+- To output events as JSON to stdout, use the following flag:
+
+  ```console
+  --output json
+  ```
+
+- To output events as JSON to `/my/out`, use the following flag:
+
+  ```console
+  --output json:/my/out
+  ```
+
+- To output events as the provided Go template to stdout, use the following flag:
+
+  ```console
+  --output gotemplate=/path/to/my.tmpl
+  ```
+
+- To output events in gob format to `/my/out`, use the following flag:
+
+  ```console
+  --output gob:/my/out
+  ```
+
+- To output events as JSON to stdout and as gob to `/my/out`, use the following flag:
+
+  ```console
+  --output json --output gob:/my/out
+  ```
+
+- To output events as JSON to both `/my/out` and `/my/out2`, use the following flag:
+
+  ```console
+  --output json:/my/out1,/my/out2
+  ```
+
+- To ignore events output, use the following flag:
+
+  ```console
+  --output none
+  ```
+
+- To output events as a table with stack addresses, use the following flag:
+
+  ```console
+  --output table --output option:stack-addresses
+  ```
+
+- To output events via the Forward protocol to `127.0.0.1` on port `24224` with the tag 'tracee' using TCP, use the following flag:
+
+  ```console
+  --output forward:tcp://user:pass@127.0.0.1:24224?tag=tracee
+  ```
+
+- To output events to the webhook endpoint `http://webhook:8080`, use the following flag:
+
+  ```console
+  --output webhook:http://webhook:8080
+  ```
+
+- To output events to the webhook endpoint `http://webhook:8080` with a timeout of 5 seconds, use the following flag:
+
+  ```console
+  --output webhook:http://webhook:8080?timeout=5s
+  ```

--- a/docs/docs/flags/rego.md
+++ b/docs/docs/flags/rego.md
@@ -1,0 +1,32 @@
+## NAME
+
+tracee **--rego** - Rego configurations
+
+## SYNOPSIS
+
+tracee **--rego** \<config-option\>
+
+## DESCRIPTION
+
+The **--rego** flag allows you to configure rego settings for Tracee.
+
+Possible configuration options:
+
+- **partial-eval**: Enable partial evaluation of rego signatures.
+- **aio**: Compile rego signatures altogether as an aggregate policy. By default, each signature is compiled separately.
+
+## EXAMPLES
+
+- To enable partial evaluation, use the following flag:
+
+  ```console
+  --rego partial-eval
+  ```
+
+- To enable partial evaluation and aggregate policy compilation, use the following flags:
+
+  ```console
+  --rego partial-eval --rego aio
+  ```
+
+Please refer to the [documentation](../events/custom/rego.md) for more information on rego signatures.

--- a/docs/docs/flags/scope.md
+++ b/docs/docs/flags/scope.md
@@ -1,0 +1,203 @@
+
+## NAME
+
+tracee **--scope** - Select the scope for tracing events
+
+## SYNOPSIS
+
+tracee **--scope** [\<[uid|pid][=|!=|\<|\>|\<=|\>=]value1(,value2...)\> | \<[mntns|pidns|tree][=|!=]value1(,value2...)\> | \<[uts|comm|container|binary][=|!=]value1(,value2...)\>] | \<[!]container\> | \<container[=|!=]value\> | \<[container|pid]=new\> | \<follow\>]  ...
+
+## DESCRIPTION
+
+The **--scope** flag allows you to select the scope for tracing events by defining filters.
+
+## FILTER EXPRESSION
+
+Filter expressions can be defined to operate on scope options or process metadata. Only events that match all filter expressions will be traced.
+
+Multiple flags are combined with AND logic, while multiple values within a single flag are combined with OR logic when using the equals operator '='. Multiple values can be specified using ','.
+
+### NUMERICAL EXPRESSION OPERATORS
+
+The following numerical fields support the operators '=', '!=', '<', '>', '<=', '>=':
+
+- uid: Select events from specific user IDs.
+- pid: Select events from specific process IDs.
+
+The following numerical fields only support the operators '=' and '!=':
+
+- mntns: Select events from specific mount namespace IDs.
+- pidns: Select events from specific process namespace IDs.
+- tree: Select events that descend from specific process IDs.
+
+NOTE: Expressions containing '\<' or '\>' tokens must be escaped!
+
+### STRING EXPRESSION OPERATORS
+
+'=', '!='
+
+Available for the following string fields:
+
+- uts: Select events based on UTS (Unix Timesharing System) names.
+- comm: Select events based on process command names.
+- container: Select events from specific container IDs.
+- binary: Select events based on the binary path.
+
+Strings can be compared as a prefix if ending with '\*', or as a suffix if starting with '\*'.
+
+NOTE: Expressions containing '\*' token must be escaped!
+
+### BOOLEAN OPERATOR (PREPENDED)
+
+'!'
+
+Available for the following boolean field:
+
+- container: Select events based on whether they originate from a container or not.
+
+## SPECIAL FILTERS
+
+The following special filters can be used within the scope filter expressions:
+
+- new: Select newly created containers or process IDs.
+- follow: Select events from the processes that match the criteria and their descendants.
+
+## EXAMPLES
+
+- To trace only events from new processes, use the following flag:
+
+  ```console
+  --scope pid=new
+  ```
+
+- To trace only events from pid 510 or pid 1709, use the following flag:
+
+  ```console
+  --scope pid=510,1709
+  ```
+
+- To trace only events from pid 510 or pid 1709 (same as above), use the following flag:
+
+  ```console
+  --scope p=510 --scope p=1709
+  ```
+
+- To trace only events from newly created containers, use the following flag:
+
+  ```console
+  --scope container=new
+  ```
+
+- To trace only events from the container with ID 'ab356bc4dd554', use the following flag:
+
+  ```console
+  --scope container=ab356bc4dd554
+  ```
+
+- To trace only events from containers, use the following flag:
+
+  ```console
+  --scope container
+  ```
+
+- To only trace events from containers (same as above), use the following flag:
+
+  ```console
+  --scope c
+  ```
+
+- To trace only events from the host, use the following flag:
+
+  ```console
+  --scope '!container'
+  ```
+
+- To trace only events from uid 0, use the following flag:
+
+  ```console
+  --scope uid=0
+  ```
+
+- To trace only events from mntns id 4026531840, use the following flag:
+
+  ```console
+  --scope mntns=4026531840
+  ```
+
+- To trace only events from pidns id not equal to 4026531836, use the following flag:
+
+  ```console
+  --scope pidns!=4026531836
+  ```
+
+- To trace only events that descend from the process with pid 476165, use the following flag:
+
+  ```console
+  --scope tree=476165
+  ```
+
+- To trace only events if they do not descend from the process with pid 5023, use the following flag:
+
+  ```console
+  --scope tree!=5023
+  ```
+
+- To trace only events if they descend from 3213 or 5200, but not 3215, use the following flag:
+
+  ```console
+  --scope tree=3213,5200 --scope tree!=3215
+  ```
+
+- To trace only events from uids greater than 0, use the following flag:
+
+  ```console
+  --scope 'uid>0'
+  ```
+
+- To trace only events from pids between 0 and 1000, use the following flag:
+
+  ```console
+  --scope 'pid>0' --scope 'pid<1000'
+  ```
+
+- To trace only events from uids greater than 0 but not 1000, use the following flag:
+
+  ```console
+  --scope 'u>0' --scope u!=1000
+  ```
+
+- To exclude events from uts name 'ab356bc4dd554', use the following flag:
+
+  ```console
+  --scope uts!=ab356bc4dd554
+  ```
+
+- To trace only events from the 'ls' command, use the following flag:
+
+  ```console
+  --scope comm=ls
+  ```
+
+- To trace only events from the '/usr/bin/ls' binary, use the following flag:
+
+  ```console
+  --scope binary=/usr/bin/ls
+  ```
+
+- To trace only events from the '/usr/bin/ls' binary in the host mount namespace, use the following flag:
+
+  ```console
+  --scope binary=host:/usr/bin/ls
+  ```
+
+- To trace only events from the '/usr/bin/ls' binary in the 4026532448 mount namespace, use the following flag:
+
+  ```console
+  --scope binary=4026532448:/usr/bin/ls
+  ```
+
+- To trace all events that originated from 'bash' or from one of the processes spawned by 'bash', use the following flag:
+
+  ```console
+  --scope comm=bash --scope follow
+  ```

--- a/docs/docs/forensics/index.md
+++ b/docs/docs/forensics/index.md
@@ -3,8 +3,14 @@
 Tracee has a unique feature that lets you capture interesting artifacts from
 running applications, using the `--capture` flag.
 
+
+
+<!-- TODO: build man page -->
+<!-- ```console
+man tracee-capture
+``` -->
+
 ```console
-sudo ./dist/tracee --help capture
 sudo ./dist/tracee --capture xxx
 ```
 

--- a/docs/docs/outputs/output-formats.md
+++ b/docs/docs/outputs/output-formats.md
@@ -1,6 +1,7 @@
 # Tracing Output Formats
 
-The `--output` flag controls where and how Tracee will output events, by specifying `--output <format>:<destination>`.  You can use the `--output` flag multiple times to output events in multiple ways. To see all output options you can run `tracee --help output`.
+<!-- TODO: build man page -->
+The `--output` flag controls where and how Tracee will output events, by specifying `--output <format>:<destination>`.  You can use the `--output` flag multiple times to output events in multiple ways.<!-- To see all output options you can run `man tracee-output`. -->
 
 The following output formats are supported:
 

--- a/docs/docs/outputs/output-options.md
+++ b/docs/docs/outputs/output-options.md
@@ -1,6 +1,7 @@
 # Tracing Output Options
 
-Tracee supports different output options for customizing the way events are printed. For a complete list of available options, run `tracee --help output`.
+<!-- TODO: build man page -->
+Tracee supports different output options for customizing the way events are printed. For a complete list of available options. <!--, see `man tracee-output`. -->
 
 Available options:
 

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -190,7 +190,9 @@ func PrepareCapture(captureSlice []string, newBinary bool) (config.CaptureConfig
 			}
 		} else {
 			if newBinary {
-				return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--help capture' for more info")
+				// TODO: build man page
+				// return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, see 'tracee-capture' man page for more info")
+				return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--help' for more info")
 			}
 
 			return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--capture help' for more info")

--- a/pkg/cmd/flags/errors.go
+++ b/pkg/cmd/flags/errors.go
@@ -14,7 +14,9 @@ func InvalidEventExcludeError(event string) error {
 
 func InvalidScopeOptionError(expr string, newBinary bool) error {
 	if newBinary {
-		return fmt.Errorf("invalid scope option specified (%s), use '--help scope' for more info", expr)
+		// TODO: build man page
+		// return fmt.Errorf("invalid scope option specified (%s), see 'tracee-scope' man page for more info", expr)
+		return fmt.Errorf("invalid scope option specified (%s), use '--help' for more info", expr)
 	}
 
 	return fmt.Errorf("invalid scope option specified (%s), use '--scope help' for more info", expr)

--- a/pkg/cmd/flags/help.go
+++ b/pkg/cmd/flags/help.go
@@ -7,7 +7,9 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func PrintAndExitIfHelp(ctx *cli.Context, newBinary bool) {
+// PrintAndExitIfHelp checks if any of the help flags are set and prints the relevant help message.
+// It is used only by the old binary (tracee-ebpf).
+func PrintAndExitIfHelp(ctx *cli.Context) {
 	keys := []string{
 		"crs",
 		"cache",
@@ -22,7 +24,7 @@ func PrintAndExitIfHelp(ctx *cli.Context, newBinary bool) {
 
 	for _, k := range keys {
 		if checkIsHelp(ctx, k) {
-			fmt.Print(GetHelpString(k, newBinary))
+			fmt.Print(GetHelpString(k))
 			os.Exit(0)
 		}
 	}
@@ -41,7 +43,7 @@ func checkIsHelp(ctx *cli.Context, k string) bool {
 	return v == "help"
 }
 
-func GetHelpString(key string, newBinary bool) string {
+func GetHelpString(key string) string {
 	switch key {
 	case "config":
 		return configHelp()
@@ -54,10 +56,7 @@ func GetHelpString(key string, newBinary bool) string {
 	case "scope", "events":
 		return filterHelp()
 	case "output":
-		if newBinary {
-			return outputHelp()
-		}
-		return traceeEbpfOutputHelp()
+		return outputHelp()
 	case "capabilities":
 		return capabilitiesHelp()
 	case "rego":

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -50,7 +50,9 @@ func invalidLogOption(err error, opt string, newBinary bool) error {
 	}
 
 	if newBinary {
-		return errfmt.Errorf("invalid log option: %s, %s, use '--help log' for more info", opt, err)
+		// TODO: build man page
+		// return errfmt.Errorf("invalid log option: %s, %s, see 'tracee-log' man page for more info", opt, err)
+		return errfmt.Errorf("invalid log option: %s, %s, use '--help' for more info", opt, err)
 	}
 
 	return errfmt.Errorf("invalid log option: %s, %s, use '--log help' for more info", opt, err)
@@ -63,7 +65,9 @@ func invalidLogOptionValue(err error, opt string, newBinary bool) error {
 	}
 
 	if newBinary {
-		return errfmt.Errorf("invalid log option value: %s, %s, use '--help log' for more info", opt, err)
+		// TODO: build man page
+		// return errfmt.Errorf("invalid log option value: %s, %s, see 'tracee-log' man page for more info", opt, err)
+		return errfmt.Errorf("invalid log option value: %s, %s, use '--help' for more info", opt, err)
 	}
 
 	return errfmt.Errorf("invalid log option value: %s, %s, use '--log help' for more info", opt, err)

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -12,50 +12,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
-func outputHelp() string {
-	return `Control how and where output is printed.
-Format options:
-table[:/path/to/file,...]                          output events in table format (default). The default path to file is stdout.
-table-verbose[:/path/to/file,...]                  output events in table format with extra fields per event. The default path to file is stdout.
-json[:/path/to/file,...]                           output events in json format. The default path to file is stdout.
-gob[:/path/to/file,...]                            output events in gob format. The default path to file is stdout.
-gotemplate=/path/to/template[:/path/to/file,...]   output events formatted using a given gotemplate file. The default path to file is stdout.
-none                                               ignore stream of events output, usually used with --capture
-
-Fluent Forward options:
-forward:url                                        send events in json format using the Forward protocol to a Fluent receiver
-
-Webhook options:
-webhook:url                                        send events in json format to the webhook url
-
-Other options:
-option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,sort-events}
-                                                   augment output according to given options (default: none)
-  stack-addresses                                  include stack memory addresses for each event
-  exec-env                                         when tracing execve/execveat, show the environment variables that were used for execution
-  relative-time                                    use relative timestamp instead of wall timestamp for events
-  exec-hash                                        when tracing sched_process_exec, show the file hash(sha256) and ctime
-  parse-arguments                                  do not show raw machine-readable values for event arguments, instead parse into human readable strings
-  parse-arguments-fds                              enable parse-arguments and enrich fd with its file path translation. This can cause pipeline slowdowns.
-  sort-events                                      enable sorting events before passing to them output. This will decrease the overall program efficiency.
-
-Examples:
-  --output json                                                  | output as json to stdout
-  --output json:/my/out                                          | output as json to /my/out
-  --output gotemplate=/path/to/my.tmpl                           | output as the provided go template to stdout
-  --output gob:/my/out                                           | output gob to /my/out
-  --output json --output gob:/my/out                             | output as json to stdout and as gob to /my/out
-  --output json:/my/out1,/my/out2                                | output as json to both /my/out and /my/out2
-  --output none                                                  | ignore events output
-  --output table --output option:stack-addresses                 | output as table with stack addresses
-  --output forward:tcp://user:pass@127.0.0.1:24224?tag=tracee    | output via the Forward protocol to 127.0.0.1 on port 24224 with the tag 'tracee' using TCP
-  --output webhook:http://webhook:8080                           | output events to the webhook endpoint
-  --output webhook:http://webhook:8080?timeout=5s                | output events to the webhook endpoint with a timeout of 5s
-
-Use this flag multiple times to choose multiple output options
-`
-}
-
 type PrepareOutputResult struct {
 	TraceeConfig   *config.OutputConfig
 	PrinterConfigs []config.PrinterConfig
@@ -83,7 +39,9 @@ func PrepareOutput(outputSlice []string, newBinary bool) (PrepareOutputResult, e
 		case "none":
 			if len(outputParts) > 1 {
 				if newBinary {
-					return outConfig, errors.New("none output does not support path. Use '--help output' for more info")
+					// TODO: build man page
+					// return outConfig, errors.New("none output does not support path. See 'tracee-output' man page for more info")
+					return outConfig, errors.New("none output does not support path. Use '--help' for more info")
 				}
 
 				return outConfig, errors.New("none output does not support path. Use '--output help' for more info")
@@ -115,7 +73,9 @@ func PrepareOutput(outputSlice []string, newBinary bool) (PrepareOutputResult, e
 			}
 		default:
 			if newBinary {
-				return outConfig, fmt.Errorf("invalid output flag: %s, use '--help output' for more info", outputParts[0])
+				// TODO: build man page
+				// return outConfig, fmt.Errorf("invalid output flag: %s, see 'tracee-output' man page for more info", outputParts[0])
+				return outConfig, fmt.Errorf("invalid output flag: %s, use '--help' for more info", outputParts[0])
 			}
 
 			return outConfig, fmt.Errorf("invalid output flag: %s, use '--output help' for more info", outputParts[0])
@@ -158,7 +118,9 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 		cfg.EventsSorting = true
 	default:
 		if newBinary {
-			return errfmt.Errorf("invalid output option: %s, use '--help output' for more info", option)
+			// TODO: build man page
+			// return errfmt.Errorf("invalid output option: %s, see 'tracee-output' man page for more info", option)
+			return errfmt.Errorf("invalid output option: %s, use '--help' for more info", option)
 		}
 
 		return errfmt.Errorf("invalid output option: %s, use '--output help' for more info", option)
@@ -209,7 +171,9 @@ func parseFormat(outputParts []string, printerMap map[string]string, newBinary b
 	for _, outPath := range strings.Split(outputParts[1], ",") {
 		if outPath == "" {
 			if newBinary {
-				return errfmt.Errorf("format flag can't be empty, use '--help output' for more info")
+				// TODO: build man page
+				// return errfmt.Errorf("format flag can't be empty, see 'tracee-output' man page for more info")
+				return errfmt.Errorf("format flag can't be empty, use '--help' for more info")
 			}
 
 			return errfmt.Errorf("format flag can't be empty, use '--output help' for more info")
@@ -217,7 +181,9 @@ func parseFormat(outputParts []string, printerMap map[string]string, newBinary b
 
 		if _, ok := printerMap[outPath]; ok {
 			if newBinary {
-				return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use '--help output' for more info", outPath)
+				// TODO: build man page
+				// return errfmt.Errorf("cannot use the same path for multiple outputs: %s, see 'tracee-output' man page for more info", outPath)
+				return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use '--help' for more info", outPath)
 			}
 
 			return errfmt.Errorf("cannot use the same path for multiple outputs: %s, use '--output help' for more info", outPath)
@@ -232,7 +198,9 @@ func parseFormat(outputParts []string, printerMap map[string]string, newBinary b
 func parseOption(outputParts []string, traceeConfig *config.OutputConfig, newBinary bool) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
 		if newBinary {
-			return errfmt.Errorf("option flag can't be empty, use '--help output' for more info")
+			// TODO: build man page
+			// return errfmt.Errorf("option flag can't be empty, see 'tracee-output' man page for more info")
+			return errfmt.Errorf("option flag can't be empty, use '--help' for more info")
 		}
 
 		return errfmt.Errorf("option flag can't be empty, use '--output help' for more info")
@@ -272,7 +240,9 @@ func createFile(path string) (*os.File, error) {
 func validateURL(outputParts []string, flag string, newBinary bool) error {
 	if len(outputParts) == 1 || outputParts[1] == "" {
 		if newBinary {
-			return errfmt.Errorf("%s flag can't be empty, use '--help output' for more info", flag)
+			// TODO: build man page
+			// return errfmt.Errorf("%s flag can't be empty, see 'tracee-output' man page for more info", flag)
+			return errfmt.Errorf("%s flag can't be empty, use '--help' for more info", flag)
 		}
 
 		return errfmt.Errorf("%s flag can't be empty, use '--output help' for more info", flag)
@@ -282,7 +252,9 @@ func validateURL(outputParts []string, flag string, newBinary bool) error {
 
 	if err != nil {
 		if newBinary {
-			return errfmt.Errorf("invalid uri for %s output %q. Use '--help output' for more info", flag, outputParts[1])
+			// TODO: build man page
+			// return errfmt.Errorf("invalid uri for %s output %q. Use 'tracee-output' man page for more info", flag, outputParts[1])
+			return errfmt.Errorf("invalid uri for %s output %q. Use '--help' for more info", flag, outputParts[1])
 		}
 
 		return errfmt.Errorf("invalid uri for %s output %q. Use '--output help' for more info", flag, outputParts[1])

--- a/pkg/cmd/flags/rego.go
+++ b/pkg/cmd/flags/rego.go
@@ -40,7 +40,9 @@ func PrepareRego(regoSlice []string) (rego.Config, error) {
 		case "aio":
 			c.AIO = true
 		default:
-			return rego.Config{}, errfmt.Errorf("invalid rego option specified, use '--help rego' for more info")
+			// TODO: build man page
+			// return rego.Config{}, errfmt.Errorf("invalid rego option specified, see 'tracee-rego' man page for more info")
+			return rego.Config{}, errfmt.Errorf("invalid rego option specified, use '--help' for more info")
 		}
 	}
 

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
-func traceeEbpfOutputHelp() string {
+func outputHelp() string {
 	return `Control how and where output is printed.
 Possible options:
 [format:]table                                     output events in table format (default)


### PR DESCRIPTION
### 1. Explain what the PR does

f68b5c95d **fix(flags)!: del help cmd, add md files for flags (#3321)** _<sub>(2023/jul/27) Geyslan Gregório \<geyslan@gmail.com\></sub>_

```
This removes the default cobra help command, leaving only the root
--help flag.

The remaining - in code - help flags strings are only used by the old
tracee-ebpf command.

With this, new binary flags help are inaccessible. To circumvent this,
the help flags are now documented in markdown files (not included to
online docs) to be used as source for man pages generation (next step).

BREAKING CHANGE: help command is gone, use --help flag instead.

commit: d882cbf (main), cherry-pick
```

### 2. Explain how to test it

### 3. Other comments