### PR TITLE
[DRAFT] playing around process tree (signal event definition)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,3 +173,6 @@ require (
 )
 
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0
+
+// TODO: remove this once PR is finished
+replace github.com/aquasecurity/tracee/types => ./types

--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -3,6 +3,7 @@
 
 #include <vmlinux.h>
 
+#include <common/hash.h>
 #include <common/network.h>
 
 // PROTOTYPES
@@ -339,6 +340,10 @@ statfunc int events_perf_submit(program_data_t *p, u32 id, long ret)
 {
     p->event->context.eventid = id;
     p->event->context.retval = ret;
+
+    // KEEP THIS FOR DEBUGGING (until process tree is fully implemented)
+    // u32 hash = (u64) hash_u32_and_u64(p->event->context.task.pid,
+    // p->event->context.task.start_time); bpf_printk("hash: %u", hash);
 
     // Get Stack trace
     if (p->config->options & OPT_CAPTURE_STACK_TRACES) {

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -1,6 +1,7 @@
 #ifndef __COMMON_CONTEXT_H__
 #define __COMMON_CONTEXT_H__
 
+#include "common/hash.h"
 #include <vmlinux.h>
 
 #include <common/task.h>

--- a/pkg/ebpf/c/common/hash.h
+++ b/pkg/ebpf/c/common/hash.h
@@ -1,0 +1,97 @@
+#ifndef __COMMON_HASH_H__
+
+#define __COMMON_HASH_H__
+
+#include "bpf/bpf_endian.h"
+#include <vmlinux.h>
+
+#include <maps.h>
+#include <common/logging.h>
+#include <common/common.h>
+
+#define MURMUR_SEED ((u32) 0x18273645) // same as in userland
+
+// PROTOTYPES
+
+u32 murmur32(const void *, u32);
+u32 hash_u32_and_u64(u32, u64);
+
+// FUNCTIONS
+
+// MurMurHash 3 x86 32-bit (https://en.wikipedia.org/wiki/MurmurHash): Small (u32), simple (for C
+// and Go), high performant, optimized and collision resistant hashing function. This function is
+// used to hash a task unique identifier (task pid + task_start_time). Userland uses this unique
+// identifier to identify a task and construct the process tree.
+
+// Murmur3 32-bit hash function implementation.
+
+u32 murmur32(const void *key, u32 len)
+{
+    const u8 *data = (const u8 *) key;
+    const int nblocks = len / 4;
+
+    u32 h1 = MURMUR_SEED;
+    u32 c1 = 0xcc9e2d51;
+    u32 c2 = 0x1b873593;
+
+    // Body
+    const u32 *blocks = (const u32 *) (data + nblocks * 4);
+
+    for (int i = -nblocks; i; i++) {
+        u32 k1 = blocks[i];
+        k1 *= c1;
+        k1 = (k1 << 15) | (k1 >> 17);
+        k1 *= c2;
+
+        h1 ^= k1;
+        h1 = (h1 << 13) | (h1 >> 19);
+        h1 = h1 * 5 + 0xe6546b64;
+    }
+
+    // Tail
+    const u8 *tail = (const u8 *) (data + nblocks * 4);
+    u32 k1 = 0;
+
+    switch (len & 3) {
+        case 3:
+            k1 ^= tail[2] << 16;
+        case 2:
+            k1 ^= tail[1] << 8;
+        case 1:
+            k1 ^= tail[0];
+            k1 *= c1;
+            k1 = (k1 << 15) | (k1 >> 17);
+            k1 *= c2;
+            h1 ^= k1;
+    };
+
+    // Final
+    h1 ^= len;
+    h1 ^= h1 >> 16;
+    h1 *= 0x85ebca6b;
+    h1 ^= h1 >> 13;
+    h1 *= 0xc2b2ae35;
+    h1 ^= h1 >> 16;
+
+    return h1;
+}
+
+// Hash a u32 and a u64 into a u32. This function is used to hash a task unique identifier.
+// Identical to Golang (userland) HashU32AndU64 function: same hash for same input.
+
+u32 hash_u32_and_u64(u32 arg1, u64 arg2)
+{
+    uint8_t buffer[sizeof(arg1) + sizeof(arg2)];
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    arg1 = __builtin_bswap32(arg1); // network byte order is big endian, convert for ...
+    arg2 = __builtin_bswap64(arg2); // ... consistent hashing among different endianness.
+#endif
+
+    __builtin_memcpy(buffer, &arg1, sizeof(arg1));
+    __builtin_memcpy(buffer + sizeof(arg1), &arg2, sizeof(arg2));
+
+    return murmur32(buffer, 4 + 8); // 4 + 8 = sizeof(u32) + sizeof(u64)
+}
+
+#endif

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5942,9 +5942,10 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_tcp_http)
 //
 // Control Plane Programs
 //
-// Control Plane programs are almost duplicate programs of select events which we send as
-// direct signals to tracee in a separate buffer.
-// This is done to mitigate the consenquences of losing these events in the main perf buffer.
+// Control Plane programs are almost duplicate programs of select events which we send as direct
+// signals to tracee in a separate buffer. This is done to mitigate the consenquences of losing
+// these events in the main perf buffer.
+//
 
 SEC("raw_tracepoint/cgroup_mkdir_signal")
 int cgroup_mkdir_signal(struct bpf_raw_tracepoint_args *ctx)
@@ -5977,7 +5978,7 @@ int cgroup_mkdir_signal(struct bpf_raw_tracepoint_args *ctx)
     save_to_submit_buf(&signal->args_buf, &cgroup_id, sizeof(u64), 0);
     save_str_to_buf(&signal->args_buf, path, 1);
     save_to_submit_buf(&signal->args_buf, &hierarchy_id, sizeof(u32), 2);
-    signal_perf_submit(ctx, signal, CGROUP_MKDIR);
+    signal_perf_submit(ctx, signal, SIGNAL_CGROUP_MKDIR);
 
     return 0;
 }
