### PR TITLE
Revert "fix: print_mem_dump fails on missing symbol (#3384)"

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -497,8 +497,8 @@ func (t *Tracee) generateInitValues() (InitValues, error) {
 		if !events.Core.IsDefined(evt) {
 			return initVals, errfmt.Errorf("event %d is undefined", evt)
 		}
-		if events.Core.GetDefinitionByID(evt).GetDependencies().GetKSymbols() != nil {
-			initVals.Kallsyms = true
+		for range events.Core.GetDefinitionByID(evt).GetDependencies().GetKSymbols() {
+			initVals.Kallsyms = true // only if length > 0
 		}
 	}
 
@@ -1700,8 +1700,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) error {
 						}
 					}
 					if err != nil {
-						logger.Warnw("print_mem_dump: failed to get symbol info", "symbol", name)
-						continue
+						return errfmt.WrapError(err)
 					}
 				}
 				eventHandle := t.triggerContexts.Store(event)

--- a/pkg/events/definition_dependencies.go
+++ b/pkg/events/definition_dependencies.go
@@ -38,12 +38,10 @@ func (d Dependencies) GetIDs() []ID {
 	return d.ids
 }
 
-// GetKSymbols returns the KSymbols dependencies of an event.
-// If nil is returned no ksymbols are needed.
-// If an empty array is returned - symbols are needed, but none should specifically
-// be loaded ahead of time.
-// A non-empty array indicates that some symbols should be queried and loaded ahead of time.
 func (d Dependencies) GetKSymbols() []KSymbol {
+	if d.kSymbols == nil {
+		return []KSymbol{}
+	}
 	return d.kSymbols
 }
 


### PR DESCRIPTION
### 1. Explain what the PR does

This reverts commit 1a47a4e4e3b565d6e06169696c533c63d94c3c1f. This is done because the commit cause the "symbols_loaded" event to fail and also cause many error messages that weren't seen before.