### PR TITLE
chore(revive): mitigate redundant warning

### DIFF
--- a/cmd/tracee-bench/main.go
+++ b/cmd/tracee-bench/main.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/api"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/urfave/cli/v2"
 )
 
@@ -86,7 +86,7 @@ func main() {
 			}
 
 			done := sigHandler()
-			prom := v1.NewAPI(client)
+			prom := promv1.NewAPI(client)
 			ticker := time.NewTicker(time.Duration(ctx.Int(periodFlag)) * time.Second)
 
 			// promql queries


### PR DESCRIPTION
Latest revive started giving a warning for redundancy. Mitigate the warning so all next builds start passing linting checks.