### PR TITLE
feat: add event enable/disable

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -570,9 +570,9 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 				continue // might happen during initialization (ctrl+c seg faults)
 			}
 
-			// Is the rule disabled for the matched policies?
-			if !t.policyManager.IsRuleEnabled(event.MatchedPoliciesUser, events.ID(event.EventID)) {
-				logger.Debugw("event dropped because matched rule disabled", "event", event.EventName)
+			// Is the event enabled for the policies or globally?
+			if !t.policyManager.IsEnabled(event.MatchedPoliciesUser, events.ID(event.EventID)) {
+				logger.Debugw("event dropped because it is not enabled", "event", event.EventName)
 				t.eventsPool.Put(event)
 				continue
 			}

--- a/pkg/ebpf/policy_manager.go
+++ b/pkg/ebpf/policy_manager.go
@@ -10,14 +10,33 @@ import (
 // policyManager is a thread-safe struct that manages the enabled policies for each rule
 type policyManager struct {
 	mutex sync.Mutex
-	rules map[events.ID]uint64
+	rules map[events.ID]*eventState
+}
+
+// eventState is a struct that holds the state of a given event
+type eventState struct {
+	policyMask uint64
+	enabled    bool
 }
 
 func newPolicyManager() *policyManager {
 	return &policyManager{
 		mutex: sync.Mutex{},
-		rules: make(map[events.ID]uint64),
+		rules: make(map[events.ID]*eventState),
 	}
+}
+
+// IsEnabled tests if a event, or a policy per event is enabled (in the future it will also check if a policy is enabled)
+// TODO: add metrics about an event being enabled/disabled, or a policy being enabled/disabled?
+func (pm *policyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	if !pm.isEventEnabled(ruleId) {
+		return false
+	}
+
+	return pm.isRuleEnabled(matchedPolicies, ruleId)
 }
 
 // IsRuleEnabled returns true if a given event policy is enabled for a given rule
@@ -25,12 +44,35 @@ func (pm *policyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID)
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
-	policyMask, ok := pm.rules[ruleId]
+	return pm.isRuleEnabled(matchedPolicies, ruleId)
+}
+
+// not synchronized, use IsRuleEnabled instead
+func (pm *policyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+	state, ok := pm.rules[ruleId]
 	if !ok {
 		return false
 	}
 
-	return policyMask&matchedPolicies != 0
+	return state.policyMask&matchedPolicies != 0
+}
+
+// IsEventEnabled returns true if a given event policy is enabled for a given rule
+func (pm *policyManager) IsEventEnabled(evenId events.ID) bool {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	return pm.isEventEnabled(evenId)
+}
+
+// not synchronized, use IsEventEnabled instead
+func (pm *policyManager) isEventEnabled(evenId events.ID) bool {
+	state, ok := pm.rules[evenId]
+	if !ok {
+		return false
+	}
+
+	return state.enabled
 }
 
 // EnableRule enables a rule for a given event policy
@@ -38,10 +80,16 @@ func (pm *policyManager) EnableRule(policyId int, ruleId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
-	policyMask := pm.rules[ruleId]
-	utils.SetBit(&policyMask, uint(policyId))
+	state, ok := pm.rules[ruleId]
+	if !ok {
+		// if you enabling/disabling a rule for an event that
+		// was not enabled/disabled yet, we assume the event should be enabled
+		state = &eventState{enabled: true}
+	}
 
-	pm.rules[ruleId] = policyMask
+	utils.SetBit(&state.policyMask, uint(policyId))
+
+	pm.rules[ruleId] = state
 }
 
 // DisableRule disables a rule for a given event policy
@@ -49,8 +97,42 @@ func (pm *policyManager) DisableRule(policyId int, ruleId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
-	policyMask := pm.rules[ruleId]
-	utils.ClearBit(&policyMask, uint(policyId))
+	state, ok := pm.rules[ruleId]
+	if !ok {
+		// if you enabling/disabling a rule for an event that
+		// was not enabled/disabled yet, we assume the event should be enabled
+		state = &eventState{enabled: true}
+	}
 
-	pm.rules[ruleId] = policyMask
+	utils.ClearBit(&state.policyMask, uint(policyId))
+
+	pm.rules[ruleId] = state
+}
+
+// EnableEvent enables a given event
+func (pm *policyManager) EnableEvent(eventId events.ID) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	state, ok := pm.rules[eventId]
+	if !ok {
+		pm.rules[eventId] = &eventState{enabled: true}
+		return
+	}
+
+	state.enabled = true
+}
+
+// DisableEvent disables a given event
+func (pm *policyManager) DisableEvent(eventId events.ID) {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	state, ok := pm.rules[eventId]
+	if !ok {
+		pm.rules[eventId] = &eventState{enabled: false}
+		return
+	}
+
+	state.enabled = false
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1773,6 +1773,28 @@ func (t *Tracee) Unsubscribe(s *streams.Stream) {
 	t.streamsManager.Unsubscribe(s)
 }
 
+func (t *Tracee) EnableEvent(eventName string) error {
+	id, found := events.Core.GetDefinitionIDByName(eventName)
+	if !found {
+		return errfmt.Errorf("error event not found: %s", eventName)
+	}
+
+	t.policyManager.EnableEvent(id)
+
+	return nil
+}
+
+func (t *Tracee) DisableEvent(eventName string) error {
+	id, found := events.Core.GetDefinitionIDByName(eventName)
+	if !found {
+		return errfmt.Errorf("error event not found: %s", eventName)
+	}
+
+	t.policyManager.DisableEvent(id)
+
+	return nil
+}
+
 // EnableRule enables a rule in the specified policies
 func (t *Tracee) EnableRule(policyNames []string, ruleId string) error {
 	eventID, found := events.Core.GetDefinitionIDByName(ruleId)


### PR DESCRIPTION
The event manager manages the state (disabled/enabled) of events globably on tracee.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

This PR is part of the work to support a [v1 for GRPC](https://github.com/aquasecurity/tracee/issues/3208), it adds an enable/disable method to the policyManager, with a state struct to hold the information about the event that is enable/disbale globally as well as per policy, this struct in the future can hold the event emit/submit mask and also a policyMask to enable/disable policies globally. 
