### PR TITLE
fix: GetEventDefinition doesn't have params

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230919122210-bc6f603d827a
+	github.com/aquasecurity/tracee/types v0.0.0-20230920143310-60be014096d9
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible
 	github.com/golang/protobuf v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c h1:1HsKk
 github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/aquasecurity/tracee/types v0.0.0-20230919122210-bc6f603d827a h1:dsuDdzVJgY+ySa8vDwISvayPcqRYW1lTserflolilOk=
 github.com/aquasecurity/tracee/types v0.0.0-20230919122210-bc6f603d827a/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
+github.com/aquasecurity/tracee/types v0.0.0-20230920143310-60be014096d9 h1:4x8Gt8EJ7PK50bzHRqfzaXyNGus1fv+wx+66NFE3+Pk=
+github.com/aquasecurity/tracee/types v0.0.0-20230920143310-60be014096d9/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=

--- a/pkg/server/grpc/tracee.go
+++ b/pkg/server/grpc/tracee.go
@@ -69,15 +69,6 @@ func getDefinitions(in *pb.GetEventDefinitionRequest) ([]events.Definition, erro
 }
 
 func convertDefinitionToProto(d events.Definition) *pb.EventDefinition {
-	params := make([]*pb.Param, len(d.GetParams()))
-
-	for i, p := range d.GetParams() {
-		params[i] = &pb.Param{
-			Name: p.Name,
-			Type: p.Type,
-		}
-	}
-
 	v := &pb.Version{
 		Major: d.GetVersion().Major(),
 		Minor: d.GetVersion().Minor(),
@@ -90,6 +81,5 @@ func convertDefinitionToProto(d events.Definition) *pb.EventDefinition {
 		Version:     v,
 		Description: d.GetDescription(),
 		Tags:        d.GetSets(),
-		Params:      params,
 	}
 }


### PR DESCRIPTION
Update types and fix GetEventDefinition endpoint, because EventDefinition doesn't have params anymore.