### PR TITLE
fix(proctree): allow regular events to create proctree nodes

### DIFF
--- a/pkg/ebpf/c/common/consts.h
+++ b/pkg/ebpf/c/common/consts.h
@@ -39,6 +39,7 @@
 #define OPT_TRANSLATE_FD_FILEPATH (1 << 7)
 #define OPT_CAPTURE_BPF           (1 << 8)
 #define OPT_CAPTURE_FILES_READ    (1 << 9)
+#define OPT_FORK_PROCTREE         (1 << 10)
 
 #define STDIN  0
 #define STDOUT 1

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -499,56 +499,61 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     if (!init_program_data(&p, ctx))
         return 0;
 
-    // Note: we don't place should_trace() here, so we can keep track of the cgroups in the system
+    // NOTE: proc_info_map updates before should_trace() as the entries are needed in other places.
+
     struct task_struct *parent = (struct task_struct *) ctx->args[0];
     struct task_struct *child = (struct task_struct *) ctx->args[1];
 
-    u64 start_time = get_task_start_time(child);
+    // Information needed before the event:
+    int parent_pid = get_task_host_tgid(parent);
+    u64 child_start_time = get_task_start_time(child);
+    int child_pid = get_task_host_tgid(child);
+    int child_tid = get_task_host_pid(child);
+    int child_ns_pid = get_task_ns_tgid(child);
+    int child_ns_tid = get_task_ns_pid(child);
+
+    // Update the task_info map with the new task's info
 
     task_info_t task = {};
     __builtin_memcpy(&task, p.task_info, sizeof(task_info_t));
     task.recompute_scope = true;
-    task.context.tid = get_task_ns_pid(child);
-    task.context.host_tid = get_task_host_pid(child);
-    task.context.start_time = start_time;
+    task.context.tid = child_ns_tid;
+    task.context.host_tid = child_tid;
+    task.context.start_time = child_start_time;
     ret = bpf_map_update_elem(&task_info_map, &task.context.host_tid, &task, BPF_ANY);
     if (ret < 0)
         tracee_log(ctx, BPF_LOG_LVL_DEBUG, BPF_LOG_ID_MAP_UPDATE_ELEM, ret);
 
-    int parent_pid = get_task_host_pid(parent);
-    int child_pid = get_task_host_pid(child);
+    // Update the proc_info_map with the new process's info (from parent)
 
-    int parent_tgid = get_task_host_tgid(parent);
-    int child_tgid = get_task_host_tgid(child);
-
-    proc_info_t *c_proc_info = bpf_map_lookup_elem(&proc_info_map, &child_tgid);
+    proc_info_t *c_proc_info = bpf_map_lookup_elem(&proc_info_map, &child_pid);
     if (c_proc_info == NULL) {
-        // this is a new process (and not just another thread) - add it to proc_info_map
-
-        proc_info_t *p_proc_info = bpf_map_lookup_elem(&proc_info_map, &parent_tgid);
+        // It is a new process (not another thread): add it to proc_info_map.
+        proc_info_t *p_proc_info = bpf_map_lookup_elem(&proc_info_map, &parent_pid);
         if (unlikely(p_proc_info == NULL)) {
-            // parent proc should exist in proc_map (init_program_data should have set it)
+            // parent should exist in proc_info_map (init_program_data sets it)
             tracee_log(ctx, BPF_LOG_LVL_WARN, BPF_LOG_ID_MAP_LOOKUP_ELEM, 0);
             return 0;
         }
 
-        bpf_map_update_elem(&proc_info_map, &child_tgid, p_proc_info, BPF_NOEXIST);
-        c_proc_info = bpf_map_lookup_elem(&proc_info_map, &child_tgid);
-        // appease the verifier
+        // Copy the parent's proc_info to the child's enty.
+        bpf_map_update_elem(&proc_info_map, &child_pid, p_proc_info, BPF_NOEXIST);
+        c_proc_info = bpf_map_lookup_elem(&proc_info_map, &child_pid);
         if (unlikely(c_proc_info == NULL)) {
             tracee_log(ctx, BPF_LOG_LVL_WARN, BPF_LOG_ID_MAP_LOOKUP_ELEM, 0);
             return 0;
         }
 
-        c_proc_info->follow_in_scopes = 0;
-        c_proc_info->new_proc = true;
+        c_proc_info->follow_in_scopes = 0; // updated later if should_trace() passes (follow filter)
+        c_proc_info->new_proc = true;      // started after tracee (new_pid filter)
     }
 
-    // update process tree map if the parent has an entry
+    // Update the process tree map (filter related) if the parent has an entry.
+
     if (p.config->proc_tree_filter_enabled_scopes) {
-        u32 *tgid_filtered = bpf_map_lookup_elem(&process_tree_map, &parent_tgid);
+        u32 *tgid_filtered = bpf_map_lookup_elem(&process_tree_map, &parent_pid);
         if (tgid_filtered) {
-            ret = bpf_map_update_elem(&process_tree_map, &child_tgid, tgid_filtered, BPF_ANY);
+            ret = bpf_map_update_elem(&process_tree_map, &child_pid, tgid_filtered, BPF_ANY);
             if (ret < 0)
                 tracee_log(ctx, BPF_LOG_LVL_DEBUG, BPF_LOG_ID_MAP_UPDATE_ELEM, ret);
         }
@@ -557,25 +562,70 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace(&p))
         return 0;
 
-    // follow every pid that passed the should_trace() checks (used by the follow filter)
+    // Always follow every pid that passed the should_trace() checks (follow filter)
     c_proc_info->follow_in_scopes = p.task_info->matched_scopes;
 
+    // Submit the event
+
     if (should_submit(SCHED_PROCESS_FORK, p.event) || p.config->options & OPT_PROCESS_INFO) {
-        int parent_ns_pid = get_task_ns_pid(parent);
-        int parent_ns_tgid = get_task_ns_tgid(parent);
-        int child_ns_pid = get_task_ns_pid(child);
-        int child_ns_tgid = get_task_ns_tgid(child);
+        // Parent information.
+        u64 parent_start_time = get_task_start_time(parent);
+        int parent_tid = get_task_host_pid(parent);
+        int parent_ns_pid = get_task_ns_tgid(parent);
+        int parent_ns_tid = get_task_ns_pid(parent);
 
-        save_to_submit_buf(&p.event->args_buf, (void *) &parent_pid, sizeof(int), 0);
-        save_to_submit_buf(&p.event->args_buf, (void *) &parent_ns_pid, sizeof(int), 1);
-        save_to_submit_buf(&p.event->args_buf, (void *) &parent_tgid, sizeof(int), 2);
-        save_to_submit_buf(&p.event->args_buf, (void *) &parent_ns_tgid, sizeof(int), 3);
-        save_to_submit_buf(&p.event->args_buf, (void *) &child_pid, sizeof(int), 4);
-        save_to_submit_buf(&p.event->args_buf, (void *) &child_ns_pid, sizeof(int), 5);
-        save_to_submit_buf(&p.event->args_buf, (void *) &child_tgid, sizeof(int), 6);
-        save_to_submit_buf(&p.event->args_buf, (void *) &child_ns_tgid, sizeof(int), 7);
-        save_to_submit_buf(&p.event->args_buf, (void *) &start_time, sizeof(u64), 8);
+        // Parent (might be a thread or a process).
+        save_to_submit_buf(&p.event->args_buf, (void *) &parent_tid, sizeof(int), 0);
+        save_to_submit_buf(&p.event->args_buf, (void *) &parent_ns_tid, sizeof(int), 1);
+        save_to_submit_buf(&p.event->args_buf, (void *) &parent_pid, sizeof(int), 2);
+        save_to_submit_buf(&p.event->args_buf, (void *) &parent_ns_pid, sizeof(int), 3);
+        save_to_submit_buf(&p.event->args_buf, (void *) &parent_start_time, sizeof(u64), 4);
 
+        // Child (might be a lwp or a process, sched_process_fork trace is calle by clone() also).
+        save_to_submit_buf(&p.event->args_buf, (void *) &child_tid, sizeof(int), 5);
+        save_to_submit_buf(&p.event->args_buf, (void *) &child_ns_tid, sizeof(int), 6);
+        save_to_submit_buf(&p.event->args_buf, (void *) &child_pid, sizeof(int), 7);
+        save_to_submit_buf(&p.event->args_buf, (void *) &child_ns_pid, sizeof(int), 8);
+        save_to_submit_buf(&p.event->args_buf, (void *) &child_start_time, sizeof(u64), 9);
+
+        // Process tree information (if needed).
+        if (p.config->options & OPT_FORK_PROCTREE) {
+            // Both, the thread group leader and the "up_parent" (the first process, not lwp, found
+            // as a parent of the child in the hierarchy), are needed by the userland process tree.
+            // The userland process tree default source of events is the signal events, but there is
+            // an option to use regular event for maintaining it as well (and it is needed for some
+            // situatins). These arguments will always be removed by userland event processors.
+            struct task_struct *leader = get_leader_task(child);
+            struct task_struct *up_parent = get_leader_task(get_parent_task(leader));
+
+            // Up Parent information: Go up in hierarchy until parent is process.
+            u64 up_parent_start_time = get_task_start_time(up_parent);
+            int up_parent_pid = get_task_host_tgid(up_parent);
+            int up_parent_tid = get_task_host_pid(up_parent);
+            int up_parent_ns_pid = get_task_ns_tgid(up_parent);
+            int up_parent_ns_tid = get_task_ns_pid(up_parent);
+            // Leader information.
+            u64 leader_start_time = get_task_start_time(leader);
+            int leader_pid = get_task_host_tgid(leader);
+            int leader_tid = get_task_host_pid(leader);
+            int leader_ns_pid = get_task_ns_tgid(leader);
+            int leader_ns_tid = get_task_ns_pid(leader);
+
+            // Up Parent: always a process (might be the same as Parent if parent is a process).
+            save_to_submit_buf(&p.event->args_buf, (void *) &up_parent_tid, sizeof(int), 10);
+            save_to_submit_buf(&p.event->args_buf, (void *) &up_parent_ns_tid, sizeof(int), 11);
+            save_to_submit_buf(&p.event->args_buf, (void *) &up_parent_pid, sizeof(int), 12);
+            save_to_submit_buf(&p.event->args_buf, (void *) &up_parent_ns_pid, sizeof(int), 13);
+            save_to_submit_buf(&p.event->args_buf, (void *) &up_parent_start_time, sizeof(u64), 14);
+            // Leader: always a process (might be the same as the Child if child is a process).
+            save_to_submit_buf(&p.event->args_buf, (void *) &leader_tid, sizeof(int), 15);
+            save_to_submit_buf(&p.event->args_buf, (void *) &leader_ns_tid, sizeof(int), 16);
+            save_to_submit_buf(&p.event->args_buf, (void *) &leader_pid, sizeof(int), 17);
+            save_to_submit_buf(&p.event->args_buf, (void *) &leader_ns_pid, sizeof(int), 18);
+            save_to_submit_buf(&p.event->args_buf, (void *) &leader_start_time, sizeof(u64), 19);
+        }
+
+        // Submit
         events_perf_submit(&p, SCHED_PROCESS_FORK, 0);
     }
 
