### PR TITLE
chore(build): add LOGFROM flag to check-pr rule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,9 @@ PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
 
 ### 1. Explain what the PR does
 
-<!-- Best advice is to put copy & paste your very well written git logs -->
+<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->
+
+"Replace me with `make check-pr` output"
 
 ### 2. Explain how to test it
 

--- a/Makefile
+++ b/Makefile
@@ -858,6 +858,8 @@ check-err: \
 # pull request verifier
 #
 
+LOGFROM ?= main
+
 .PHONY: check-pr
 check-pr: \
 	check-fmt check-lint check-code \
@@ -868,9 +870,14 @@ check-pr: \
 	@echo
 
 	@$(CMD_GIT) \
-		log main..HEAD \
-		--pretty=format:'%C(auto,yellow)%h%Creset **%C(auto,red)%s%Creset** _<sub>%C(auto,cyan)(%ad)%Creset %C(auto,green)%an \<%ae\>%Creset</sub>_%n%n```%n%b```%n' \
-		--date=format:"%Y/%b/%d"
+		log $(LOGFROM)..HEAD \
+		--pretty=format:'%C(auto,yellow)%h%Creset **%C(auto,red)%s%Creset**'
+
+	@echo
+
+	@$(CMD_GIT) \
+		log $(LOGFROM)..HEAD \
+		--pretty=format:'commit %C(auto,yellow)%h%Creset%n%n```%n%b```%n'
 
 	@echo
 	@echo "*** PR Comment END"


### PR DESCRIPTION
### 1. Explain what the PR does

cf7137649 **chore(build): add LOGFROM flag to check-pr rule**

commit cf7137649

```
With this flag, the git log output is filtered to only include commits
from the specified commit to the current HEAD.

make check-pr                # from main (default)
make check-pr LOGFROM=v0.1.0 # from tag/branch
make check-pr LOGFROM=HEAD~1 # from commit
make check-pr LOGFROM=f3a4b2 # from commit

This also changes check-pr output format and adds information for using
its output in the PULL_REQUEST_TEMPLATE.md file.
```
### 2. Explain how to test it

See commit above.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
