### PR TITLE
fix(decoder): read uint16 from buffer

### DIFF
--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -78,7 +78,7 @@ func (decoder *EbpfDecoder) DecodeContext(ctx *Context) error {
 	ctx.MatchedPolicies = binary.LittleEndian.Uint64(decoder.buffer[offset+120 : offset+128])
 	ctx.Retval = int64(binary.LittleEndian.Uint64(decoder.buffer[offset+128 : offset+136]))
 	ctx.StackID = binary.LittleEndian.Uint32(decoder.buffer[offset+136 : offset+140])
-	ctx.ProcessorId = binary.LittleEndian.Uint16(decoder.buffer[offset+140 : offset+144])
+	ctx.ProcessorId = binary.LittleEndian.Uint16(decoder.buffer[offset+140 : offset+142])
 	// 2 byte padding
 	// event_context end
 


### PR DESCRIPTION
### 1. Explain what the PR does

3d617243a **fix(decoder): read uint16 from buffer**

```
ProcessorId is uint16. This fixes the reading to 2 bytes instead of 4.
```

### 2. Explain how to test it

### 3. Other comments

