### PR TITLE
fix: print_mem_dump fails on missing symbol

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1700,7 +1700,8 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 						}
 					}
 					if err != nil {
-						return errfmt.WrapError(err)
+						logger.Warnw("print_mem_dump: failed to get symbol info", "symbol", name)
+						continue
 					}
 				}
 				eventHandle := t.triggerContexts.Store(event)

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -497,8 +497,8 @@ func (t *Tracee) generateInitValues() (InitValues, error) {
 		if !events.Core.IsDefined(evt) {
 			return initVals, errfmt.Errorf("event %d is undefined", evt)
 		}
-		for range events.Core.GetDefinitionByID(evt).GetDependencies().GetKSymbols() {
-			initVals.Kallsyms = true // only if length > 0
+		if events.Core.GetDefinitionByID(evt).GetDependencies().GetKSymbols() != nil {
+			initVals.Kallsyms = true
 		}
 	}
 

--- a/pkg/events/definition_dependencies.go
+++ b/pkg/events/definition_dependencies.go
@@ -38,10 +38,12 @@ func (d Dependencies) GetIDs() []ID {
 	return d.ids
 }
 
+// GetKSymbols returns the KSymbols dependencies of an event.
+// If nil is returned no ksymbols are needed.
+// If an empty array is returned - symbols are needed, but none should specifically
+// be loaded ahead of time.
+// A non-empty array indicates that some symbols should be queried and loaded ahead of time.
 func (d Dependencies) GetKSymbols() []KSymbol {
-	if d.kSymbols == nil {
-		return []KSymbol{}
-	}
 	return d.kSymbols
 }
 


### PR DESCRIPTION
Fix #3382
commit cbac4047cf596712a353542a0a9b6586c8cf3844
```
Date:   Sun Aug 13 12:38:37 2023 +0000

    fix: non-nil empty ksymbols dependency
    
    The events group refactor (commit aa3fd66) changed the semantics of
    ksymbols dependency so that kernel symbols would only be loaded if a
    specific list was set.
    This broke several events which require kernel symbols in general, but
    not any specifically (being set through argument "parameter" lists).
    Fix this by bringing back previous semantics.
```

Fix #3383 
commit b57331706b726343af011af9a85c2711dd25c633
```
Date:   Sun Aug 13 12:41:05 2023 +0000

    fix: print_mem_dump fail on missing symbol
    
    print_mem_dump trigger currently fails when failing to query a symbol.
    However print_mem_dump can potentially include many symbols in its
    parameters, and shouldn't fail the whole trigger based on one symbol.
    Skip the error return when a symbol query fails and log a WARN level
    message instead.
```