@@ -6010,7 +6011,7 @@ int cgroup_rmdir_signal(struct bpf_raw_tracepoint_args *ctx)
     save_to_submit_buf(&signal->args_buf, &cgroup_id, sizeof(u64), 0);
     save_str_to_buf(&signal->args_buf, path, 1);
     save_to_submit_buf(&signal->args_buf, &hierarchy_id, sizeof(u32), 2);
-    signal_perf_submit(ctx, signal, CGROUP_RMDIR);
+    signal_perf_submit(ctx, signal, SIGNAL_CGROUP_RMDIR);
 
     return 0;
 }

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -7,32 +7,37 @@
 #include <linux/limits.h>
 #include <common/consts.h>
 
+// NOTE: Both, the task_start_time and parent_start_time, are used to uniquely identify a task. The
+//       uniqueness of a task is a hash(pid, start_time) u32 result. We need both, the task and its
+//       parent, to be unique in order to construct a faithful process tree (relating tasks not only
+//       by their pid, but also by their start time).
+
 typedef struct task_context {
-    u64 start_time; // thread's start time
-    u64 cgroup_id;
-    u32 pid;       // PID as in the userspace term
-    u32 tid;       // TID as in the userspace term
-    u32 ppid;      // Parent PID as in the userspace term
-    u32 host_pid;  // PID in host pid namespace
-    u32 host_tid;  // TID in host pid namespace
-    u32 host_ppid; // Parent PID in host pid namespace
-    u32 uid;
-    u32 mnt_id;
-    u32 pid_id;
-    char comm[TASK_COMM_LEN];
-    char uts_name[TASK_COMM_LEN];
-    u32 flags;
+    u64 start_time;               // task's start time
+    u64 cgroup_id;                // control group ID
+    u32 pid;                      // PID as in the userspace term
+    u32 tid;                      // TID as in the userspace term
+    u32 ppid;                     // Parent PID as in the userspace term
+    u32 host_pid;                 // PID in host pid namespace
+    u32 host_tid;                 // TID in host pid namespace
+    u32 host_ppid;                // Parent PID in host pid namespace
+    u32 uid;                      // task's effective UID
+    u32 mnt_id;                   // task's mount namespace ID
+    u32 pid_id;                   // task's pid namespace ID
+    char comm[TASK_COMM_LEN];     // task's comm
+    char uts_name[TASK_COMM_LEN]; // task's uts name
+    u32 flags;                    // task's status flags (see context_flags_e)
 } task_context_t;
 
 typedef struct event_context {
-    u64 ts; // Timestamp
+    u64 ts; // timestamp
     task_context_t task;
     u32 eventid;
-    s32 syscall; // The syscall which triggered the event
+    s32 syscall; // syscall that triggered the event
     u64 matched_policies;
     s64 retval;
     u32 stack_id;
-    u16 processor_id; // The ID of the processor which processed the event
+    u16 processor_id; // ID of the processor that processed the event
 } event_context_t;
 
 enum event_id_e

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -131,7 +131,10 @@ enum event_id_e
 enum signal_evet_id_e
 {
     SIGNAL_CGROUP_MKDIR = 5000,
-    SIGNAL_CGROUP_RMDIR
+    SIGNAL_CGROUP_RMDIR,
+    SIGNAL_SCHED_PROCESS_FORK,
+    SIGNAL_SCHED_PROCESS_EXEC,
+    SIGNAL_SCHED_PROCESS_EXIT,
 };
 
 typedef struct args {

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -128,6 +128,12 @@ enum event_id_e
     MAX_EVENT_ID,
 };
 