@@ -1079,6 +1129,8 @@ int lkm_seeker_new_mod_only_tail(struct pt_regs *ctx)
     return 0;
 }
 
+// clang-format off
+
 // trace/events/sched.h: TP_PROTO(struct task_struct *p, pid_t old_pid, struct linux_binprm *bprm)
 SEC("raw_tracepoint/sched_process_exec")
 int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
@@ -1087,9 +1139,10 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     if (!init_program_data(&p, ctx))
         return 0;
 
-    // Perform the following checks before should_trace() so we can filter by newly created
-    // containers/processes.  We assume that a new container/pod has started when a process of a
-    // newly created cgroup and mount ns executed a binary
+    // Perform checks below before should_trace(), so tracee can filter by newly created containers
+    // or processes. Assume that a new container, or pod, has started when a process of a newly
+    // created cgroup and mount ns executed a binary.
+
     if (p.task_info->container_state == CONTAINER_CREATED) {
         u32 mntns = get_task_mnt_ns_id(p.event->task);
         struct task_struct *parent = get_parent_task(p.event->task);
@@ -1099,30 +1152,31 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
             u8 state = CONTAINER_STARTED;
             bpf_map_update_elem(&containers_map, &cgroup_id_lsb, &state, BPF_ANY);
             p.task_info->container_state = state;
-            p.event->context.task.flags |= CONTAINER_STARTED_FLAG; // Change for current event
-            p.task_info->context.flags |= CONTAINER_STARTED_FLAG;  // Change for future task events
+            p.event->context.task.flags |= CONTAINER_STARTED_FLAG; // change for current event
+            p.task_info->context.flags |= CONTAINER_STARTED_FLAG;  // change for future task events
         }
     }
 
-    p.task_info->recompute_scope = true;
+    p.task_info->recompute_scope = true; // a new task should always have the scope recomputed
 
     struct linux_binprm *bprm = (struct linux_binprm *) ctx->args[2];
-    if (bprm == NULL) {
+    if (bprm == NULL)
         return -1;
-    }
+
     struct file *file = get_file_ptr_from_bprm(bprm);
     void *file_path = get_path_str(__builtin_preserve_access_index(&file->f_path));
 
+    // Pick data about the process from proc_info_map
     proc_info_t *proc_info = bpf_map_lookup_elem(&proc_info_map, &p.event->context.task.host_pid);
     if (proc_info == NULL) {
-        // entry should exist in proc_map (init_program_data should have set it otherwise)
+        // init_program_data should have created an entry in proc_info_map for this pid
         tracee_log(ctx, BPF_LOG_LVL_WARN, BPF_LOG_ID_MAP_LOOKUP_ELEM, 0);
         return 0;
     }
 
-    proc_info->new_proc = true;
+    proc_info->new_proc = true; // task has started after tracee started running
 
-    // extract the binary name to be used in should_trace
+    // Extract the binary name to be used in should_trace
     __builtin_memset(proc_info->binary.path, 0, MAX_BIN_PATH_SIZE);
     bpf_probe_read_str(proc_info->binary.path, MAX_BIN_PATH_SIZE, file_path);
     proc_info->binary.mnt_id = p.event->context.task.mnt_id;
@@ -1130,44 +1184,53 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace(&p))
         return 0;
 
-    // Follow this task for matched scopes
-    proc_info->follow_in_scopes = p.task_info->matched_scopes;
+    proc_info->follow_in_scopes = p.task_info->matched_scopes; // follow task for matched scopes
 
     if (!should_submit(SCHED_PROCESS_EXEC, p.event) &&
         (p.config->options & OPT_PROCESS_INFO) != OPT_PROCESS_INFO)
         return 0;
 
-    // Note: Starting from kernel 5.9, there are two new interesting fields in bprm that we
-    // should consider adding:
-    // 1. struct file *executable - can be used to get the executable name passed to an
-    // interpreter
-    // 2. fdpath                  - generated filename for execveat (after resolving dirfd)
+    // Note: From v5.9+, there are two interesting fields in bprm that could be added:
+    // 1. struct file *executable: the executable name passed to an interpreter
+    // 2. fdpath: generated filename for execveat (after resolving dirfd)
+
     const char *filename = get_binprm_filename(bprm);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
     u64 ctime = get_ctime_nanosec_from_file(file);
     umode_t inode_mode = get_inode_mode_from_file(file);
 
-    save_str_to_buf(&p.event->args_buf, (void *) filename, 0);
-    save_str_to_buf(&p.event->args_buf, file_path, 1);
-    save_to_submit_buf(&p.event->args_buf, &s_dev, sizeof(dev_t), 2);
-    save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 3);
-    save_to_submit_buf(&p.event->args_buf, &ctime, sizeof(u64), 4);
-    save_to_submit_buf(&p.event->args_buf, &inode_mode, sizeof(umode_t), 5);
-    // If the interpreter file is the same as the executed one, it means that there is no
-    // interpreter. For more information, see the load_elf_phdrs kprobe program.
-    if (proc_info->interpreter.id.inode != 0 && (proc_info->interpreter.id.device != s_dev ||
-                                                 proc_info->interpreter.id.inode != inode_nr)) {
-        save_str_to_buf(&p.event->args_buf, &proc_info->interpreter.pathname, 6);
-        save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.device, sizeof(dev_t), 7);
-        save_to_submit_buf(
-            &p.event->args_buf, &proc_info->interpreter.id.inode, sizeof(unsigned long), 8);
-        save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.ctime, sizeof(u64), 9);
+    save_str_to_buf(&p.event->args_buf, (void *) filename, 0);                   // executable name
+    save_str_to_buf(&p.event->args_buf, file_path, 1);                           // executable path
+    save_to_submit_buf(&p.event->args_buf, &s_dev, sizeof(dev_t), 2);            // device number
+    save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 3); // inode number 
+    save_to_submit_buf(&p.event->args_buf, &ctime, sizeof(u64), 4);              // changed time
+    save_to_submit_buf(&p.event->args_buf, &inode_mode, sizeof(umode_t), 5);     // inode mode
+
+    // NOTES:
+    // - interp is the real interpreter (sh, bash, python, perl, ...)
+    // - interpreter is the binary interpreter (ld.so), also known as the loader
+    // - interpreter might be the same as executable (so there is no interpreter)
+
+    // Check if there is an interpreter and if it is different from the executable:
+
+    bool itp_inode_exists = proc_info->interpreter.id.inode != 0;
+    bool itp_dev_diff = proc_info->interpreter.id.device != s_dev;
+    bool itp_inode_diff = proc_info->interpreter.id.inode != inode_nr;
+
+    if (itp_inode_exists && (itp_dev_diff || itp_inode_diff)) {
+        save_str_to_buf(&p.event->args_buf, &proc_info->interpreter.pathname, 6);                    // interpreter path
+        save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.device, sizeof(dev_t), 7); // interpreter device number
+        save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.inode, sizeof(u64), 8);    // interpreter inode number
+        save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.ctime, sizeof(u64), 9);    // interpreter changed time
     }
 
     bpf_tail_call(ctx, &prog_array_tp, TAIL_SCHED_PROCESS_EXEC_EVENT_SUBMIT);
