### PR TITLE
Fix closed chan read

### DIFF
--- a/pkg/ebpf/bpf_log.go
+++ b/pkg/ebpf/bpf_log.go
@@ -191,16 +191,15 @@ func (t *Tracee) processBPFLogs(ctx context.Context) {
 				logger.Errorw("Incrementing BPF logs count", "error", err)
 			}
 
-		case lost := <-t.lostBPFLogChannel:
-			// When terminating tracee-ebpf the lost channel receives multiple "0 lost events" events.
-			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
-			// https://github.com/aquasecurity/libbpfgo/issues/122
-			if lost > 0 {
-				if err := t.stats.LostBPFLogsCount.Increment(lost); err != nil {
-					logger.Errorw("Incrementing lost BPF logs count", "error", err)
-				}
-				logger.Warnw(fmt.Sprintf("Lost %d ebpf logs events", lost))
+		case lost, ok := <-t.lostBPFLogChannel:
+			if !ok { // channel closed
+				continue
 			}
+
+			if err := t.stats.LostBPFLogsCount.Increment(lost); err != nil {
+				logger.Errorw("Incrementing lost BPF logs count", "error", err)
+			}
+			logger.Warnw(fmt.Sprintf("Lost %d ebpf logs events", lost))
 
 		case <-ctx.Done():
 			return

--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -213,16 +213,15 @@ func (t *Tracee) processFileCaptures(ctx context.Context) {
 				}
 			}
 
-		case lost := <-t.lostCapturesChannel:
-			// When terminating tracee-ebpf the lost channel receives multiple "0 lost events" events.
-			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
-			// https://github.com/aquasecurity/libbpfgo/issues/122
-			if lost > 0 {
-				if err := t.stats.LostWrCount.Increment(lost); err != nil {
-					logger.Errorw("Incrementing lost capture count", "error", err)
-				}
-				logger.Warnw(fmt.Sprintf("Lost %d capture events", lost))
+		case lost, ok := <-t.lostCapturesChannel:
+			if !ok { // channel closed
+				continue
 			}
+
+			if err := t.stats.LostWrCount.Increment(lost); err != nil {
+				logger.Errorw("Incrementing lost capture count", "error", err)
+			}
+			logger.Warnw(fmt.Sprintf("Lost %d capture events", lost))
 
 		case <-ctx.Done():
 			return

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1366,16 +1366,16 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	t.ready(ctx)          // executes ready callback, non blocking
 	<-ctx.Done()          // block until ctx is cancelled elsewhere
 
-	// Stop perf buffers
+	// Close perf buffers
 
-	t.eventsPerfMap.Stop()
+	t.eventsPerfMap.Close()
 	if t.config.BlobPerfBufferSize > 0 {
-		t.fileWrPerfMap.Stop()
+		t.fileWrPerfMap.Close()
 	}
 	if pcaps.PcapsEnabled(t.config.Capture.Net) {
-		t.netCapPerfMap.Stop()
+		t.netCapPerfMap.Close()
 	}
-	t.bpfLogsPerfMap.Stop()
+	t.bpfLogsPerfMap.Close()
 
 	// TODO: move logic below somewhere else (related to file writes)
 


### PR DESCRIPTION
Close: https://github.com/aquasecurity/libbpfgo/issues/122

### 1. Explain what the PR does

68f094814 **fix(ebpf): close perfbuf instead of just stop**
32a028c8c **fix(ebpf): closed channel read**


68f094814 **fix(ebpf): close perfbuf instead of just stop**

```
This was an old TODO comment removed by https://github.com/aquasecurity/tracee/pull/296/files#diff-82aa2eb77c3ce782b8ebfb70eaba8a1a5a8a2dce9f3349352a3a3c0f909478f1L604
```


32a028c8c **fix(ebpf): closed channel read**

```
This libbpfgo issue https://github.com/aquasecurity/libbpfgo/issues/122
it's actually a Tracee problem. It was caused by read attempts on closed
channels, when libbpgo had already closed them.
```

### 2. Explain how to test it

Run tracee and kill it via `^C`.

One must want to put a print call after the `!ok` check:

```go
func (t *Tracee) processLostEvents() {
	logger.Debugw("Starting processLostEvents goroutine")
	defer logger.Debugw("Stopped processLostEvents goroutine")

	for {
		select {
		case lost, ok := <-t.lostEvChannel:
			if !ok { // channel closed
				return
			}

			// Won't be printed as before.
			fmt.Printf("Lost %d events\n", lost)

			if err := t.stats.LostEvCount.Increment(lost); err != nil {
				logger.Errorw("Incrementing lost event count", "error", err)
			}
			logger.Warnw(fmt.Sprintf("Lost %d events", lost))

		// Since this is an end-state goroutine, it should be terminated only
		// when Tracee done channel is closed.
		case <-t.done:
			return
		}
	}
}
```

### 3. Other comments
