### PR TITLE
Add enable/disable rule

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -561,6 +561,13 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 				continue // might happen during initialization (ctrl+c seg faults)
 			}
 
+			// Is the rule disabled for the matched policies?
+			if !t.policyManager.IsRuleEnabled(event.MatchedPoliciesUser, events.ID(event.EventID)) {
+				logger.Debugw("event dropped because matched rule disabled", "event", event.EventName)
+				t.eventsPool.Put(event)
+				continue
+			}
+
 			// Only emit events requested by the user and matched by at least one policy.
 			id := events.ID(event.EventID)
 			event.MatchedPoliciesUser &= t.eventsState[id].Emit

--- a/pkg/ebpf/policy_manager.go
+++ b/pkg/ebpf/policy_manager.go
@@ -1,0 +1,56 @@
+package ebpf
+
+import (
+	"sync"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// policyManager is a thread-safe struct that manages the enabled policies for each rule
+type policyManager struct {
+	mutex sync.Mutex
+	rules map[events.ID]uint64
+}
+
+func newPolicyManager() *policyManager {
+	return &policyManager{
+		mutex: sync.Mutex{},
+		rules: make(map[events.ID]uint64),
+	}
+}
+
+// IsRuleEnabled returns true if a given event policy is enabled for a given rule
+func (pm *policyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	policyMask, ok := pm.rules[ruleId]
+	if !ok {
+		return false
+	}
+
+	return policyMask&matchedPolicies != 0
+}
+
+// EnableRule enables a rule for a given event policy
+func (pm *policyManager) EnableRule(policyId int, ruleId events.ID) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	policyMask := pm.rules[ruleId]
+	utils.SetBit(&policyMask, uint(policyId))
+
+	pm.rules[ruleId] = policyMask
+}
+
+// DisableRule disables a rule for a given event policy
+func (pm *policyManager) DisableRule(policyId int, ruleId events.ID) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	policyMask := pm.rules[ruleId]
+	utils.ClearBit(&policyMask, uint(policyId))
+
+	pm.rules[ruleId] = policyMask
+}

--- a/pkg/ebpf/policy_manager_test.go
+++ b/pkg/ebpf/policy_manager_test.go
@@ -1,0 +1,107 @@
+package ebpf
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/policy"
+)
+
+func TestEventsManagerEnableRule(t *testing.T) {
+	policyManager := newPolicyManager()
+
+	policy1Mached := uint64(0b10)
+	policy2Mached := uint64(0b100)
+	policy1And2Mached := uint64(0b110)
+
+	assert.False(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
+	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
+	assert.False(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+
+	policyManager.EnableRule(1, events.SecurityBPF)
+
+	assert.True(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
+	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
+	assert.True(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+
+	policyManager.EnableRule(2, events.SecurityBPF)
+	assert.True(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
+	assert.True(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
+	assert.True(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+}
+
+func TestEventsManagerDisableRule(t *testing.T) {
+	policyManager := newPolicyManager()
+
+	policy1Mached := uint64(0b10)
+	policy2Mached := uint64(0b100)
+	policy1And2Mached := uint64(0b110)
+
+	policyManager.EnableRule(1, events.SecurityBPF)
+
+	assert.True(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
+	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
+	assert.True(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+
+	policyManager.DisableRule(1, events.SecurityBPF)
+
+	assert.False(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
+	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
+	assert.False(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+}
+
+func TestEventsManagerEnableAndDisableConcurrent(t *testing.T) {
+	eventsToEnable := []events.ID{
+		events.SecurityBPF,
+		events.SchedGetPriorityMax,
+		events.SchedProcessExec,
+		events.SchedProcessExit,
+		events.Ptrace,
+	}
+
+	eventsToDisable := []events.ID{
+		events.SecurityBPFMap,
+		events.Openat2,
+		events.SchedProcessFork,
+		events.MagicWrite,
+		events.FileModification,
+	}
+
+	policyManager := newPolicyManager()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		for i := 0; i < policy.MaxPolicies; i++ {
+			for _, e := range eventsToEnable {
+				policyManager.EnableRule(i, e)
+			}
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		for i := 0; i < policy.MaxPolicies; i++ {
+			for _, e := range eventsToDisable {
+				policyManager.DisableRule(i, e)
+			}
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	for i := 0; i < policy.MaxPolicies; i++ {
+		for _, e := range eventsToEnable {
+			assert.True(t, policyManager.IsRuleEnabled(policy.AllPoliciesOn, e))
+		}
+		for _, e := range eventsToDisable {
+			assert.False(t, policyManager.IsRuleEnabled(policy.AllPoliciesOn, e))
+		}
+	}
+}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR is part of the work to support a [v1 for GRPC](https://github.com/aquasecurity/tracee/issues/3208).  It adds support to enable/disable rules per policy globally. The GRPC endpoints will be implemented in a following PR. 

This is a temporary solution, the enable/disable rules in the future should by extensions code @rafaeldtinoco is currently creating/refactoring, and probably load and unload configuration from kernel layer. But to support a feature now, we are creating some code that handles it by dropping the events, instead of unloading it. Also I created a specific structure to handle it, to avoid mutex code scattered around the tracee struct.