-    return -1;
+
+    return 0;
 }
+
+// clang-format on
 
 SEC("raw_tracepoint/sched_process_exec_event_submit_tail")
 int sched_process_exec_event_submit_tail(struct bpf_raw_tracepoint_args *ctx)
@@ -6081,9 +6144,10 @@ int sched_process_fork_signal(struct bpf_raw_tracepoint_args *ctx)
     if (unlikely(signal == NULL))
         return 0;
 
+    struct task_struct *parent = (struct task_struct *) ctx->args[0];
     struct task_struct *child = (struct task_struct *) ctx->args[1];
     struct task_struct *leader = get_leader_task(child);
-    struct task_struct *parent = get_leader_task(get_parent_task(leader));
+    struct task_struct *up_parent = get_leader_task(get_parent_task(leader));
 
     // In the Linux kernel:
     //
@@ -6112,55 +6176,65 @@ int sched_process_fork_signal(struct bpf_raw_tracepoint_args *ctx)
     // userland pid = kernel tgid
     // userland tgid = kernel pid
 
-    u64 parent_starttime = get_task_start_time(parent);
+    // The event timestamp, so process tree info can be changelog'ed.
+    u64 timestamp = bpf_ktime_get_ns();
+    save_to_submit_buf(&signal->args_buf, &timestamp, sizeof(u64), 0);
+
+    // Parent information.
+    u64 parent_start_time = get_task_start_time(parent);
     int parent_pid = get_task_host_tgid(parent);
     int parent_tid = get_task_host_pid(parent);
     int parent_ns_pid = get_task_ns_tgid(parent);
     int parent_ns_tid = get_task_ns_pid(parent);
 
-    u64 leader_starttime = get_task_start_time(leader);
-    int leader_pid = get_task_host_tgid(leader);
-    int leader_tid = get_task_host_pid(leader);
-    int leader_ns_pid = get_task_ns_tgid(leader);
-    int leader_ns_tid = get_task_ns_pid(leader);
-
-    u64 child_starttime = get_task_start_time(child);
+    // Child information.
+    u64 child_start_time = get_task_start_time(child);
     int child_pid = get_task_host_tgid(child);
     int child_tid = get_task_host_pid(child);
     int child_ns_pid = get_task_ns_tgid(child);
     int child_ns_tid = get_task_ns_pid(child);
 
-    // The event timestamp, so process tree info can be changelog'ed.
-    u64 timestamp = bpf_ktime_get_ns();
-    save_to_submit_buf(&signal->args_buf, &timestamp, sizeof(u64), 0);
+    // Up Parent information: Go up in hierarchy until parent is process.
+    u64 up_parent_start_time = get_task_start_time(up_parent);
+    int up_parent_pid = get_task_host_tgid(up_parent);
+    int up_parent_tid = get_task_host_pid(up_parent);
+    int up_parent_ns_pid = get_task_ns_tgid(up_parent);
+    int up_parent_ns_tid = get_task_ns_pid(up_parent);
 
-    // The hash is always calculated with "task_struct->pid + start_time".
-    u32 task_hash = hash_task_id(child_tid, child_starttime);
-    u32 parent_hash = hash_task_id(parent_tid, parent_starttime);
-    u32 leader_hash = hash_task_id(leader_tid, leader_starttime);
+    // Leader information.
+    u64 leader_start_time = get_task_start_time(leader);
+    int leader_pid = get_task_host_tgid(leader);
+    int leader_tid = get_task_host_pid(leader);
+    int leader_ns_pid = get_task_ns_tgid(leader);
+    int leader_ns_tid = get_task_ns_pid(leader);
 
-    // hashes
-    save_to_submit_buf(&signal->args_buf, (void *) &task_hash, sizeof(u32), 1);
-    save_to_submit_buf(&signal->args_buf, (void *) &parent_hash, sizeof(u32), 2);
-    save_to_submit_buf(&signal->args_buf, (void *) &leader_hash, sizeof(u32), 3);
-    // parent
-    save_to_submit_buf(&signal->args_buf, (void *) &parent_tid, sizeof(int), 4);
-    save_to_submit_buf(&signal->args_buf, (void *) &parent_ns_tid, sizeof(int), 5);
-    save_to_submit_buf(&signal->args_buf, (void *) &parent_pid, sizeof(int), 6);
-    save_to_submit_buf(&signal->args_buf, (void *) &parent_ns_pid, sizeof(int), 7);
-    save_to_submit_buf(&signal->args_buf, (void *) &parent_starttime, sizeof(u64), 8);
-    // leader
-    save_to_submit_buf(&signal->args_buf, (void *) &leader_tid, sizeof(int), 9);
-    save_to_submit_buf(&signal->args_buf, (void *) &leader_ns_tid, sizeof(int), 10);
-    save_to_submit_buf(&signal->args_buf, (void *) &leader_pid, sizeof(int), 11);
-    save_to_submit_buf(&signal->args_buf, (void *) &leader_ns_pid, sizeof(int), 12);
-    save_to_submit_buf(&signal->args_buf, (void *) &leader_starttime, sizeof(u64), 13);
-    // child
-    save_to_submit_buf(&signal->args_buf, (void *) &child_tid, sizeof(int), 14);
-    save_to_submit_buf(&signal->args_buf, (void *) &child_ns_tid, sizeof(int), 15);
-    save_to_submit_buf(&signal->args_buf, (void *) &child_pid, sizeof(int), 16);
-    save_to_submit_buf(&signal->args_buf, (void *) &child_ns_pid, sizeof(int), 17);
-    save_to_submit_buf(&signal->args_buf, (void *) &child_starttime, sizeof(u64), 18);
+    // Parent (might be a thread or a process).
+    save_to_submit_buf(&signal->args_buf, (void *) &parent_tid, sizeof(int), 1);
+    save_to_submit_buf(&signal->args_buf, (void *) &parent_ns_tid, sizeof(int), 2);
+    save_to_submit_buf(&signal->args_buf, (void *) &parent_pid, sizeof(int), 3);
+    save_to_submit_buf(&signal->args_buf, (void *) &parent_ns_pid, sizeof(int), 4);
+    save_to_submit_buf(&signal->args_buf, (void *) &parent_start_time, sizeof(u64), 5);
+
+    // Child (might be a thread or a process, sched_process_fork trace is calle by clone() also).
+    save_to_submit_buf(&signal->args_buf, (void *) &child_tid, sizeof(int), 6);
+    save_to_submit_buf(&signal->args_buf, (void *) &child_ns_tid, sizeof(int), 7);
+    save_to_submit_buf(&signal->args_buf, (void *) &child_pid, sizeof(int), 8);
+    save_to_submit_buf(&signal->args_buf, (void *) &child_ns_pid, sizeof(int), 9);
+    save_to_submit_buf(&signal->args_buf, (void *) &child_start_time, sizeof(u64), 10);
+
+    // Up Parent: always a real process (might be the same as Parent if it is a real process).
+    save_to_submit_buf(&signal->args_buf, (void *) &up_parent_tid, sizeof(int), 11);
+    save_to_submit_buf(&signal->args_buf, (void *) &up_parent_ns_tid, sizeof(int), 12);
+    save_to_submit_buf(&signal->args_buf, (void *) &up_parent_pid, sizeof(int), 13);
+    save_to_submit_buf(&signal->args_buf, (void *) &up_parent_ns_pid, sizeof(int), 14);
+    save_to_submit_buf(&signal->args_buf, (void *) &up_parent_start_time, sizeof(u64), 15);
+
+    // Leader: always a real process (might be the same as the Child if child is a real process).
+    save_to_submit_buf(&signal->args_buf, (void *) &leader_tid, sizeof(int), 16);
+    save_to_submit_buf(&signal->args_buf, (void *) &leader_ns_tid, sizeof(int), 17);
+    save_to_submit_buf(&signal->args_buf, (void *) &leader_pid, sizeof(int), 18);
+    save_to_submit_buf(&signal->args_buf, (void *) &leader_ns_pid, sizeof(int), 19);
+    save_to_submit_buf(&signal->args_buf, (void *) &leader_start_time, sizeof(u64), 20);
 
     signal_perf_submit(ctx, signal, SIGNAL_SCHED_PROCESS_FORK);
 