+enum signal_evet_id_e
+{
+    SIGNAL_CGROUP_MKDIR = 5000,
+    SIGNAL_CGROUP_RMDIR
+};
+
 typedef struct args {
     unsigned long args[6];
 } args_t;

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -92,6 +92,8 @@ func (p *Controller) processSignal(signal signal) error {
 		return p.processCgroupMkdir(signal.args)
 	case events.SignalCgroupRmdir:
 		return p.processCgroupRmdir(signal.args)
+	case events.SignalSchedProcessFork:
+		fmt.Printf("TODO\n")
 	}
 	return nil
 }

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -206,6 +206,8 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		ModuleLoad:                 NewTraceProbe(RawTracepoint, "module:module_load", "tracepoint__module__module_load"),
 		ModuleFree:                 NewTraceProbe(RawTracepoint, "module:module_free", "tracepoint__module__module_free"),
 		LayoutAndAllocate:          NewTraceProbe(KretProbe, "layout_and_allocate", "trace_ret_layout_and_allocate"),
+		SignalCgroupMkdir:          NewTraceProbe(RawTracepoint, "cgroup:cgroup_mkdir", "cgroup_mkdir_signal"),
+		SignalCgroupRmdir:          NewTraceProbe(RawTracepoint, "cgroup:cgroup_rmdir", "cgroup_rmdir_signal"),
 	}
 
 	if !netEnabled {

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -208,6 +208,9 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		LayoutAndAllocate:          NewTraceProbe(KretProbe, "layout_and_allocate", "trace_ret_layout_and_allocate"),
 		SignalCgroupMkdir:          NewTraceProbe(RawTracepoint, "cgroup:cgroup_mkdir", "cgroup_mkdir_signal"),
 		SignalCgroupRmdir:          NewTraceProbe(RawTracepoint, "cgroup:cgroup_rmdir", "cgroup_rmdir_signal"),
+		SignalSchedProcessFork:     NewTraceProbe(RawTracepoint, "sched:sched_process_fork", "sched_process_fork_signal"),
+		SignalSchedProcessExec:     NewTraceProbe(RawTracepoint, "sched:sched_process_exec", "sched_process_exec_signal"),
+		SignalSchedProcessExit:     NewTraceProbe(RawTracepoint, "sched:sched_process_exit", "sched_process_exit_signal"),
 	}
 
 	if !netEnabled {

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -129,4 +129,7 @@ const (
 	LayoutAndAllocate
 	SignalCgroupMkdir
 	SignalCgroupRmdir
+	SignalSchedProcessFork
+	SignalSchedProcessExec
+	SignalSchedProcessExit
 )

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -127,4 +127,6 @@ const (
 	ModuleLoad
 	ModuleFree
 	LayoutAndAllocate
+	SignalCgroupMkdir
+	SignalCgroupRmdir
 )

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -215,6 +215,9 @@ func New(cfg config.Config) (*Tracee, error) {
 
 	t.eventsState[events.SignalCgroupMkdir] = policy.AlwaysSubmit
 	t.eventsState[events.SignalCgroupRmdir] = policy.AlwaysSubmit
+	t.eventsState[events.SignalSchedProcessFork] = policy.AlwaysSubmit
+	// t.eventsState[events.SignalSchedProcessExec] = policy.AlwaysSubmit
+	// t.eventsState[events.SignalSchedProcessExit] = policy.AlwaysSubmit
 
 	// Pseudo events added by capture (if enabled by the user)
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -122,83 +122,63 @@ func (t *Tracee) Stats() *metrics.Stats {
 	return &t.stats
 }
 
-// GetEssentialEventsList sets the default events used by tracee
-func GetEssentialEventsList() map[events.ID]events.EventState {
-	// Set essential events
-	return map[events.ID]events.EventState{
-		events.SchedProcessExec: {},
-		events.SchedProcessExit: {},
-		events.SchedProcessFork: {},
-	}
-}
-
-// GetCaptureEventsList sets events used to capture data
+// GetCaptureEventsList sets events used to capture data.
 func GetCaptureEventsList(cfg config.Config) map[events.ID]events.EventState {
 	captureEvents := make(map[events.ID]events.EventState)
 
-	// All capture events should be placed, at least for now, to
-	// all matched policies, or else the event won't be set to
-	// matched policy in eBPF and should_submit() won't submit
-	// the capture event to userland.
+	// INFO: All capture events should be placed, at least for now, to all matched policies, or else
+	// the event won't be set to matched policy in eBPF and should_submit() won't submit the capture
+	// event to userland.
 
 	if cfg.Capture.Exec {
-		captureEvents[events.CaptureExec] = events.EventState{
-			Submit: 0xFFFFFFFFFFFFFFFF,
-		}
+		captureEvents[events.CaptureExec] = policy.AlwaysSubmit
 	}
 	if cfg.Capture.FileWrite.Capture {
-		captureEvents[events.CaptureFileWrite] = events.EventState{
-			Submit: 0xFFFFFFFFFFFFFFFF,
-		}
+		captureEvents[events.CaptureFileWrite] = policy.AlwaysSubmit
 	}
 	if cfg.Capture.FileRead.Capture {
-		captureEvents[events.CaptureFileRead] = events.EventState{}
+		captureEvents[events.CaptureFileRead] = policy.AlwaysSubmit
 	}
 	if cfg.Capture.Module {
-		captureEvents[events.CaptureModule] = events.EventState{
-			Submit: 0xFFFFFFFFFFFFFFFF,
-		}
+		captureEvents[events.CaptureModule] = policy.AlwaysSubmit
 	}
 	if cfg.Capture.Mem {
-		captureEvents[events.CaptureMem] = events.EventState{
-			Submit: 0xFFFFFFFFFFFFFFFF,
-		}
+		captureEvents[events.CaptureMem] = policy.AlwaysSubmit
 	}
 	if cfg.Capture.Bpf {
-		captureEvents[events.CaptureBpf] = events.EventState{
-			Submit: 0xFFFFFFFFFFFFFFFF,
-		}
+		captureEvents[events.CaptureBpf] = policy.AlwaysSubmit
 	}
 	if pcaps.PcapsEnabled(cfg.Capture.Net) {
-		captureEvents[events.CaptureNetPacket] = events.EventState{
-			Submit: 0xFFFFFFFFFFFFFFFF,
-		}
+		captureEvents[events.CaptureNetPacket] = policy.AlwaysSubmit
 	}
 
 	return captureEvents
 }
 
-func (t *Tracee) handleEventsDependencies(givenEventId events.ID, submitMap uint64) {
-	givenEventDefinition := events.Core.GetDefinitionByID(givenEventId)
-	for _, depEventId := range givenEventDefinition.GetDependencies().GetIDs() {
-		depEventState, ok := t.eventsState[depEventId]
+// handleEventsDependencies handles all events dependencies recursively.
+func (t *Tracee) handleEventsDependencies(givenEvtId events.ID, givenEvtState events.EventState) {
+	givenEvtDefinition := events.Core.GetDefinitionByID(givenEvtId)
+
+	for _, depEventId := range givenEvtDefinition.GetDependencies().GetIDs() {
+		t.handleEventsDependencies(depEventId, givenEvtState) // deps of deps of deps...
+
+		dependEvtState, ok := t.eventsState[depEventId]
 		if !ok {
-			depEventState = events.EventState{}
-			t.handleEventsDependencies(depEventId, submitMap)
+			t.eventsState[depEventId] = events.EventState{}
 		}
 
-		depEventState.Submit |= submitMap
-		t.eventsState[depEventId] = depEventState
+		// Make sure dependencies are submitted if the given event is submitted.
+		dependEvtState.Submit |= givenEvtState.Submit
 
-		if events.Core.GetDefinitionByID(givenEventId).IsSignature() {
+		// If the given event is a signature, mark all dependencies as signatures.
+		if events.Core.GetDefinitionByID(givenEvtId).IsSignature() {
 			t.eventSignatures[depEventId] = true
 		}
 	}
 }
 
-// New creates a new Tracee instance based on a given valid Config. It is
-// expected that it won't cause external system side effects (reads, writes,
-// etc.)
+// New creates a new Tracee instance based on a given valid Config. It is expected that it won't
+// cause external system side effects (reads, writes, etc).
 func New(cfg config.Config) (*Tracee, error) {
 	err := cfg.Validate()
 	if err != nil {
@@ -213,7 +193,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		writtenFiles:    make(map[string]string),
 		readFiles:       make(map[string]string),
 		capturedFiles:   make(map[string]int64),
-		eventsState:     GetEssentialEventsList(),
+		eventsState:     make(map[events.ID]events.EventState),
 		eventSignatures: make(map[events.ID]bool),
 	}
 
@@ -225,7 +205,18 @@ func New(cfg config.Config) (*Tracee, error) {
 	}
 	caps := capabilities.GetInstance()
 
-	// Pseudo events added by capture
+	// Initialize events state with mandatory events
+
+	t.eventsState[events.SchedProcessExec] = events.EventState{}
+	t.eventsState[events.SchedProcessExit] = events.EventState{}
+	t.eventsState[events.SchedProcessFork] = events.EventState{}
+
+	// Pseudo events added by control plane: EventState only used so Tracee can initialize them
+
+	t.eventsState[events.SignalCgroupMkdir] = policy.AlwaysSubmit
+	t.eventsState[events.SignalCgroupRmdir] = policy.AlwaysSubmit
+
+	// Pseudo events added by capture (if enabled by the user)
 
 	for eventID, eCfg := range GetCaptureEventsList(cfg) {
 		t.eventsState[eventID] = eCfg
@@ -248,8 +239,8 @@ func New(cfg config.Config) (*Tracee, error) {
 
 	// Handle all essential events dependencies
 
-	for id, evt := range t.eventsState {
-		t.handleEventsDependencies(id, evt.Submit)
+	for id, state := range t.eventsState {
+		t.handleEventsDependencies(id, state)
 	}
 
 	// Update capabilities rings with all events dependencies
@@ -1147,14 +1138,7 @@ func (t *Tracee) populateBPFMaps() error {
 func (t *Tracee) attachProbes() error {
 	var err error
 
-	// attach control plane probes first
-	err = t.controlPlane.Attach()
-	if err != nil {
-		return errfmt.WrapError(err)
-	}
-
-	// attach selected tracing events probes
-
+	// attach all probes for the events being filtered
 	for tr := range t.eventsState {
 		if !events.Core.IsDefined(tr) {
 			continue
@@ -1328,10 +1312,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	go t.lkmSeekerRoutine(ctx)
 
 	// Start control plane
-	err = t.controlPlane.Start()
-	if err != nil {
-		return err
-	}
+	t.controlPlane.Start()
 	go t.controlPlane.Run(ctx)
 
 	// Main event loop (polling events perf buffer)
@@ -1432,16 +1413,16 @@ func updateCaptureMapFile(fileDir *os.File, filePath string, capturedFiles map[s
 
 // Close cleans up created resources
 func (t *Tracee) Close() {
-	if t.probes != nil {
-		err := t.probes.DetachAll()
-		if err != nil {
-			logger.Errorw("failed to detach probes when closing tracee", "err", err)
-		}
-	}
 	if t.controlPlane != nil {
 		err := t.controlPlane.Stop()
 		if err != nil {
 			logger.Errorw("failed to stop control plane when closing tracee", "err", err)
+		}
+	}
+	if t.probes != nil {
+		err := t.probes.DetachAll()
+		if err != nil {
+			logger.Errorw("failed to detach probes when closing tracee", "err", err)
 		}
 	}
 	if t.bpfModule != nil {

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -149,6 +149,9 @@ const (
 const (
 	SignalCgroupMkdir ID = iota + 5000
 	SignalCgroupRmdir
+	SignalSchedProcessFork
+	SignalSchedProcessExec
+	SignalSchedProcessExit
 )
 
 // Signature events
@@ -10569,6 +10572,85 @@ var CoreEvents = map[ID]Definition{
 			{Type: "u32", Name: "hierarchy_id"},
 		},
 	},
+	SignalSchedProcessFork: {
+		id:      SignalSchedProcessFork,
+		id32Bit: Sys32Undefined,
+		name:    "signal_sched_process_fork",
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.SignalSchedProcessFork, required: true},
+			},
+		},
+		sets: []string{},
+		params: []trace.ArgMeta{
+			{Type: "int", Name: "parent_tid"},
+			{Type: "int", Name: "parent_ns_tid"},
+			{Type: "int", Name: "parent_pid"},
+			{Type: "int", Name: "parent_ns_pid"},
+			{Type: "unsigned long", Name: "parent_start_time"},
+			{Type: "int", Name: "child_tid"},
+			{Type: "int", Name: "child_ns_tid"},
+			{Type: "int", Name: "child_pid"},
+			{Type: "int", Name: "child_ns_pid"},
+			{Type: "unsigned long", Name: "child_start_time"},
+		},
+	},
+	// SignalSchedProcessExec: {
+	// 	id:      SignalSchedProcessExec,
+	// 	id32Bit: Sys32Undefined,
+	// 	name:    "signal_sched_process_exec",
+	// 	dependencies: Dependencies{
+	// 		probes: []Probe{
+	// 			{handle: probes.SignalSchedProcessExec, required: true},
+	// 			{handle: probes.LoadElfPhdrs, required: false},
+	// 		},
+	// 		tailCalls: []TailCall{
+	// 			{
+	// 				"prog_array_tp",
+	// 				"sched_process_exec_event_submit_tail",
+	// 				[]uint32{TailSchedProcessExecEventSubmit},
+	// 			},
+	// 		},
+	// 		capabilities: Capabilities{
+	// 			base: []cap.Value{},
+	// 		},
+	// 	},
+	// 	sets: []string{"default", "proc"},
+	// 	params: []trace.ArgMeta{
+	// 		{Type: "const char*", Name: "cmdpath"},
+	// 		{Type: "const char*", Name: "pathname"},
+	// 		{Type: "dev_t", Name: "dev"},
+	// 		{Type: "unsigned long", Name: "inode"},
+	// 		{Type: "unsigned long", Name: "ctime"},
+	// 		{Type: "umode_t", Name: "inode_mode"},
+	// 		{Type: "const char*", Name: "interpreter_pathname"},
+	// 		{Type: "dev_t", Name: "interpreter_dev"},
+	// 		{Type: "unsigned long", Name: "interpreter_inode"},
+	// 		{Type: "unsigned long", Name: "interpreter_ctime"},
+	// 		{Type: "const char**", Name: "argv"},
+	// 		{Type: "const char*", Name: "interp"},
+	// 		{Type: "umode_t", Name: "stdin_type"},
+	// 		{Type: "char*", Name: "stdin_path"},
+	// 		{Type: "int", Name: "invoked_from_kernel"},
+	// 		{Type: "const char**", Name: "env"},
+	// 	},
+	// },
+	// SignalSchedProcessExit: {
+	// 	id:      SignalSchedProcessExit,
+	// 	id32Bit: Sys32Undefined,
+	// 	name:    "signal_sched_process_exit",
+	// 	dependencies: Dependencies{
+	// 		probes: []Probe{
+	// 			{handle: probes.SignalSchedProcessExit, required: true},
+	// 			{handle: probes.SchedProcessFree, required: true},
+	// 		},
+	// 	},
+	// 	sets: []string{"proc", "proc_life"},
+	// 	params: []trace.ArgMeta{
+	// 		{Type: "long", Name: "exit_code"},
+	// 		{Type: "bool", Name: "process_group_exit"},
+	// 	},
+	// },
 	//
 	// Begin of Network Protocol Event Types
 	//

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -144,6 +144,13 @@ const (
 	CaptureFileRead
 )
 
+// Signal meta-events
+
+const (
+	SignalCgroupMkdir ID = iota + 5000
+	SignalCgroupRmdir
+)
+
 // Signature events
 const (
 	StartSignatureID ID = 6000
@@ -10525,6 +10532,41 @@ var CoreEvents = map[ID]Definition{
 			{Type: "int", Name: "kernel_invoked"},
 			{Type: "const char*const*", Name: "binary.arguments"},
 			{Type: "const char*const*", Name: "environment"},
+		},
+	},
+	//
+	// Begin of Signal Events (Control Plane)
+	//
+	SignalCgroupMkdir: {
+		id:      SignalCgroupMkdir,
+		id32Bit: Sys32Undefined,
+		name:    "signal_cgroup_mkdir",
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.SignalCgroupMkdir, required: true},
+			},
+		},
+		sets: []string{},
+		params: []trace.ArgMeta{
+			{Type: "u64", Name: "cgroup_id"},
+			{Type: "const char*", Name: "cgroup_path"},
+			{Type: "u32", Name: "hierarchy_id"},
+		},
+	},
+	SignalCgroupRmdir: {
+		id:      SignalCgroupRmdir,
+		id32Bit: Sys32Undefined,
+		name:    "signal_cgroup_rmdir",
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.SignalCgroupRmdir, required: true},
+			},
+		},
+		sets: []string{},
+		params: []trace.ArgMeta{
+			{Type: "u64", Name: "cgroup_id"},
+			{Type: "const char*", Name: "cgroup_path"},
+			{Type: "u32", Name: "hierarchy_id"},
 		},
 	},
 	//

--- a/pkg/events/parse/params.go
+++ b/pkg/events/parse/params.go
@@ -11,7 +11,12 @@ func ArgVal[T any](args []trace.Argument, argName string) (T, error) {
 			val, ok := arg.Value.(T)
 			if !ok {
 				zeroVal := *new(T)
-				return zeroVal, errfmt.Errorf("argument %s is not of type %T", argName, zeroVal)
+				return zeroVal, errfmt.Errorf(
+					"argument %s is not of type %T, is of type %T",
+					argName,
+					zeroVal,
+					arg.Value,
+				)
 			}
 			return val, nil
 		}

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -3,9 +3,18 @@ package policy
 import (
 	"sync/atomic"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
+
+const (
+	allPoliciesOn = 0xFFFFFFFFFFFFFFFF
+)
+
+var AlwaysSubmit = events.EventState{
+	Submit: allPoliciesOn,
+}
 
 // TODO: add locking mechanism as policies will change at runtime
 type Policies struct {

--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -1,0 +1,77 @@
+package utils
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+// MurMurHash 3 x86 32-bit (https://en.wikipedia.org/wiki/MurmurHash): Small (u32), simple (for C
+// and Go), high performant, optimized and collision resistant hashing function. This function is
+// used to hash a task unique identifier (task pid + task_start_time). Userland uses this unique
+// identifier to identify a task and construct the process tree.
+
+const (
+	murmurSeed = 0x18273645 // same as in eBPF kernel code
+)
+
+// Murmur32 is a Murmur3 32-bit hash function implementation.
+func Murmur32(key []byte) uint32 {
+	data := key
+	nblocks := len(data) / 4
+
+	h1 := uint32(murmurSeed)
+	c1 := uint32(0xcc9e2d51)
+	c2 := uint32(0x1b873593)
+
+	// Body
+	blocks := data[:nblocks*4]
+
+	for i := 0; i < nblocks; i++ {
+		k1 := *(*uint32)(unsafe.Pointer(&blocks[i*4]))
+
+		k1 *= c1
+		k1 = (k1 << 15) | (k1 >> 17)
+		k1 *= c2
+
+		h1 ^= k1
+		h1 = (h1 << 13) | (h1 >> 19)
+		h1 = h1*5 + 0xe6546b64
+	}
+
+	// Tail
+	tail := data[nblocks*4:]
+	k1 := uint32(0)
+
+	switch len(tail) {
+	case 3:
+		k1 ^= uint32(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint32(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint32(tail[0])
+		k1 *= c1
+		k1 = (k1 << 15) | (k1 >> 17)
+		k1 *= c2
+		h1 ^= k1
+	}
+
+	// Final
+	h1 ^= uint32(len(data))
+	h1 ^= h1 >> 16
+	h1 *= 0x85ebca6b
+	h1 ^= h1 >> 13
+	h1 *= 0xc2b2ae35
+	h1 ^= h1 >> 16
+
+	return h1
+}
+
+// HashU32AndU64 is a wrapper around Murmur32 making sure network byte order is used.
+func HashU32AndU64(arg1 uint32, arg2 uint64) uint32 {
+	buffer := make([]byte, 4+8)                  // u32 + u64
+	binary.BigEndian.PutUint32(buffer, arg1)     // network byte order
+	binary.BigEndian.PutUint64(buffer[4:], arg2) // network byte order
+	return Murmur32(buffer)
+}

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -42,9 +42,17 @@ type Event struct {
 	Syscall               string       `json:"syscall"`
 	StackAddresses        []uint64     `json:"stackAddresses"`
 	ContextFlags          ContextFlags `json:"contextFlags"`
-	Args                  []Argument   `json:"args"` // Arguments are ordered according their appearance in the original event
+	EntityID              uint32       `json:"-"`    // task unique identifier (*)
+	Args                  []Argument   `json:"args"` // args are ordered according their appearance in the original event
 	Metadata              *Metadata    `json:"metadata,omitempty"`
 }
+
+// (*) For an OS task to be uniquely identified, tracee builds a hash consisting of:
+//
+// u64: task start time (from event context)
+// u32: task thread id (from event context)
+//
+// murmur([]byte) where slice of bytes is a concatenation (not a sum) of the 2 values above.
 
 type Container struct {
 	ID          string `json:"id,omitempty"`


### PR DESCRIPTION
Based on the reviews at: https://github.com/aquasecurity/tracee/pull/3364

I would like some feedback before moving further.

I have created "signal events", which are regular event definitions but for the control plane. This allows us to initialize the event dependencies just like we do for all other events (removing probe group creation from the control plane).

I have also created an example (unfinished) for the SchedProcessFork to check if duplicating the eBPF programs like this is what was asked.

@yanivagman Please provide feedback if this is good so I can move further (based on your inputs in the last PR).