### PR TITLE
fix(definitions): ksymbols dependencies handled wrongly

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -10344,7 +10344,13 @@ var CoreEvents = map[ID]Definition{
 			ids: []ID{
 				DoInitModule,
 			},
-			kSymbols: []KSymbol{},
+			kSymbols: []KSymbol{
+				// Special case for this event: Single symbol, common to all kernel versions. Placed
+				// here so the ksymbols engine is always enabled, during tracee startup. The symbols
+				// are resolved dynamically, during runtime depending on the arguments passed to
+				// the event.
+				{symbol: "_stext", required: true},
+			},
 			capabilities: Capabilities{
 				base: []cap.Value{
 					cap.SYSLOG, // read /proc/kallsyms


### PR DESCRIPTION
commit fad5fc043 (HEAD -> ksymboldepsregression, rafaeldtinoco/ksymboldepsregression)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Sep 5 16:33:13 2023

    fix(event): enable ksymbols engine for PrintMemDump
    
    Commit 1a47a4e4e attempted to fix this issue by reverting some changes
    made during the event definitions (and dependencies) refactor. That
    change caused some regressions because of another fix made together,
    but, since it was reverted, this commit fixes the same issue with a much
    simpler approach (at least until the event definitions refactor work is
    finished).
    
    Fixes: #3382