@@ -6203,6 +6277,7 @@ int sched_process_exec_signal(struct bpf_raw_tracepoint_args *ctx)
     if (bprm == NULL)
         return -1;
 
+    // Pick the interpreter path from the proc_info map, which is set by the "load_elf_phdrs".
     u32 host_pid = get_task_host_tgid(task);
     proc_info_t *proc_info = bpf_map_lookup_elem(&proc_info_map, &host_pid);
     if (proc_info == NULL)
@@ -6210,25 +6285,24 @@ int sched_process_exec_signal(struct bpf_raw_tracepoint_args *ctx)
 
     struct file *file = get_file_ptr_from_bprm(bprm);
     void *file_path = get_path_str(__builtin_preserve_access_index(&file->f_path));
-
     const char *filename = get_binprm_filename(bprm);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
     u64 ctime = get_ctime_nanosec_from_file(file);
     umode_t inode_mode = get_inode_mode_from_file(file);
 
-    save_str_to_buf(&signal->args_buf, (void *) filename, 4);                   // cmdpath
-    save_str_to_buf(&signal->args_buf, file_path, 5);                           // pathname
-    save_to_submit_buf(&signal->args_buf, &s_dev, sizeof(dev_t), 6);            // dev
-    save_to_submit_buf(&signal->args_buf, &inode_nr, sizeof(unsigned long), 7); // inode
-    save_to_submit_buf(&signal->args_buf, &ctime, sizeof(u64), 8);              // ctime
-    save_to_submit_buf(&signal->args_buf, &inode_mode, sizeof(umode_t), 9);     // inode_mode
-
+    save_str_to_buf(&signal->args_buf, (void *) filename, 4);                   // executable name
+    save_str_to_buf(&signal->args_buf, file_path, 5);                           // executable path
+    save_to_submit_buf(&signal->args_buf, &s_dev, sizeof(dev_t), 6);            // device number
+    save_to_submit_buf(&signal->args_buf, &inode_nr, sizeof(unsigned long), 7); // inode number
+    save_to_submit_buf(&signal->args_buf, &ctime, sizeof(u64), 8);              // creation time
+    save_to_submit_buf(&signal->args_buf, &inode_mode, sizeof(umode_t), 9);     // inode mode
+    
     // The proc_info interpreter field is set by "load_elf_phdrs" kprobe program.
-    save_str_to_buf(&signal->args_buf, &proc_info->interpreter.pathname, 10);                           // interpreter_pathname
-    save_to_submit_buf(&signal->args_buf, &proc_info->interpreter.id.device, sizeof(dev_t), 11);        // interpreter_dev
-    save_to_submit_buf(&signal->args_buf, &proc_info->interpreter.id.inode, sizeof(unsigned long), 12); // interpreter_inode
-    save_to_submit_buf(&signal->args_buf, &proc_info->interpreter.id.ctime, sizeof(u64), 13);           // interpreter_ctime
+    save_str_to_buf(&signal->args_buf, &proc_info->interpreter.pathname, 10);                    // interpreter path
+    save_to_submit_buf(&signal->args_buf, &proc_info->interpreter.id.device, sizeof(dev_t), 11); // interpreter device number
+    save_to_submit_buf(&signal->args_buf, &proc_info->interpreter.id.inode, sizeof(u64), 12);    // interpreter inode number
+    save_to_submit_buf(&signal->args_buf, &proc_info->interpreter.id.ctime, sizeof(u64), 13);    // interpreter creation time
 
     struct mm_struct *mm = get_mm_from_task(task); // bprm->mm is null here, but task->mm is not
 
@@ -6248,9 +6322,9 @@ int sched_process_exec_signal(struct bpf_raw_tracepoint_args *ctx)
 
     save_args_str_arr_to_buf(&signal->args_buf, (void *) arg_start, (void *) arg_end, argc, 14); // argv
     save_str_to_buf(&signal->args_buf, (void *) interp, 15);                                     // interp
-    save_to_submit_buf(&signal->args_buf, &stdin_type, sizeof(unsigned short), 16);              // stdin_type
-    save_str_to_buf(&signal->args_buf, stdin_path, 17);                                          // stdin_path
-    save_to_submit_buf(&signal->args_buf, &invoked_from_kernel, sizeof(int), 18);                // invoked_from_kernel
+    save_to_submit_buf(&signal->args_buf, &stdin_type, sizeof(unsigned short), 16);              // stdin type
+    save_str_to_buf(&signal->args_buf, stdin_path, 17);                                          // stdin path
+    save_to_submit_buf(&signal->args_buf, &invoked_from_kernel, sizeof(int), 18);                // invoked from kernel ?
 
     signal_perf_submit(ctx, signal, SIGNAL_SCHED_PROCESS_EXEC);
 

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -101,12 +101,13 @@ func (ctrl *Controller) processSignal(signal signal) error {
 	case events.SignalCgroupRmdir:
 		return ctrl.processCgroupRmdir(signal.args)
 	case events.SignalSchedProcessFork:
-		return ctrl.processSchedProcessFork(signal.args)
+		return ctrl.procTreeForkProcessor(signal.args)
 	case events.SignalSchedProcessExec:
-		return ctrl.processSchedProcessExec(signal.args)
+		return ctrl.procTreeExecProcessor(signal.args)
 	case events.SignalSchedProcessExit:
-		return ctrl.processSchedProcessExit(signal.args)
+		return ctrl.procTreeExitProcessor(signal.args)
 	}
+
 	return nil
 }
 
@@ -115,11 +116,7 @@ func (ctrl *Controller) processSignal(signal signal) error {
 // debug prints the process tree every 5 seconds (for debugging purposes).
 func (ctrl *Controller) debug(enable bool) {
 	//
-	// A "hash does not match" warning is enough to tell developers there is something wrong with
-	// the Hash calculation. After that, having, or not having, the hash available won't give you
-	// any details (as you need the "tid" and "starttime" in both ends: userland and bpf).
-	//
-	// This is where the "debug" function enters. The "best way" to debug hash problems is:
+	// The "best way" to debug hash problems is:
 	//
 	// 1. To enable the process tree "display" (this function);
 	// 2. To bpf_printk the "hash" and "start_time" at sched_process_exit_signal() in eBPF code;

--- a/pkg/ebpf/controlplane/processes.go
+++ b/pkg/ebpf/controlplane/processes.go
@@ -1,8 +1,6 @@
 package controlplane
 
 import (
-	"github.com/aquasecurity/tracee/pkg/errfmt"
-	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/proctree"
 	"github.com/aquasecurity/tracee/pkg/utils"
@@ -10,118 +8,68 @@ import (
 )
 
 //
-// Processes Lifecycle
+// Processes Lifecycle (will feed the process tree)
 //
 
-func (ctrl *Controller) processSchedProcessFork(args []trace.Argument) error {
+func (ctrl *Controller) procTreeForkProcessor(args []trace.Argument) error {
+	var errs []error
+
 	if ctrl.processTree == nil {
 		return nil // process tree is disabled
 	}
 
-	paramsLength := len(events.Core.GetDefinitionByID(events.SignalSchedProcessFork).GetParams())
-	if len(args) != paramsLength {
-		return errfmt.Errorf("got %d args instead of %d", len(args), paramsLength)
-	}
+	// NOTE: The "parent" related arguments can be ignored for process tree purposes.
 
 	// Process & Event identification arguments
-
 	timestamp, err := parse.ArgVal[uint64](args, "timestamp")
-	if err != nil {
-		return errfmt.Errorf("error parsing timestamp: %v", err)
-	}
-	childHash, err := parse.ArgVal[uint32](args, "task_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing task_hash: %v", err)
-	}
-	parentHash, err := parse.ArgVal[uint32](args, "parent_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_hash: %v", err)
-	}
-	leaderHash, err := parse.ArgVal[uint32](args, "leader_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_hash: %v", err)
-	}
+	errs = append(errs, err)
 
-	// Parent (the parent of the thread group leader, no matter if child is a process or LWP)
-
-	parentTid, err := parse.ArgVal[int32](args, "parent_tid")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_tid: %v", err)
-	}
-	parentNsTid, err := parse.ArgVal[int32](args, "parent_ns_tid")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_ns_tid: %v", err)
-	}
-	parentPid, err := parse.ArgVal[int32](args, "parent_pid")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_pid: %v", err)
-	}
-	parentNsPid, err := parse.ArgVal[int32](args, "parent_ns_pid")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_ns_pid: %v", err)
-	}
-	parentStartTime, err := parse.ArgVal[uint64](args, "parent_start_time")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_start_time: %v", err)
-	}
+	// Up Parent (Up in hierarchy until parent is a process and not a lwp)
+	parentTid, err := parse.ArgVal[int32](args, "up_parent_tid")
+	errs = append(errs, err)
+	parentNsTid, err := parse.ArgVal[int32](args, "up_parent_ns_tid")
+	errs = append(errs, err)
+	parentPid, err := parse.ArgVal[int32](args, "up_parent_pid")
+	errs = append(errs, err)
+	parentNsPid, err := parse.ArgVal[int32](args, "up_parent_ns_pid")
+	errs = append(errs, err)
+	parentStartTime, err := parse.ArgVal[uint64](args, "up_parent_start_time")
+	errs = append(errs, err)
 
 	// Thread Group Leader (might be the same as the "child", if "child" is a process)
