### PR TITLE
Add streams endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230920143310-60be014096d9
+	github.com/aquasecurity/tracee/types v0.0.0-20230923123718-eb2945f4d1e1
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible
 	github.com/golang/protobuf v1.5.3
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/kubernetes/cri-api v0.27.1
+	github.com/mennanov/fmutils v0.2.0
 	github.com/open-policy-agent/opa v0.52.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/pyroscope-io/pyroscope v0.37.2

--- a/go.sum
+++ b/go.sum
@@ -75,12 +75,10 @@ github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2 h1:Yywi9wC3GPDOgR8wr6P9geY2qv
 github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2/go.mod h1:0rEApF1YBHGuZ4C8OYI9q5oDBVpgqtRqYATePl9mCDk=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
-github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c h1:1HsKkFRTBxJ6MkwWq7bMlKq85VkcRxlc+57FV5zhu80=
-github.com/aquasecurity/tracee/types v0.0.0-20230912172206-3c8a64ecec2c/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
-github.com/aquasecurity/tracee/types v0.0.0-20230919122210-bc6f603d827a h1:dsuDdzVJgY+ySa8vDwISvayPcqRYW1lTserflolilOk=
-github.com/aquasecurity/tracee/types v0.0.0-20230919122210-bc6f603d827a/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
-github.com/aquasecurity/tracee/types v0.0.0-20230920143310-60be014096d9 h1:4x8Gt8EJ7PK50bzHRqfzaXyNGus1fv+wx+66NFE3+Pk=
-github.com/aquasecurity/tracee/types v0.0.0-20230920143310-60be014096d9/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
+github.com/aquasecurity/tracee/types v0.0.0-20230920231749-19f281f945aa h1:rmU9H6s5GAx3oh+vYiiAPWXz9t4E1VVWJQoZ+pzYqqo=
+github.com/aquasecurity/tracee/types v0.0.0-20230920231749-19f281f945aa/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
+github.com/aquasecurity/tracee/types v0.0.0-20230923123718-eb2945f4d1e1 h1:L0Ruc8PS27YdUk4uxjszXVZypH4tn3gLG7ugGQpZjWQ=
+github.com/aquasecurity/tracee/types v0.0.0-20230923123718-eb2945f4d1e1/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
@@ -343,6 +341,8 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mennanov/fmutils v0.2.0 h1:Hw/iuQPdKtiB2B9YYh+NX8iv7U7eQu1rICPjr8NvxSo=
+github.com/mennanov/fmutils v0.2.0/go.mod h1:DE+qeI9Xy5s1GA4trgq8H26jr5DgJ4a9+0D1DPVCqyk=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -123,5 +123,15 @@ func getMetadataFromSignatureMetadata(sigMetadata detect.SignatureMetadata) *tra
 	metadata.Properties["signatureID"] = sigMetadata.ID
 	metadata.Properties["signatureName"] = sigMetadata.Name
 
+	// This is temporary, we passing all the signatures metadata,
+	// so we can create the Threat in the protobuf for the grpc API,
+	// once we refactor tracee to use the new event structure,
+	// we will create the Threat here, or maybe return it from the rule engine
+	metadata.Properties["Severity"] = sigMetadata.Properties["Severity"]
+	metadata.Properties["Category"] = sigMetadata.Properties["Category"]
+	metadata.Properties["Technique"] = sigMetadata.Properties["Technique"]
+	metadata.Properties["id"] = sigMetadata.Properties["id"]
+	metadata.Properties["external_id"] = sigMetadata.Properties["external_id"]
+
 	return metadata
 }

--- a/pkg/ebpf/finding_test.go
+++ b/pkg/ebpf/finding_test.go
@@ -68,6 +68,11 @@ func TestFindingToEvent(t *testing.T) {
 				"prop2":         1,
 				"signatureID":   "fake_signature_id",
 				"signatureName": "fake_signature_event",
+				"Severity":      2,
+				"Category":      "privilege-escalation",
+				"Technique":     "Exploitation for Privilege Escalation",
+				"id":            "attack-pattern--b21c3b2d-02e6-45b1-980b-e69051040839",
+				"external_id":   "t1000",
 			},
 		},
 	}
