### PR TITLE
fix(networking): fix net_packet_http errors on empty OK

### DIFF
--- a/pkg/events/derive/net_packet_http.go
+++ b/pkg/events/derive/net_packet_http.go
@@ -3,6 +3,7 @@ package derive
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"net/http"
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -139,6 +140,9 @@ func eventToProtoHTTP(event *trace.Event) (*netPair, *trace.ProtoHTTP, error) {
 		} else if event.ReturnValue&protoHttpResponse == protoHttpResponse {
 			httpRes, err = http.ReadResponse(reader, nil)
 			if err != nil {
+				if err == io.ErrUnexpectedEOF {
+					return nil, nil, nil // 200 OK response without body, for example
+				}
 				return nil, nil, errfmt.WrapError(err)
 			}
 
@@ -210,6 +214,9 @@ func eventToProtoHTTPResponse(event *trace.Event) (*netPair, *trace.ProtoHTTPRes
 
 		httpRes, err := http.ReadResponse(reader, nil)
 		if err != nil {
+			if err == io.ErrUnexpectedEOF {
+				return nil, nil, nil // 200 OK response without body, for example
+			}
 			return nil, nil, errfmt.WrapError(err)
 		}
 


### PR DESCRIPTION
The net_packet_http and net_packet_http_response events are failing for empty replies (such as HTTP/1.x 200 OK replies, for example). Ignore if there is some EOF trying to parse response... it usually means there is a single code response with no body.