-
 	leaderTid, err := parse.ArgVal[int32](args, "leader_tid")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_tid: %v", err)
-	}
+	errs = append(errs, err)
 	leaderNsTid, err := parse.ArgVal[int32](args, "leader_ns_tid")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_ns_tid: %v", err)
-	}
+	errs = append(errs, err)
 	leaderPid, err := parse.ArgVal[int32](args, "leader_pid")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_pid: %v", err)
-	}
+	errs = append(errs, err)
 	leaderNsPid, err := parse.ArgVal[int32](args, "leader_ns_pid")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_ns_pid: %v", err)
-	}
+	errs = append(errs, err)
 	leaderStartTime, err := parse.ArgVal[uint64](args, "leader_start_time")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_start_time: %v", err)
-	}
+	errs = append(errs, err)
 
 	// Child (might be a process or a thread)
-
 	childTid, err := parse.ArgVal[int32](args, "child_tid")
-	if err != nil {
-		return errfmt.Errorf("error parsing child_tid: %v", err)
-	}
+	errs = append(errs, err)
 	childNsTid, err := parse.ArgVal[int32](args, "child_ns_tid")
-	if err != nil {
-		return errfmt.Errorf("error parsing child_ns_tid: %v", err)
-	}
+	errs = append(errs, err)
 	childPid, err := parse.ArgVal[int32](args, "child_pid")
-	if err != nil {
-		return errfmt.Errorf("error parsing child_pid: %v", err)
-	}
+	errs = append(errs, err)
 	childNsPid, err := parse.ArgVal[int32](args, "child_ns_pid")
-	if err != nil {
-		return errfmt.Errorf("error parsing child_ns_pid: %v", err)
-	}
-	childStartTime, err := parse.ArgVal[uint64](args, "child_start_time")
-	if err != nil {
-		return errfmt.Errorf("error parsing child_start_time: %v", err)
+	errs = append(errs, err)
+	childStartTime, err := parse.ArgVal[uint64](args, "start_time") // child_start_time
+	errs = append(errs, err)
+
+	// Handle errors
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
 	}
 
-	// Sanity check: check if eBPF Hash matches userland Hash
-
-	taskHashVerifier := utils.HashTaskID(uint32(childTid), childStartTime)
-	parentHashVerifier := utils.HashTaskID(uint32(parentTid), parentStartTime)
-	leaderHashVerifier := utils.HashTaskID(uint32(leaderTid), leaderStartTime)
-
-	if childHash != taskHashVerifier ||
-		parentHash != parentHashVerifier ||
-		leaderHash != leaderHashVerifier {
-		return errfmt.Errorf("eBPF Hash does not match")
-	}
+	childHash := utils.HashTaskID(uint32(childTid), childStartTime)
+	parentHash := utils.HashTaskID(uint32(parentTid), parentStartTime)
+	leaderHash := utils.HashTaskID(uint32(leaderTid), leaderStartTime)
 
 	return ctrl.processTree.FeedFromFork(
 		proctree.ForkFeed{
@@ -148,88 +96,60 @@ func (ctrl *Controller) processSchedProcessFork(args []trace.Argument) error {
 	)
 }
 
-func (ctrl *Controller) processSchedProcessExec(args []trace.Argument) error {
+func (ctrl *Controller) procTreeExecProcessor(args []trace.Argument) error {
+	var errs []error
+
 	if ctrl.processTree == nil {
 		return nil // process tree is disabled
 	}
 
-	paramsLength := len(events.Core.GetDefinitionByID(events.SignalSchedProcessExec).GetParams())
-	if len(args) != paramsLength {
-		return errfmt.Errorf("got %d args instead of %d", len(args), paramsLength)
-	}
-
-	// Process & Event identification arguments
-
+	// Process & Event identification arguments (won't exist for regular events)
 	timestamp, err := parse.ArgVal[uint64](args, "timestamp")
-	if err != nil {
-		return errfmt.Errorf("error parsing timestamp: %v", err)
-	}
-	taskHash, err := parse.ArgVal[uint32](args, "task_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing task_hash: %v", err)
-	}
-	parentHash, err := parse.ArgVal[uint32](args, "parent_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_hash: %v", err)
-	}
-	leaderHash, err := parse.ArgVal[uint32](args, "leader_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_hash: %v", err)
-	}
+	errs = append(errs, err)
+	taskHash, _ := parse.ArgVal[uint32](args, "task_hash")
+	errs = append(errs, err)
+	parentHash, _ := parse.ArgVal[uint32](args, "parent_hash")
+	errs = append(errs, err)
+	leaderHash, _ := parse.ArgVal[uint32](args, "leader_hash")
+	errs = append(errs, err)
 
 	// Executable
-
 	cmdPath, err := parse.ArgVal[string](args, "cmdpath")
-	if err != nil {
-		return errfmt.Errorf("error parsing cmdpath: %v", err)
-	}
+	errs = append(errs, err)
 	pathName, err := parse.ArgVal[string](args, "pathname")
-	if err != nil {
-		return errfmt.Errorf("error parsing pathname: %v", err)
-	}
+	errs = append(errs, err)
 	dev, err := parse.ArgVal[uint32](args, "dev")
-	if err != nil {
-		return errfmt.Errorf("error parsing dev: %v", err)
-	}
+	errs = append(errs, err)
 	inode, err := parse.ArgVal[uint64](args, "inode")
-	if err != nil {
-		return errfmt.Errorf("error parsing inode: %v", err)
-	}
+	errs = append(errs, err)
 	ctime, err := parse.ArgVal[uint64](args, "ctime")
-	if err != nil {
-		return errfmt.Errorf("error parsing ctime: %v", err)
-	}
+	errs = append(errs, err)
 	inodeMode, err := parse.ArgVal[uint16](args, "inode_mode")
-	if err != nil {
-		return errfmt.Errorf("error parsing inode_mode: %v", err)
-	}
+	errs = append(errs, err)
 
-	// Interpreter
-
-	// these 4 fields might be empty, do not check of error
+	// Binary Interpreter (or Loader): might come empty from the kernel
 	interPathName, _ := parse.ArgVal[string](args, "interpreter_pathname")
 	interDev, _ := parse.ArgVal[uint32](args, "interpreter_dev")
 	interInode, _ := parse.ArgVal[uint64](args, "interpreter_inode")
 	interCtime, _ := parse.ArgVal[uint64](args, "interpreter_ctime")
 
+	// Real Interpreter
 	interp, err := parse.ArgVal[string](args, "interp")
-	if err != nil {
-		return errfmt.Errorf("error parsing interp: %v", err)
-	}
+	errs = append(errs, err)
 
-	// Other
-
+	// Others
 	stdinType, err := parse.ArgVal[uint16](args, "stdin_type")
-	if err != nil {
-		return errfmt.Errorf("error parsing stdin_type: %v", err)
-	}
+	errs = append(errs, err)
 	stdinPath, err := parse.ArgVal[string](args, "stdin_path")
-	if err != nil {
-		return errfmt.Errorf("error parsing stdin_path: %v", err)
-	}
+	errs = append(errs, err)
 	invokedFromKernel, err := parse.ArgVal[int32](args, "invoked_from_kernel")
-	if err != nil {
-		return errfmt.Errorf("error parsing invoked_from_kernel: %v", err)
+	errs = append(errs, err)
+
+	// Handle errors
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
 	}
 
 	return ctrl.processTree.FeedFromExec(
@@ -256,44 +176,34 @@ func (ctrl *Controller) processSchedProcessExec(args []trace.Argument) error {
 	)
 }
 
-func (ctrl *Controller) processSchedProcessExit(args []trace.Argument) error {
+func (ctrl *Controller) procTreeExitProcessor(args []trace.Argument) error {
+	var errs []error
+
 	if ctrl.processTree == nil {
 		return nil // process tree is disabled
 	}
 
-	paramsLength := len(events.Core.GetDefinitionByID(events.SignalSchedProcessExit).GetParams())
-	if len(args) != paramsLength {
-		return errfmt.Errorf("got %d args instead of %d", len(args), paramsLength)
-	}
-
-	// Process & Event identification arguments
-
+	// Process & Event identification arguments (won't exist for regular events)
 	timestamp, err := parse.ArgVal[uint64](args, "timestamp")
-	if err != nil {
-		return errfmt.Errorf("error parsing timestamp: %v", err)
-	}
+	errs = append(errs, err)
 	taskHash, err := parse.ArgVal[uint32](args, "task_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing task_hash: %v", err)
-	}
+	errs = append(errs, err)
 	parentHash, err := parse.ArgVal[uint32](args, "parent_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing parent_hash: %v", err)
-	}
+	errs = append(errs, err)
 	leaderHash, err := parse.ArgVal[uint32](args, "leader_hash")