@@ -118,8 +123,13 @@ func createFakeEventAndFinding() detect.Finding {
 			Description: "description",
 			Tags:        []string{"tag1", "tag2"},
 			Properties: map[string]interface{}{
-				"prop1": "value1",
-				"prop2": 1,
+				"prop1":       "value1",
+				"prop2":       1,
+				"Severity":    2,
+				"Category":    "privilege-escalation",
+				"Technique":   "Exploitation for Privilege Escalation",
+				"id":          "attack-pattern--b21c3b2d-02e6-45b1-980b-e69051040839",
+				"external_id": "t1000",
 			},
 		},
 		Data: map[string]interface{}{

--- a/pkg/server/grpc/tracee_test.go
+++ b/pkg/server/grpc/tracee_test.go
@@ -1,0 +1,126 @@
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+
+	pb "github.com/aquasecurity/tracee/types/api/v1beta1"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+func Test_convertEventWithProcessContext(t *testing.T) {
+	unixTime := int(time.Now().UnixNano())
+
+	traceEvent := trace.Event{
+		Timestamp:           unixTime,
+		ThreadStartTime:     unixTime,
+		ProcessID:           1,
+		ThreadID:            2,
+		HostProcessID:       3,
+		HostThreadID:        4,
+		ParentProcessID:     5,
+		HostParentProcessID: 6,
+		UserID:              7,
+		ProcessName:         "processTest",
+		EventID:             8,
+		EventName:           "eventTest",
+		MatchedPolicies:     []string{"policyTest"},
+		Syscall:             "syscall",
+		ContextFlags:        trace.ContextFlags{ContainerStarted: true},
+		EntityID:            9,
+	}
+
+	protoEvent := convertTraceeEventToProto(traceEvent)
+
+	assert.Equal(t, uint32(1), protoEvent.Context.Process.NamespacedPid.Value)
+	assert.Equal(t, uint32(2), protoEvent.Context.Process.Thread.NamespacedTid.Value)
+	assert.Equal(t, uint32(3), protoEvent.Context.Process.Pid.Value)
+	assert.Equal(t, uint32(4), protoEvent.Context.Process.Thread.Tid.Value)
+	assert.Equal(t, uint32(5), protoEvent.Context.Process.Parent.NamespacedPid.Value)
+	assert.Equal(t, uint32(6), protoEvent.Context.Process.Parent.Pid.Value)
+	assert.Equal(t, uint32(7), protoEvent.Context.Process.RealUser.Id.Value)
+	assert.Equal(t, uint32(8), protoEvent.Id)
+	assert.Equal(t, uint32(9), protoEvent.Context.Process.EntityId.Value)
+	assert.Equal(t, "eventTest", protoEvent.Name)
+	assert.DeepEqual(t, []string{"policyTest"}, protoEvent.Policies.Matched)
+	assert.Equal(t, "processTest", protoEvent.Context.Process.Thread.Name)
+	assert.Equal(t, "syscall", protoEvent.Context.Process.Thread.Syscall)
+	assert.Equal(t, true, protoEvent.Context.Process.Thread.Compat)
+}
+
+func Test_convertEventWithStackaddresses(t *testing.T) {
+	traceEvent := trace.Event{
+		StackAddresses: []uint64{1, 2, 3},
+	}
+
+	protoEvent := convertTraceeEventToProto(traceEvent)
+
+	expected := []*pb.StackAddress{
+		{Address: 1},
+		{Address: 2},
+		{Address: 3},
+	}
+
+	for i := range expected {
+		assert.DeepEqual(t, expected[i].Address, protoEvent.Context.Process.Thread.UserStackTrace.Addresses[i].Address)
+	}
+}
+
+func Test_convertEventWithContainerContext(t *testing.T) {
+	traceEvent := trace.Event{
+		Container: trace.Container{
+			ID:          "containerID",
+			Name:        "containerName",
+			ImageName:   "imageName",
+			ImageDigest: "imageDigest",
+		},
+	}
+
+	protoEvent := convertTraceeEventToProto(traceEvent)
+
+	assert.Equal(t, "containerID", protoEvent.Context.Container.Id)
+	assert.Equal(t, "containerName", protoEvent.Context.Container.Name)
+	assert.Equal(t, "imageName", protoEvent.Context.Container.Image.Name)
+	assert.DeepEqual(t, []string{"imageDigest"}, protoEvent.Context.Container.Image.RepoDigests)
+}
+
+func Test_convertEventWithK8sContext(t *testing.T) {
+	traceEvent := trace.Event{
+		Kubernetes: trace.Kubernetes{
+			PodName:      "podName",
+			PodNamespace: "podNamespace",
+			PodUID:       "podUID",
+		},
+	}
+
+	protoEvent := convertTraceeEventToProto(traceEvent)
+
+	assert.Equal(t, "podName", protoEvent.Context.K8S.Pod.Name)
+	assert.Equal(t, "podNamespace", protoEvent.Context.K8S.Namespace.Name)
+	assert.Equal(t, "podUID", protoEvent.Context.K8S.Pod.Uid)
+}
+
+func Test_convertEventWithThreat(t *testing.T) {
+	traceEvent := trace.Event{
+		Metadata: &trace.Metadata{
+			Description: "An attempt to abuse the Docker UNIX ..",
+			Properties: map[string]interface{}{
+				"Severity":    2,
+				"Category":    "privilege-escalation",
+				"Technique":   "Exploitation for Privilege Escalation",
+				"id":          "attack-pattern--b21c3b2d",
+				"external_id": "T1068",
+			},
+		},
+	}
+
+	protoEvent := convertTraceeEventToProto(traceEvent)
+
+	assert.Equal(t, "An attempt to abuse the Docker UNIX ..", protoEvent.Threat.Description)
+	assert.Equal(t, "privilege-escalation", protoEvent.Threat.MitreTactic.Name)
+	assert.Equal(t, "Exploitation for Privilege Escalation", protoEvent.Threat.MitreTechnique.Name)
+	assert.Equal(t, "attack-pattern--b21c3b2d", protoEvent.Threat.MitreTechnique.Id)
+	assert.Equal(t, "T1068", protoEvent.Threat.MitreTechnique.ExternalId)
+}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does


This PR adds the stream endpoint to the grpc server, which closes the implementation of the v1beta1 of the grpc API. The user needs pass which policies to create a stream, and optionally he can filter with fields to get as a response with the field mask. 

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

### 2. Explain how to test it

test streams:

```
func main() {
	kk := keepalive.ClientParameters{
		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
		Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
		PermitWithoutStream: true,             // send pings even without active streams
	}

	var opts []grpc.DialOption
	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
	opts = append(opts, grpc.WithKeepaliveParams(kk))

	conn, err := grpc.Dial(":4466", opts...)
	if err != nil {
		log.Fatalf("fail to dial: %v", err)
	}
	defer conn.Close()

	client := pb.NewTraceeServiceClient(conn)

	stream, err := client.StreamEvents(context.Background(), &pb.StreamEventsRequest{
		Policies: []string{"signature-events", "test"},
	})
	if err != nil {
		log.Fatal(err)
	}
	for {
		event, err := stream.Recv()
		if err == io.EOF {
			break
		}
		if err != nil {
			log.Fatal(err)
		}
		fmt.Printf("receive event: %v", event)
	}
}
```


test fieldmask:

```
func main() {
	kk := keepalive.ClientParameters{
		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
		Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
		PermitWithoutStream: true,             // send pings even without active streams
	}

	var opts []grpc.DialOption
	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
	opts = append(opts, grpc.WithKeepaliveParams(kk))

	conn, err := grpc.Dial(":4466", opts...)
	if err != nil {
		log.Fatalf("fail to dial: %v", err)
	}
	defer conn.Close()

	client := pb.NewTraceeServiceClient(conn)

	stream, err := client.StreamEvents(context.Background(), &pb.StreamEventsRequest{
		Policies: []string{"signature-events", "test"},
		Mask: &fieldmaskpb.FieldMask{
			Paths: []string{
				"name",
			},
		},
	})
	if err != nil {
		log.Fatal(err)
	}
	for {
		event, err := stream.Recv()
		if err == io.EOF {
			break
		}
		if err != nil {
			log.Fatal(err)
		}
		fmt.Println("receive event", event)
	}
}
```

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
