### PR TITLE
[v0.17.0] chore (engine): split Init from NewEngine (#3342)

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -156,7 +156,11 @@ func main() {
 				c.Bool(server.PProfEndpointFlag),
 				c.Bool(server.PyroscopeAgentFlag),
 			)
+			if err != nil {
+				return err
+			}
 
+			err = e.Init()
 			if err != nil {
 				return err
 			}

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -357,9 +357,11 @@ func TestEngine_ConsumeSources(t *testing.T) {
 
 			e, err := NewEngine(tc.config, inputs, outputChan)
 			require.NoError(t, err, "constructing engine")
-			go func() {
-				e.Start(ctx)
-			}()
+
+			err = e.Init()
+			require.NoError(t, err, "initializing engine")
+
+			go e.Start(ctx)
 
 			// send a test event
 			e.inputs.Tracee <- tc.inputEvent
@@ -419,6 +421,10 @@ func TestEngine_GetSelectedEvents(t *testing.T) {
 	config := Config{Signatures: sigs}
 	e, err := NewEngine(config, EventSources{Tracee: make(chan protocol.Event)}, make(chan detect.Finding))
 	require.NoError(t, err, "constructing engine")
+
+	err = e.Init()
+	require.NoError(t, err, "initializing engine")
+
 	se := e.GetSelectedEvents()
 	expected := []detect.SignatureEventSelector{
 		{


### PR DESCRIPTION
### 1. Explain what the PR does

46266e12d **chore (engine): split Init from NewEngine (#3342)** _<sub>(2023/jul/27) Nadav Strahilevitz \<nadav.strahilevitz@aquasec.com\></sub>_

```
Previously data sources could not be registered after the NewEngine call
call and be used in signatures, due to the Init calls being made in
NewEngine.

Fix by moving the loadSignature and initial data source registers to
a new Init method from NewEngine.

In addition, export a method in tracee to prepare the builtin data
sources provided out of the box.

commit: efa0ec4 (main), cherry-pick
```

### 2. Explain how to test it

### 3. Other comments