-	if err != nil {
-		return errfmt.Errorf("error parsing leader_hash: %v", err)
-	}
+	errs = append(errs, err)
 
 	// Exit logic arguments
-
 	exitCode, err := parse.ArgVal[int64](args, "exit_code")
-	if err != nil {
-		return errfmt.Errorf("error parsing exit_code: %v", err)
-	}
+	errs = append(errs, err)
 	groupExit, err := parse.ArgVal[bool](args, "process_group_exit")
-	if err != nil {
-		return errfmt.Errorf("error parsing process_group_exit: %v", err)
+	errs = append(errs, err)
+
+	// Handle errors
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
 	}
 
 	return ctrl.processTree.FeedFromExit(

--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -1,0 +1,163 @@
+package ebpf
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aquasecurity/libbpfgo/helpers"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+var (
+	kernelReadFileTypes map[int32]trace.KernelReadType
+	onceExecHash        sync.Once // capabilities for exec hash enabled only once
+)
+
+func init() {
+	initKernelReadFileTypes() // init kernelReadFileTypes
+}
+
+// processEvent processes an event by passing it through all registered event processors.
+func (t *Tracee) processEvent(event *trace.Event) []error {
+	errs := []error{}
+
+	eventId := events.ID(event.EventID)     // pick event id from event
+	processors := t.eventProcessor[eventId] // pick processors from eventProcessor map
+
+	for _, procFunc := range processors {
+		err := procFunc(event) // process event
+		if err != nil {
+			logger.Errorw("Error processing event", "event", event.EventName, "error", err)
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// processLost handles lost events in a separate goroutine.
+func (t *Tracee) processLostEvents() {
+	logger.Debugw("Starting processLostEvents goroutine")
+	defer logger.Debugw("Stopped processLostEvents goroutine")
+
+	// Since this is an end-stage goroutine, it should be terminated when:
+	// - lostEvChannel is closed, or finally when;
+	// - internal done channel is closed (not ctx).
+	for {
+		select {
+		case lost, ok := <-t.lostEvChannel:
+			if !ok {
+				return // lostEvChannel is closed, lost is zero value
+			}
+
+			if err := t.stats.LostEvCount.Increment(lost); err != nil {
+				logger.Errorw("Incrementing lost event count", "error", err)
+			}
+			logger.Warnw(fmt.Sprintf("Lost %d events", lost))
+
+		// internal done channel is closed when Tracee is stopped via Tracee.Close()
+		case <-t.done:
+			return
+		}
+	}
+}
+
+// RegisterEventProcessor registers a new event processor for a specific event id.
+func (t *Tracee) RegisterEventProcessor(id events.ID, proc func(evt *trace.Event) error) {
+	if t.eventProcessor == nil {
+		t.eventProcessor = make(map[events.ID][]func(evt *trace.Event) error)
+	}
+	if t.eventProcessor[id] == nil {
+		t.eventProcessor[id] = make([]func(evt *trace.Event) error, 0)
+	}
+	t.eventProcessor[id] = append(t.eventProcessor[id], proc)
+}
+
+// registerEventProcessors registers all event processors, each to a specific event id.
+func (t *Tracee) registerEventProcessors() {
+	t.RegisterEventProcessor(events.VfsWrite, t.processWriteEvent)
+	t.RegisterEventProcessor(events.VfsWritev, t.processWriteEvent)
+	t.RegisterEventProcessor(events.KernelWrite, t.processWriteEvent)
+	t.RegisterEventProcessor(events.SecurityKernelReadFile, processKernelReadFile)
+	t.RegisterEventProcessor(events.SecurityPostReadFile, processKernelReadFile)
+	t.RegisterEventProcessor(events.SchedProcessExec, t.processSchedProcessExec)
+	t.RegisterEventProcessor(events.DoInitModule, t.processDoInitModule)
+	t.RegisterEventProcessor(events.HookedProcFops, t.processHookedProcFops)
+	t.RegisterEventProcessor(events.PrintNetSeqOps, t.processTriggeredEvent)
+	t.RegisterEventProcessor(events.PrintSyscallTable, t.processTriggeredEvent)
+	t.RegisterEventProcessor(events.PrintMemDump, t.processTriggeredEvent)
+	t.RegisterEventProcessor(events.PrintMemDump, t.processPrintMemDump)
+}
+
+func initKernelReadFileTypes() {
+	osInfo, err := helpers.GetOSInfo()
+	if err != nil {
+		return
+	}
+
+	kernel593ComparedToRunningKernel, err := osInfo.CompareOSBaseKernelRelease("5.9.3")
+	if err != nil {
+		return
+	}
+	kernel570ComparedToRunningKernel, err := osInfo.CompareOSBaseKernelRelease("5.7.0")
+	if err != nil {
+		return
+	}
+	kernel592ComparedToRunningKernel, err := osInfo.CompareOSBaseKernelRelease("5.9.2")
+	if err != nil {
+		return
+	}
+	kernel5818ComparedToRunningKernel, err := osInfo.CompareOSBaseKernelRelease("5.8.18")
+	if err != nil {
+		return
+	}
+	kernel4180ComparedToRunningKernel, err := osInfo.CompareOSBaseKernelRelease("4.18.0")
+	if err != nil {
+		return
+	}
+
+	if kernel593ComparedToRunningKernel == helpers.KernelVersionOlder {
+		// running kernel version: >=5.9.3
+		kernelReadFileTypes = map[int32]trace.KernelReadType{
+			0: trace.KernelReadUnknown,
+			1: trace.KernelReadFirmware,
+			2: trace.KernelReadKernelModule,
+			3: trace.KernelReadKExecImage,
+			4: trace.KernelReadKExecInitRAMFS,
+			5: trace.KernelReadSecurityPolicy,
+			6: trace.KernelReadx509Certificate,
+		}
+	} else if kernel570ComparedToRunningKernel == helpers.KernelVersionOlder /* Running kernel is newer than 5.7.0 */ &&
+		kernel592ComparedToRunningKernel != helpers.KernelVersionOlder /* Running kernel is equal or older than 5.9.2*/ &&
+		kernel5818ComparedToRunningKernel != helpers.KernelVersionEqual /* Running kernel is not 5.8.18 */ {
+		// running kernel version: >=5.7 && <=5.9.2 && !=5.8.18
+		kernelReadFileTypes = map[int32]trace.KernelReadType{
+			0: trace.KernelReadUnknown,
+			1: trace.KernelReadFirmware,
+			2: trace.KernelReadFirmware,
+			3: trace.KernelReadFirmware,
+			4: trace.KernelReadKernelModule,
+			5: trace.KernelReadKExecImage,
+			6: trace.KernelReadKExecInitRAMFS,
+			7: trace.KernelReadSecurityPolicy,
+			8: trace.KernelReadx509Certificate,
+		}
+	} else if kernel5818ComparedToRunningKernel == helpers.KernelVersionEqual /* Running kernel is 5.8.18 */ ||
+		(kernel570ComparedToRunningKernel == helpers.KernelVersionNewer && /* Running kernel is older than 5.7.0 */
+			kernel4180ComparedToRunningKernel != helpers.KernelVersionOlder) /* Running kernel is 4.18 or newer */ {
+		// running kernel version: ==5.8.18 || (<5.7 && >=4.18)
+		kernelReadFileTypes = map[int32]trace.KernelReadType{
+			0: trace.KernelReadUnknown,
+			1: trace.KernelReadFirmware,
+			2: trace.KernelReadFirmware,
+			3: trace.KernelReadKernelModule,
+			4: trace.KernelReadKExecImage,
+			5: trace.KernelReadKExecInitRAMFS,
+			6: trace.KernelReadSecurityPolicy,
+			7: trace.KernelReadx509Certificate,
+		}
+	}
+}

--- a/pkg/ebpf/processor_proctree.go
+++ b/pkg/ebpf/processor_proctree.go
@@ -1,0 +1,245 @@
+package ebpf
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/proctree"
+	"github.com/aquasecurity/tracee/pkg/utils"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+//
+// Process Lifecycle (will feed the process tree)
+//
+
+// procTreeForkProcessor handles process fork events.
+func (t *Tracee) procTreeForkProcessor(event *trace.Event) error {
+	var errs []error
+
+	if t.processTree == nil {
+		return fmt.Errorf("process tree is disabled")
+	}
+
+	// NOTE: The "parent" related arguments can be ignored for process tree purposes.
+
+	// Up Parent (Up in hierarchy until parent is a process and not a lwp)
+	parentTid, err := parse.ArgVal[int32](event.Args, "up_parent_tid")
+	errs = append(errs, err)
+	parentNsTid, err := parse.ArgVal[int32](event.Args, "up_parent_ns_tid")
+	errs = append(errs, err)
+	parentPid, err := parse.ArgVal[int32](event.Args, "up_parent_pid")
+	errs = append(errs, err)
+	parentNsPid, err := parse.ArgVal[int32](event.Args, "up_parent_ns_pid")
+	errs = append(errs, err)
+	parentStartTime, err := parse.ArgVal[uint64](event.Args, "up_parent_start_time")
+	errs = append(errs, err)
+
+	// Thread Group Leader (might be the same as the "child", if "child" is a process)
+	leaderTid, err := parse.ArgVal[int32](event.Args, "leader_tid")
+	errs = append(errs, err)
+	leaderNsTid, err := parse.ArgVal[int32](event.Args, "leader_ns_tid")
+	errs = append(errs, err)
+	leaderPid, err := parse.ArgVal[int32](event.Args, "leader_pid")
+	errs = append(errs, err)
+	leaderNsPid, err := parse.ArgVal[int32](event.Args, "leader_ns_pid")
+	errs = append(errs, err)
+	leaderStartTime, err := parse.ArgVal[uint64](event.Args, "leader_start_time")
+	errs = append(errs, err)
+
+	// Child (might be a process or a thread)
+	childTid, err := parse.ArgVal[int32](event.Args, "child_tid")
+	errs = append(errs, err)
+	childNsTid, err := parse.ArgVal[int32](event.Args, "child_ns_tid")
+	errs = append(errs, err)
+	childPid, err := parse.ArgVal[int32](event.Args, "child_pid")
+	errs = append(errs, err)
+	childNsPid, err := parse.ArgVal[int32](event.Args, "child_ns_pid")
+	errs = append(errs, err)
+	childStartTime, err := parse.ArgVal[uint64](event.Args, "start_time") // child_start_time
+	errs = append(errs, err)
+
+	// Deal with errors
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	// Calculate hashes
+	childHash := utils.HashTaskID(uint32(childTid), uint64(childStartTime))
+	parentHash := utils.HashTaskID(uint32(parentTid), uint64(parentStartTime))
+	leaderHash := utils.HashTaskID(uint32(leaderTid), uint64(leaderStartTime))
+
+	return t.processTree.FeedFromFork(
+		proctree.ForkFeed{
+			TimeStamp:       childStartTime, // event timestamp is the same
+			ChildHash:       childHash,
+			ParentHash:      parentHash,
+			LeaderHash:      leaderHash,
+			ParentTid:       parentTid,
+			ParentNsTid:     parentNsTid,
+			ParentPid:       parentPid,
+			ParentNsPid:     parentNsPid,
+			ParentStartTime: parentStartTime,
+			LeaderTid:       leaderTid,
+			LeaderNsTid:     leaderNsTid,
+			LeaderPid:       leaderPid,
+			LeaderNsPid:     leaderNsPid,
+			LeaderStartTime: leaderStartTime,
+			ChildTid:        childTid,
+			ChildNsTid:      childNsTid,
+			ChildPid:        childPid,
+			ChildNsPid:      childNsPid,
+			ChildStartTime:  childStartTime,
+		},
+	)
+}
+
+// procTreeForkRemoveArgs removes arguments needed for the process tree only (when source is events).
+func (t *Tracee) procTreeForkRemoveArgs(event *trace.Event) error {
+	argsToRemove := []string{
+		"up_parent_tid",
+		"up_parent_ns_tid",
+		"up_parent_pid",
+		"up_parent_ns_pid",
+		"up_parent_start_time",
+		"leader_tid",
+		"leader_ns_tid",
+		"leader_pid",
+		"leader_ns_pid",
+		"leader_start_time",
+	}
+
+	m := make(map[string]trace.Argument)
+	for _, arg := range event.Args {
+		m[arg.Name] = arg
+	}
+
+	for _, argName := range argsToRemove {
+		delete(m, argName)
+	}
+
+	event.Args = make([]trace.Argument, 0, len(m))
+	for _, arg := range m {
+		event.Args = append(event.Args, arg)
+	}
+
+	return nil
+}
+
+// procTreeExecProcessor handles process exec events.
+func (t *Tracee) procTreeExecProcessor(event *trace.Event) error {
+	var errs []error
+
+	if t.processTree == nil {
+		return fmt.Errorf("process tree is disabled")
+	}
+	if event.HostProcessID != event.HostThreadID {
+		return nil // chek FeedFromExec for TODO of execve() handled by threads
+	}
+
+	timestamp := uint64(event.Timestamp)
+	taskHash := utils.HashTaskID(uint32(event.HostThreadID), uint64(event.ThreadStartTime))
+
+	// Executable
+	cmdPath, err := parse.ArgVal[string](event.Args, "cmdpath")
+	errs = append(errs, err)
+	pathName, err := parse.ArgVal[string](event.Args, "pathname")
+	errs = append(errs, err)
+	dev, err := parse.ArgVal[uint32](event.Args, "dev")
+	errs = append(errs, err)
+	inode, err := parse.ArgVal[uint64](event.Args, "inode")
+	errs = append(errs, err)
+	ctime, err := parse.ArgVal[uint64](event.Args, "ctime")
+	errs = append(errs, err)
+	inodeMode, err := parse.ArgVal[uint16](event.Args, "inode_mode")
+	errs = append(errs, err)
+
+	// Binary Interpreter (or Loader): might come empty from the kernel
+	interPathName, _ := parse.ArgVal[string](event.Args, "interpreter_pathname")
+	interDev, _ := parse.ArgVal[uint32](event.Args, "interpreter_dev")
+	interInode, _ := parse.ArgVal[uint64](event.Args, "interpreter_inode")
+	interCtime, _ := parse.ArgVal[uint64](event.Args, "interpreter_ctime")
+
+	// Real Interpreter
+	interp, err := parse.ArgVal[string](event.Args, "interp")
+	errs = append(errs, err)
+
+	// Others
+	stdinType, err := parse.ArgVal[uint16](event.Args, "stdin_type")
+	errs = append(errs, err)
+	stdinPath, err := parse.ArgVal[string](event.Args, "stdin_path")
+	errs = append(errs, err)
+	invokedFromKernel, err := parse.ArgVal[int32](event.Args, "invoked_from_kernel")
+	errs = append(errs, err)
+
+	// Handle errors
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	return t.processTree.FeedFromExec(
+		proctree.ExecFeed{
+			TimeStamp:         timestamp,
+			TaskHash:          taskHash,
+			ParentHash:        0, // regular pipeline does not have parent hash
+			LeaderHash:        0, // regular pipeline does not have leader hash
+			CmdPath:           cmdPath,
+			PathName:          pathName,
+			Dev:               dev,
+			Inode:             inode,
+			Ctime:             ctime,
+			InodeMode:         inodeMode,
+			InterpreterPath:   interPathName,
+			InterpreterDev:    interDev,
+			InterpreterInode:  interInode,
+			InterpreterCtime:  interCtime,
+			Interp:            interp,
+			StdinType:         stdinType,
+			StdinPath:         stdinPath,
+			InvokedFromKernel: invokedFromKernel,
+		},
+	)
+}
+
+// procTreeExitProcessor handles process exit events.
+func (t *Tracee) procTreeExitProcessor(event *trace.Event) error {
+	var errs []error
+
+	if t.processTree == nil {
+		return fmt.Errorf("process tree is disabled")
+	}
+	if event.HostProcessID != event.HostThreadID {
+		return nil // chek FeedFromExec for TODO of execve() handled by threads
+	}
+
+	timestamp := uint64(event.Timestamp)
+	taskHash := utils.HashTaskID(uint32(event.HostThreadID), uint64(event.ThreadStartTime))
+
+	// Exit logic arguments
+	exitCode, err := parse.ArgVal[int64](event.Args, "exit_code")
+	errs = append(errs, err)
+	groupExit, err := parse.ArgVal[bool](event.Args, "process_group_exit")
+	errs = append(errs, err)
+
+	// Handle errors
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+
+	return t.processTree.FeedFromExit(
+		proctree.ExitFeed{
+			TimeStamp:  timestamp, // time of exit is already a timestamp
+			TaskHash:   taskHash,
+			ParentHash: 0, // regular pipeline does not have parent hash
+			LeaderHash: 0, // regular pipeline does not have leader hash
+			ExitCode:   exitCode,
+			Group:      groupExit,
+		},
+	)
+}

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -10,8 +10,10 @@ import (
 )
 
 const (
-	Sys32Undefined ID = 0xfffffff - 1 // u32 overflows are compiler implementation dependent.
-	Undefined      ID = 0xfffffff
+	// use (0xfffffff - x) as most overflows behavior is undefined
+	All            ID = 0xfffffff - 1
+	Undefined      ID = 0xfffffff - 2
+	Sys32Undefined ID = 0xfffffff - 3
 	Unsupported    ID = 10000
 )
 
@@ -9351,15 +9353,32 @@ var CoreEvents = map[ID]Definition{
 		},
 		sets: []string{},
 		params: []trace.ArgMeta{
+			// Real Parent
 			{Type: "int", Name: "parent_tid"},
 			{Type: "int", Name: "parent_ns_tid"},
 			{Type: "int", Name: "parent_pid"},
 			{Type: "int", Name: "parent_ns_pid"},
+			{Type: "unsigned long", Name: "parent_start_time"},
+			// Child
 			{Type: "int", Name: "child_tid"},
 			{Type: "int", Name: "child_ns_tid"},
 			{Type: "int", Name: "child_pid"},
 			{Type: "int", Name: "child_ns_pid"},
-			{Type: "unsigned long", Name: "start_time"},
+			{Type: "unsigned long", Name: "start_time"}, // child_start_time
+			// Arguments set by OPT_PROCESS_FORK (when process tree source is enabled for fork events).
+			// These arguments are always removed after process tree processing.
+			// Up Parent (Up in hierarchy until parent is a process and not a lwp)
+			{Type: "int", Name: "up_parent_tid"},
+			{Type: "int", Name: "up_parent_ns_tid"},
+			{Type: "int", Name: "up_parent_pid"},
+			{Type: "int", Name: "up_parent_ns_pid"},
+			{Type: "unsigned long", Name: "up_parent_start_time"},
+			// Thread Group Leader
+			{Type: "int", Name: "leader_tid"},
+			{Type: "int", Name: "leader_ns_tid"},
+			{Type: "int", Name: "leader_pid"},
+			{Type: "int", Name: "leader_ns_pid"},
+			{Type: "unsigned long", Name: "leader_start_time"},
 		},
 	},
 	SchedProcessExec: {
@@ -11155,27 +11174,30 @@ var CoreEvents = map[ID]Definition{
 		sets: []string{"signal"},
 		params: []trace.ArgMeta{
 			{Type: "u64", Name: "timestamp"},
-			{Type: "u32", Name: "task_hash"},
-			{Type: "u32", Name: "parent_hash"},
-			{Type: "u32", Name: "leader_hash"},
-			// parent
+			// Real Parent
 			{Type: "int", Name: "parent_tid"},
 			{Type: "int", Name: "parent_ns_tid"},
 			{Type: "int", Name: "parent_pid"},
 			{Type: "int", Name: "parent_ns_pid"},
 			{Type: "unsigned long", Name: "parent_start_time"},
-			// leader
+			// Child
+			{Type: "int", Name: "child_tid"},
+			{Type: "int", Name: "child_ns_tid"},
+			{Type: "int", Name: "child_pid"},
+			{Type: "int", Name: "child_ns_pid"},
+			{Type: "unsigned long", Name: "start_time"}, // child_start_time
+			// Up Parent (Up in hierarchy until parent is a process and not a lwp)
+			{Type: "int", Name: "up_parent_tid"},
+			{Type: "int", Name: "up_parent_ns_tid"},
+			{Type: "int", Name: "up_parent_pid"},
+			{Type: "int", Name: "up_parent_ns_pid"},
+			{Type: "unsigned long", Name: "up_parent_start_time"},
+			// Thread Group Leader
 			{Type: "int", Name: "leader_tid"},
 			{Type: "int", Name: "leader_ns_tid"},
 			{Type: "int", Name: "leader_pid"},
 			{Type: "int", Name: "leader_ns_pid"},
 			{Type: "unsigned long", Name: "leader_start_time"},
-			// child
-			{Type: "int", Name: "child_tid"},
-			{Type: "int", Name: "child_ns_tid"},
-			{Type: "int", Name: "child_pid"},
-			{Type: "int", Name: "child_ns_pid"},
-			{Type: "unsigned long", Name: "child_start_time"},
 		},
 	},
 	SignalSchedProcessExec: {

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -8,12 +8,8 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
-const (
-	allPoliciesOn = 0xFFFFFFFFFFFFFFFF
-)
-
 var AlwaysSubmit = events.EventState{
-	Submit: allPoliciesOn,
+	Submit: AllPoliciesOn,
 }
 
 // TODO: add locking mechanism as policies will change at runtime

--- a/pkg/proctree/proctree_output.go
+++ b/pkg/proctree/proctree_output.go
@@ -76,11 +76,17 @@ func (pt *ProcessTree) String() string {
 		return thrTids
 	}
 
+	//
+	// The whole process tree output is for debugging only, but if the developer is seeking to debug
+	// the hashing for processes and threads, then they should uncomment some lines below to add
+	// "hash" and "start_time" to the table.
+	//
+
 	// Use tablewriter to print the tree in a table
 	newTable := func() *tablewriter.Table {
 		table := tablewriter.NewWriter(buffer)
 		table.SetHeader([]string{"Ppid", "Tid", "Pid", "Date", "Comm", "Children", "Threads"})
-		// If debug() is enabled:
+		// uncomment to add "hash" and "start_time" to the table
 		// table.SetHeader([]string{"Ppid", "Tid", "Pid", "StartTime", "Hash", "CMD", "Children", "Threads"})
 		table.SetAutoWrapText(false)
 		table.SetRowLine(false)
@@ -90,6 +96,13 @@ func (pt *ProcessTree) String() string {
 		table.SetHeaderLine(true)
 		table.SetBorder(true)
 		return table
+	}
+
+	stringify := func(value int) string {
+		if value == 0 {
+			return ""
+		}
+		return fmt.Sprintf("%v", value)
 	}
 
 	unsortedRows := [][]string{}
@@ -111,18 +124,21 @@ func (pt *ProcessTree) String() string {
 		if len(execName) > 25 {
 			execName = execName[:20] + "..."
 		}
-		// If debug() is enabled (and add hashString and start_time to unsortedRows)
+		// uncomment to add "hash" and "start_time" to the table
 		// hashStr := fmt.Sprintf("%v", process.GetHash())
-		// start_time := process.GetInfo().GetStartTimeNS()
-		tid := fmt.Sprintf("%v", processFeed.Tid)
-		pid := fmt.Sprintf("%v", processFeed.Pid)
-		ppid := fmt.Sprintf("%v", processFeed.PPid)
+		// startTime := fmt.Sprintf("%v", process.GetInfo().GetStartTimeNS())
+		tid := stringify(processFeed.Tid)
+		pid := stringify(processFeed.Pid)
+		ppid := stringify(processFeed.PPid)
 		date := process.GetInfo().GetStartTime().Format("2006-01-02 15:04:05")
 
 		// add the row to the table
 		unsortedRows = append(unsortedRows,
 			[]string{
-				ppid, tid, pid, date, execName,
+				ppid, tid, pid,
+				// uncomment to add "hash" and "start_time" to the table
+				// startTime, hashStr,
+				date, execName,
 				getListOfChildrenPids(process),
 				getListOfThreadsTids(process),
 			},

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -67,10 +67,9 @@ func startTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 	cfg.PerfBufferSize = 1024
 	cfg.BlobPerfBufferSize = 1024
 
+	// No process tree in the integration tests
 	cfg.ProcTree = proctree.ProcTreeConfig{
-		Enabled:          true,
-		ProcessCacheSize: 4096,
-		ThreadCacheSize:  4096,
+		Source: proctree.SourceNone,
 	}
 
 	errChan := make(chan error)


### PR DESCRIPTION
commit 0ac586115 (HEAD -> proctreestuff, rafaeldtinoco/proctreestuff)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Thu Sep 21 23:37:10 2023

    fix(proctree): allow regular events to create proctree nodes
    
    It is not impossible, although it is unlikely, that a fork/exec/exit
    event arrives first in the regular events pipeline. There is also a
    possibility that the signal event is lost.
    
    This change allows tracee to choose which source of events the process
    tree should be fed with. Using the control plane (and the fork, exec and
    exit signal events) is preferrable, but user can also opt to use regular
    sched events OR even both.
    
    There is also another need for this: the analyze mode. If the signatures
    rely in data source entries to work, when running tracee analyze mode
    there will be a need to "process events" from the regular pipeline in a
    way that those data sources exist in memory for the signature processing
    as well (TBD later).
    
    There is also the case where the pipeline is almost empty, and the
    userland (and go runtime) context switching may cause one event
    processor to need proc tree data that hasn't yet been saved. Having
    "both" as the source for proc tree is needed in this case.
    
    This commit also:
    
    - creates a generic way to normalize timing args to relative time (or not)

commit 05bedbc6f
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Sep 19 08:38:11 2023

    chore(events_processor): create a file for processor functions
    
    ... preparing terrain for refactoring and for process tree processors.