### PR TITLE
Revert "feat: filter file capture by ELF type (#3361)"

### DIFF
--- a/docs/docs/forensics/index.md
+++ b/docs/docs/forensics/index.md
@@ -30,7 +30,7 @@ Tracee can capture the following types of artifacts:
     file will be captured. I/O files can be filtered using 3 optional filters:
     1. path - prefix of the file written/read. Up to 3 path filters can be
        provided per capture type.
-    2. type - file's type can be `pipe`, `socket`, `elf` or `regular`.
+    2. type - file's type can be `pipe`, `socket` or `regular`.
     3. fd - standard FD, one of the following: `stdin`, `stdout` and `stderr`.
 
     ***write example***

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -48,7 +48,7 @@ The different filter types have logical 'and' between them, but logical 'or' bet
 The filter is given in the following format - <read/write>:<filter_type>=<filter_value>
 Filters types:
 path               A filter for the file path prefix (up to 50 characters). Up to 3 filters can be given. Identical to using '<read/write>=/path/prefix*'.
-type               A file type from the following options: 'regular', 'pipe', 'socket' and 'elf'.
+type               A file type from the following options: 'regular', 'pipe' and 'socket'.
 fd                 The file descriptor of the file. Can be one of the three standards - 'stdin', 'stdout' and 'stderr'.
 
 
@@ -272,7 +272,6 @@ var captureFileTypeStringToFlag = map[string]config.FileCaptureType{
 	"pipe":    config.CapturePipeFiles,
 	"socket":  config.CaptureSocketFiles,
 	"regular": config.CaptureRegularFiles,
-	"elf":     config.CaptureELFFiles,
 }
 
 // parseFileCaptureType parse file type string to its matching bit-flag value

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,7 +123,6 @@ const (
 	CaptureRegularFiles FileCaptureType = 1 << iota
 	CapturePipeFiles
 	CaptureSocketFiles
-	CaptureELFFiles
 )
 
 // Filters for FDs flags

--- a/pkg/ebpf/c/capture_filtering.h
+++ b/pkg/ebpf/c/capture_filtering.h
@@ -15,12 +15,11 @@
 #define FILTER_NORMAL_FILES (1 << (FILTER_FILE_TYPE_START_BIT + 0))
 #define FILTER_PIPE_FILES   (1 << (FILTER_FILE_TYPE_START_BIT + 1))
 #define FILTER_SOCKET_FILES (1 << (FILTER_FILE_TYPE_START_BIT + 2))
-#define FILTER_ELF_FILES    (1 << (FILTER_FILE_TYPE_START_BIT + 3))
 #define FILTER_STDIN_FILES  (1 << (FILTER_FILE_FD_START_BIT + STDIN))
 #define FILTER_STDOUT_FILES (1 << (FILTER_FILE_FD_START_BIT + STDOUT))
 #define FILTER_STDERR_FILES (1 << (FILTER_FILE_FD_START_BIT + STDERR))
 
-#define FILTER_FILE_TYPE_MASK ((FILTER_ELF_FILES << 1) - FILTER_NORMAL_FILES)
+#define FILTER_FILE_TYPE_MASK ((FILTER_SOCKET_FILES << 1) - FILTER_NORMAL_FILES)
 #define FILTER_FDS_MASK       ((FILTER_STDERR_FILES << 1) - FILTER_STDIN_FILES)
 
 #define CAPTURE_READ_TYPE_FILTER_IDX  0
@@ -29,7 +28,7 @@
 // PROTOTYPES
 
 statfunc bool filter_file_path(void *, void *, struct file *);
-statfunc bool filter_file_type(void *, void *, size_t, struct file *, io_data_t, off_t);
+statfunc bool filter_file_type(void *, void *, size_t, struct file *);
 statfunc bool filter_file_fd(void *, void *, size_t, struct file *);
 
 // FUNCTIONS
@@ -73,12 +72,7 @@ statfunc bool filter_file_path(void *ctx, void *filter_map, struct file *file)
 
 // Return if the file does not match any given file type filters in the filter map (so it should be
 // filtered out). The result will be false if no filter exist.
