### PR TITLE
feature: validate kernel version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/fluent-forward-go v0.2.1
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690
-	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
+	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230801162555-7c27537dcf7b
 	github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1 h
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690 h1:iDvZaf9Xcw9JfzJyqG9L9cYDwSpaFRg5pLddu4IvId0=
 github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690/go.mod h1:UD3Mfr+JZ/ASK2VMucI/zAdEhb35LtvYXvAUdrdqE9s=
-github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
-github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230801162555-7c27537dcf7b h1:MN1UP8miVWqYFx1k9tDxRr98CEAyk/YMjdzWkdP1cXM=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230801162555-7c27537dcf7b/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf h1:bSWqjqjFPGyn+thqof/rph4A5jSqd2d7xWJK5MGMb0I=
 github.com/aquasecurity/tracee/types v0.0.0-20230602152109-e48d0a548fbf/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
@@ -1632,6 +1634,9 @@ func Test_EventFilters(t *testing.T) {
 	}
 
 	// run tests cases
+	osinfo, err := libbpfgo.GetOSInfo()
+	require.NoError(t, err)
+
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			// prepare tracee config
@@ -1641,6 +1646,7 @@ func Test_EventFilters(t *testing.T) {
 				Capabilities: &config.CapabilitiesConfig{
 					BypassCaps: true,
 				},
+				OSInfo: osinfo,
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Tue Aug 1 12:29:06 2023 +0000

    feature: validate kernel version
    
    Tracee so far never explicitly validated kernel version when running.
    It is implicitly validated through available BTFs, and in NON-CORE it
    was validated through a compile time directive.
    When using tracee as a library this is an issue as no validation is done
    and undefined behavior may occur in unsupported kernels.
```

```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Tue Aug 1 12:59:15 2023 +0000

    chore(go.mod): bump libbpfgo helpers
    
    Include fix to osinfo parsing for centos.
```

Fix #3354