### PR TITLE
fix: rename policy apiVersion and kind

### DIFF
--- a/deploy/helm/tracee/templates/tracee-policies.yaml
+++ b/deploy/helm/tracee/templates/tracee-policies.yaml
@@ -7,8 +7,8 @@ metadata:
     {{- include "tracee.labels" . | nindent 4 }}
 data:
   signatures.yaml: |-
-    apiVersion: aquasecurity.github.io/v1beta1
-    kind: TraceePolicy
+    apiVersion: tracee.aquasec.com/v1beta1
+    kind: Policy
     metadata:
       name: signature-events
       annotations:

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -9,8 +9,8 @@ metadata:
   name: tracee-policies
 data:
   signatures.yaml: |-
-    apiVersion: aquasecurity.github.io/v1beta1
-    kind: TraceePolicy
+    apiVersion: tracee.aquasec.com/v1beta1
+    kind: Policy
     metadata:
       name: signature-events
       annotations:

--- a/docs/docs/events/overview.md
+++ b/docs/docs/events/overview.md
@@ -18,8 +18,8 @@ Tracing `execve` events with [policies]:
 
 ```
 cat <<EOF >sample_policy.yaml
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
 	name: sample-policy
 	annotations:

--- a/docs/docs/policies/index.md
+++ b/docs/docs/policies/index.md
@@ -10,8 +10,8 @@ You can load multiple (up to 64) policies into Tracee using the --policy flag pr
 Following is a sample policy:
 
 ```yaml
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
 	name: overview-policy
 	annotations:

--- a/docs/docs/policies/rules.md
+++ b/docs/docs/policies/rules.md
@@ -70,8 +70,8 @@ spec:
 Context is data which is collected along the event. They can be filtered like:
 
 ```yaml
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
 	name: sample-context-filter
 	annotations:
@@ -245,8 +245,8 @@ filters:
 Events have arguments, which can be filtered. 
 
 ```yaml
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
 	name: sample-argument-filter
 	annotations:
@@ -275,8 +275,8 @@ tracee -e security_file_open --output json
 Return values can also be filtered.
 
 ```yaml
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
 	name: sample-return-value
 	annotations:

--- a/docs/tutorials/k8s-policies.md
+++ b/docs/tutorials/k8s-policies.md
@@ -56,8 +56,8 @@ Data
 ====
 signatures.yaml:
 ----
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
 	name: signature-events
 	annotations:
@@ -113,8 +113,8 @@ To add a new policy for tracking execve events, add the following YAML block bef
 ```yaml
 data:
   events.yaml: |-
-    apiVersion: aquasecurity.github.io/v1beta1
-    kind: TraceePolicy
+    apiVersion: tracee.aquasec.com/v1beta1
+    kind: Policy
     metadata:
         name: execve-event
         annotations:

--- a/examples/policies/container_dns_events.yaml
+++ b/examples/policies/container_dns_events.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: container-dns-events
   annotations:

--- a/examples/policies/context_comm.yaml
+++ b/examples/policies/context_comm.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: context-comm
   annotations:

--- a/examples/policies/dig.yaml
+++ b/examples/policies/dig.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: dig
   annotations:

--- a/examples/policies/new_containers.yaml
+++ b/examples/policies/new_containers.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: new-containers
   annotations:

--- a/examples/policies/new_pids.yaml
+++ b/examples/policies/new_pids.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: new-pids
   annotations:

--- a/examples/policies/not_containers.yaml
+++ b/examples/policies/not_containers.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: not-containers
   annotations:

--- a/examples/policies/openat_args_pahtname.yaml
+++ b/examples/policies/openat_args_pahtname.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: openat-args-pathname
   annotations:

--- a/examples/policies/pid_equal.yaml
+++ b/examples/policies/pid_equal.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: pid-equal
   annotations:

--- a/examples/policies/scope_comm.yaml
+++ b/examples/policies/scope_comm.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: comm-strace
   annotations:

--- a/examples/policies/signature_events.yaml
+++ b/examples/policies/signature_events.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: signature-events
   annotations:

