### PR TITLE
fix(ebpf): fix symbol name on error

### DIFF
--- a/pkg/ebpf/events_processor.go
+++ b/pkg/ebpf/events_processor.go
@@ -343,8 +343,8 @@ func (t *Tracee) processDoInitModule(event *trace.Event) error {
 			t.triggerSeqOpsIntegrityCheck(*event)
 		}
 		if okMemDump {
-			err := t.triggerMemDump(*event)
-			if err != nil {
+			errs := t.triggerMemDump(*event)
+			for _, err := range errs {
 				logger.Warnw("Memory dump", "error", err)
 			}
 		}


### PR DESCRIPTION
Close: #3383 

### 1. Explain what the PR does

826d30f022b872fb5e02b6be1a2aff3a43fea4c2 **fix(ebpf): fix symbol name on error**

```
When not finding a symbol, the error message was showing the symbol name
prefixed with the last attempted symbol name. Now it shows all attempted
symbol names.

This also fixes a bug where it just returned after the first option
lookup failure, instead of trying all.
```

### 2. Explain how to test it

`sudo ./dist/tracee -e print_mem_dump.args.symbol_name=compat_filldir64,do_sys_open,bleh,proc_sys_open,compat_filldir`

```
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
{"level":"warn","ts":1695346496.5952117,"msg":"Memory dump","error":"ebpf.(*Tracee).triggerMemDump: policy 0: invalid symbols provided to print_mem_dump event: {system_,sys_,__x64_sys_,__arm64_sys_}compat_filldir64"}
{"level":"warn","ts":1695346496.5952415,"msg":"Memory dump","error":"ebpf.(*Tracee).triggerMemDump: policy 0: invalid symbols provided to print_mem_dump event: {system_,sys_,__x64_sys_,__arm64_sys_}bleh"}
21:00:00:000000  0                       0       0       0                print_mem_dump            bytes: [102 15 31 0 15 31 68 0 0 72 131 236 32 101 72 139 4 37 40 0 0 0 72 137 68 36 24 137 208 247 194 0 0 32 0 116 58 37 0 0 43 0 49 201 72 137 226 72 137 4 36 72 137 76 36 8 72 199 68 36 16 0 0 0 0 232 106 245 255 255 72 139 84 36 24 101 72 43 20 37 40 0 0 0 117 37 72 131 196 32 195 204 204 204 204 129 225 255 15 0 0 37 195 255 127 0 129 226 64 0 64 0 186 0 0 0 0 72 15 68 202 235 177 232 112 155 140], address: 0xffffffffbc97cdf0, length: 127, caller_context_id: 1, arch: x86_64, symbol_name: do_sys_open, symbol_owner: system
21:00:00:000000  0                       0       0       0                print_mem_dump            bytes: [243 15 30 250 15 31 68 0 0 65 84 72 199 192 104 245 82 190 73 137 244 85 72 137 253 83 72 139 95 216 72 199 199 64 141 223 190 72 133 219 72 15 68 216 232 63 216 130 0 72 131 123 24 0 117 106 131 67 8 1 72 199 199 64 141 223 190 232 184 216 130 0 72 139 69 224 72 129 251 0 240 255 255 119 96 72 139 64 40 72 133 192 116 11 72 99 0 73 137 132 36 200 0 0 0 72 199 199 64 141 223 190 232 251 215 130 0 131 107 8 1 116 23 72 199 199 64], address: 0xffffffffbca2c610, length: 127, caller_context_id: 2, arch: x86_64, symbol_name: proc_sys_open, symbol_owner: system
21:00:00:000000  0                       0       0       0                print_mem_dump            bytes: [243 15 30 250 15 31 68 0 0 65 87 65 86 73 137 206 65 85 77 137 197 65 84 73 137 244 85 72 99 234 83 141 85 15 72 137 251 137 238 131 226 252 76 137 231 65 137 215 72 131 236 8 68 137 76 36 4 232 82 250 255 255 133 192 15 133 219 0 0 0 199 67 32 234 255 255 255 68 57 123 28 15 140 135 0 0 0 76 137 232 72 193 232 32 117 119 72 99 67 24 133 192 15 133 147 0 0 0 65 141 12 7 72 139 123 16 72 99 201 72 190 0 240 255 255 255 127], address: 0xffffffffbc999c30, length: 127, caller_context_id: 3, arch: x86_64, symbol_name: compat_filldir, symbol_owner: system
^C
End of events stream
Stats: {EventCount:{value:3} EventsFiltered:{value:0} NetCapCount:{value:0} BPFLogsCount:{value:0} ErrorCount:{value:0} LostEvCount:{value:0} LostWrCount:{value:0} LostNtCapCount:{value:0} LostBPFLogsCount:{value:0}}
```

### 3. Other comments

