### PR TITLE
fix: ignore error for cgroups that doesn't exist

### DIFF
--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -479,5 +479,13 @@ func (c *Containers) RemoveFromBPFMap(bpfModule *libbpfgo.Module, cgroupId uint6
 	}
 
 	cgroupIdLsb := uint32(cgroupId)
-	return containersMap.DeleteKey(unsafe.Pointer(&cgroupIdLsb))
+	err = containersMap.DeleteKey(unsafe.Pointer(&cgroupIdLsb))
+
+	// ignores the error if the cgroup was already deleted
+	if errors.Is(err, syscall.ENOENT) {
+		logger.Debugw("cgroup already deleted", "error", err)
+		return nil
+	}
+
+	return err
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3396

When running tracee on gke we see a lot of errors due to deletion of groups that don't exist (probably because they are not related to containers), on this PR we ignore this error, and add a debug logging for whenever it happens.

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