-statfunc bool filter_file_type(void *ctx,
-                               void *filter_map,
-                               size_t map_idx,
-                               struct file *file,
-                               io_data_t io_data,
-                               off_t start_pos)
+statfunc bool filter_file_type(void *ctx, void *filter_map, size_t map_idx, struct file *file)
 {
     bool has_type_filter = false;
     bool type_filter_match = false;
@@ -98,48 +92,18 @@ statfunc bool filter_file_type(void *ctx,
             struct pipe_inode_info *pipe = get_file_pipe_info(file);
             if (pipe != NULL) {
                 type_filter_match = true;
-                goto exit;
             }
-        }
-        if (*type_filter & FILTER_SOCKET_FILES) {
+        } else if (*type_filter & FILTER_SOCKET_FILES) {
             if (imode_mode & S_IFSOCK) {
                 type_filter_match = true;
-                goto exit;
             }
-        }
-        if (*type_filter & FILTER_NORMAL_FILES) {
+        } else if (*type_filter & FILTER_NORMAL_FILES) {
             if (imode_mode & S_IFREG) {
                 type_filter_match = true;
-                goto exit;
-            }
-        }
-        if (*type_filter & FILTER_ELF_FILES) {
-            file_id_t file_id = get_file_id(file);
-            file_id.ctime = 0;
-            if (start_pos == 0) {
-                // Check if header is matching ELF header
-                u8 header[FILE_MAGIC_HDR_SIZE] = {};
-                fill_file_header(header, io_data);
-                if (header[0] == 0x7f && header[1] == 0x45 && header[2] == 0x4c &&
-                    header[3] == 0x46) {
-                    type_filter_match = true;
-                    bpf_map_update_elem(&elf_files_map, &file_id, &type_filter_match, BPF_ANY);
-                } else {
-                    // Avoid considering the file ELF if further IO operation will occur
-                    bpf_map_delete_elem(&elf_files_map, &file_id);
-                }
-            } else {
-                // In the case of IO operation in chunks one after another, we want to check
-                // if the file is already confirmed to be an ELF file in previous operation.
-                bool *is_elf = bpf_map_lookup_elem(&elf_files_map, &file_id);
-                if (is_elf != NULL && *is_elf == true) {
-                    type_filter_match = true;
-                }
             }
         }
     }
 
-exit:
     return (has_type_filter && !type_filter_match);
 }
 

--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -37,7 +37,6 @@ statfunc struct super_block *get_super_block_from_inode(struct inode *);
 statfunc unsigned long get_s_magic_from_super_block(struct super_block *);
 statfunc void fill_vfs_file_metadata(struct file *, u32, u8 *);
 statfunc void fill_vfs_file_bin_args_io_data(io_data_t, bin_args_t *);
-statfunc void fill_file_header(u8[FILE_MAGIC_HDR_SIZE], io_data_t);
 statfunc void
 fill_vfs_file_bin_args(u32, struct file *, loff_t *, io_data_t, size_t, int, bin_args_t *);
 
@@ -447,25 +446,6 @@ statfunc void fill_vfs_file_bin_args(u32 type,
     fill_vfs_file_metadata(file, pid, &bin_args->metadata[0]);
     bin_args->start_off = start_pos;
     fill_vfs_file_bin_args_io_data(io_data, bin_args);
-}
-
-statfunc void fill_file_header(u8 header[FILE_MAGIC_HDR_SIZE], io_data_t io_data)
-{
-    u32 len = (u32) io_data.len;
-    if (io_data.is_buf) {
-        if (len < FILE_MAGIC_HDR_SIZE)
-            bpf_probe_read(header, len & FILE_MAGIC_MASK, io_data.ptr);
-        else
-            bpf_probe_read(header, FILE_MAGIC_HDR_SIZE, io_data.ptr);
-    } else {
-        struct iovec io_vec;
-        __builtin_memset(&io_vec, 0, sizeof(io_vec));
-        bpf_probe_read(&io_vec, sizeof(struct iovec), io_data.ptr);
-        if (len < FILE_MAGIC_HDR_SIZE)
-            bpf_probe_read(header, len & FILE_MAGIC_MASK, io_vec.iov_base);
-        else
-            bpf_probe_read(header, FILE_MAGIC_HDR_SIZE, io_vec.iov_base);
-    }
 }
 
 #endif

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -117,7 +117,6 @@ BPF_HASH(logs_count, bpf_log_t, bpf_log_count_t, 4096);            // logs count
 BPF_PERCPU_ARRAY(scratch_map, scratch_t, 1);                       // scratch space to avoid allocating stuff on the stack
 BPF_LRU_HASH(file_modification_map, file_mod_key_t, int, 10240);   // hold file data to decide if should submit file modification event
 BPF_LRU_HASH(io_file_path_cache_map, file_id_t, path_buf_t, 5);    // store cache for IO operations path
-BPF_LRU_HASH(elf_files_map, file_id_t, bool, 64);                  // store cache for file ELF type check
 
 // clang-format on
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2044,40 +2044,22 @@ int BPF_KPROBE(trace_security_inode_unlink)
     if (!should_trace(&p))
         return 0;
 
-    bool should_trace_inode_unlink = should_submit(SECURITY_INODE_UNLINK, p.event);
-    bool should_capture_io = false;
-    if ((p.config->options & (OPT_CAPTURE_FILES_READ | OPT_CAPTURE_FILES_WRITE)) != 0)
-        should_capture_io = true;
-
-    if (!should_trace_inode_unlink && !should_capture_io)
+    if (!should_submit(SECURITY_INODE_UNLINK, p.event))
         return 0;
