### PR TITLE
Add definition grpc endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.4.8-libbpf-1.2.0.0.20230509162948-80f41e18e690
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230817130859-7d4b8c20396c
+	github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible
 	github.com/golang/protobuf v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/aquasecurity/tracee/types v0.0.0-20230816112254-7c722620761f h1:lMVQW
 github.com/aquasecurity/tracee/types v0.0.0-20230816112254-7c722620761f/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/aquasecurity/tracee/types v0.0.0-20230817130859-7d4b8c20396c h1:0fTbrZsLLIFC17bbm1XGoMZEJvFyfIT3mJJhwXMHVpA=
 github.com/aquasecurity/tracee/types v0.0.0-20230817130859-7d4b8c20396c/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
+github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c h1:1HsKkFRTBxJ6MkwWq7bMlKq85VkcRxlc+57FV5zhu80=
+github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=

--- a/pkg/server/grpc/tracee.go
+++ b/pkg/server/grpc/tracee.go
@@ -2,7 +2,9 @@ package grpc
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/version"
 	pb "github.com/aquasecurity/tracee/types/api/v1beta1"
 )
@@ -11,6 +13,63 @@ type TraceeService struct {
 	pb.UnimplementedTraceeServiceServer
 }
 
+func (s *TraceeService) GetEventDefinition(ctx context.Context, in *pb.GetEventDefinitionRequest) (*pb.GetEventDefinitionResponse, error) {
+	definitions, err := getDefinitions(in)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]*pb.EventDefinition, 0, len(definitions))
+
+	for _, d := range definitions {
+		ed := convertDefinitionToProto(d)
+		out = append(out, ed)
+	}
+
+	return &pb.GetEventDefinitionResponse{
+		Definitions: out,
+	}, nil
+}
+
 func (s *TraceeService) GetVersion(ctx context.Context, in *pb.GetVersionRequest) (*pb.GetVersionResponse, error) {
 	return &pb.GetVersionResponse{Version: version.GetVersion()}, nil
+}
+
+func getDefinitions(in *pb.GetEventDefinitionRequest) ([]events.Definition, error) {
+	if in.Name == "" {
+		return events.Core.GetDefinitions(), nil
+	}
+
+	id, ok := events.Core.GetDefinitionIDByName(in.Name)
+	if !ok {
+		return nil, fmt.Errorf("event %s not found", in.Name)
+	}
+
+	return []events.Definition{events.Core.GetDefinitionByID(id)}, nil
+}
+
+func convertDefinitionToProto(d events.Definition) *pb.EventDefinition {
+	params := make([]*pb.Param, len(d.GetParams()))
+
+	for i, p := range d.GetParams() {
+		params[i] = &pb.Param{
+			Name: p.Name,
+			Type: p.Type,
+		}
+	}
+
+	v := &pb.Version{
+		Major: d.GetVersion().Major(),
+		Minor: d.GetVersion().Minor(),
+		Patch: d.GetVersion().Patch(),
+	}
+
+	return &pb.EventDefinition{
+		Id:          int32(d.GetID()),
+		Name:        d.GetName(),
+		Version:     v,
+		Description: d.GetDescription(),
+		Tags:        d.GetSets(),
+		Params:      params,
+	}
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR is part of the work to support a [v1 for GRPC](https://github.com/aquasecurity/tracee/issues/3208), it add the implementation to the `GetEventDefinition` rpc call.  

### 2. Explain how to test it

```
func main() {
	var opts []grpc.DialOption
	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))

	conn, err := grpc.Dial(":4466", opts...)
	if err != nil {
		log.Fatalf("fail to dial: %v", err)
	}

	client := pb.NewTraceeServiceClient(conn)

	definitions, err := client.GetEventDefinition(
		context.Background(),
		&pb.GetEventDefinitionRequest{Name: "openat"},
	)
	if err != nil {
		log.Fatal(err)
	}

        for _, definition := range definitions.Definitions {
		v := fmt.Sprintf("%d.%d.%d", definition.Version.Major, definition.Version.Minor, definition.Version.Patch)
		fmt.Println("Id:", definition.Id)
		fmt.Println("Name:", definition.Name)
		fmt.Println("Description:", definition.Description)
		fmt.Println("Version:", v)
		fmt.Printf("Tags: %v\n", definition.Tags)
		fmt.Printf("Params: %v\n", definition.Params)
	}
}
```

### 3. Other comments

depends on https://github.com/aquasecurity/tracee/pull/3447 and https://github.com/aquasecurity/tracee/pull/3437
