### PR TITLE
`--help` flag parsing

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -20,9 +20,10 @@ import (
 )
 
 var (
-	cfgFile  string
-	helpFlag bool
-	rootCmd  = &cobra.Command{
+	cfgFileFlag string
+	helpFlag    bool
+
+	rootCmd = &cobra.Command{
 		Use:   "tracee",
 		Short: "Trace OS events and syscalls using eBPF",
 		Long: `Tracee uses eBPF technology to tap into your system and give you
@@ -44,7 +45,7 @@ access to hundreds of events that help you understand how your system behaves.`,
 					}
 					os.Exit(0)
 				}
-				initConfig()
+				checkConfigFlag()
 			}
 		},
 		Run: func(cmd *cobra.Command, args []string) {
@@ -138,7 +139,7 @@ func initCmd() error {
 
 	// config is not bound to viper
 	rootCmd.Flags().StringVar(
-		&cfgFile,
+		&cfgFileFlag,
 		"config",
 		"",
 		"<file>\t\t\t\tGlobal config file (yaml, json between others - see documentation)",
@@ -323,12 +324,12 @@ func initCmd() error {
 	return nil
 }
 
-func initConfig() {
-	if cfgFile == "" {
+func checkConfigFlag() {
+	if cfgFileFlag == "" {
 		return
 	}
 
-	cfgFile, err := filepath.Abs(cfgFile)
+	cfgFile, err := filepath.Abs(cfgFileFlag)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", errfmt.WrapError(err))
 		os.Exit(1)


### PR DESCRIPTION
Close: #3372

### 1. Explain what the PR does

0611b6dae **chore(cmd): refactor config flag**
add405434 **fix(cmd): --help flag parsing**


**fix(cmd): --help flag parsing**

```
The --help flag was not being parsed correctly, i.e.
`sudo ./dist/tracee --help whatever` was not showing the help message.

This commit fixes the issue by using the `--help` flag as a boolean flag
and leaving the hard work to cobra.
```

### 2. Explain how to test it

`sudo ./dist/tracee --help`
`sudo ./dist/tracee --help --scope comm=who`
`sudo ./dist/tracee --scope comm=who --help`

Expected failing:

`sudo ./dist/tracee --scope --help`
`sudo ./dist/tracee --help whatever`

### 3. Other comments

