### PR TITLE
fix: link cosign tutorial to mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Tutorials: 
       - Overview: tutorials/overview.md
       - Working with Tracee's Policies on Kubernetes: tutorials/k8s-policies.md
+      - Cosign - verify tracee signature: tutorials/verify-tracee-signature.md
       - Deploy Tracee Grafana Dashboard: tutorials/deploy-grafana-dashboard.md
       - Accessing Tracee Logs through Promtail and Loki: tutorials/promtail.md
       - Additional Resources: tutorials/additional-resources.md


### PR DESCRIPTION
<img width="1045" alt="Screenshot 2023-09-28 at 7 22 45 AM" src="https://github.com/aquasecurity/tracee/assets/34032/03ca458a-6556-46ae-9972-8d6888cc816c">
