### PR TITLE
chore(revive): disable unchecked-type-assertion

### DIFF
--- a/.revive.toml
+++ b/.revive.toml
@@ -127,6 +127,8 @@ enableAllRules = true
     Disabled = true # TODO: rename variables correctly
 [rule.var-declaration]
     Disabled = false
+[rule.unchecked-type-assertion]
+    Disabled = true
 [rule.unconditional-recursion]
     Disabled = false
 [rule.unexported-naming]


### PR DESCRIPTION
### 1. Explain what the PR does

04b6639d1 **chore(revive): disable unchecked-type-assertion**

```
This probably should be re-enabled at some point.
```

### 2. Explain how to test it

### 3. Other comments

After revive [update](https://github.com/mgechev/revive/commit/95acb880a1b545bdf74dc393a1b80a6df1176cda) `check-lint` outputs:

```
make check-lint                            
Linting golang code...
pkg/signatures/benchmark/signature/golang/code_injection.go:94:20: type cast result is unchecked in request.Value.(string) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:113:8: type cast result is unchecked in source.Value.(string) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:118:8: type cast result is unchecked in source.Value.([]string) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:125:9: type cast result is unchecked in source.Value.(uint32) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:138:8: type cast result is unchecked in source.Value.(uint64) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:143:8: type cast result is unchecked in source.Value.(int32) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:148:8: type cast result is unchecked in source.Value.(int64) - type assertion will panic if not matched
pkg/signatures/celsig/wrapper/wrapper.go:153:8: type cast result is unchecked in source.Value.(map[string]string) - type assertion will panic if not matched
pkg/signatures/benchmark/signature/golang/anti_debugging.go:59:19: type cast result is unchecked in request.Value.(string) - type assertion will panic if not matched
pkg/signatures/celsig/signature.go:72:13: type cast result is unchecked in out.Value().(bool) - type assertion will panic if not matched
pkg/signatures/celsig/library.go:67:11: type cast result is unchecked in lhs.Value().(*wrapper.Event) - type assertion will panic if not matched
pkg/signatures/celsig/library.go:68:13: type cast result is unchecked in rhs.Value().(string) - type assertion will panic if not matched
pkg/signatures/celsig/library.go:77:11: type cast result is unchecked in lhs.Value().(*wrapper.Event) - type assertion will panic if not matched
pkg/signatures/celsig/library.go:78:13: type cast result is unchecked in rhs.Value().(string) - type assertion will panic if not matched
pkg/utils/sharedobjs/host_symbols_loader.go:95:14: type cast result is unchecked in objInfoIface.(*dynamicSymbols) - type assertion will panic if not matched
tests/integration/event_filters_test.go:2037:17: type cast result is unchecked in actArg.Value.(string) - type assertion will panic if not matched
tests/integration/event_filters_test.go:2153:17: type cast result is unchecked in actArg.Value.(string) - type assertion will panic if not matched
tests/integration/event_filters_test.go:2254:17: type cast result is unchecked in actArg.Value.(string) - type assertion will panic if not matched
pkg/ebpf/events_pipeline_bench_test.go:73:12: type cast result is unchecked in evtPool.Get().(*trace.Event) - type assertion will panic if not matched
pkg/ebpf/events_pipeline_bench_test.go:123:16: type cast result is unchecked in evtPool.Get().(*trace.Event) - type assertion will panic if not matched
pkg/events/derive/symbols_collision.go:255:16: type cast result is unchecked in loadedObjsIface.([]sharedobjs.ObjInfo) - type assertion will panic if not matched
pkg/events/derive/symbols_collision.go:332:17: type cast result is unchecked in collisionsIface.([]string) - type assertion will panic if not matched
pkg/events/derive/symbols_collision_test.go:433:14: type cast result is unchecked in path.(string) - type assertion will panic if not matched
pkg/events/derive/symbols_collision_test.go:437:14: type cast result is unchecked in col.([]string) - type assertion will panic if not matched
pkg/ebpf/events_pipeline.go:222:11: type cast result is unchecked in t.eventsPool.Get().(*trace.Event) - type assertion will panic if not matched
types/trace/trace.go:214:16: type cast result is unchecked in arg.Value.([]interface{}) - type assertion will panic if not matched
make[1]: *** [builder/Makefile.checkers:152: lint-check] Error 1
make: *** [Makefile:819: check-lint] Error 2
```