### PR TITLE
Fix closed chan read 2

### DIFF
--- a/pkg/ebpf/bpf_log.go
+++ b/pkg/ebpf/bpf_log.go
@@ -192,15 +192,10 @@ func (t *Tracee) processBPFLogs(ctx context.Context) {
 			}
 
 		case lost := <-t.lostBPFLogChannel:
-			// When terminating tracee-ebpf the lost channel receives multiple "0 lost events" events.
-			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
-			// https://github.com/aquasecurity/libbpfgo/issues/122
-			if lost > 0 {
-				if err := t.stats.LostBPFLogsCount.Increment(lost); err != nil {
-					logger.Errorw("Incrementing lost BPF logs count", "error", err)
-				}
-				logger.Warnw(fmt.Sprintf("Lost %d ebpf logs events", lost))
+			if err := t.stats.LostBPFLogsCount.Increment(lost); err != nil {
+				logger.Errorw("Incrementing lost BPF logs count", "error", err)
 			}
+			logger.Warnw(fmt.Sprintf("Lost %d ebpf logs events", lost))
 
 		case <-ctx.Done():
 			return

--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -214,15 +214,10 @@ func (t *Tracee) processFileCaptures(ctx context.Context) {
 			}
 
 		case lost := <-t.lostCapturesChannel:
-			// When terminating tracee-ebpf the lost channel receives multiple "0 lost events" events.
-			// This check prevents those 0 lost events messages to be written to stderr until the bug is fixed:
-			// https://github.com/aquasecurity/libbpfgo/issues/122
-			if lost > 0 {
-				if err := t.stats.LostWrCount.Increment(lost); err != nil {
-					logger.Errorw("Incrementing lost capture count", "error", err)
-				}
-				logger.Warnw(fmt.Sprintf("Lost %d capture events", lost))
+			if err := t.stats.LostWrCount.Increment(lost); err != nil {
+				logger.Errorw("Incrementing lost capture count", "error", err)
 			}
+			logger.Warnw(fmt.Sprintf("Lost %d capture events", lost))
 
 		case <-ctx.Done():
 			return

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -62,13 +62,10 @@ func (t *Tracee) processNetCapEvents(ctx context.Context, in <-chan *trace.Event
 				_ = t.stats.NetCapCount.Increment()
 
 			case lost := <-t.lostNetCapChannel:
-				if lost > 0 {
-					// https://github.com/aquasecurity/libbpfgo/issues/122
-					if err := t.stats.LostNtCapCount.Increment(lost); err != nil {
-						logger.Errorw("Incrementing lost network events count", "error", err)
-					}
-					logger.Warnw(fmt.Sprintf("Lost %d network capture events", lost))
+				if err := t.stats.LostNtCapCount.Increment(lost); err != nil {
+					logger.Errorw("Incrementing lost network events count", "error", err)
 				}
+				logger.Warnw(fmt.Sprintf("Lost %d network capture events", lost))
 
 			case <-ctx.Done():
 				return

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1366,16 +1366,16 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	t.ready(ctx)          // executes ready callback, non blocking
 	<-ctx.Done()          // block until ctx is cancelled elsewhere
 
-	// Stop perf buffers
+	// Close perf buffers
 
-	t.eventsPerfMap.Stop()
+	t.eventsPerfMap.Close()
 	if t.config.BlobPerfBufferSize > 0 {
-		t.fileWrPerfMap.Stop()
+		t.fileWrPerfMap.Close()
 	}
 	if pcaps.PcapsEnabled(t.config.Capture.Net) {
-		t.netCapPerfMap.Stop()
+		t.netCapPerfMap.Close()
 	}
-	t.bpfLogsPerfMap.Stop()
+	t.bpfLogsPerfMap.Close()
 
 	// TODO: move logic below somewhere else (related to file writes)
 


### PR DESCRIPTION
Close: aquasecurity/libbpfgo#122

### 1. Explain what the PR does

eebd7e714 **fix(ebpf): close perfbuf instead of just stop**
667a86315 **fix(ebpf): closed channel read**


eebd7e714 **fix(ebpf): close perfbuf instead of just stop**

```
This was an old TODO comment removed by https://github.com/aquasecurity/tracee/pull/296/files#diff-82aa2eb77c3ce782b8ebfb70eaba8a1a5a8a2dce9f3349352a3a3c0f909478f1L604
```


667a86315 **fix(ebpf): closed channel read**

```
This libbpfgo issue aquasecurity/libbpfgo#122
is actually a Tracee problem. It was caused by read attempts on a
closed channel (lostEvChannel), when libbpgo had already closed it.
```

### 2. Explain how to test it

Run tracee and kill it via `^C`.

### 3. Other comments