--- a/examples/policies/uid_higher_than_or_equal_to_zero.yaml
+++ b/examples/policies/uid_higher_than_or_equal_to_zero.yaml
@@ -1,5 +1,5 @@
-apiVersion: aquasecurity.github.io/v1beta1
-kind: TraceePolicy
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
 metadata:
   name: uid-higher-than-or-equal-to-zero
   annotations:

--- a/pkg/policy/v1beta1/policy_file.go
+++ b/pkg/policy/v1beta1/policy_file.go
@@ -72,11 +72,11 @@ func (p PolicyFile) Validate() error {
 		return errfmt.Errorf("policy name %s is invalid: %s", p.Name(), err)
 	}
 
-	if p.APIVersion != "aquasecurity.github.io/v1beta1" {
+	if p.APIVersion != "tracee.aquasec.com/v1beta1" {
 		return errfmt.Errorf("policy %s, apiVersion not supported", p.Name())
 	}
 
-	if p.Kind != "TraceePolicy" {
+	if p.Kind != "Policy" {
 		return errfmt.Errorf("policy %s, kind not supported", p.Name())
 	}
 

--- a/pkg/policy/v1beta1/policy_file_test.go
+++ b/pkg/policy/v1beta1/policy_file_test.go
@@ -59,7 +59,7 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty Kind",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
+				APIVersion: "tracee.aquasec.com/v1beta1",
 				Metadata:   Metadata{Name: "empty-kind"},
 			},
 			expectedError: errors.New("policy empty-kind, kind not supported"),
@@ -67,8 +67,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid Kind",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "Policy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policies",
 				Metadata:   Metadata{Name: "invalid-kind"},
 			},
 			expectedError: errors.New("policy invalid-kind, kind not supported"),
@@ -76,8 +76,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty scope",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-scope",
 				},
@@ -91,8 +91,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty rules",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-rules",
 				},
@@ -107,8 +107,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty event name",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-event-name",
 				},
@@ -125,8 +125,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid event name",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-event-name",
 				},
@@ -143,8 +143,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid_scope_operator",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-scope-operator",
 				},
@@ -161,8 +161,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid_scope",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-scope",
 				},
@@ -179,8 +179,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "global scope must be unique",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "global-scope-must-be-unique",
 				},
@@ -197,8 +197,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "duplicated event",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "duplicated-event",
 				},
@@ -216,8 +216,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid filter operator",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-filter-operator",
 				},
@@ -239,8 +239,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid policy action",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-policy-action",
 				},
@@ -257,8 +257,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid retval",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-retval",
 				},
@@ -280,8 +280,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty retval",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-retval",
 				},
@@ -303,8 +303,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "retval not an integer",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "retval-not-an-integer",
 				},
@@ -326,8 +326,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty arg name 1",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-filter-arg-1",
 				},
@@ -349,8 +349,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty arg name 3",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-filter-arg-3",
 				},
@@ -372,8 +372,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty arg name 4",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-filter-arg-4",
 				},
@@ -395,8 +395,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "invalid arg",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "invalid-arg",
 				},
@@ -418,8 +418,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty arg value",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-arg-value",
 				},
@@ -441,8 +441,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "empty arg value",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "empty-arg-value",
 				},
@@ -464,8 +464,8 @@ func TestPolicyValidate(t *testing.T) {
 		{
 			testName: "signature filter arg",
 			policy: PolicyFile{
-				APIVersion: "aquasecurity.github.io/v1beta1",
-				Kind:       "TraceePolicy",
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
 				Metadata: Metadata{
 					Name: "signature-filter-arg",
 				},


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/3462


This PR renames policy apiVersion and kind to be:

```
apiVersion: tracee.aquasec.com/v1beta1
kind: Policy
metadata:
  name: dig
  annotations:
    description: traces dns events from the dig executable
spec:
  scope:
    - executable=/usr/bin/dig
  rules:
    - event: net_packet_dns_request
    - event: net_packet_dns_response

```