### PR TITLE
events: adjust hidden kernel module event to v6.4

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -688,7 +688,21 @@ struct kset {
     struct list_head list;
 };
 
-struct module_layout {
+enum mod_mem_type
+{
+    MOD_TEXT = 0,
+    MOD_DATA,
+    MOD_RODATA,
+    MOD_RO_AFTER_INIT,
+    MOD_INIT_TEXT,
+    MOD_INIT_DATA,
+    MOD_INIT_RODATA,
+
+    MOD_MEM_NUM_TYPES,
+    MOD_INVALID = -1,
+};
+
+struct module_memory {
     void *base;
 };
 
@@ -698,7 +712,7 @@ struct module {
     const char *version;
     const char *srcversion;
     struct module_kobject mkobj;
-    struct module_layout core_layout;
+    struct module_memory mem[MOD_MEM_NUM_TYPES]; // kernel versions >= 6.4
 };
 
 struct rb_node {

--- a/pkg/ebpf/c/vmlinux_flavors.h
+++ b/pkg/ebpf/c/vmlinux_flavors.h
@@ -85,6 +85,18 @@ struct kernel_cap_struct___older {
 
 typedef struct kernel_cap_struct___older kernel_cap_t___older;
 
+// struct module //
+
+struct module_layout {
+    void *base;
+};
+
+struct module___older_v64 {
+    struct module_layout core_layout;
+};
+
+///////////////////
+
 #pragma clang attribute pop
 
 #endif


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The struct that kept the address of which the module resides has changed - we now use the correct field based on kernel version in runtime

close #3339