### PR TITLE
docs(contributing): update vagrant hypervisor info

### DIFF
--- a/docs/contributing/setup-development-machine-with-vagrant.md
+++ b/docs/contributing/setup-development-machine-with-vagrant.md
@@ -12,7 +12,9 @@ be on their way.
 ## Prerequisites
 
 - [Vagrant]
-- [Hypervisor] supported by Vagrant, such as [VirtualBox].
+- [Hypervisor] supported by Vagrant, such as [VirtualBox] on a amd64 (Linux)
+machine or [Parallels] on an arm64 M1 (Darwin) machine.
+
 
 ## Create Development Machine
 
@@ -317,6 +319,7 @@ documentation pages.
 [Vagrantfile]: https://github.com/aquasecurity/tracee/blob/{{ git.tag }}/Vagrantfile
 [Hypervisor]: https://www.vagrantup.com/docs/providers
 [VirtualBox]: https://www.virtualbox.org
+[Parallels]: https://www.parallels.com
 [MicroK8s]: https://microk8s.io
 [MicroK8s add-ons]: https://microk8s.io/docs/addons
 [kubectl]: https://kubernetes.io/docs/tasks/tools/#kubectl


### PR DESCRIPTION
### 1. Explain what the PR does

e59673705 **docs(contributing): update vagrant hypervisor info**

```
Add parallels as a hypervisor option for vagrant running on a M1 Mac.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

Context: #3464
