### PR TITLE
feat: add version and description to definition

### DIFF
--- a/pkg/cmd/initialize/sigs.go
+++ b/pkg/cmd/initialize/sigs.go
@@ -1,6 +1,8 @@
 package initialize
 
 import (
+	"strconv"
+
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -35,10 +37,27 @@ func CreateEventsFromSignatures(startId events.ID, sigs []detect.Signature) {
 			evtDependency = append(evtDependency, eventDefID)
 		}
 
+		version, err := events.NewVersionFromString(m.Version)
+		// if the version is not valid semver, set it to 1.0.X,
+		// where X is either 0 or the version number from the signature
+		if err != nil {
+			var x uint64
+
+			if m.Version != "" {
+				n, _ := strconv.Atoi(m.Version)
+				// if there is an error, n is 0, setting the version to 1.0.0
+				x = uint64(n)
+			}
+
+			version = events.NewVersion(1, 0, x)
+		}
+
 		newEventDef := events.NewDefinition(
 			newEventDefID,                     // id,
 			events.Sys32Undefined,             // id32
 			m.EventName,                       // eventName
+			version,                           // version
+			m.Description,                     // description
 			"",                                // docPath
 			false,                             // internal
 			false,                             // syscall

--- a/pkg/cmd/initialize/sigs_test.go
+++ b/pkg/cmd/initialize/sigs_test.go
@@ -32,6 +32,8 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 					events.ID(6001),                   // id,
 					events.Sys32Undefined,             // id32
 					"fake_event_0",                    // eventName
+					events.NewVersion(1, 0, 0),        // version
+					"fake_description",                // description
 					"",                                // docPath
 					false,                             // internal
 					false,                             // syscall
@@ -64,6 +66,8 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 					events.ID(6010),                   // id,
 					events.Sys32Undefined,             // id32
 					"fake_event_1",                    // eventName
+					events.NewVersion(1, 0, 0),        // version
+					"fake_description",                // description
 					"",                                // docPath
 					false,                             // internal
 					false,                             // syscall
@@ -81,6 +85,8 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 					events.ID(6011),                   // id,
 					events.Sys32Undefined,             // id32
 					"fake_event_2",                    // eventName
+					events.NewVersion(1, 0, 0),        // version
+					"fake_description",                // description
 					"",                                // docPath
 					false,                             // internal
 					false,                             // syscall
@@ -115,6 +121,8 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 					events.ID(6100),                   // id,
 					events.Sys32Undefined,             // id32
 					"fake_event_3",                    // eventName
+					events.NewVersion(1, 0, 0),        // version
+					"fake_description",                // description
 					"",                                // docPath
 					false,                             // internal
 					false,                             // syscall
@@ -163,7 +171,9 @@ func newFakeSignature(name string, deps []string) detect.Signature {
 	return &signature.FakeSignature{
 		FakeGetMetadata: func() (detect.SignatureMetadata, error) {
 			return detect.SignatureMetadata{
-				EventName: name,
+				EventName:   name,
+				Description: "fake_description",
+				Version:     "1.0.0",
 			}, nil
 		},
 		FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {

--- a/pkg/ebpf/finding_test.go
+++ b/pkg/ebpf/finding_test.go
@@ -88,13 +88,15 @@ func createFakeEventAndFinding() detect.Finding {
 	eventName := "fake_signature_event"
 
 	eventDefinition := events.NewDefinition(
-		0,                      // id
-		events.Sys32Undefined,  // id32
-		eventName,              // eventName
-		"",                     // docPath
-		false,                  // internal
-		false,                  // syscall
-		[]string{"signatures"}, // sets
+		0,                          // id
+		events.Sys32Undefined,      // id32
+		eventName,                  // eventName
+		events.NewVersion(1, 0, 0), // Version
+		"fake_description",         // description
+		"",                         // docPath
+		false,                      // internal
+		false,                      // syscall
+		[]string{"signatures"},     // sets
 		events.NewDependencies(
 			[]events.ID{events.Ptrace},
 			[]events.KSymbol{},

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -172,6 +172,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Read,
 		id32Bit: Sys32read,
 		name:    "read",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -192,6 +193,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Write,
 		id32Bit: Sys32write,
 		name:    "write",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -212,6 +214,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Open,
 		id32Bit: Sys32open,
 		name:    "open",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -232,6 +235,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Close,
 		id32Bit: Sys32close,
 		name:    "close",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -250,6 +254,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Stat,
 		id32Bit: Sys32stat,
 		name:    "stat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -269,6 +274,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fstat,
 		id32Bit: Sys32fstat,
 		name:    "fstat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -288,6 +294,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lstat,
 		id32Bit: Sys32lstat,
 		name:    "lstat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -307,6 +314,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Poll,
 		id32Bit: Sys32poll,
 		name:    "poll",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -327,6 +335,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lseek,
 		id32Bit: Sys32lseek,
 		name:    "lseek",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -347,6 +356,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mmap,
 		id32Bit: Sys32mmap,
 		name:    "mmap",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -370,6 +380,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mprotect,
 		id32Bit: Sys32mprotect,
 		name:    "mprotect",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -390,6 +401,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Munmap,
 		id32Bit: Sys32munmap,
 		name:    "munmap",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -409,6 +421,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Brk,
 		id32Bit: Sys32brk,
 		name:    "brk",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -427,6 +440,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigaction,
 		id32Bit: Sys32rt_sigaction,
 		name:    "rt_sigaction",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -448,6 +462,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigprocmask,
 		id32Bit: Sys32rt_sigprocmask,
 		name:    "rt_sigprocmask",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -469,6 +484,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigreturn,
 		id32Bit: Sys32rt_sigreturn,
 		name:    "rt_sigreturn",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params:  []trace.ArgMeta{},
@@ -485,6 +501,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ioctl,
 		id32Bit: Sys32ioctl,
 		name:    "ioctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_fd_ops"},
 		params: []trace.ArgMeta{
@@ -505,6 +522,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pread64,
 		id32Bit: Sys32pread64,
 		name:    "pread64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -526,6 +544,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pwrite64,
 		id32Bit: Sys32pwrite64,
 		name:    "pwrite64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -547,6 +566,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Readv,
 		id32Bit: Sys32readv,
 		name:    "readv",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -567,6 +587,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Writev,
 		id32Bit: Sys32writev,
 		name:    "writev",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -587,6 +608,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Access,
 		id32Bit: Sys32access,
 		name:    "access",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -606,6 +628,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pipe,
 		id32Bit: Sys32pipe,
 		name:    "pipe",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		params: []trace.ArgMeta{
@@ -624,6 +647,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Select,
 		id32Bit: Sys32_newselect,
 		name:    "select",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -646,6 +670,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedYield,
 		id32Bit: Sys32sched_yield,
 		name:    "sched_yield",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params:  []trace.ArgMeta{},
@@ -662,6 +687,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mremap,
 		id32Bit: Sys32mremap,
 		name:    "mremap",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -684,6 +710,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Msync,
 		id32Bit: Sys32msync,
 		name:    "msync",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_sync"},
 		params: []trace.ArgMeta{
@@ -704,6 +731,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mincore,
 		id32Bit: Sys32mincore,
 		name:    "mincore",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -724,6 +752,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Madvise,
 		id32Bit: Sys32madvise,
 		name:    "madvise",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -744,6 +773,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Shmget,
 		id32Bit: Sys32shmget,
 		name:    "shmget",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_shm"},
 		params: []trace.ArgMeta{
@@ -764,6 +794,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Shmat,
 		id32Bit: Sys32shmat,
 		name:    "shmat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_shm"},
 		params: []trace.ArgMeta{
@@ -784,6 +815,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Shmctl,
 		id32Bit: Sys32shmctl,
 		name:    "shmctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_shm"},
 		params: []trace.ArgMeta{
@@ -804,6 +836,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Dup,
 		id32Bit: Sys32dup,
 		name:    "dup",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_fd_ops"},
 		params: []trace.ArgMeta{
@@ -822,6 +855,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Dup2,
 		id32Bit: Sys32dup2,
 		name:    "dup2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_fd_ops"},
 		params: []trace.ArgMeta{
@@ -841,6 +875,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pause,
 		id32Bit: Sys32pause,
 		name:    "pause",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params:  []trace.ArgMeta{},
@@ -857,6 +892,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Nanosleep,
 		id32Bit: Sys32nanosleep,
 		name:    "nanosleep",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -876,6 +912,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getitimer,
 		id32Bit: Sys32getitimer,
 		name:    "getitimer",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -895,6 +932,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Alarm,
 		id32Bit: Sys32alarm,
 		name:    "alarm",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -913,6 +951,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setitimer,
 		id32Bit: Sys32setitimer,
 		name:    "setitimer",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -933,6 +972,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getpid,
 		id32Bit: Sys32getpid,
 		name:    "getpid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -949,6 +989,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sendfile,
 		id32Bit: Sys32sendfile64,
 		name:    "sendfile",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -970,6 +1011,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Socket,
 		id32Bit: Sys32socket,
 		name:    "socket",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -990,6 +1032,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Connect,
 		id32Bit: Sys32connect,
 		name:    "connect",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1010,6 +1053,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Accept,
 		id32Bit: Sys32Undefined,
 		name:    "accept",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1030,6 +1074,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sendto,
 		id32Bit: Sys32sendto,
 		name:    "sendto",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_snd_rcv"},
 		params: []trace.ArgMeta{
@@ -1053,6 +1098,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Recvfrom,
 		id32Bit: Sys32recvfrom,
 		name:    "recvfrom",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_snd_rcv"},
 		params: []trace.ArgMeta{
@@ -1076,6 +1122,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sendmsg,
 		id32Bit: Sys32sendmsg,
 		name:    "sendmsg",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_snd_rcv"},
 		params: []trace.ArgMeta{
@@ -1096,6 +1143,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Recvmsg,
 		id32Bit: Sys32recvmsg,
 		name:    "recvmsg",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_snd_rcv"},
 		params: []trace.ArgMeta{
@@ -1116,6 +1164,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Shutdown,
 		id32Bit: Sys32shutdown,
 		name:    "shutdown",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1135,6 +1184,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Bind,
 		id32Bit: Sys32bind,
 		name:    "bind",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1155,6 +1205,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Listen,
 		id32Bit: Sys32listen,
 		name:    "listen",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1174,6 +1225,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getsockname,
 		id32Bit: Sys32getsockname,
 		name:    "getsockname",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1194,6 +1246,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getpeername,
 		id32Bit: Sys32getpeername,
 		name:    "getpeername",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1214,6 +1267,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Socketpair,
 		id32Bit: Sys32socketpair,
 		name:    "socketpair",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1235,6 +1289,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setsockopt,
 		id32Bit: Sys32setsockopt,
 		name:    "setsockopt",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1257,6 +1312,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getsockopt,
 		id32Bit: Sys32getsockopt,
 		name:    "getsockopt",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -1279,6 +1335,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Clone,
 		id32Bit: Sys32clone,
 		name:    "clone",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -1301,6 +1358,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fork,
 		id32Bit: Sys32fork,
 		name:    "fork",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params:  []trace.ArgMeta{},
@@ -1317,6 +1375,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Vfork,
 		id32Bit: Sys32vfork,
 		name:    "vfork",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params:  []trace.ArgMeta{},
@@ -1333,6 +1392,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Execve,
 		id32Bit: Sys32execve,
 		name:    "execve",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -1354,6 +1414,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Exit,
 		id32Bit: Sys32exit,
 		name:    "exit",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -1372,6 +1433,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Wait4,
 		id32Bit: Sys32wait4,
 		name:    "wait4",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -1393,6 +1455,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Kill,
 		id32Bit: Sys32kill,
 		name:    "kill",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -1412,6 +1475,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Uname,
 		id32Bit: Sys32uname,
 		name:    "uname",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -1430,6 +1494,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Semget,
 		id32Bit: Sys32semget,
 		name:    "semget",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_sem"},
 		params: []trace.ArgMeta{
@@ -1450,6 +1515,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Semop,
 		id32Bit: Sys32Undefined,
 		name:    "semop",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_sem"},
 		params: []trace.ArgMeta{
@@ -1470,6 +1536,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Semctl,
 		id32Bit: Sys32semctl,
 		name:    "semctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_sem"},
 		params: []trace.ArgMeta{
@@ -1491,6 +1558,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Shmdt,
 		id32Bit: Sys32shmdt,
 		name:    "shmdt",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_shm"},
 		params: []trace.ArgMeta{
@@ -1509,6 +1577,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Msgget,
 		id32Bit: Sys32msgget,
 		name:    "msgget",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -1528,6 +1597,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Msgsnd,
 		id32Bit: Sys32msgsnd,
 		name:    "msgsnd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -1549,6 +1619,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Msgrcv,
 		id32Bit: Sys32msgrcv,
 		name:    "msgrcv",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -1571,6 +1642,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Msgctl,
 		id32Bit: Sys32msgctl,
 		name:    "msgctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -1591,6 +1663,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fcntl,
 		id32Bit: Sys32fcntl,
 		name:    "fcntl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_fd_ops"},
 		params: []trace.ArgMeta{
@@ -1611,6 +1684,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Flock,
 		id32Bit: Sys32flock,
 		name:    "flock",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_fd_ops"},
 		params: []trace.ArgMeta{
@@ -1630,6 +1704,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fsync,
 		id32Bit: Sys32fsync,
 		name:    "fsync",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_sync"},
 		params: []trace.ArgMeta{
@@ -1648,6 +1723,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fdatasync,
 		id32Bit: Sys32fdatasync,
 		name:    "fdatasync",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_sync"},
 		params: []trace.ArgMeta{
@@ -1666,6 +1742,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Truncate,
 		id32Bit: Sys32truncate,
 		name:    "truncate",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -1685,6 +1762,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ftruncate,
 		id32Bit: Sys32ftruncate,
 		name:    "ftruncate",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -1704,6 +1782,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getdents,
 		id32Bit: Sys32getdents,
 		name:    "getdents",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -1724,6 +1803,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getcwd,
 		id32Bit: Sys32getcwd,
 		name:    "getcwd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -1743,6 +1823,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Chdir,
 		id32Bit: Sys32chdir,
 		name:    "chdir",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -1761,6 +1842,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fchdir,
 		id32Bit: Sys32fchdir,
 		name:    "fchdir",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -1779,6 +1861,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Rename,
 		id32Bit: Sys32rename,
 		name:    "rename",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -1798,6 +1881,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mkdir,
 		id32Bit: Sys32mkdir,
 		name:    "mkdir",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -1817,6 +1901,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Rmdir,
 		id32Bit: Sys32rmdir,
 		name:    "rmdir",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -1835,6 +1920,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Creat,
 		id32Bit: Sys32creat,
 		name:    "creat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -1854,6 +1940,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Link,
 		id32Bit: Sys32link,
 		name:    "link",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -1873,6 +1960,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Unlink,
 		id32Bit: Sys32unlink,
 		name:    "unlink",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -1891,6 +1979,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Symlink,
 		id32Bit: Sys32symlink,
 		name:    "symlink",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -1910,6 +1999,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Readlink,
 		id32Bit: Sys32readlink,
 		name:    "readlink",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -1930,6 +2020,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Chmod,
 		id32Bit: Sys32chmod,
 		name:    "chmod",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -1949,6 +2040,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fchmod,
 		id32Bit: Sys32fchmod,
 		name:    "fchmod",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -1968,6 +2060,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Chown,
 		id32Bit: Sys32chown32,
 		name:    "chown",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -1988,6 +2081,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fchown,
 		id32Bit: Sys32fchown32,
 		name:    "fchown",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -2008,6 +2102,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lchown,
 		id32Bit: Sys32lchown32,
 		name:    "lchown",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -2028,6 +2123,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Umask,
 		id32Bit: Sys32umask,
 		name:    "umask",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -2046,6 +2142,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Gettimeofday,
 		id32Bit: Sys32gettimeofday,
 		name:    "gettimeofday",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_tod"},
 		params: []trace.ArgMeta{
@@ -2065,6 +2162,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getrlimit,
 		id32Bit: Sys32ugetrlimit,
 		name:    "getrlimit",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2084,6 +2182,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getrusage,
 		id32Bit: Sys32getrusage,
 		name:    "getrusage",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2103,6 +2202,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sysinfo,
 		id32Bit: Sys32sysinfo,
 		name:    "sysinfo",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -2121,6 +2221,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Times,
 		id32Bit: Sys32times,
 		name:    "times",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2139,6 +2240,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ptrace,
 		id32Bit: Sys32ptrace,
 		name:    "ptrace",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2160,6 +2262,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getuid,
 		id32Bit: Sys32getuid32,
 		name:    "getuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2176,6 +2279,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Syslog,
 		id32Bit: Sys32syslog,
 		name:    "syslog",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -2196,6 +2300,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getgid,
 		id32Bit: Sys32getgid32,
 		name:    "getgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2212,6 +2317,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setuid,
 		id32Bit: Sys32setuid32,
 		name:    "setuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2230,6 +2336,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setgid,
 		id32Bit: Sys32setgid32,
 		name:    "setgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2248,6 +2355,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Geteuid,
 		id32Bit: Sys32geteuid32,
 		name:    "geteuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2264,6 +2372,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getegid,
 		id32Bit: Sys32getegid32,
 		name:    "getegid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2280,6 +2389,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setpgid,
 		id32Bit: Sys32setpgid,
 		name:    "setpgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2299,6 +2409,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getppid,
 		id32Bit: Sys32getppid,
 		name:    "getppid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2315,6 +2426,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getpgrp,
 		id32Bit: Sys32getpgrp,
 		name:    "getpgrp",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2331,6 +2443,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setsid,
 		id32Bit: Sys32setsid,
 		name:    "setsid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -2347,6 +2460,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setreuid,
 		id32Bit: Sys32setreuid32,
 		name:    "setreuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2366,6 +2480,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setregid,
 		id32Bit: Sys32setregid32,
 		name:    "setregid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2385,6 +2500,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getgroups,
 		id32Bit: Sys32getgroups32,
 		name:    "getgroups",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2404,6 +2520,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setgroups,
 		id32Bit: Sys32setgroups32,
 		name:    "setgroups",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2423,6 +2540,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setresuid,
 		id32Bit: Sys32setresuid32,
 		name:    "setresuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2443,6 +2561,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getresuid,
 		id32Bit: Sys32getresuid32,
 		name:    "getresuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2463,6 +2582,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setresgid,
 		id32Bit: Sys32setresgid32,
 		name:    "setresgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2483,6 +2603,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getresgid,
 		id32Bit: Sys32getresgid32,
 		name:    "getresgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2503,6 +2624,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getpgid,
 		id32Bit: Sys32getpgid,
 		name:    "getpgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2521,6 +2643,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setfsuid,
 		id32Bit: Sys32setfsuid32,
 		name:    "setfsuid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2539,6 +2662,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setfsgid,
 		id32Bit: Sys32setfsgid32,
 		name:    "setfsgid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2557,6 +2681,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getsid,
 		id32Bit: Sys32getsid,
 		name:    "getsid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
@@ -2575,6 +2700,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Capget,
 		id32Bit: Sys32capget,
 		name:    "capget",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2594,6 +2720,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Capset,
 		id32Bit: Sys32capset,
 		name:    "capset",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2613,6 +2740,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigpending,
 		id32Bit: Sys32rt_sigpending,
 		name:    "rt_sigpending",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -2632,6 +2760,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigtimedwait,
 		id32Bit: Sys32rt_sigtimedwait_time64,
 		name:    "rt_sigtimedwait",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -2653,6 +2782,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigqueueinfo,
 		id32Bit: Sys32rt_sigqueueinfo,
 		name:    "rt_sigqueueinfo",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -2673,6 +2803,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigsuspend,
 		id32Bit: Sys32rt_sigsuspend,
 		name:    "rt_sigsuspend",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -2692,6 +2823,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sigaltstack,
 		id32Bit: Sys32sigaltstack,
 		name:    "sigaltstack",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -2711,6 +2843,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Utime,
 		id32Bit: Sys32utime,
 		name:    "utime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -2730,6 +2863,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mknod,
 		id32Bit: Sys32mknod,
 		name:    "mknod",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -2750,6 +2884,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Uselib,
 		id32Bit: Sys32uselib,
 		name:    "uselib",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -2768,6 +2903,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Personality,
 		id32Bit: Sys32personality,
 		name:    "personality",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -2786,6 +2922,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ustat,
 		id32Bit: Sys32ustat,
 		name:    "ustat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_info"},
 		params: []trace.ArgMeta{
@@ -2805,6 +2942,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Statfs,
 		id32Bit: Sys32statfs,
 		name:    "statfs",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_info"},
 		params: []trace.ArgMeta{
@@ -2824,6 +2962,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fstatfs,
 		id32Bit: Sys32fstatfs,
 		name:    "fstatfs",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_info"},
 		params: []trace.ArgMeta{
@@ -2843,6 +2982,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sysfs,
 		id32Bit: Sys32sysfs,
 		name:    "sysfs",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_info"},
 		params: []trace.ArgMeta{
@@ -2861,6 +3001,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getpriority,
 		id32Bit: Sys32getpriority,
 		name:    "getpriority",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2880,6 +3021,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setpriority,
 		id32Bit: Sys32setpriority,
 		name:    "setpriority",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2900,6 +3042,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedSetparam,
 		id32Bit: Sys32sched_setparam,
 		name:    "sched_setparam",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2919,6 +3062,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedGetparam,
 		id32Bit: Sys32sched_getparam,
 		name:    "sched_getparam",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2938,6 +3082,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedSetscheduler,
 		id32Bit: Sys32sched_setscheduler,
 		name:    "sched_setscheduler",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2958,6 +3103,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedGetscheduler,
 		id32Bit: Sys32sched_getscheduler,
 		name:    "sched_getscheduler",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2976,6 +3122,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedGetPriorityMax,
 		id32Bit: Sys32sched_get_priority_max,
 		name:    "sched_get_priority_max",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -2994,6 +3141,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedGetPriorityMin,
 		id32Bit: Sys32sched_get_priority_min,
 		name:    "sched_get_priority_min",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -3012,6 +3160,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedRrGetInterval,
 		id32Bit: Sys32sched_rr_get_interval_time64,
 		name:    "sched_rr_get_interval",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -3031,6 +3180,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mlock,
 		id32Bit: Sys32mlock,
 		name:    "mlock",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -3050,6 +3200,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Munlock,
 		id32Bit: Sys32munlock,
 		name:    "munlock",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -3069,6 +3220,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mlockall,
 		id32Bit: Sys32mlockall,
 		name:    "mlockall",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -3087,6 +3239,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Munlockall,
 		id32Bit: Sys32munlockall,
 		name:    "munlockall",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params:  []trace.ArgMeta{},
@@ -3103,6 +3256,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Vhangup,
 		id32Bit: Sys32vhangup,
 		name:    "vhangup",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params:  []trace.ArgMeta{},
@@ -3119,6 +3273,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ModifyLdt,
 		id32Bit: Sys32modify_ldt,
 		name:    "modify_ldt",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -3139,6 +3294,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PivotRoot,
 		id32Bit: Sys32pivot_root,
 		name:    "pivot_root",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -3158,6 +3314,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sysctl,
 		id32Bit: Sys32_sysctl,
 		name:    "sysctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -3176,6 +3333,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Prctl,
 		id32Bit: Sys32prctl,
 		name:    "prctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -3198,6 +3356,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ArchPrctl,
 		id32Bit: Sys32arch_prctl,
 		name:    "arch_prctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -3217,6 +3376,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Adjtimex,
 		id32Bit: Sys32adjtimex,
 		name:    "adjtimex",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_clock"},
 		params: []trace.ArgMeta{
@@ -3235,6 +3395,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setrlimit,
 		id32Bit: Sys32setrlimit,
 		name:    "setrlimit",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -3254,6 +3415,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Chroot,
 		id32Bit: Sys32chroot,
 		name:    "chroot",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -3272,6 +3434,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sync,
 		id32Bit: Sys32sync,
 		name:    "sync",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_sync"},
 		params:  []trace.ArgMeta{},
@@ -3288,6 +3451,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Acct,
 		id32Bit: Sys32acct,
 		name:    "acct",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -3306,6 +3470,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Settimeofday,
 		id32Bit: Sys32settimeofday,
 		name:    "settimeofday",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_tod"},
 		params: []trace.ArgMeta{
@@ -3325,6 +3490,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mount,
 		id32Bit: Sys32mount,
 		name:    "mount",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -3347,6 +3513,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Umount2,
 		id32Bit: Sys32umount2,
 		name:    "umount2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -3366,6 +3533,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Swapon,
 		id32Bit: Sys32swapon,
 		name:    "swapon",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -3385,6 +3553,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Swapoff,
 		id32Bit: Sys32swapoff,
 		name:    "swapoff",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -3403,6 +3572,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Reboot,
 		id32Bit: Sys32reboot,
 		name:    "reboot",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -3424,6 +3594,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sethostname,
 		id32Bit: Sys32sethostname,
 		name:    "sethostname",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net"},
 		params: []trace.ArgMeta{
@@ -3443,6 +3614,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setdomainname,
 		id32Bit: Sys32setdomainname,
 		name:    "setdomainname",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net"},
 		params: []trace.ArgMeta{
@@ -3462,6 +3634,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Iopl,
 		id32Bit: Sys32iopl,
 		name:    "iopl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -3480,6 +3653,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ioperm,
 		id32Bit: Sys32ioperm,
 		name:    "ioperm",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -3500,6 +3674,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CreateModule,
 		id32Bit: Sys32create_module,
 		name:    "create_module",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_module"},
 		params:  []trace.ArgMeta{},
@@ -3516,6 +3691,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InitModule,
 		id32Bit: Sys32init_module,
 		name:    "init_module",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "system", "system_module"},
 		params: []trace.ArgMeta{
@@ -3536,6 +3712,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DeleteModule,
 		id32Bit: Sys32delete_module,
 		name:    "delete_module",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_module"},
 		params: []trace.ArgMeta{
@@ -3555,6 +3732,7 @@ var CoreEvents = map[ID]Definition{
 		id:      GetKernelSyms,
 		id32Bit: Sys32get_kernel_syms,
 		name:    "get_kernel_syms",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_module"},
 		params:  []trace.ArgMeta{},
@@ -3571,6 +3749,7 @@ var CoreEvents = map[ID]Definition{
 		id:      QueryModule,
 		id32Bit: Sys32query_module,
 		name:    "query_module",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_module"},
 		params:  []trace.ArgMeta{},
@@ -3587,6 +3766,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Quotactl,
 		id32Bit: Sys32quotactl,
 		name:    "quotactl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -3608,6 +3788,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Nfsservctl,
 		id32Bit: Sys32nfsservctl,
 		name:    "nfsservctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params:  []trace.ArgMeta{},
@@ -3624,6 +3805,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getpmsg,
 		id32Bit: Sys32getpmsg,
 		name:    "getpmsg",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params:  []trace.ArgMeta{},
@@ -3640,6 +3822,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Putpmsg,
 		id32Bit: Sys32putpmsg,
 		name:    "putpmsg",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params:  []trace.ArgMeta{},
@@ -3656,6 +3839,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Afs,
 		id32Bit: Sys32Undefined,
 		name:    "afs",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params:  []trace.ArgMeta{},
@@ -3672,6 +3856,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Tuxcall,
 		id32Bit: Sys32Undefined,
 		name:    "tuxcall",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params:  []trace.ArgMeta{},
@@ -3688,6 +3873,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Security,
 		id32Bit: Sys32Undefined,
 		name:    "security",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params:  []trace.ArgMeta{},
@@ -3704,6 +3890,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Gettid,
 		id32Bit: Sys32gettid,
 		name:    "gettid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
@@ -3720,6 +3907,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Readahead,
 		id32Bit: Sys32readahead,
 		name:    "readahead",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -3740,6 +3928,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setxattr,
 		id32Bit: Sys32setxattr,
 		name:    "setxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3762,6 +3951,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lsetxattr,
 		id32Bit: Sys32lsetxattr,
 		name:    "lsetxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3784,6 +3974,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fsetxattr,
 		id32Bit: Sys32fsetxattr,
 		name:    "fsetxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3806,6 +3997,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getxattr,
 		id32Bit: Sys32getxattr,
 		name:    "getxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3827,6 +4019,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lgetxattr,
 		id32Bit: Sys32lgetxattr,
 		name:    "lgetxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3848,6 +4041,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fgetxattr,
 		id32Bit: Sys32fgetxattr,
 		name:    "fgetxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3869,6 +4063,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Listxattr,
 		id32Bit: Sys32listxattr,
 		name:    "listxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3889,6 +4084,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Llistxattr,
 		id32Bit: Sys32llistxattr,
 		name:    "llistxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3909,6 +4105,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Flistxattr,
 		id32Bit: Sys32flistxattr,
 		name:    "flistxattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3929,6 +4126,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Removexattr,
 		id32Bit: Sys32removexattr,
 		name:    "removexattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3948,6 +4146,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lremovexattr,
 		id32Bit: Sys32lremovexattr,
 		name:    "lremovexattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3967,6 +4166,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fremovexattr,
 		id32Bit: Sys32fremovexattr,
 		name:    "fremovexattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -3986,6 +4186,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Tkill,
 		id32Bit: Sys32tkill,
 		name:    "tkill",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -4005,6 +4206,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Time,
 		id32Bit: Sys32time,
 		name:    "time",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_tod"},
 		params: []trace.ArgMeta{
@@ -4023,6 +4225,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Futex,
 		id32Bit: Sys32futex_time64,
 		name:    "futex",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_futex"},
 		params: []trace.ArgMeta{
@@ -4046,6 +4249,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedSetaffinity,
 		id32Bit: Sys32sched_setaffinity,
 		name:    "sched_setaffinity",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -4066,6 +4270,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedGetaffinity,
 		id32Bit: Sys32sched_getaffinity,
 		name:    "sched_getaffinity",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -4086,6 +4291,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SetThreadArea,
 		id32Bit: Sys32set_thread_area,
 		name:    "set_thread_area",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -4104,6 +4310,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoSetup,
 		id32Bit: Sys32io_setup,
 		name:    "io_setup",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_async_io"},
 		params: []trace.ArgMeta{
@@ -4123,6 +4330,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoDestroy,
 		id32Bit: Sys32io_destroy,
 		name:    "io_destroy",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_async_io"},
 		params: []trace.ArgMeta{
@@ -4141,6 +4349,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoGetevents,
 		id32Bit: Sys32io_getevents,
 		name:    "io_getevents",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_async_io"},
 		params: []trace.ArgMeta{
@@ -4163,6 +4372,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoSubmit,
 		id32Bit: Sys32io_submit,
 		name:    "io_submit",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_async_io"},
 		params: []trace.ArgMeta{
@@ -4183,6 +4393,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoCancel,
 		id32Bit: Sys32io_cancel,
 		name:    "io_cancel",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_async_io"},
 		params: []trace.ArgMeta{
@@ -4203,6 +4414,7 @@ var CoreEvents = map[ID]Definition{
 		id:      GetThreadArea,
 		id32Bit: Sys32get_thread_area,
 		name:    "get_thread_area",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -4221,6 +4433,7 @@ var CoreEvents = map[ID]Definition{
 		id:      LookupDcookie,
 		id32Bit: Sys32lookup_dcookie,
 		name:    "lookup_dcookie",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -4241,6 +4454,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollCreate,
 		id32Bit: Sys32epoll_create,
 		name:    "epoll_create",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -4259,6 +4473,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollCtlOld,
 		id32Bit: Sys32Undefined,
 		name:    "epoll_ctl_old",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params:  []trace.ArgMeta{},
@@ -4275,6 +4490,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollWaitOld,
 		id32Bit: Sys32Undefined,
 		name:    "epoll_wait_old",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params:  []trace.ArgMeta{},
@@ -4291,6 +4507,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RemapFilePages,
 		id32Bit: Sys32remap_file_pages,
 		name:    "remap_file_pages",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -4313,6 +4530,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getdents64,
 		id32Bit: Sys32getdents64,
 		name:    "getdents64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -4333,6 +4551,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SetTidAddress,
 		id32Bit: Sys32set_tid_address,
 		name:    "set_tid_address",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -4351,6 +4570,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RestartSyscall,
 		id32Bit: Sys32restart_syscall,
 		name:    "restart_syscall",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params:  []trace.ArgMeta{},
@@ -4367,6 +4587,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Semtimedop,
 		id32Bit: Sys32semtimedop_time64,
 		name:    "semtimedop",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_sem"},
 		params: []trace.ArgMeta{
@@ -4388,6 +4609,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fadvise64,
 		id32Bit: Sys32fadvise64,
 		name:    "fadvise64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -4409,6 +4631,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerCreate,
 		id32Bit: Sys32timer_create,
 		name:    "timer_create",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -4429,6 +4652,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerSettime,
 		id32Bit: Sys32timer_settime64,
 		name:    "timer_settime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -4450,6 +4674,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerGettime,
 		id32Bit: Sys32timer_gettime64,
 		name:    "timer_gettime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -4469,6 +4694,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerGetoverrun,
 		id32Bit: Sys32timer_getoverrun,
 		name:    "timer_getoverrun",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -4487,6 +4713,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerDelete,
 		id32Bit: Sys32timer_delete,
 		name:    "timer_delete",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -4505,6 +4732,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockSettime,
 		id32Bit: Sys32clock_settime64,
 		name:    "clock_settime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_clock"},
 		params: []trace.ArgMeta{
@@ -4524,6 +4752,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockGettime,
 		id32Bit: Sys32clock_gettime64,
 		name:    "clock_gettime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_clock"},
 		params: []trace.ArgMeta{
@@ -4543,6 +4772,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockGetres,
 		id32Bit: Sys32clock_getres_time64,
 		name:    "clock_getres",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_clock"},
 		params: []trace.ArgMeta{
@@ -4562,6 +4792,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockNanosleep,
 		id32Bit: Sys32clock_nanosleep_time64,
 		name:    "clock_nanosleep",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_clock"},
 		params: []trace.ArgMeta{
@@ -4583,6 +4814,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ExitGroup,
 		id32Bit: Sys32exit_group,
 		name:    "exit_group",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -4601,6 +4833,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollWait,
 		id32Bit: Sys32epoll_wait,
 		name:    "epoll_wait",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -4622,6 +4855,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollCtl,
 		id32Bit: Sys32epoll_ctl,
 		name:    "epoll_ctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -4643,6 +4877,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Tgkill,
 		id32Bit: Sys32tgkill,
 		name:    "tgkill",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -4663,6 +4898,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Utimes,
 		id32Bit: Sys32utimes,
 		name:    "utimes",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -4682,6 +4918,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Vserver,
 		id32Bit: Sys32vserver,
 		name:    "vserver",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params:  []trace.ArgMeta{},
@@ -4698,6 +4935,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mbind,
 		id32Bit: Sys32mbind,
 		name:    "mbind",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_numa"},
 		params: []trace.ArgMeta{
@@ -4721,6 +4959,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SetMempolicy,
 		id32Bit: Sys32set_mempolicy,
 		name:    "set_mempolicy",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_numa"},
 		params: []trace.ArgMeta{
@@ -4741,6 +4980,7 @@ var CoreEvents = map[ID]Definition{
 		id:      GetMempolicy,
 		id32Bit: Sys32get_mempolicy,
 		name:    "get_mempolicy",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_numa"},
 		params: []trace.ArgMeta{
@@ -4763,6 +5003,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqOpen,
 		id32Bit: Sys32mq_open,
 		name:    "mq_open",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -4784,6 +5025,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqUnlink,
 		id32Bit: Sys32mq_unlink,
 		name:    "mq_unlink",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -4802,6 +5044,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqTimedsend,
 		id32Bit: Sys32mq_timedsend_time64,
 		name:    "mq_timedsend",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -4824,6 +5067,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqTimedreceive,
 		id32Bit: Sys32mq_timedreceive_time64,
 		name:    "mq_timedreceive",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -4846,6 +5090,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqNotify,
 		id32Bit: Sys32mq_notify,
 		name:    "mq_notify",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -4865,6 +5110,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqGetsetattr,
 		id32Bit: Sys32mq_getsetattr,
 		name:    "mq_getsetattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_msgq"},
 		params: []trace.ArgMeta{
@@ -4885,6 +5131,7 @@ var CoreEvents = map[ID]Definition{
 		id:      KexecLoad,
 		id32Bit: Sys32kexec_load,
 		name:    "kexec_load",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -4906,6 +5153,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Waitid,
 		id32Bit: Sys32waitid,
 		name:    "waitid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -4928,6 +5176,7 @@ var CoreEvents = map[ID]Definition{
 		id:      AddKey,
 		id32Bit: Sys32add_key,
 		name:    "add_key",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_keys"},
 		params: []trace.ArgMeta{
@@ -4950,6 +5199,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RequestKey,
 		id32Bit: Sys32request_key,
 		name:    "request_key",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_keys"},
 		params: []trace.ArgMeta{
@@ -4971,6 +5221,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Keyctl,
 		id32Bit: Sys32keyctl,
 		name:    "keyctl",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_keys"},
 		params: []trace.ArgMeta{
@@ -4993,6 +5244,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoprioSet,
 		id32Bit: Sys32ioprio_set,
 		name:    "ioprio_set",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -5013,6 +5265,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoprioGet,
 		id32Bit: Sys32ioprio_get,
 		name:    "ioprio_get",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -5032,6 +5285,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InotifyInit,
 		id32Bit: Sys32inotify_init,
 		name:    "inotify_init",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_monitor"},
 		params:  []trace.ArgMeta{},
@@ -5048,6 +5302,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InotifyAddWatch,
 		id32Bit: Sys32inotify_add_watch,
 		name:    "inotify_add_watch",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_monitor"},
 		params: []trace.ArgMeta{
@@ -5068,6 +5323,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InotifyRmWatch,
 		id32Bit: Sys32inotify_rm_watch,
 		name:    "inotify_rm_watch",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_monitor"},
 		params: []trace.ArgMeta{
@@ -5087,6 +5343,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MigratePages,
 		id32Bit: Sys32migrate_pages,
 		name:    "migrate_pages",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_numa"},
 		params: []trace.ArgMeta{
@@ -5108,6 +5365,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Openat,
 		id32Bit: Sys32openat,
 		name:    "openat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -5129,6 +5387,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mkdirat,
 		id32Bit: Sys32mkdirat,
 		name:    "mkdirat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
@@ -5149,6 +5408,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mknodat,
 		id32Bit: Sys32mknodat,
 		name:    "mknodat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -5170,6 +5430,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fchownat,
 		id32Bit: Sys32fchownat,
 		name:    "fchownat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -5192,6 +5453,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Futimesat,
 		id32Bit: Sys32futimesat,
 		name:    "futimesat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -5212,6 +5474,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Newfstatat,
 		id32Bit: Sys32fstatat64,
 		name:    "newfstatat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -5233,6 +5496,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Unlinkat,
 		id32Bit: Sys32unlinkat,
 		name:    "unlinkat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -5253,6 +5517,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Renameat,
 		id32Bit: Sys32renameat,
 		name:    "renameat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -5274,6 +5539,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Linkat,
 		id32Bit: Sys32linkat,
 		name:    "linkat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -5296,6 +5562,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Symlinkat,
 		id32Bit: Sys32symlinkat,
 		name:    "symlinkat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -5316,6 +5583,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Readlinkat,
 		id32Bit: Sys32readlinkat,
 		name:    "readlinkat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_link_ops"},
 		params: []trace.ArgMeta{
@@ -5337,6 +5605,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fchmodat,
 		id32Bit: Sys32fchmodat,
 		name:    "fchmodat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -5358,6 +5627,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Faccessat,
 		id32Bit: Sys32faccessat,
 		name:    "faccessat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -5379,6 +5649,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pselect6,
 		id32Bit: Sys32pselect6_time64,
 		name:    "pselect6",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -5402,6 +5673,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ppoll,
 		id32Bit: Sys32ppoll_time64,
 		name:    "ppoll",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -5424,6 +5696,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Unshare,
 		id32Bit: Sys32unshare,
 		name:    "unshare",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -5442,6 +5715,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SetRobustList,
 		id32Bit: Sys32set_robust_list,
 		name:    "set_robust_list",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_futex"},
 		params: []trace.ArgMeta{
@@ -5461,6 +5735,7 @@ var CoreEvents = map[ID]Definition{
 		id:      GetRobustList,
 		id32Bit: Sys32get_robust_list,
 		name:    "get_robust_list",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_futex"},
 		params: []trace.ArgMeta{
@@ -5481,6 +5756,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Splice,
 		id32Bit: Sys32splice,
 		name:    "splice",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		params: []trace.ArgMeta{
@@ -5504,6 +5780,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Tee,
 		id32Bit: Sys32tee,
 		name:    "tee",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		params: []trace.ArgMeta{
@@ -5525,6 +5802,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SyncFileRange,
 		id32Bit: Sys32sync_file_range,
 		name:    "sync_file_range",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_sync"},
 		params: []trace.ArgMeta{
@@ -5546,6 +5824,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Vmsplice,
 		id32Bit: Sys32vmsplice,
 		name:    "vmsplice",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		params: []trace.ArgMeta{
@@ -5567,6 +5846,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MovePages,
 		id32Bit: Sys32move_pages,
 		name:    "move_pages",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_numa"},
 		params: []trace.ArgMeta{
@@ -5590,6 +5870,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Utimensat,
 		id32Bit: Sys32utimensat_time64,
 		name:    "utimensat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -5611,6 +5892,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollPwait,
 		id32Bit: Sys32epoll_pwait,
 		name:    "epoll_pwait",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -5634,6 +5916,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Signalfd,
 		id32Bit: Sys32signalfd,
 		name:    "signalfd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -5654,6 +5937,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerfdCreate,
 		id32Bit: Sys32timerfd_create,
 		name:    "timerfd_create",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -5673,6 +5957,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Eventfd,
 		id32Bit: Sys32eventfd,
 		name:    "eventfd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -5692,6 +5977,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fallocate,
 		id32Bit: Sys32fallocate,
 		name:    "fallocate",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -5713,6 +5999,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerfdSettime,
 		id32Bit: Sys32timerfd_settime64,
 		name:    "timerfd_settime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -5734,6 +6021,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerfdGettime,
 		id32Bit: Sys32timerfd_gettime64,
 		name:    "timerfd_gettime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_timer"},
 		params: []trace.ArgMeta{
@@ -5753,6 +6041,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Accept4,
 		id32Bit: Sys32accept4,
 		name:    "accept4",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_sock"},
 		params: []trace.ArgMeta{
@@ -5774,6 +6063,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Signalfd4,
 		id32Bit: Sys32signalfd4,
 		name:    "signalfd4",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -5795,6 +6085,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Eventfd2,
 		id32Bit: Sys32eventfd2,
 		name:    "eventfd2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -5814,6 +6105,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollCreate1,
 		id32Bit: Sys32epoll_create1,
 		name:    "epoll_create1",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -5832,6 +6124,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Dup3,
 		id32Bit: Sys32dup3,
 		name:    "dup3",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_fd_ops"},
 		params: []trace.ArgMeta{
@@ -5852,6 +6145,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pipe2,
 		id32Bit: Sys32pipe2,
 		name:    "pipe2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		params: []trace.ArgMeta{
@@ -5871,6 +6165,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InotifyInit1,
 		id32Bit: Sys32inotify_init1,
 		name:    "inotify_init1",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_monitor"},
 		params: []trace.ArgMeta{
@@ -5889,6 +6184,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Preadv,
 		id32Bit: Sys32preadv,
 		name:    "preadv",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -5911,6 +6207,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pwritev,
 		id32Bit: Sys32pwritev,
 		name:    "pwritev",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -5933,6 +6230,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtTgsigqueueinfo,
 		id32Bit: Sys32rt_tgsigqueueinfo,
 		name:    "rt_tgsigqueueinfo",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -5954,6 +6252,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PerfEventOpen,
 		id32Bit: Sys32perf_event_open,
 		name:    "perf_event_open",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -5976,6 +6275,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Recvmmsg,
 		id32Bit: Sys32recvmmsg_time64,
 		name:    "recvmmsg",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_snd_rcv"},
 		params: []trace.ArgMeta{
@@ -5998,6 +6298,7 @@ var CoreEvents = map[ID]Definition{
 		id:      FanotifyInit,
 		id32Bit: Sys32fanotify_init,
 		name:    "fanotify_init",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_monitor"},
 		params: []trace.ArgMeta{
@@ -6017,6 +6318,7 @@ var CoreEvents = map[ID]Definition{
 		id:      FanotifyMark,
 		id32Bit: Sys32fanotify_mark,
 		name:    "fanotify_mark",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_monitor"},
 		params: []trace.ArgMeta{
@@ -6039,6 +6341,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Prlimit64,
 		id32Bit: Sys32prlimit64,
 		name:    "prlimit64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -6060,6 +6363,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NameToHandleAt,
 		id32Bit: Sys32name_to_handle_at,
 		name:    "name_to_handle_at",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -6082,6 +6386,7 @@ var CoreEvents = map[ID]Definition{
 		id:      OpenByHandleAt,
 		id32Bit: Sys32open_by_handle_at,
 		name:    "open_by_handle_at",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -6102,6 +6407,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockAdjtime,
 		id32Bit: Sys32clock_adjtime,
 		name:    "clock_adjtime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "time", "time_clock"},
 		params: []trace.ArgMeta{
@@ -6121,6 +6427,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Syncfs,
 		id32Bit: Sys32syncfs,
 		name:    "syncfs",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_sync"},
 		params: []trace.ArgMeta{
@@ -6139,6 +6446,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sendmmsg,
 		id32Bit: Sys32sendmmsg,
 		name:    "sendmmsg",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "net", "net_snd_rcv"},
 		params: []trace.ArgMeta{
@@ -6160,6 +6468,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setns,
 		id32Bit: Sys32setns,
 		name:    "setns",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -6179,6 +6488,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getcpu,
 		id32Bit: Sys32getcpu,
 		name:    "getcpu",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system", "system_numa"},
 		params: []trace.ArgMeta{
@@ -6199,6 +6509,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ProcessVmReadv,
 		id32Bit: Sys32process_vm_readv,
 		name:    "process_vm_readv",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -6222,6 +6533,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ProcessVmWritev,
 		id32Bit: Sys32process_vm_writev,
 		name:    "process_vm_writev",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -6245,6 +6557,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Kcmp,
 		id32Bit: Sys32kcmp,
 		name:    "kcmp",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -6267,6 +6580,7 @@ var CoreEvents = map[ID]Definition{
 		id:      FinitModule,
 		id32Bit: Sys32finit_module,
 		name:    "finit_module",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "system", "system_module"},
 		params: []trace.ArgMeta{
@@ -6287,6 +6601,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedSetattr,
 		id32Bit: Sys32sched_setattr,
 		name:    "sched_setattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -6307,6 +6622,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedGetattr,
 		id32Bit: Sys32sched_getattr,
 		name:    "sched_getattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_sched"},
 		params: []trace.ArgMeta{
@@ -6328,6 +6644,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Renameat2,
 		id32Bit: Sys32renameat2,
 		name:    "renameat2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -6350,6 +6667,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Seccomp,
 		id32Bit: Sys32seccomp,
 		name:    "seccomp",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
@@ -6370,6 +6688,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getrandom,
 		id32Bit: Sys32getrandom,
 		name:    "getrandom",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -6390,6 +6709,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MemfdCreate,
 		id32Bit: Sys32memfd_create,
 		name:    "memfd_create",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -6409,6 +6729,7 @@ var CoreEvents = map[ID]Definition{
 		id:      KexecFileLoad,
 		id32Bit: Sys32Undefined,
 		name:    "kexec_file_load",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -6431,6 +6752,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Bpf,
 		id32Bit: Sys32bpf,
 		name:    "bpf",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -6451,6 +6773,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Execveat,
 		id32Bit: Sys32execveat,
 		name:    "execveat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -6474,6 +6797,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Userfaultfd,
 		id32Bit: Sys32userfaultfd,
 		name:    "userfaultfd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "system"},
 		params: []trace.ArgMeta{
@@ -6492,6 +6816,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Membarrier,
 		id32Bit: Sys32membarrier,
 		name:    "membarrier",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -6511,6 +6836,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mlock2,
 		id32Bit: Sys32mlock2,
 		name:    "mlock2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -6531,6 +6857,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CopyFileRange,
 		id32Bit: Sys32copy_file_range,
 		name:    "copy_file_range",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -6554,6 +6881,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Preadv2,
 		id32Bit: Sys32preadv2,
 		name:    "preadv2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -6577,6 +6905,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pwritev2,
 		id32Bit: Sys32pwritev2,
 		name:    "pwritev2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_read_write"},
 		params: []trace.ArgMeta{
@@ -6600,6 +6929,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PkeyMprotect,
 		id32Bit: Sys32pkey_mprotect,
 		name:    "pkey_mprotect",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -6621,6 +6951,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PkeyAlloc,
 		id32Bit: Sys32pkey_alloc,
 		name:    "pkey_alloc",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -6640,6 +6971,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PkeyFree,
 		id32Bit: Sys32pkey_free,
 		name:    "pkey_free",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_mem"},
 		params: []trace.ArgMeta{
@@ -6658,6 +6990,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Statx,
 		id32Bit: Sys32statx,
 		name:    "statx",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -6680,6 +7013,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoPgetevents,
 		id32Bit: Sys32io_pgetevents_time64,
 		name:    "io_pgetevents",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_async_io"},
 		params: []trace.ArgMeta{
@@ -6703,6 +7037,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Rseq,
 		id32Bit: Sys32rseq,
 		name:    "rseq",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -6724,6 +7059,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PidfdSendSignal,
 		id32Bit: Sys32pidfd_send_signal,
 		name:    "pidfd_send_signal",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "signals"},
 		params: []trace.ArgMeta{
@@ -6745,6 +7081,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoUringSetup,
 		id32Bit: Sys32io_uring_setup,
 		name:    "io_uring_setup",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -6764,6 +7101,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoUringEnter,
 		id32Bit: Sys32io_uring_enter,
 		name:    "io_uring_enter",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -6786,6 +7124,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoUringRegister,
 		id32Bit: Sys32io_uring_register,
 		name:    "io_uring_register",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -6807,6 +7146,7 @@ var CoreEvents = map[ID]Definition{
 		id:      OpenTree,
 		id32Bit: Sys32open_tree,
 		name:    "open_tree",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -6827,6 +7167,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MoveMount,
 		id32Bit: Sys32move_mount,
 		name:    "move_mount",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"default", "syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -6849,6 +7190,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fsopen,
 		id32Bit: Sys32fsopen,
 		name:    "fsopen",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -6868,6 +7210,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fsconfig,
 		id32Bit: Sys32fsconfig,
 		name:    "fsconfig",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -6890,6 +7233,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fsmount,
 		id32Bit: Sys32fsmount,
 		name:    "fsmount",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -6910,6 +7254,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fspick,
 		id32Bit: Sys32fspick,
 		name:    "fspick",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -6930,6 +7275,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PidfdOpen,
 		id32Bit: Sys32pidfd_open,
 		name:    "pidfd_open",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -6949,6 +7295,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Clone3,
 		id32Bit: Sys32clone3,
 		name:    "clone3",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "proc_life"},
 		params: []trace.ArgMeta{
@@ -6968,6 +7315,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CloseRange,
 		id32Bit: Sys32close_range,
 		name:    "close_range",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -6987,6 +7335,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Openat2,
 		id32Bit: Sys32openat2,
 		name:    "openat2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
@@ -7008,6 +7357,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PidfdGetfd,
 		id32Bit: Sys32pidfd_getfd,
 		name:    "pidfd_getfd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -7028,6 +7378,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Faccessat2,
 		id32Bit: Sys32faccessat2,
 		name:    "faccessat2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
@@ -7049,6 +7400,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ProcessMadvise,
 		id32Bit: Sys32process_madvise,
 		name:    "process_madvise",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -7071,6 +7423,7 @@ var CoreEvents = map[ID]Definition{
 		id:      EpollPwait2,
 		id32Bit: Sys32epoll_pwait2,
 		name:    "epoll_pwait2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs", "fs_mux_io"},
 		params: []trace.ArgMeta{
@@ -7093,6 +7446,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MountSetatt,
 		id32Bit: Sys32mount_setattr,
 		name:    "mount_setattr",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -7115,6 +7469,7 @@ var CoreEvents = map[ID]Definition{
 		id:      QuotactlFd,
 		id32Bit: Sys32quotactl_fd,
 		name:    "quotactl_fd",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
@@ -7136,6 +7491,7 @@ var CoreEvents = map[ID]Definition{
 		id:      LandlockCreateRuleset,
 		id32Bit: Sys32landlock_create_ruleset,
 		name:    "landlock_create_ruleset",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "fs"},
 		params: []trace.ArgMeta{
@@ -7156,6 +7512,7 @@ var CoreEvents = map[ID]Definition{
 		id:      LandlockAddRule,
 		id32Bit: Sys32landlock_add_rule,
 		name:    "landlock_add_rule",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "fs"},
 		params: []trace.ArgMeta{
@@ -7177,6 +7534,7 @@ var CoreEvents = map[ID]Definition{
 		id:      LandloclRestrictSet,
 		id32Bit: Sys32landlock_restrict_self,
 		name:    "landlock_restrict_self",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "proc", "fs"},
 		params: []trace.ArgMeta{
@@ -7196,6 +7554,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MemfdSecret,
 		id32Bit: Sys32memfd_secret,
 		name:    "memfd_secret",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -7214,6 +7573,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ProcessMrelease,
 		id32Bit: Sys32process_mrelease,
 		name:    "process_mrelease",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls"},
 		params: []trace.ArgMeta{
@@ -7233,6 +7593,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Waitpid,
 		id32Bit: Sys32waitpid,
 		name:    "waitpid",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7253,6 +7614,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Oldfstat,
 		id32Bit: Sys32oldfstat,
 		name:    "oldfstat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7269,6 +7631,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Break,
 		id32Bit: Sys32break,
 		name:    "break",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7285,6 +7648,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Oldstat,
 		id32Bit: Sys32oldstat,
 		name:    "oldstat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7304,6 +7668,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Umount,
 		id32Bit: Sys32umount,
 		name:    "umount",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7322,6 +7687,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Stime,
 		id32Bit: Sys32stime,
 		name:    "stime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7340,6 +7706,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Stty,
 		id32Bit: Sys32stty,
 		name:    "stty",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7356,6 +7723,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Gtty,
 		id32Bit: Sys32gtty,
 		name:    "gtty",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7372,6 +7740,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Nice,
 		id32Bit: Sys32nice,
 		name:    "nice",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7390,6 +7759,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ftime,
 		id32Bit: Sys32ftime,
 		name:    "ftime",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7406,6 +7776,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Prof,
 		id32Bit: Sys32prof,
 		name:    "prof",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7422,6 +7793,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Signal,
 		id32Bit: Sys32signal,
 		name:    "signal",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7441,6 +7813,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lock,
 		id32Bit: Sys32lock,
 		name:    "lock",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7457,6 +7830,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mpx,
 		id32Bit: Sys32mpx,
 		name:    "mpx",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7473,6 +7847,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ulimit,
 		id32Bit: Sys32ulimit,
 		name:    "ulimit",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7489,6 +7864,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Oldolduname,
 		id32Bit: Sys32oldolduname,
 		name:    "oldolduname",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7507,6 +7883,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sigaction,
 		id32Bit: Sys32sigaction,
 		name:    "sigaction",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7527,6 +7904,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sgetmask,
 		id32Bit: Sys32sgetmask,
 		name:    "sgetmask",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7543,6 +7921,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ssetmask,
 		id32Bit: Sys32ssetmask,
 		name:    "ssetmask",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7561,6 +7940,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sigsuspend,
 		id32Bit: Sys32sigsuspend,
 		name:    "sigsuspend",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7579,6 +7959,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sigpending,
 		id32Bit: Sys32sigpending,
 		name:    "sigpending",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7597,6 +7978,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Oldlstat,
 		id32Bit: Sys32oldlstat,
 		name:    "oldlstat",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7616,6 +7998,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Readdir,
 		id32Bit: Sys32readdir,
 		name:    "readdir",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7636,6 +8019,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Profil,
 		id32Bit: Sys32profil,
 		name:    "profil",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7652,6 +8036,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Socketcall,
 		id32Bit: Sys32socketcall,
 		name:    "socketcall",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7671,6 +8056,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Olduname,
 		id32Bit: Sys32olduname,
 		name:    "olduname",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7689,6 +8075,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Idle,
 		id32Bit: Sys32idle,
 		name:    "idle",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7705,6 +8092,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Vm86old,
 		id32Bit: Sys32vm86old,
 		name:    "vm86old",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7723,6 +8111,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ipc,
 		id32Bit: Sys32ipc,
 		name:    "ipc",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7746,6 +8135,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sigreturn,
 		id32Bit: Sys32sigreturn,
 		name:    "sigreturn",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7762,6 +8152,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sigprocmask,
 		id32Bit: Sys32sigprocmask,
 		name:    "sigprocmask",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7782,6 +8173,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Bdflush,
 		id32Bit: Sys32bdflush,
 		name:    "bdflush",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7798,6 +8190,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Afs_syscall,
 		id32Bit: Sys32afs_syscall,
 		name:    "afs_syscall",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -7814,6 +8207,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Llseek,
 		id32Bit: Sys32_llseek,
 		name:    "llseek",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7836,6 +8230,7 @@ var CoreEvents = map[ID]Definition{
 		id:      OldSelect,
 		id32Bit: Sys32select,
 		name:    "old_select",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7858,6 +8253,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Vm86,
 		id32Bit: Sys32vm86,
 		name:    "vm86",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7877,6 +8273,7 @@ var CoreEvents = map[ID]Definition{
 		id:      OldGetrlimit,
 		id32Bit: Sys32getrlimit,
 		name:    "old_getrlimit",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7896,6 +8293,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Mmap2,
 		id32Bit: Sys32mmap2,
 		name:    "mmap2",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7919,6 +8317,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Truncate64,
 		id32Bit: Sys32truncate64,
 		name:    "truncate64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7938,6 +8337,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Ftruncate64,
 		id32Bit: Sys32ftruncate64,
 		name:    "ftruncate64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7957,6 +8357,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Stat64,
 		id32Bit: Sys32stat64,
 		name:    "stat64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7976,6 +8377,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lstat64,
 		id32Bit: Sys32lstat64,
 		name:    "lstat64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -7995,6 +8397,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fstat64,
 		id32Bit: Sys32fstat64,
 		name:    "fstat64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8014,6 +8417,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Lchown16,
 		id32Bit: Sys32lchown,
 		name:    "lchown16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8034,6 +8438,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getuid16,
 		id32Bit: Sys32getuid,
 		name:    "getuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -8050,6 +8455,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getgid16,
 		id32Bit: Sys32getgid,
 		name:    "getgid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -8066,6 +8472,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Geteuid16,
 		id32Bit: Sys32geteuid,
 		name:    "geteuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -8082,6 +8489,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getegid16,
 		id32Bit: Sys32getegid,
 		name:    "getegid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -8098,6 +8506,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setreuid16,
 		id32Bit: Sys32setreuid,
 		name:    "setreuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8117,6 +8526,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setregid16,
 		id32Bit: Sys32setregid,
 		name:    "setregid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8136,6 +8546,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getgroups16,
 		id32Bit: Sys32getgroups,
 		name:    "getgroups16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8155,6 +8566,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setgroups16,
 		id32Bit: Sys32setgroups,
 		name:    "setgroups16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8174,6 +8586,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fchown16,
 		id32Bit: Sys32fchown,
 		name:    "fchown16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8194,6 +8607,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setresuid16,
 		id32Bit: Sys32setresuid,
 		name:    "setresuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8214,6 +8628,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getresuid16,
 		id32Bit: Sys32getresuid,
 		name:    "getresuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8234,6 +8649,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setresgid16,
 		id32Bit: Sys32setresgid,
 		name:    "setresgid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8254,6 +8670,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Getresgid16,
 		id32Bit: Sys32getresgid,
 		name:    "getresgid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8274,6 +8691,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Chown16,
 		id32Bit: Sys32chown,
 		name:    "chown16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8294,6 +8712,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setuid16,
 		id32Bit: Sys32setuid,
 		name:    "setuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8312,6 +8731,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setgid16,
 		id32Bit: Sys32setgid,
 		name:    "setgid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8330,6 +8750,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setfsuid16,
 		id32Bit: Sys32setfsuid,
 		name:    "setfsuid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8348,6 +8769,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Setfsgid16,
 		id32Bit: Sys32setfsgid,
 		name:    "setfsgid16",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8366,6 +8788,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fcntl64,
 		id32Bit: Sys32fcntl64,
 		name:    "fcntl64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8386,6 +8809,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Sendfile32,
 		id32Bit: Sys32sendfile,
 		name:    "sendfile32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8407,6 +8831,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Statfs64,
 		id32Bit: Sys32statfs64,
 		name:    "statfs64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8427,6 +8852,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fstatfs64,
 		id32Bit: Sys32fstatfs64,
 		name:    "fstatfs64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8447,6 +8873,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Fadvise64_64,
 		id32Bit: Sys32fadvise64_64,
 		name:    "fadvise64_64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8468,6 +8895,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockGettime32,
 		id32Bit: Sys32clock_gettime,
 		name:    "clock_gettime32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8487,6 +8915,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockSettime32,
 		id32Bit: Sys32clock_settime,
 		name:    "clock_settime32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8506,6 +8935,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockAdjtime64,
 		id32Bit: Sys32clock_adjtime64,
 		name:    "clock_adjtime64",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -8522,6 +8952,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockGetresTime32,
 		id32Bit: Sys32clock_getres,
 		name:    "clock_getres_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8541,6 +8972,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ClockNanosleepTime32,
 		id32Bit: Sys32clock_nanosleep,
 		name:    "clock_nanosleep_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8562,6 +8994,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerGettime32,
 		id32Bit: Sys32timer_gettime,
 		name:    "timer_gettime32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8581,6 +9014,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerSettime32,
 		id32Bit: Sys32timer_settime,
 		name:    "timer_settime32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8602,6 +9036,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerfdGettime32,
 		id32Bit: Sys32timerfd_gettime,
 		name:    "timerfd_gettime32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8621,6 +9056,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TimerfdSettime32,
 		id32Bit: Sys32timerfd_settime,
 		name:    "timerfd_settime32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8642,6 +9078,7 @@ var CoreEvents = map[ID]Definition{
 		id:      UtimensatTime32,
 		id32Bit: Sys32utimensat,
 		name:    "utimensat_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8663,6 +9100,7 @@ var CoreEvents = map[ID]Definition{
 		id:      Pselect6Time32,
 		id32Bit: Sys32pselect6,
 		name:    "pselect6_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8686,6 +9124,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PpollTime32,
 		id32Bit: Sys32ppoll,
 		name:    "ppoll_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8708,6 +9147,7 @@ var CoreEvents = map[ID]Definition{
 		id:      IoPgeteventsTime32,
 		id32Bit: Sys32io_pgetevents,
 		name:    "io_pgetevents_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params:  []trace.ArgMeta{},
@@ -8724,6 +9164,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RecvmmsgTime32,
 		id32Bit: Sys32recvmmsg,
 		name:    "recvmmsg_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8746,6 +9187,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqTimedsendTime32,
 		id32Bit: Sys32mq_timedsend,
 		name:    "mq_timedsend_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8768,6 +9210,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MqTimedreceiveTime32,
 		id32Bit: Sys32mq_timedreceive,
 		name:    "mq_timedreceive_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8790,6 +9233,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RtSigtimedwaitTime32,
 		id32Bit: Sys32rt_sigtimedwait,
 		name:    "rt_sigtimedwait_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8811,6 +9255,7 @@ var CoreEvents = map[ID]Definition{
 		id:      FutexTime32,
 		id32Bit: Sys32futex,
 		name:    "futex_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8834,6 +9279,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedRrGetInterval32,
 		id32Bit: Sys32sched_rr_get_interval,
 		name:    "sched_rr_get_interval_time32",
+		version: NewVersion(1, 0, 0),
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
@@ -8856,6 +9302,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SysEnter,
 		id32Bit: Sys32Undefined,
 		name:    "sys_enter",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SysEnter, required: true},
@@ -8870,6 +9317,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SysExit,
 		id32Bit: Sys32Undefined,
 		name:    "sys_exit",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SysExit, required: true},
@@ -8884,6 +9332,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedProcessFork,
 		id32Bit: Sys32Undefined,
 		name:    "sched_process_fork",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SchedProcessFork, required: true},
@@ -8906,6 +9355,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedProcessExec,
 		id32Bit: Sys32Undefined,
 		name:    "sched_process_exec",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SchedProcessExec, required: true},
@@ -8950,6 +9400,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedProcessExit,
 		id32Bit: Sys32Undefined,
 		name:    "sched_process_exit",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SchedProcessExit, required: true},
@@ -8969,6 +9420,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SchedSwitch,
 		id32Bit: Sys32Undefined,
 		name:    "sched_switch",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SchedSwitch, required: true},
@@ -8987,6 +9439,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DoExit,
 		id32Bit: Sys32Undefined,
 		name:    "do_exit",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{{handle: probes.DoExit, required: true}},
 		},
@@ -8997,6 +9450,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CapCapable,
 		id32Bit: Sys32Undefined,
 		name:    "cap_capable",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.CapCapable, required: true},
@@ -9011,6 +9465,7 @@ var CoreEvents = map[ID]Definition{
 		id:      VfsWrite,
 		id32Bit: Sys32Undefined,
 		name:    "vfs_write",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.VfsWrite, required: true},
@@ -9030,6 +9485,7 @@ var CoreEvents = map[ID]Definition{
 		id:      VfsWritev,
 		id32Bit: Sys32Undefined,
 		name:    "vfs_writev",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.VfsWriteV, required: true},
@@ -9049,6 +9505,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MemProtAlert,
 		id32Bit: Sys32Undefined,
 		name:    "mem_prot_alert",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityMmapAddr, required: true},
@@ -9080,6 +9537,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CommitCreds,
 		id32Bit: Sys32Undefined,
 		name:    "commit_creds",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.CommitCreds, required: true},
@@ -9095,6 +9553,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SwitchTaskNS,
 		id32Bit: Sys32Undefined,
 		name:    "switch_task_ns",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SwitchTaskNS, required: true},
@@ -9115,6 +9574,7 @@ var CoreEvents = map[ID]Definition{
 		id:      MagicWrite,
 		id32Bit: Sys32Undefined,
 		name:    "magic_write",
+		version: NewVersion(1, 0, 0),
 		docPath: "security_alerts/magic_write.md",
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9138,6 +9598,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CgroupAttachTask,
 		id32Bit: Sys32Undefined,
 		name:    "cgroup_attach_task",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.CgroupAttachTask, required: true},
@@ -9154,6 +9615,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CgroupMkdir,
 		id32Bit: Sys32Undefined,
 		name:    "cgroup_mkdir",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.CgroupMkdir, required: true},
@@ -9170,6 +9632,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CgroupRmdir,
 		id32Bit: Sys32Undefined,
 		name:    "cgroup_rmdir",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.CgroupRmdir, required: true},
@@ -9186,6 +9649,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityBprmCheck,
 		id32Bit: Sys32Undefined,
 		name:    "security_bprm_check",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityBPRMCheck, required: true},
@@ -9202,6 +9666,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityFileOpen,
 		id32Bit: Sys32Undefined,
 		name:    "security_file_open",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityFileOpen, required: true},
@@ -9233,6 +9698,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityInodeUnlink,
 		id32Bit: Sys32Undefined,
 		name:    "security_inode_unlink",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityInodeUnlink, required: true},
@@ -9250,6 +9716,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySocketCreate,
 		id32Bit: Sys32Undefined,
 		name:    "security_socket_create",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySocketCreate, required: true},
@@ -9267,6 +9734,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySocketListen,
 		id32Bit: Sys32Undefined,
 		name:    "security_socket_listen",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySocketListen, required: true},
@@ -9287,6 +9755,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySocketConnect,
 		id32Bit: Sys32Undefined,
 		name:    "security_socket_connect",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySocketConnect, required: true},
@@ -9306,6 +9775,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySocketAccept,
 		id32Bit: Sys32Undefined,
 		name:    "security_socket_accept",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySocketAccept, required: true},
@@ -9325,6 +9795,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySocketBind,
 		id32Bit: Sys32Undefined,
 		name:    "security_socket_bind",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySocketBind, required: true},
@@ -9344,6 +9815,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySocketSetsockopt,
 		id32Bit: Sys32Undefined,
 		name:    "security_socket_setsockopt",
+		version: NewVersion(1, 0, 0),
 		docPath: "lsm_hooks/security_socket_setsockopt.md",
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9366,6 +9838,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecuritySbMount,
 		id32Bit: Sys32Undefined,
 		name:    "security_sb_mount",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySbMount, required: true},
@@ -9383,6 +9856,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityBPF,
 		id32Bit: Sys32Undefined,
 		name:    "security_bpf",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityBPF, required: true},
@@ -9397,6 +9871,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityBPFMap,
 		id32Bit: Sys32Undefined,
 		name:    "security_bpf_map",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityBPFMap, required: true},
@@ -9412,6 +9887,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityKernelReadFile,
 		id32Bit: Sys32Undefined,
 		name:    "security_kernel_read_file",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityKernelReadFile, required: true},
@@ -9430,6 +9906,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityPostReadFile,
 		id32Bit: Sys32Undefined,
 		name:    "security_kernel_post_read_file",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityKernelPostReadFile, required: true},
@@ -9446,6 +9923,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityInodeMknod,
 		id32Bit: Sys32Undefined,
 		name:    "security_inode_mknod",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityInodeMknod, required: true},
@@ -9462,6 +9940,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityInodeSymlinkEventId,
 		id32Bit: Sys32Undefined,
 		name:    "security_inode_symlink",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityInodeSymlink, required: true},
@@ -9477,6 +9956,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityMmapFile,
 		id32Bit: Sys32Undefined,
 		name:    "security_mmap_file",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityMmapFile, required: true},
@@ -9497,6 +9977,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DoMmap,
 		id32Bit: Sys32Undefined,
 		name:    "do_mmap",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DoMmap, required: true},
@@ -9521,6 +10002,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityFileMprotect,
 		id32Bit: Sys32Undefined,
 		name:    "security_file_mprotect",
+		version: NewVersion(1, 0, 0),
 		docPath: "lsm_hooks/security_file_mprotect.md",
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9546,6 +10028,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InitNamespaces,
 		id32Bit: Sys32Undefined,
 		name:    "init_namespaces",
+		version: NewVersion(1, 0, 0),
 		sets:    []string{},
 		dependencies: Dependencies{
 			capabilities: Capabilities{
@@ -9571,6 +10054,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SocketDup,
 		id32Bit: Sys32Undefined,
 		name:    "socket_dup",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			tailCalls: []TailCall{
 				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
@@ -9589,6 +10073,7 @@ var CoreEvents = map[ID]Definition{
 		id:      HiddenInodes,
 		id32Bit: Sys32Undefined,
 		name:    "hidden_inodes",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.Filldir64, required: true},
@@ -9603,6 +10088,7 @@ var CoreEvents = map[ID]Definition{
 		id:      KernelWrite,
 		id32Bit: Sys32Undefined,
 		name:    "__kernel_write",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.KernelWrite, required: true},
@@ -9622,6 +10108,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DirtyPipeSplice,
 		id32Bit: Sys32Undefined,
 		name:    "dirty_pipe_splice",
+		version: NewVersion(1, 0, 0),
 		sets:    []string{},
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9646,6 +10133,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ContainerCreate,
 		id32Bit: Sys32Undefined,
 		name:    "container_create",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{CgroupMkdir},
 		},
@@ -9667,6 +10155,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ContainerRemove,
 		id32Bit: Sys32Undefined,
 		name:    "container_remove",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{CgroupRmdir},
 		},
@@ -9680,6 +10169,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ExistingContainer,
 		id32Bit: Sys32Undefined,
 		name:    "existing_container",
+		version: NewVersion(1, 0, 0),
 		sets:    []string{"containers"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "runtime"},
@@ -9698,6 +10188,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ProcCreate,
 		id32Bit: Sys32Undefined,
 		name:    "proc_create",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.ProcCreate, required: true},
@@ -9713,6 +10204,7 @@ var CoreEvents = map[ID]Definition{
 		id:      KprobeAttach,
 		id32Bit: Sys32Undefined,
 		name:    "kprobe_attach",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.RegisterKprobe, required: true},
@@ -9730,6 +10222,7 @@ var CoreEvents = map[ID]Definition{
 		id:      CallUsermodeHelper,
 		id32Bit: Sys32Undefined,
 		name:    "call_usermodehelper",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.CallUsermodeHelper, required: true},
@@ -9747,6 +10240,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DebugfsCreateFile,
 		id32Bit: Sys32Undefined,
 		name:    "debugfs_create_file",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DebugfsCreateFile, required: true},
@@ -9764,6 +10258,7 @@ var CoreEvents = map[ID]Definition{
 		id:       PrintSyscallTable,
 		id32Bit:  Sys32Undefined,
 		name:     "print_syscall_table",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9783,6 +10278,7 @@ var CoreEvents = map[ID]Definition{
 		id:      HiddenKernelModule,
 		id32Bit: Sys32Undefined,
 		name:    "hidden_kernel_module",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				HiddenKernelModuleSeeker,
@@ -9799,6 +10295,7 @@ var CoreEvents = map[ID]Definition{
 		id:       HiddenKernelModuleSeeker,
 		id32Bit:  Sys32Undefined,
 		name:     "hidden_kernel_module_seeker",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9834,6 +10331,7 @@ var CoreEvents = map[ID]Definition{
 		id:      HookedSyscalls,
 		id32Bit: Sys32Undefined,
 		name:    "hooked_syscalls",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			kSymbols: []KSymbol{
 				{symbol: "_stext", required: true},
@@ -9859,6 +10357,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DebugfsCreateDir,
 		id32Bit: Sys32Undefined,
 		name:    "debugfs_create_dir",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DebugfsCreateDir, required: true},
@@ -9874,6 +10373,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DeviceAdd,
 		id32Bit: Sys32Undefined,
 		name:    "device_add",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DeviceAdd, required: true},
@@ -9889,6 +10389,7 @@ var CoreEvents = map[ID]Definition{
 		id:      RegisterChrdev,
 		id32Bit: Sys32Undefined,
 		name:    "register_chrdev",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.RegisterChrdev, required: true},
@@ -9907,6 +10408,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SharedObjectLoaded,
 		id32Bit: Sys32Undefined,
 		name:    "shared_object_loaded",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityMmapFile, required: true},
@@ -9930,6 +10432,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SymbolsLoaded,
 		id32Bit: Sys32Undefined,
 		name:    "symbols_loaded",
+		version: NewVersion(1, 0, 0),
 		docPath: "security_alerts/symbols_load.md",
 		dependencies: Dependencies{
 			ids: []ID{
@@ -9947,6 +10450,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SymbolsCollision,
 		id32Bit: Sys32Undefined,
 		name:    "symbols_collision",
+		version: NewVersion(1, 0, 0),
 		docPath: "security_alerts/symbols_collision.md",
 		dependencies: Dependencies{
 			ids: []ID{
@@ -9965,6 +10469,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureFileWrite,
 		id32Bit:  Sys32Undefined,
 		name:     "capture_file_write",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -9991,6 +10496,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureFileRead,
 		id32Bit:  Sys32Undefined,
 		name:     "capture_file_read",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10014,6 +10520,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureExec,
 		id32Bit:  Sys32Undefined,
 		name:     "capture_exec",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10030,6 +10537,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureModule,
 		id32Bit:  Sys32Undefined,
 		name:     "capture_module",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10051,6 +10559,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureMem,
 		id32Bit:  Sys32Undefined,
 		name:     "capture_mem",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			tailCalls: []TailCall{
@@ -10062,6 +10571,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureBpf,
 		id32Bit:  Sys32Undefined,
 		name:     "capture_bpf",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10076,6 +10586,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DoInitModule,
 		id32Bit: Sys32Undefined,
 		name:    "do_init_module",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DoInitModule, required: true},
@@ -10093,6 +10604,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ModuleLoad,
 		id32Bit: Sys32Undefined,
 		name:    "module_load",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.ModuleLoad, required: true},
@@ -10109,6 +10621,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ModuleFree,
 		id32Bit: Sys32Undefined,
 		name:    "module_free",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.ModuleFree, required: true},
@@ -10125,6 +10638,7 @@ var CoreEvents = map[ID]Definition{
 		id:       SocketAccept,
 		id32Bit:  Sys32Undefined,
 		name:     "socket_accept",
+		version:  NewVersion(1, 0, 0),
 		internal: false,
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10149,6 +10663,7 @@ var CoreEvents = map[ID]Definition{
 		id:      LoadElfPhdrs,
 		id32Bit: Sys32Undefined,
 		name:    "load_elf_phdrs",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.LoadElfPhdrs, required: true},
@@ -10165,6 +10680,7 @@ var CoreEvents = map[ID]Definition{
 		id:      HookedProcFops,
 		id32Bit: Sys32Undefined,
 		name:    "hooked_proc_fops",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityFilePermission, required: true},
@@ -10191,6 +10707,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PrintNetSeqOps,
 		id32Bit: Sys32Undefined,
 		name:    "print_net_seq_ops",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.PrintNetSeqOps, required: true},
@@ -10215,6 +10732,7 @@ var CoreEvents = map[ID]Definition{
 		id:      HookedSeqOps,
 		id32Bit: Sys32Undefined,
 		name:    "hooked_seq_ops",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			kSymbols: []KSymbol{
 				{symbol: "_stext", required: true},
@@ -10239,6 +10757,7 @@ var CoreEvents = map[ID]Definition{
 		id:      TaskRename,
 		id32Bit: Sys32Undefined,
 		name:    "task_rename",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.TaskRename, required: true},
@@ -10254,6 +10773,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityInodeRename,
 		id32Bit: Sys32Undefined,
 		name:    "security_inode_rename",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecurityInodeRename, required: true},
@@ -10269,6 +10789,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DoSigaction,
 		id32Bit: Sys32Undefined,
 		name:    "do_sigaction",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DoSigaction, required: true},
@@ -10293,6 +10814,7 @@ var CoreEvents = map[ID]Definition{
 		id:      BpfAttach,
 		id32Bit: Sys32Undefined,
 		name:    "bpf_attach",
+		version: NewVersion(1, 0, 0),
 		docPath: "docs/events/builtin/extra/bpf_attach.md",
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10319,6 +10841,7 @@ var CoreEvents = map[ID]Definition{
 		id:      KallsymsLookupName,
 		id32Bit: Sys32Undefined,
 		name:    "kallsyms_lookup_name",
+		version: NewVersion(1, 0, 0),
 		docPath: "kprobes/kallsyms_lookup_name.md",
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10336,6 +10859,7 @@ var CoreEvents = map[ID]Definition{
 		id:      PrintMemDump,
 		id32Bit: Sys32Undefined,
 		name:    "print_mem_dump",
+		version: NewVersion(1, 0, 0),
 		sets:    []string{},
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10365,6 +10889,7 @@ var CoreEvents = map[ID]Definition{
 		id:      VfsRead,
 		id32Bit: Sys32Undefined,
 		name:    "vfs_read",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.VfsRead, required: true},
@@ -10384,6 +10909,7 @@ var CoreEvents = map[ID]Definition{
 		id:      VfsReadv,
 		id32Bit: Sys32Undefined,
 		name:    "vfs_readv",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.VfsReadV, required: true},
@@ -10403,6 +10929,7 @@ var CoreEvents = map[ID]Definition{
 		id:      VfsUtimes,
 		id32Bit: Sys32Undefined,
 		name:    "vfs_utimes",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.VfsUtimes, required: false},    // this probe exits in kernels >= 5.9
@@ -10422,6 +10949,7 @@ var CoreEvents = map[ID]Definition{
 		id:      DoTruncate,
 		id32Bit: Sys32Undefined,
 		name:    "do_truncate",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.DoTruncate, required: true},
@@ -10439,6 +10967,7 @@ var CoreEvents = map[ID]Definition{
 		id:      FileModification,
 		id32Bit: Sys32Undefined,
 		name:    "file_modification",
+		version: NewVersion(1, 0, 0),
 		docPath: "kprobes/file_modification.md",
 		sets:    []string{},
 		params: []trace.ArgMeta{
@@ -10463,6 +10992,7 @@ var CoreEvents = map[ID]Definition{
 		id:      InotifyWatch,
 		id32Bit: Sys32Undefined,
 		name:    "inotify_watch",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.InotifyFindInode, required: true},
@@ -10480,6 +11010,7 @@ var CoreEvents = map[ID]Definition{
 		id:      SecurityBpfProg,
 		id32Bit: Sys32Undefined,
 		name:    "security_bpf_prog",
+		version: NewVersion(1, 0, 0),
 		docPath: "docs/events/builtin/extra/security_bpf_prog.md",
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10502,6 +11033,7 @@ var CoreEvents = map[ID]Definition{
 		id:      ProcessExecuteFailed,
 		id32Bit: Sys32Undefined,
 		name:    "process_execute_failed",
+		version: NewVersion(1, 0, 0),
 		sets:    []string{"proc"},
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -10536,6 +11068,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketBase,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			capabilities: Capabilities{
@@ -10561,6 +11094,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketIPBase,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_ip_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10576,6 +11110,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketIPv4,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_ipv4",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketIPBase,
@@ -10592,6 +11127,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketIPv6,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_ipv6",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketIPBase,
@@ -10608,6 +11144,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketTCPBase,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_tcp_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10623,6 +11160,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketTCP,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_tcp",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketTCPBase,
@@ -10641,6 +11179,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketUDPBase,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_udp_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10656,6 +11195,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketUDP,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_udp",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketUDPBase,
@@ -10674,6 +11214,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketICMPBase,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_icmp_base",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketBase,
@@ -10689,6 +11230,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketICMP,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_icmp",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketICMPBase,
@@ -10705,6 +11247,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketICMPv6Base,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_icmpv6_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10720,6 +11263,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketICMPv6,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_icmpv6",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketICMPv6Base,
@@ -10736,6 +11280,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketDNSBase,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_dns_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10751,6 +11296,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketDNS,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_dns", // preferred event to write signatures
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketDNSBase,
@@ -10769,6 +11315,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketDNSRequest,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_dns_request", // simple dns event compatible dns_request (deprecated)
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketDNSBase,
@@ -10784,6 +11331,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketDNSResponse,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_dns_response", // simple dns event compatible dns_response (deprecated)
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketDNSBase,
@@ -10799,6 +11347,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketHTTPBase,
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_http_base",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10814,6 +11363,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketHTTP,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_http", // preferred event to write signatures
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketHTTPBase,
@@ -10832,6 +11382,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketHTTPRequest,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_http_request",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketHTTPBase,
@@ -10847,6 +11398,7 @@ var CoreEvents = map[ID]Definition{
 		id:      NetPacketHTTPResponse,
 		id32Bit: Sys32Undefined,
 		name:    "net_packet_http_response",
+		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			ids: []ID{
 				NetPacketHTTPBase,
@@ -10862,6 +11414,7 @@ var CoreEvents = map[ID]Definition{
 		id:       NetPacketCapture, // all packets have full payload (sent in a dedicated perfbuffer)
 		id32Bit:  Sys32Undefined,
 		name:     "net_packet_capture",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{
@@ -10876,6 +11429,7 @@ var CoreEvents = map[ID]Definition{
 		id:       CaptureNetPacket, // network packet capture pseudo event
 		id32Bit:  Sys32Undefined,
 		name:     "capture_net_packet",
+		version:  NewVersion(1, 0, 0),
 		internal: true,
 		dependencies: Dependencies{
 			ids: []ID{

--- a/pkg/events/core_test.go
+++ b/pkg/events/core_test.go
@@ -1,0 +1,16 @@
+package events
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllEventsHaveVersion(t *testing.T) {
+	for _, event := range CoreEvents {
+		_, err := semver.StrictNewVersion(event.version.String())
+		assert.NoError(t, err, fmt.Sprintf("event %s has invalid version", event.name))
+	}
+}

--- a/pkg/events/definition.go
+++ b/pkg/events/definition.go
@@ -8,6 +8,8 @@ type Definition struct {
 	id           ID // TODO: use id ?
 	id32Bit      ID
 	name         string
+	version      Version
+	description  string
 	docPath      string // Relative to the 'doc/events' directory
 	internal     bool
 	syscall      bool
@@ -20,6 +22,8 @@ func NewDefinition(
 	id ID,
 	id32Bit ID,
 	name string,
+	version Version,
+	description string,
 	docPath string,
 	internal bool,
 	syscall bool,
@@ -31,6 +35,8 @@ func NewDefinition(
 		id:           id,
 		id32Bit:      id32Bit,
 		name:         name,
+		version:      version,
+		description:  description,
 		docPath:      docPath,
 		internal:     internal,
 		syscall:      syscall,
@@ -52,6 +58,14 @@ func (d Definition) GetID32Bit() ID {
 
 func (d Definition) GetName() string {
 	return d.name
+}
+
+func (d Definition) GetVersion() Version {
+	return d.version
+}
+
+func (d Definition) GetDescription() string {
+	return d.description
 }
 
 func (d Definition) GetDocPath() string {

--- a/pkg/events/definition_group_test.go
+++ b/pkg/events/definition_group_test.go
@@ -10,6 +10,8 @@ import (
 
 var amountOfTestThreads = 100
 
+var version = NewVersion(1, 0, 0)
+
 var getNames = func() map[string]ID {
 	names := map[string]ID{}
 
@@ -25,7 +27,8 @@ func TestDefinitionGroup_Add(t *testing.T) {
 	defGroup := NewDefinitionGroup()
 
 	id := ID(1)
-	def := NewDefinition(id, id+1000, "def", "", false, false, []string{}, Dependencies{}, nil)
+
+	def := NewDefinition(id, id+1000, "def", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	err := defGroup.Add(id, def)
 	require.NoError(t, err)
@@ -41,8 +44,8 @@ func TestDefinitionGroup_AddBatch(t *testing.T) {
 	id1 := ID(1)
 	id2 := ID(2)
 
-	def1 := NewDefinition(id1, id1+1000, "def1", "", false, false, []string{}, Dependencies{}, nil)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	err := defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2})
 	require.NoError(t, err)
@@ -61,8 +64,8 @@ func TestDefinitionGroup_GetDefinitionIDByName(t *testing.T) {
 	id1 := ID(1)
 	id2 := ID(2)
 
-	def1 := NewDefinition(id1, id1+1000, "def1", "", false, false, []string{}, Dependencies{}, nil)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2})
 
@@ -82,8 +85,8 @@ func TestDefinitionGroup_GetDefinitionByID(t *testing.T) {
 	id1 := ID(1)
 	id2 := ID(2)
 
-	def1 := NewDefinition(id1, id1+1000, "def1", "", false, false, []string{}, Dependencies{}, nil)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2})
 
@@ -107,13 +110,14 @@ func TestDefinitionGroup_Length(t *testing.T) {
 	require.Equal(t, defGroup.Length(), 0) // empty definition group
 
 	id := ID(1)
-	def := NewDefinition(id, id+1000, "def", "", false, false, []string{}, Dependencies{}, nil)
+
+	def := NewDefinition(id, id+1000, "def", version, "", "", false, false, []string{}, Dependencies{}, nil)
 	defGroup.Add(id, def)
 
 	require.Equal(t, defGroup.Length(), 1) // definition group with one definition
 
 	id2 := ID(2)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 	defGroup.Add(id2, def2)
 
 	require.Equal(t, defGroup.Length(), 2) // definition group with two definitions
@@ -126,8 +130,8 @@ func TestDefinitionGroup_GetDefinitions(t *testing.T) {
 	id1 := ID(1)
 	id2 := ID(2)
 
-	def1 := NewDefinition(id1, id1+1000, "def1", "", false, false, []string{}, Dependencies{}, nil)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2})
 
@@ -145,8 +149,8 @@ func TestDefinitionGroup_NamesToIDs(t *testing.T) {
 	id1 := ID(1)
 	id2 := ID(2)
 
-	def1 := NewDefinition(id1, id1+1000, "def1", "", false, false, []string{}, Dependencies{}, nil)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2})
 
@@ -164,8 +168,8 @@ func TestDefinitionGroup_IDs32ToIDs(t *testing.T) {
 	id1 := ID(1)
 	id2 := ID(2)
 
-	def1 := NewDefinition(id1, id1+1000, "def1", "", false, false, []string{}, Dependencies{}, nil)
-	def2 := NewDefinition(id2, id2+1000, "def2", "", false, false, []string{}, Dependencies{}, nil)
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{}, Dependencies{}, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 	defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2})
 
@@ -191,7 +195,7 @@ func TestDefinitionGroup_AddBatch_MultipleThreads(t *testing.T) {
 	for name, id := range names {
 		wg.Add(1)
 		go func(name string, id ID) {
-			def := NewDefinition(id, id+1000, name, "", false, false, []string{}, Dependencies{}, nil)
+			def := NewDefinition(id, id+1000, name, version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 			err := defGroup.AddBatch(map[ID]Definition{id: def})
 			require.NoError(t, err)
@@ -221,7 +225,7 @@ func TestDefinitionGroup_Length_MultipleThreads(t *testing.T) {
 	for name, id := range names {
 		wg.Add(1)
 		go func(name string, id ID) {
-			def := NewDefinition(id, id+1000, name, "", false, false, []string{}, Dependencies{}, nil)
+			def := NewDefinition(id, id+1000, name, version, "", "", false, false, []string{}, Dependencies{}, nil)
 			err := defGroup.AddBatch(map[ID]Definition{id: def})
 			require.NoError(t, err)
 			defGroup.Length() // concurrent calls
@@ -245,7 +249,7 @@ func TestDefinitionGroup_GetDefinitions_MultipleThread(t *testing.T) {
 	for name, id := range names {
 		wg.Add(1)
 		go func(name string, id ID) {
-			def := NewDefinition(id, id+1000, name, "", false, false, []string{}, Dependencies{}, nil)
+			def := NewDefinition(id, id+1000, name, version, "", "", false, false, []string{}, Dependencies{}, nil)
 			err := defGroup.AddBatch(map[ID]Definition{id: def})
 			require.NoError(t, err)
 			defGroup.GetDefinitions() // concurrent calls
@@ -269,7 +273,7 @@ func TestDefinitionGroup_NamesToIDs_MultipleThreads(t *testing.T) {
 	for name, id := range names {
 		wg.Add(1)
 		go func(name string, id ID) {
-			def := NewDefinition(id, id+1000, name, "", false, false, []string{}, Dependencies{}, nil)
+			def := NewDefinition(id, id+1000, name, version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 			err := defGroup.Add(id, def)
 			require.NoError(t, err)
@@ -296,7 +300,7 @@ func TestDefinitionGroup_IDs32ToIDs_MultipleThreads(t *testing.T) {
 	for name, id := range names {
 		wg.Add(1)
 		go func(name string, id ID) {
-			def := NewDefinition(id, id+1000, name, "", false, false, []string{}, Dependencies{}, nil)
+			def := NewDefinition(id, id+1000, name, version, "", "", false, false, []string{}, Dependencies{}, nil)
 
 			err := defGroup.Add(id, def)
 			require.NoError(t, err)

--- a/pkg/events/definition_test.go
+++ b/pkg/events/definition_test.go
@@ -25,6 +25,8 @@ func TestNewDefinition(t *testing.T) {
 		0,
 		Sys32Undefined,
 		"hooked_seq_ops2",
+		version,
+		"",
 		"",
 		false,
 		false,

--- a/pkg/events/derive/derive_test.go
+++ b/pkg/events/derive/derive_test.go
@@ -79,14 +79,16 @@ func Test_DeriveSingleEvent(t *testing.T) {
 	testEventID := events.ID(0)
 
 	eventDefinition := events.NewDefinition(
-		testEventID,           // ID
-		events.Sys32Undefined, // ID32Bit
-		"test_event",          // Name
-		"test_event",          // DocPath
-		false,                 // Internal
-		false,                 // Syscall
-		[]string{},            // Sets
-		events.Dependencies{}, // Dependencies
+		testEventID,                // ID
+		events.Sys32Undefined,      // ID32Bit
+		"test_event",               // Name
+		events.NewVersion(1, 0, 0), // Version
+		"description",              // Description
+		"test_event",               // DocPath
+		false,                      // Internal
+		false,                      // Syscall
+		[]string{},                 // Sets
+		events.Dependencies{},      // Dependencies
 		[]trace.ArgMeta{
 			{
 				Name: "arg1",
@@ -175,14 +177,16 @@ func TestDeriveMultipleEvents(t *testing.T) {
 	testEventID := events.ID(0)
 
 	eventDefinition := events.NewDefinition(
-		testEventID,           // ID
-		events.Sys32Undefined, // ID32Bit
-		"test_event",          // Name
-		"test_event",          // DocPath
-		false,                 // Internal
-		false,                 // Syscall
-		[]string{},            // Sets
-		events.Dependencies{}, // Dependencies
+		testEventID,                // ID
+		events.Sys32Undefined,      // ID32Bit
+		"test_event",               // Name
+		events.NewVersion(1, 0, 0), // Version
+		"description",              // Description
+		"test_event",               // DocPath
+		false,                      // Internal
+		false,                      // Syscall
+		[]string{},                 // Sets
+		events.Dependencies{},      // Dependencies
 		[]trace.ArgMeta{
 			{
 				Name: "arg1",

--- a/pkg/events/version.go
+++ b/pkg/events/version.go
@@ -1,0 +1,62 @@
+package events
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// 1. Major field is bumped whenever some data the event used to have was changed
+// e.g. a field was renamed or removed
+// 2. Minor field is bumped whenever a non breaking change occurs
+// e.g. a new field was added to the event
+// 3. Patch field is bumped whenever something is changed in the way the event works internally
+// e.g. some bug was fixed in the code
+type Version struct {
+	major uint64
+	minor uint64
+	patch uint64
+}
+
+// NewVersion creates a new version
+func NewVersion(major, minor, patch uint64) Version {
+	return Version{
+		major,
+		minor,
+		patch,
+	}
+}
+
+// NewVersionFromString creates a new version from a string
+func NewVersionFromString(v string) (Version, error) {
+	version, err := semver.StrictNewVersion(v)
+	if err != nil {
+		return Version{}, err
+	}
+
+	return Version{
+		major: version.Major(),
+		minor: version.Minor(),
+		patch: version.Patch(),
+	}, nil
+}
+
+// Major returns the major version of the event
+func (v Version) Major() uint64 {
+	return v.major
+}
+
+// Minor returns the minor version of the event
+func (v Version) Minor() uint64 {
+	return v.minor
+}
+
+// Patch returns the patch version of the event
+func (v Version) Patch() uint64 {
+	return v.patch
+}
+
+// String returns the string representation of the event version
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}

--- a/pkg/policy/v1beta1/policy_file_test.go
+++ b/pkg/policy/v1beta1/policy_file_test.go
@@ -15,6 +15,8 @@ func TestPolicyValidate(t *testing.T) {
 		0,
 		events.Sys32Undefined,
 		"fake_signature",
+		events.NewVersion(1, 0, 0), // Version
+		"fake_description",
 		"",
 		false,
 		false,


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR is part of the work to support a [v1 for GRPC](https://github.com/aquasecurity/tracee/issues/3208), and also the https://github.com/aquasecurity/tracee/issues/2870, because the new event structure won't have metadata, and instead static data from the event will come from the definition, so users will be able to query the grpc endpoint to get a definition, but there is two important fields missing from the definition:

- the event description
- the event version, which will be bumped if we change the Params, to inform users that the event schema changed

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

