### PR TITLE
chore(ebpf): not fail if some ksymbol is not found

### DIFF
--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -37,20 +37,6 @@ func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helper
 	return nil
 }
 
-// ValidateKsymbolsTable checks if the addresses in the table are valid by
-// checking a specific symbol address. The reason for the addresses to be
-// invalid is if the capabilities required to read the kallsyms file are not
-// given. The chosen symbol used here is "security_file_open" because it is a
-// must-have symbol for tracee to run.
-func ValidateKsymbolsTable(ksyms helpers.KernelSymbolTable) bool {
-	sym, err := ksyms.GetSymbolByName(globalSymbolOwner, "security_file_open")
-	if err != nil || sym.Address == 0 {
-		return false
-	}
-
-	return true
-}
-
 func (t *Tracee) NewKernelSymbols() error {
 	// reading kallsyms needs CAP_SYSLOG
 	kernelSymbols, err := helpers.NewLazyKernelSymbolsMap()
@@ -58,9 +44,6 @@ func (t *Tracee) NewKernelSymbols() error {
 		return errfmt.WrapError(err)
 	}
 
-	if !ValidateKsymbolsTable(kernelSymbols) {
-		return errfmt.Errorf("invalid ksymbol table (capabilities issue ?)")
-	}
 	t.kernelSymbols = kernelSymbols
 
 	return nil

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -928,10 +928,13 @@ func (t *Tracee) validateKallsymsDependencies() {
 	// Figuring out for each event if it has missing required symbols and which
 	missingSymsPerEvent := make(map[events.ID][]string)
 	for sym, depEventsIDs := range symsToDependentEvents {
-		_, ok := kallsymsValues[sym]
-		if ok {
+		ksym, ok := kallsymsValues[sym]
+		if ok && ksym.Address != 0 {
+			// found and valid address
 			continue
 		}
+
+		// missing symbol or invalid address
 		for _, depEventID := range depEventsIDs {
 			eventMissingSyms, ok := missingSymsPerEvent[depEventID]
 			if ok {


### PR DESCRIPTION
Close: #3460 

### 1. Explain what the PR does

7b76c016f **chore(ebpf): not fail if some ksymbol is not found**

```
Continue the execution even if some ksymbol is not found or valid.
```

### 2. Explain how to test it

### 3. Other comments