-
-    file_id_t unlinked_file_id = {};
-    int ret = 0;
 
     // struct inode *dir = (struct inode *)PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
-    unlinked_file_id.inode = get_inode_nr_from_dentry(dentry);
-    unlinked_file_id.device = get_dev_from_dentry(dentry);
+    void *dentry_path = get_dentry_path_str(dentry);
+    unsigned long inode_nr = get_inode_nr_from_dentry(dentry);
+    dev_t dev = get_dev_from_dentry(dentry);
+    u64 ctime = get_ctime_nanosec_from_dentry(dentry);
 
-    if (should_trace_inode_unlink) {
-        void *dentry_path = get_dentry_path_str(dentry);
-        unlinked_file_id.ctime = get_ctime_nanosec_from_dentry(dentry);
+    save_str_to_buf(&p.event->args_buf, dentry_path, 0);
+    save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 1);
+    save_to_submit_buf(&p.event->args_buf, &dev, sizeof(dev_t), 2);
+    save_to_submit_buf(&p.event->args_buf, &ctime, sizeof(u64), 3);
 
-        save_str_to_buf(&p.event->args_buf, dentry_path, 0);
-        save_to_submit_buf(&p.event->args_buf, &unlinked_file_id.inode, sizeof(unsigned long), 1);
-        save_to_submit_buf(&p.event->args_buf, &unlinked_file_id.device, sizeof(dev_t), 2);
-        save_to_submit_buf(&p.event->args_buf, &unlinked_file_id.ctime, sizeof(u64), 3);
-        ret = events_perf_submit(&p, SECURITY_INODE_UNLINK, 0);
-    }
-
-    if (should_capture_io) {
-        // We want to avoid reacquisition of the same inode-device affecting capture behavior
-        unlinked_file_id.ctime = 0;
-        bpf_map_delete_elem(&elf_files_map, &unlinked_file_id);
-    }
-
-    return ret;
+    return events_perf_submit(&p, SECURITY_INODE_UNLINK, 0);
 }
 
 SEC("kprobe/commit_creds")
@@ -2751,7 +2733,20 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
 
     save_str_to_buf(&(p->event->args_buf), file_info->pathname_p, 0);
 
-    fill_file_header(header, io_data);
+    if (io_data.is_buf) {
+        if (header_bytes < FILE_MAGIC_HDR_SIZE)
+            bpf_probe_read(header, header_bytes & FILE_MAGIC_MASK, io_data.ptr);
+        else
+            bpf_probe_read(header, FILE_MAGIC_HDR_SIZE, io_data.ptr);
+    } else {
+        struct iovec io_vec;
+        __builtin_memset(&io_vec, 0, sizeof(io_vec));
+        bpf_probe_read(&io_vec, sizeof(struct iovec), io_data.ptr);
+        if (header_bytes < FILE_MAGIC_HDR_SIZE)
+            bpf_probe_read(header, header_bytes & FILE_MAGIC_MASK, io_vec.iov_base);
+        else
+            bpf_probe_read(header, FILE_MAGIC_HDR_SIZE, io_vec.iov_base);
+    }
 
     save_bytes_to_buf(&(p->event->args_buf), header, header_bytes, 1);
     save_to_submit_buf(&(p->event->args_buf), &file_info->id.device, sizeof(dev_t), 2);
@@ -2860,16 +2855,10 @@ extract_vfs_ret_io_data(struct pt_regs *ctx, args_t *saved_args, io_data_t *io_d
 }
 
 // Filter capture of file writes according to path prefix, type and fd.
-statfunc bool
-filter_file_write_capture(program_data_t *p, struct file *file, io_data_t io_data, off_t start_pos)
+statfunc bool filter_file_write_capture(program_data_t *p, struct file *file)
 {
     return filter_file_path(p->ctx, &file_write_path_filter, file) ||
-           filter_file_type(p->ctx,
-                            &file_type_filter,
-                            CAPTURE_WRITE_TYPE_FILTER_IDX,
-                            file,
-                            io_data,
-                            start_pos) ||
+           filter_file_type(p->ctx, &file_type_filter, CAPTURE_WRITE_TYPE_FILTER_IDX, file) ||
            filter_file_fd(p->ctx, &file_type_filter, CAPTURE_WRITE_TYPE_FILTER_IDX, file);
 }
 
@@ -2900,15 +2889,8 @@ statfunc int capture_file_write(struct pt_regs *ctx, u32 event_id, bool is_buf)
     extract_vfs_ret_io_data(ctx, &saved_args, &io_data, is_buf);
     struct file *file = (struct file *) saved_args.args[0];
     loff_t *pos = (loff_t *) saved_args.args[3];
