### PR TITLE
Add grpc diagnostic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230816112254-7c722620761f
+	github.com/aquasecurity/tracee/types v0.0.0-20230817130859-7d4b8c20396c
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible
 	github.com/golang/protobuf v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/aquasecurity/tracee/types v0.0.0-20230814175534-37865f710007 h1:daNzg
 github.com/aquasecurity/tracee/types v0.0.0-20230814175534-37865f710007/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
 github.com/aquasecurity/tracee/types v0.0.0-20230816112254-7c722620761f h1:lMVQW0cNpXyFM4ZwZ1A7cg0shnmNuEoiHwjVVYVsSQg=
 github.com/aquasecurity/tracee/types v0.0.0-20230816112254-7c722620761f/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
+github.com/aquasecurity/tracee/types v0.0.0-20230817130859-7d4b8c20396c h1:0fTbrZsLLIFC17bbm1XGoMZEJvFyfIT3mJJhwXMHVpA=
+github.com/aquasecurity/tracee/types v0.0.0-20230817130859-7d4b8c20396c/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -291,6 +291,7 @@ func PrepareLogger(logOptions []string, newBinary bool) (logger.LoggingConfig, e
 	llogger := logger.NewLogger(loggerCfg)
 	return logger.LoggingConfig{
 		Logger:        llogger,
+		LoggerConfig:  loggerCfg,
 		Filter:        filter,
 		Aggregate:     agg,
 		FlushInterval: interval,

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -47,7 +47,7 @@ func (r Runner) Run(ctx context.Context) error {
 
 			// start server if one is configured
 			if r.GRPCServer != nil {
-				go r.GRPCServer.Start(ctx)
+				go r.GRPCServer.Start(ctx, t)
 			}
 		},
 	)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -88,7 +88,7 @@ const (
 // Tracee offers aggregation and filtering support on top of any logger implementation complying to it's interface.
 type LoggingConfig struct {
 	Logger        LoggerInterface
-	loggerConfig  LoggerConfig
+	LoggerConfig  LoggerConfig
 	Filter        LoggerFilter
 	Aggregate     bool
 	FlushInterval time.Duration
@@ -105,7 +105,7 @@ type LoggerConfig struct {
 // SetLevel sets the logging level of the package level logger.
 // It is thread safe.
 func (lc LoggingConfig) SetLevel(lvl Level) {
-	lc.loggerConfig.Level.SetLevel(lvl)
+	lc.LoggerConfig.Level.SetLevel(lvl)
 }
 
 func defaultEncoder() Encoder {
@@ -124,7 +124,7 @@ func NewDefaultLoggingConfig() LoggingConfig {
 	loggerConfig := NewDefaultLoggerConfig()
 	return LoggingConfig{
 		Logger:        NewLogger(loggerConfig),
-		loggerConfig:  loggerConfig,
+		LoggerConfig:  loggerConfig,
 		Filter:        NewLoggerFilter(),
 		Aggregate:     false,
 		FlushInterval: DefaultFlushInterval,

--- a/pkg/server/grpc/diagnostic.go
+++ b/pkg/server/grpc/diagnostic.go
@@ -1,0 +1,75 @@
+package grpc
+
+import (
+	"context"
+	"runtime"
+
+	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	pb "github.com/aquasecurity/tracee/types/api/v1beta1"
+)
+
+type DiagnosticService struct {
+	pb.UnimplementedDiagnosticServiceServer
+	tracee *tracee.Tracee
+}
+
+func (s *DiagnosticService) GetMetrics(ctx context.Context, in *pb.GetMetricsRequest) (*pb.GetMetricsResponse, error) {
+	stats := s.tracee.Stats()
+	metrics := &pb.GetMetricsResponse{
+		EventCount:       stats.EventCount.Get(),
+		EventsFiltered:   stats.EventsFiltered.Get(),
+		NetCapCount:      stats.NetCapCount.Get(),
+		BPFLogsCount:     stats.BPFLogsCount.Get(),
+		ErrorCount:       stats.ErrorCount.Get(),
+		LostEvCount:      stats.LostEvCount.Get(),
+		LostWrCount:      stats.LostWrCount.Get(),
+		LostNtCapCount:   stats.LostNtCapCount.Get(),
+		LostBPFLogsCount: stats.LostBPFLogsCount.Get(),
+	}
+
+	return metrics, nil
+}
+
+func (s *DiagnosticService) ChangeLogLevel(ctx context.Context, in *pb.ChangeLogLevelRequest) (*pb.ChangeLogLevelResponse, error) {
+	// default level
+	level := logger.InfoLevel
+
+	switch in.Level {
+	case pb.LogLevel_Debug:
+		level = logger.DebugLevel
+	case pb.LogLevel_Warn:
+		level = logger.WarnLevel
+	case pb.LogLevel_Error:
+		level = logger.ErrorLevel
+	case pb.LogLevel_DPanic:
+		level = logger.DPanicLevel
+	case pb.LogLevel_Panic:
+		level = logger.PanicLevel
+	case pb.LogLevel_Fatal:
+		level = logger.FatalLevel
+	}
+
+	logger.SetLevel(level)
+
+	return &pb.ChangeLogLevelResponse{}, nil
+}
+
+func (s *DiagnosticService) GetStacktrace(ctx context.Context, in *pb.GetStacktraceRequest) (*pb.GetStacktraceResponse, error) {
+	return &pb.GetStacktraceResponse{
+		Stacktrace: stack(),
+	}, nil
+}
+
+// This func is based on runtime.Stack(),
+// but instead if pass true to runtime.Stack in order to include all goroutines.
+func stack() []byte {
+	buf := make([]byte, 1024)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return buf[:n]
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}

--- a/pkg/server/grpc/server_test.go
+++ b/pkg/server/grpc/server_test.go
@@ -31,7 +31,7 @@ func TestServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go grpcServer.Start(ctx)
+	go grpcServer.Start(ctx, nil)
 
 	c := grpcClient("unix", unixSock)
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR is part of the work to support a [v1 for GRPC](https://github.com/aquasecurity/tracee/issues/3208). This PR implements the diagnostic rpc service. I've tested with `-race` no data races were found here. 

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->


### 2. Explain how to test it

The below clients can be used to test the GRPC API:

```go
import (
        pb "github.com/aquasecurity/tracee/types/api/v1beta1"
)
```

```go
func main() {
        var opts []grpc.DialOption
        opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

        conn, err := grpc.Dial(":4466", opts...)
        if err != nil {
                log.Fatalf("fail to dial: %v", err)
        }

        client := pb.NewDiagnosticServiceClient(conn)

        changelog := &pb.ChangeLogLevelRequest{
                Level: pb.LogLevel_Info,
        }

        _, err = client.ChangeLogLevel(context.Background(), changelog)
        if err != nil {
                log.Fatal(err)
        }

        fmt.Println("Log level changed to DEBUG")
}
```

```go
func main() {
	var opts []grpc.DialOption
	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

	conn, err := grpc.Dial(":4466", opts...)
	if err != nil {
		log.Fatalf("fail to dial: %v", err)
	}

	client := pb.NewDiagnosticServiceClient(conn)

	stacktrace, err := client.GetStacktrace(context.Background(), &pb.GetStacktraceRequest{})
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println(string(stacktrace.Stacktrace))
}
```

```go
func main() {
	var opts []grpc.DialOption
	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

	conn, err := grpc.Dial(":4466", opts...)
	if err != nil {
		log.Fatalf("fail to dial: %v", err)
	}

	client := pb.NewDiagnosticServiceClient(conn)

	metrics, err := client.GetMetrics(context.Background(), &pb.GetMetricsRequest{})
	if err != nil {
		log.Fatal(err)
	}

	fmt.Println("EventCount", metrics.EventCount)
	fmt.Println("EventsFiltered", metrics.EventsFiltered)
	fmt.Println("NetCapCount", metrics.NetCapCount)
	fmt.Println("BPFLogsCount", metrics.BPFLogsCount)
	fmt.Println("ErrorCount", metrics.ErrorCount)
	fmt.Println("LostEvCount", metrics.LostEvCount)
	fmt.Println("LostWrCount", metrics.LostWrCount)
	fmt.Println("LostNtCapCount", metrics.LostNtCapCount)
	fmt.Println("LostBPFLogsCount", metrics.LostBPFLogsCount)
}
```
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

depends on https://github.com/aquasecurity/tracee/pull/3395

<!--
Links? References? Anything pointing to more context about the change.
-->