-    size_t written_bytes = PT_REGS_RC(ctx);
 
-    off_t start_pos;
-    bpf_probe_read(&start_pos, sizeof(off_t), pos);
-    // Calculate write start offset
-    if (start_pos != 0)
-        start_pos -= written_bytes;
-
-    if (filter_file_write_capture(&p, file, io_data, start_pos)) {
+    if (filter_file_write_capture(&p, file)) {
         // There is a filter, but no match
         del_args(event_id);
         return 0;
@@ -2934,12 +2916,10 @@ statfunc int capture_file_write(struct pt_regs *ctx, u32 event_id, bool is_buf)
 }
 
 // Filter capture of file reads according to path prefix, type and fd.
-statfunc bool
-filter_file_read_capture(program_data_t *p, struct file *file, io_data_t io_data, off_t start_pos)
+statfunc bool filter_file_read_capture(program_data_t *p, struct file *file)
 {
     return filter_file_path(p->ctx, &file_read_path_filter, file) ||
-           filter_file_type(
-               p->ctx, &file_type_filter, CAPTURE_READ_TYPE_FILTER_IDX, file, io_data, start_pos) ||
+           filter_file_type(p->ctx, &file_type_filter, CAPTURE_READ_TYPE_FILTER_IDX, file) ||
            filter_file_fd(p->ctx, &file_type_filter, CAPTURE_READ_TYPE_FILTER_IDX, file);
 }
 
@@ -2966,15 +2946,8 @@ statfunc int capture_file_read(struct pt_regs *ctx, u32 event_id, bool is_buf)
     extract_vfs_ret_io_data(ctx, &saved_args, &io_data, is_buf);
     struct file *file = (struct file *) saved_args.args[0];
     loff_t *pos = (loff_t *) saved_args.args[3];
-    size_t read_bytes = PT_REGS_RC(ctx);
 
-    off_t start_pos;
-    bpf_probe_read(&start_pos, sizeof(off_t), pos);
-    // Calculate write start offset
-    if (start_pos != 0)
-        start_pos -= read_bytes;
-
-    if (filter_file_read_capture(&p, file, io_data, start_pos)) {
+    if (filter_file_read_capture(&p, file)) {
         // There is a filter, but no match
         del_args(event_id);
         return 0;

--- a/pkg/ebpf/c/tracee.h
+++ b/pkg/ebpf/c/tracee.h
@@ -56,9 +56,9 @@ statfunc int submit_magic_write(program_data_t *, file_info_t *, io_data_t, u32)
 statfunc bool should_submit_io_event(u32, program_data_t *);
 statfunc int do_file_io_operation(struct pt_regs *, u32, u32, bool, bool);
 statfunc void extract_vfs_ret_io_data(struct pt_regs *, args_t *, io_data_t *, bool);
-statfunc bool filter_file_write_capture(program_data_t *, struct file *, io_data_t, off_t);
+statfunc bool filter_file_write_capture(program_data_t *, struct file *);
 statfunc int capture_file_write(struct pt_regs *, u32, bool);
-statfunc bool filter_file_read_capture(program_data_t *, struct file *, io_data_t, off_t);
+statfunc bool filter_file_read_capture(program_data_t *, struct file *);
 statfunc int capture_file_read(struct pt_regs *, u32, bool);
 statfunc struct pipe_buffer *get_last_write_pipe_buffer(struct pipe_inode_info *);
 

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -9974,7 +9974,6 @@ var CoreEvents = map[ID]Definition{
 				{handle: probes.VfsWriteVRet, required: false},
 				{handle: probes.KernelWrite, required: false},
 				{handle: probes.KernelWriteRet, required: false},
-				{handle: probes.SecurityInodeUnlink, required: false}, // Used for ELF filter
 			},
 			tailCalls: []TailCall{
 				{"prog_array", "trace_ret_vfs_write_tail", []uint32{TailVfsWrite}},
@@ -9998,7 +9997,6 @@ var CoreEvents = map[ID]Definition{
 				{handle: probes.VfsReadRet, required: true},
 				{handle: probes.VfsReadV, required: false},
 				{handle: probes.VfsReadVRet, required: false},
-				{handle: probes.SecurityInodeUnlink, required: false}, // Used for ELF filter
 			},
 			tailCalls: []TailCall{
 				{"prog_array", "trace_ret_vfs_read_tail", []uint32{TailVfsRead}},


### PR DESCRIPTION
### 1. Explain what the PR does

This reverts commit fd47dfb74412d88066cbb5a3c285a677bbb356a0.
We revert it because e2e tests environment failed to load the BPF object, because verifier error.
Will revert until we will manage to prevent the error.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
