### PR TITLE
Improve tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -715,6 +715,7 @@ test-unit: \
 		-tags ebpf \
 		-short \
 		-race \
+		-shuffle on \
 		-v \
 		-coverprofile=coverage.txt \
 		./cmd/... \
@@ -729,6 +730,7 @@ test-types: \
 	@cd ./types && $(CMD_GO) test \
 		-short \
 		-race \
+		-shuffle on \
 		-v \
 		-coverprofile=coverage.txt \
 		./...
@@ -758,6 +760,7 @@ test-integration: \
 			-extldflags \"$(CGO_EXT_LDFLAGS_EBPF)\" \
 			-X main.version=\"$(VERSION)\" \
 			" \
+		-shuffle on \
 		-race \
 		-v \
 		-p 1 \
@@ -794,6 +797,7 @@ test-performance: \
 			-X main.version=\"$(VERSION)\" \
 			" \
 		-race \
+		-shuffle on \
 		-v \
 		-p 1 \
 		-count=1 \

--- a/cmd/tracee-bench/main_test.go
+++ b/cmd/tracee-bench/main_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestParseQueryResString(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		resultString   string
 		expectedResult float64

--- a/cmd/tracee-rules/main_test.go
+++ b/cmd/tracee-rules/main_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func Test_listSigs(t *testing.T) {
+	t.Parallel()
+
 	fakeSigs := []*signature.FakeSignature{
 		{
 			FakeGetMetadata: func() (detect.SignatureMetadata, error) {
@@ -54,6 +56,8 @@ BAR-1      bar signature                       4.5.6   bar signature helps with 
 }
 
 func Test_listEvents(t *testing.T) {
+	t.Parallel()
+
 	fakeSigs := []*signature.FakeSignature{
 		{
 			FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {

--- a/cmd/tracee-rules/output_test.go
+++ b/cmd/tracee-rules/output_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func Test_setupOutput(t *testing.T) {
+	t.Parallel()
+
 	var testCases = []struct {
 		name           string
 		inputEvent     protocol.Event
@@ -125,6 +127,8 @@ func checkOutput(t *testing.T, testName string, actualOutput *SyncBuffer, expect
 }
 
 func Test_sendToWebhook(t *testing.T) {
+	t.Parallel()
+
 	var testCases = []struct {
 		name               string
 		inputTemplateFile  string
@@ -170,7 +174,11 @@ func Test_sendToWebhook(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			ts := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 				got, err := io.ReadAll(request.Body)
 				require.NoError(t, err)
@@ -209,6 +217,8 @@ func Test_sendToWebhook(t *testing.T) {
 }
 
 func TestOutputTemplates(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testName     string
 		finding      detect.Finding
@@ -272,7 +282,11 @@ func TestOutputTemplates(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+
 			var buf bytes.Buffer
 			err := jsonTemplate.Execute(&buf, tc.finding)
 			require.NoError(t, err)

--- a/pkg/bucketscache/bucketscache_test.go
+++ b/pkg/bucketscache/bucketscache_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestBucketsCache(t *testing.T) {
+	t.Parallel()
+
 	var cache bucketscache.BucketsCache
 	cache.Init(5)
 	cache.AddBucketItem(1, 32)

--- a/pkg/bufferdecoder/decoder_test.go
+++ b/pkg/bufferdecoder/decoder_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestDecodeContext(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	ctxExpected := Context{
 		Ts:          11,
@@ -49,6 +51,8 @@ func TestDecodeContext(t *testing.T) {
 }
 
 func TestDecodeUint8(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected uint8 = 42
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -69,6 +73,8 @@ func TestDecodeUint8(t *testing.T) {
 }
 
 func TestDecodeInt8(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected int8 = -42
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -89,6 +95,8 @@ func TestDecodeInt8(t *testing.T) {
 }
 
 func TestDecodeUint16(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected uint16 = 5555
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -109,6 +117,8 @@ func TestDecodeUint16(t *testing.T) {
 }
 
 func TestDecodeUint16BigEndian(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected uint16 = 5555
 	err := binary.Write(buf, binary.BigEndian, expected)
@@ -128,6 +138,8 @@ func TestDecodeUint16BigEndian(t *testing.T) {
 	assert.Equal(t, 2, cursorAfter-cursorBefore) // cursor should move 2 byte
 }
 func TestDecodeInt16(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected int16 = -3456
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -148,6 +160,8 @@ func TestDecodeInt16(t *testing.T) {
 }
 
 func TestDecodeUint32(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected uint32 = 5555
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -168,6 +182,8 @@ func TestDecodeUint32(t *testing.T) {
 }
 
 func TestDecodeUint32BigEndian(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected uint32 = 5555
 	err := binary.Write(buf, binary.BigEndian, expected)
@@ -187,6 +203,8 @@ func TestDecodeUint32BigEndian(t *testing.T) {
 	assert.Equal(t, cursorAfter-cursorBefore, 4) // cursor should move 4 byte
 }
 func TestDecodeInt32(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected int32 = -3456
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -207,6 +225,8 @@ func TestDecodeInt32(t *testing.T) {
 }
 
 func TestDecodeUint64(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected uint64 = 5555
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -227,6 +247,8 @@ func TestDecodeUint64(t *testing.T) {
 }
 
 func TestDecodeInt64(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	var expected int64 = -3456
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -247,6 +269,8 @@ func TestDecodeInt64(t *testing.T) {
 }
 
 func TestDecodeBoolTrue(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := true
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -267,6 +291,8 @@ func TestDecodeBoolTrue(t *testing.T) {
 }
 
 func TestDecodeBoolFalse(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := false
 	err := binary.Write(buf, binary.LittleEndian, expected)
@@ -288,6 +314,8 @@ func TestDecodeBoolFalse(t *testing.T) {
 
 // TODO DecodeBytes and DecodeIntArray
 func TestDecodeBytes(t *testing.T) {
+	t.Parallel()
+
 	type JustAStruct struct {
 		A1 uint32
 		A2 uint64
@@ -313,6 +341,8 @@ func TestDecodeBytes(t *testing.T) {
 }
 
 func TestDecodeIntArray(t *testing.T) {
+	t.Parallel()
+
 	var raw []byte
 	raw = append(raw, 1, 2, 3, 4, 5, 6, 7, 8)
 	decoder := New(raw)
@@ -329,6 +359,8 @@ func TestDecodeIntArray(t *testing.T) {
 }
 
 func TestDecodeSlimCred(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := SlimCred{
 		Uid:            43,
@@ -358,6 +390,8 @@ func TestDecodeSlimCred(t *testing.T) {
 }
 
 func TestDecodeChunkMeta(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := ChunkMeta{
 		BinType:  54,
@@ -377,6 +411,8 @@ func TestDecodeChunkMeta(t *testing.T) {
 }
 
 func TestDecodeVfsWriteMeta(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := VfsFileMeta{
 		DevID: 54,
@@ -395,6 +431,8 @@ func TestDecodeVfsWriteMeta(t *testing.T) {
 }
 
 func TestDecodeKernelModuleMeta(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := KernelModuleMeta{
 		DevID: 7489,
@@ -413,6 +451,8 @@ func TestDecodeKernelModuleMeta(t *testing.T) {
 }
 
 func TestDecodeBpfObjectMeta(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := BpfObjectMeta{
 		Name: [16]byte{80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80},
@@ -431,6 +471,8 @@ func TestDecodeBpfObjectMeta(t *testing.T) {
 }
 
 func TestDecodeMprotectWriteMeta(t *testing.T) {
+	t.Parallel()
+
 	buf := new(bytes.Buffer)
 	expected := MprotectWriteMeta{
 		Pid: 12,

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestReadArgFromBuff(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name          string
 		input         []byte
@@ -165,22 +167,30 @@ func TestReadArgFromBuff(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		decoder := New(tc.input)
-		_, actual, err := readArgFromBuff(0, decoder, tc.params)
+		tc := tc
 
-		if tc.expectedError != nil {
-			assert.ErrorContains(t, err, tc.expectedError.Error())
-		}
-		assert.Equal(t, tc.expectedArg, actual.Value)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		if tc.name == "unknown" {
-			continue
-		}
-		assert.Empty(t, decoder.BuffLen()-decoder.ReadAmountBytes(), tc.name) // passed in buffer should be emptied out
+			decoder := New(tc.input)
+			_, actual, err := readArgFromBuff(0, decoder, tc.params)
+
+			if tc.expectedError != nil {
+				assert.ErrorContains(t, err, tc.expectedError.Error())
+			}
+			assert.Equal(t, tc.expectedArg, actual.Value)
+
+			if tc.name == "unknown" {
+				return
+			}
+			assert.Empty(t, decoder.BuffLen()-decoder.ReadAmountBytes(), tc.name) // passed in buffer should be emptied out
+		})
 	}
 }
 
 func TestPrintUint32IP(t *testing.T) {
+	t.Parallel()
+
 	var input uint32 = 3232238339
 	ip := PrintUint32IP(input)
 
@@ -189,6 +199,8 @@ func TestPrintUint32IP(t *testing.T) {
 }
 
 func TestPrint16BytesSliceIP(t *testing.T) {
+	t.Parallel()
+
 	input := []byte{32, 1, 13, 184, 133, 163, 0, 0, 0, 0, 138, 46, 3, 112, 115, 52}
 	ip := Print16BytesSliceIP(input)
 

--- a/pkg/bufferdecoder/protocol_test.go
+++ b/pkg/bufferdecoder/protocol_test.go
@@ -15,35 +15,47 @@ import (
 // If so, then this means you need to update the decoder functions and GetSizeBytes functions.
 
 func TestContextSize(t *testing.T) {
+	t.Parallel()
+
 	var v Context
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size, int(v.GetSizeBytes()))
 }
 func TestChunkMetaSize(t *testing.T) {
+	t.Parallel()
+
 	var v ChunkMeta
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size-7, int(v.GetSizeBytes()))
 }
 
 func TestVfsWriteMetaSize(t *testing.T) {
+	t.Parallel()
+
 	var v VfsFileMeta
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size-4, int(v.GetSizeBytes()))
 }
 
 func TestKernelModuleMetaSize(t *testing.T) {
+	t.Parallel()
+
 	var v KernelModuleMeta
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size-4, int(v.GetSizeBytes()))
 }
 
 func TestBpfObjectMetaSize(t *testing.T) {
+	t.Parallel()
+
 	var v BpfObjectMeta
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size, int(v.GetSizeBytes()))
 }
 
 func TestMprotectWriteMetaSize(t *testing.T) {
+	t.Parallel()
+
 	var v MprotectWriteMeta
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size-4, int(v.GetSizeBytes()))

--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestChangelog(t *testing.T) {
+	t.Parallel()
+
 	cl := NewChangelog[int]()
 
 	// Test GetCurrent on an empty changelog

--- a/pkg/cmd/flags/cache_test.go
+++ b/pkg/cmd/flags/cache_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPrepareCache(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testName      string
 		cacheSlice    []string
@@ -52,7 +54,11 @@ func TestPrepareCache(t *testing.T) {
 	}
 
 	for _, testcase := range testCases {
+		testcase := testcase
+
 		t.Run(testcase.testName, func(t *testing.T) {
+			t.Parallel()
+
 			cache, err := PrepareCache(testcase.cacheSlice)
 			if testcase.expectedError != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())

--- a/pkg/cmd/flags/capture_test.go
+++ b/pkg/cmd/flags/capture_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestPrepareCapture(t *testing.T) {
+	t.Parallel()
+
 	t.Run("various capture options", func(t *testing.T) {
 		testCases := []struct {
 			testName        string
@@ -225,7 +227,11 @@ func TestPrepareCapture(t *testing.T) {
 			},
 		}
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.testName, func(t *testing.T) {
+				t.Parallel()
+
 				capture, err := PrepareCapture(tc.captureSlice, false)
 				if tc.expectedError == nil {
 					require.NoError(t, err)

--- a/pkg/cmd/flags/event_test.go
+++ b/pkg/cmd/flags/event_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestParseEventFlag(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name          string
 		eventFlag     string
@@ -404,7 +406,11 @@ func TestParseEventFlag(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			parsedEventFlag, err := parseEventFlag(tt.eventFlag)
 			if err != nil {
 				require.Contains(t, err.Error(), tt.expectedError.Error())
@@ -416,6 +422,8 @@ func TestParseEventFlag(t *testing.T) {
 }
 
 func TestPrepareEventMapFromFlags(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name      string
 		eventsArr []string
@@ -503,7 +511,11 @@ func TestPrepareEventMapFromFlags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			eventMap, err := PrepareEventMapFromFlags(tc.eventsArr)
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expected, eventMap)

--- a/pkg/cmd/flags/filter_test.go
+++ b/pkg/cmd/flags/filter_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestFilter_prepareEventsToTrace(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name        string
 		eventFilter eventFilter
@@ -80,7 +82,11 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 		}
 	}
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			res, err := prepareEventsToTrace(tc.eventFilter, eventsNameToID)
 			if tc.expectedErr != nil {
 				assert.Equal(t, err.Error(), tc.expectedErr.Error())

--- a/pkg/cmd/flags/flags_test.go
+++ b/pkg/cmd/flags/flags_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func Test_hasLeadingOrTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input  string
 		output bool
@@ -34,6 +36,8 @@ func Test_hasLeadingOrTrailingWhitespace(t *testing.T) {
 }
 
 func Test_isFlagOperatorValid(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input  string
 		output bool
@@ -66,6 +70,8 @@ func Test_isFlagOperatorValid(t *testing.T) {
 }
 
 func Test_getEventFilterParts(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name          string
 		filter        string
@@ -157,7 +163,11 @@ func Test_getEventFilterParts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			parts, err := getEventFilterParts(tc.filter, tc.flag)
 
 			if tc.expectedError == nil {

--- a/pkg/cmd/flags/logger_test.go
+++ b/pkg/cmd/flags/logger_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPrepareLogger(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testName       string
 		logOptions     []string
@@ -352,7 +354,11 @@ func TestPrepareLogger(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+
 			logCfg, err := PrepareLogger(tc.logOptions, false)
 			if tc.expectedError != nil {
 				require.Equal(t, logger.LoggingConfig{}, logCfg)

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPrepareOutput(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testName       string
 		outputSlice    []string
@@ -402,7 +404,11 @@ func TestPrepareOutput(t *testing.T) {
 		},
 	}
 	for _, testcase := range testCases {
+		testcase := testcase
+
 		t.Run(testcase.testName, func(t *testing.T) {
+			t.Parallel()
+
 			output, err := PrepareOutput(testcase.outputSlice, false)
 			if err != nil {
 				assert.Contains(t, err.Error(), testcase.expectedError.Error())

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -25,6 +25,8 @@ var readEvtFlag = eventFlag{
 }
 
 func TestPrepareFilterMapsFromPolicies(t *testing.T) {
+	t.Parallel()
+
 	description := map[string]string{"description": "this is a policy"}
 	tests := []struct {
 		testName           string
@@ -1783,7 +1785,11 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.testName, func(t *testing.T) {
+			t.Parallel()
+
 			policyScopeMap, policyEventMap, err := PrepareFilterMapsFromPolicies([]v1beta1.PolicyFile{test.policy})
 			assert.NoError(t, err)
 
@@ -1818,6 +1824,8 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 }
 
 func TestCreatePolicies(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testName        string
 		scopeFlags      []string
@@ -2048,7 +2056,11 @@ func TestCreatePolicies(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+
 			policyEventsMap, err := PrepareEventMapFromFlags(tc.evtFlags)
 			if tc.expectEvtErr != nil {
 				assert.ErrorContains(t, err, tc.expectEvtErr.Error())

--- a/pkg/cmd/flags/rego_test.go
+++ b/pkg/cmd/flags/rego_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPrepareRego(t *testing.T) {
+	t.Parallel()
+
 	t.Run("various rego options", func(t *testing.T) {
 		testCases := []struct {
 			testName      string
@@ -51,7 +53,11 @@ func TestPrepareRego(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
+			tc := tc
+
 			t.Run(tc.testName, func(t *testing.T) {
+				t.Parallel()
+
 				rego, err := PrepareRego(tc.regoSlice)
 				if tc.expectedError == nil {
 					require.NoError(t, err)

--- a/pkg/cmd/flags/scope_test.go
+++ b/pkg/cmd/flags/scope_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func Test_parseScopeFlag(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name           string
 		flag           string
@@ -318,7 +320,11 @@ func Test_parseScopeFlag(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result, err := parseScopeFlag(tt.flag)
 			if err != nil {
 				require.Contains(t, err.Error(), tt.expectedError.Error())

--- a/pkg/cmd/flags/tracee_ebpf_output_test.go
+++ b/pkg/cmd/flags/tracee_ebpf_output_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPrepareTraceeEbpfOutput(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		testName       string
 		outputSlice    []string
@@ -149,7 +151,11 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 		},
 	}
 	for _, testcase := range testCases {
+		testcase := testcase
+
 		t.Run(testcase.testName, func(t *testing.T) {
+			t.Parallel()
+
 			output, err := TraceeEbpfPrepareOutput(testcase.outputSlice, false)
 			if err != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())

--- a/pkg/cmd/initialize/sigs_test.go
+++ b/pkg/cmd/initialize/sigs_test.go
@@ -12,12 +12,16 @@ import (
 )
 
 func Test_CreateEventsFromSigs(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
+		name       string
 		startId    events.ID
 		signatures []detect.Signature
 		expected   []events.Definition
 	}{
 		{
+			name:    "fake_event_0",
 			startId: events.ID(6001),
 			signatures: []detect.Signature{
 				newFakeSignature(
@@ -50,6 +54,7 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 			},
 		},
 		{
+			name:    "fake_event_1/2",
 			startId: events.ID(6010),
 			signatures: []detect.Signature{
 				newFakeSignature(
@@ -106,6 +111,7 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 			},
 		},
 		{
+			name:    "fake_event_3",
 			startId: events.ID(6100),
 			signatures: []detect.Signature{
 				newFakeSignature(
@@ -144,26 +150,32 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		CreateEventsFromSignatures(test.startId, test.signatures)
+		test := test
 
-		for _, expected := range test.expected {
-			eventDefID, ok := events.Core.GetDefinitionIDByName(expected.GetName())
-			assert.True(t, ok)
-			eventDefinition := events.Core.GetDefinitionByID(eventDefID)
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-			assert.Equal(t, expected.GetID(), eventDefinition.GetID())
-			assert.Equal(t, expected.GetID32Bit(), eventDefinition.GetID32Bit())
-			assert.Equal(t, expected.GetName(), eventDefinition.GetName())
-			assert.Equal(t, expected.GetDocPath(), eventDefinition.GetDocPath())
-			assert.Equal(t, expected.IsInternal(), eventDefinition.IsInternal())
-			assert.Equal(t, expected.IsSyscall(), eventDefinition.IsSyscall())
-			assert.ElementsMatch(t, expected.GetSets(), eventDefinition.GetSets())
-			assert.ElementsMatch(t, expected.GetParams(), eventDefinition.GetParams())
+			CreateEventsFromSignatures(test.startId, test.signatures)
 
-			dependencies := eventDefinition.GetDependencies()
-			expDependencies := expected.GetDependencies()
-			assert.ElementsMatch(t, expDependencies.GetIDs(), dependencies.GetIDs())
-		}
+			for _, expected := range test.expected {
+				eventDefID, ok := events.Core.GetDefinitionIDByName(expected.GetName())
+				assert.True(t, ok)
+				eventDefinition := events.Core.GetDefinitionByID(eventDefID)
+
+				assert.Equal(t, expected.GetID(), eventDefinition.GetID())
+				assert.Equal(t, expected.GetID32Bit(), eventDefinition.GetID32Bit())
+				assert.Equal(t, expected.GetName(), eventDefinition.GetName())
+				assert.Equal(t, expected.GetDocPath(), eventDefinition.GetDocPath())
+				assert.Equal(t, expected.IsInternal(), eventDefinition.IsInternal())
+				assert.Equal(t, expected.IsSyscall(), eventDefinition.IsSyscall())
+				assert.ElementsMatch(t, expected.GetSets(), eventDefinition.GetSets())
+				assert.ElementsMatch(t, expected.GetParams(), eventDefinition.GetParams())
+
+				dependencies := eventDefinition.GetDependencies()
+				expDependencies := expected.GetDependencies()
+				assert.ElementsMatch(t, expDependencies.GetIDs(), dependencies.GetIDs())
+			}
+		})
 	}
 }
 

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTraceeEbpfPrepareOutputPrinterConfig(t *testing.T) {
+	t.Parallel()
 
 	testCases := []struct {
 		testName        string
@@ -61,7 +62,11 @@ func TestTraceeEbpfPrepareOutputPrinterConfig(t *testing.T) {
 		},
 	}
 	for _, testcase := range testCases {
+		testcase := testcase
+
 		t.Run(testcase.testName, func(t *testing.T) {
+			t.Parallel()
+
 			outputConfig, err := flags.TraceeEbpfPrepareOutput(testcase.outputSlice, false)
 			if err != nil {
 				assert.ErrorContains(t, err, testcase.expectedError.Error())

--- a/pkg/containers/path_resolver_test.go
+++ b/pkg/containers/path_resolver_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Mountns cache tests", func(t *testing.T) {
 		type process struct {
 			pid   uint32
@@ -69,7 +71,11 @@ func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, testCase := range testCases {
+			testCase := testCase
+
 			t.Run(testCase.Name, func(t *testing.T) {
+				t.Parallel()
+
 				// Initialize a mock for the os.Stat function
 				mfs := fstest.MapFS{}
 				bucket := bucketscache.BucketsCache{}
@@ -131,7 +137,11 @@ func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
 		bucket.Init(20)
 		bucket.AddBucketItem(uint32(testMntNS), 1)
 		for _, testCase := range testCases {
+			testCase := testCase
+
 			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
 				// Initialize a mock for the os.Stat function
 				mfs := fstest.MapFS{}
 				if testCase.pathExist {

--- a/pkg/counter/counter_test.go
+++ b/pkg/counter/counter_test.go
@@ -11,6 +11,8 @@ import (
 // Increment
 
 func TestIncrement(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(1)
 	c := NewCounter(0)
 
@@ -21,6 +23,8 @@ func TestIncrement(t *testing.T) {
 }
 
 func TestIncrementWithValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(0)
 
@@ -31,6 +35,8 @@ func TestIncrementWithValue(t *testing.T) {
 }
 
 func TestIncrementWithMultipleValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(0)
 
@@ -41,6 +47,8 @@ func TestIncrementWithMultipleValue(t *testing.T) {
 }
 
 func TestIncrementAndRead(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(0)
 
@@ -52,6 +60,8 @@ func TestIncrementAndRead(t *testing.T) {
 }
 
 func TestZeroedIncrementWithValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(9)
 
@@ -62,6 +72,8 @@ func TestZeroedIncrementWithValue(t *testing.T) {
 }
 
 func TestZeroedIncrementWithMultipleValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(9)
 
@@ -72,6 +84,8 @@ func TestZeroedIncrementWithMultipleValue(t *testing.T) {
 }
 
 func TestIncrementOverflow(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(0)
 	c := NewCounter(uint64(math.MaxUint64) - 1)
 
@@ -85,6 +99,8 @@ func TestIncrementOverflow(t *testing.T) {
 }
 
 func TestIncrementWithValueOverflow(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(0)
 	c := NewCounter(0)
 
@@ -98,6 +114,8 @@ func TestIncrementWithValueOverflow(t *testing.T) {
 }
 
 func TestIncrement_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(100000)
 	c := NewCounter(0)
 
@@ -122,6 +140,8 @@ func TestIncrement_MultipleThreads(t *testing.T) {
 // Decrement
 
 func TestDecrement(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(0)
 	c := NewCounter(1)
 
@@ -132,6 +152,8 @@ func TestDecrement(t *testing.T) {
 }
 
 func TestDecrementWithValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(1)
 	c := NewCounter(10)
 
@@ -142,6 +164,8 @@ func TestDecrementWithValue(t *testing.T) {
 }
 
 func TestDecrementWithMultipleValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(1)
 	c := NewCounter(10)
 
@@ -152,6 +176,8 @@ func TestDecrementWithMultipleValue(t *testing.T) {
 }
 
 func TestDecrementAndRead(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(1)
 	c := NewCounter(10)
 
@@ -163,6 +189,8 @@ func TestDecrementAndRead(t *testing.T) {
 }
 
 func TestZeroedDecrementWithValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(9)
 
@@ -173,6 +201,8 @@ func TestZeroedDecrementWithValue(t *testing.T) {
 }
 
 func TestZeroedDecrementWithMultipleValue(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(9)
 	c := NewCounter(9)
 
@@ -183,6 +213,8 @@ func TestZeroedDecrementWithMultipleValue(t *testing.T) {
 }
 
 func TestDecrementOverflow(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(math.MaxUint64)
 	c := NewCounter(0)
 
@@ -198,6 +230,8 @@ func TestDecrementOverflow(t *testing.T) {
 }
 
 func TestDecrementWithValueOverflow(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(math.MaxUint64 - 8)
 	c := NewCounter(0)
 
@@ -207,6 +241,8 @@ func TestDecrementWithValueOverflow(t *testing.T) {
 }
 
 func TestDecrement_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(0)
 	c := NewCounter(100000)
 
@@ -231,6 +267,8 @@ func TestDecrement_MultipleThreads(t *testing.T) {
 // Increment + Decrement
 
 func TestIncrementDecrement(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(0)
 	c := NewCounter(0)
 
@@ -244,6 +282,8 @@ func TestIncrementDecrement(t *testing.T) {
 }
 
 func TestIncrementDecrement_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	expected := uint64(0)
 	c := NewCounter(0)
 

--- a/pkg/ebpf/finding_test.go
+++ b/pkg/ebpf/finding_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestFindingToEvent(t *testing.T) {
+	t.Parallel()
+
 	expected := &trace.Event{
 		EventID:             int(events.StartSignatureID),
 		EventName:           "fake_signature_event",

--- a/pkg/ebpf/policy_manager_test.go
+++ b/pkg/ebpf/policy_manager_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPolicyManagerEnableRule(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	policy1Mached := uint64(0b10)
@@ -35,6 +37,8 @@ func TestPolicyManagerEnableRule(t *testing.T) {
 }
 
 func TestPolicyManagerDisableRule(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	policy1Mached := uint64(0b10)
@@ -55,6 +59,8 @@ func TestPolicyManagerDisableRule(t *testing.T) {
 }
 
 func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
+	t.Parallel()
+
 	eventsToEnable := []events.ID{
 		events.SecurityBPF,
 		events.SchedGetPriorityMax,
@@ -108,6 +114,8 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 }
 
 func TestPolicyManagerEnableEvent(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	assert.False(t, policyManager.isEventEnabled(events.SecurityBPF))
@@ -124,6 +132,8 @@ func TestPolicyManagerEnableEvent(t *testing.T) {
 }
 
 func TestPolicyManagerDisableEvent(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	policyManager.EnableEvent(events.SecurityBPF)
@@ -143,6 +153,8 @@ func TestPolicyManagerDisableEvent(t *testing.T) {
 }
 
 func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
+	t.Parallel()
+
 	eventsToEnable := []events.ID{
 		events.SecurityBPF,
 		events.SchedGetPriorityMax,
@@ -201,6 +213,8 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 }
 
 func TestEnableRuleAlsoEnableEvent(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityBPF))
@@ -211,6 +225,8 @@ func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 }
 
 func TestDisableRuleAlsoEnableEvent(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityFileOpen))
@@ -221,6 +237,8 @@ func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 }
 
 func TestPolicyManagerIsEnabled(t *testing.T) {
+	t.Parallel()
+
 	policyManager := newPolicyManager()
 
 	policy1Mached := uint64(0b10)

--- a/pkg/errfmt/errfmt_test.go
+++ b/pkg/errfmt/errfmt_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestErrorf(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		format string
@@ -36,7 +38,11 @@ func TestErrorf(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := Errorf(tt.format, tt.args...)
 			if tt.want == nil {
 				assert.Equal(t, tt.want, got)
@@ -48,6 +54,8 @@ func TestErrorf(t *testing.T) {
 }
 
 func TestWrapError(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		err  error
@@ -66,7 +74,11 @@ func TestWrapError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := WrapError(tt.err)
 			if tt.want == nil {
 				assert.Equal(t, tt.want, got)

--- a/pkg/events/core_test.go
+++ b/pkg/events/core_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAllEventsHaveVersion(t *testing.T) {
+	t.Parallel()
+
 	for _, event := range CoreEvents {
 		_, err := semver.StrictNewVersion(event.version.String())
 		assert.NoError(t, err, fmt.Sprintf("event %s has invalid version", event.name))

--- a/pkg/events/definition_group_test.go
+++ b/pkg/events/definition_group_test.go
@@ -24,6 +24,8 @@ var getNames = func() map[string]ID {
 
 // TestDefinitionGroup_Add tests that Add adds a definition to the definition group.
 func TestDefinitionGroup_Add(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id := ID(1)
@@ -39,6 +41,8 @@ func TestDefinitionGroup_Add(t *testing.T) {
 
 // TestDefinitionGroup_AddBatch tests that AddBatch adds multiple definitions to the definition group.
 func TestDefinitionGroup_AddBatch(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id1 := ID(1)
@@ -59,6 +63,8 @@ func TestDefinitionGroup_AddBatch(t *testing.T) {
 
 // TestDefinitionGroup_GetDefinitionIDByName tests that GetDefinitionIDByName returns a definition ID by its name.
 func TestDefinitionGroup_GetDefinitionIDByName(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id1 := ID(1)
@@ -80,6 +86,8 @@ func TestDefinitionGroup_GetDefinitionIDByName(t *testing.T) {
 
 // TestDefinitionGroup_GetDefinitionByID tests that GetDefinitionByID returns a definition by its ID.
 func TestDefinitionGroup_GetDefinitionByID(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id1 := ID(1)
@@ -105,6 +113,8 @@ func TestDefinitionGroup_GetDefinitionByID(t *testing.T) {
 
 // TestDefinitionGroup_Length tests that Length returns the number of definitions in the definition group.
 func TestDefinitionGroup_Length(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	require.Equal(t, defGroup.Length(), 0) // empty definition group
@@ -125,6 +135,8 @@ func TestDefinitionGroup_Length(t *testing.T) {
 
 // TestDefinitionGroup_GetDefinitions tests that GetDefinitions returns a map of definition IDs to their definitions.
 func TestDefinitionGroup_GetDefinitions(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id1 := ID(1)
@@ -144,6 +156,8 @@ func TestDefinitionGroup_GetDefinitions(t *testing.T) {
 
 // TestDefinitionGroup_NamesToIDs tests that NamesToIDs returns a map of definition names to their IDs.
 func TestDefinitionGroup_NamesToIDs(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id1 := ID(1)
@@ -163,6 +177,8 @@ func TestDefinitionGroup_NamesToIDs(t *testing.T) {
 
 // TestDefinitionGroup_IDs32ToIDs tests that IDs32ToIDs returns a map of definition IDs to their 32-bit IDs.
 func TestDefinitionGroup_IDs32ToIDs(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	id1 := ID(1)
@@ -186,6 +202,8 @@ func TestDefinitionGroup_IDs32ToIDs(t *testing.T) {
 
 // TestDefinitionGroup_AddBatchAndGetDefinitions_MultipleThreads tests Add and Get functions for thread-safety.
 func TestDefinitionGroup_AddBatch_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	names := getNames()
@@ -216,6 +234,8 @@ func TestDefinitionGroup_AddBatch_MultipleThreads(t *testing.T) {
 
 // TestDefinitionGroup_Length_MultipleThreads tests that Length is thread-safe.
 func TestDefinitionGroup_Length_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	names := getNames()
@@ -240,6 +260,8 @@ func TestDefinitionGroup_Length_MultipleThreads(t *testing.T) {
 
 // TestDefinitionGroup_GetDefinitions_MultipleThread tests that GetDefinitions is thread-safe.
 func TestDefinitionGroup_GetDefinitions_MultipleThread(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	names := getNames()
@@ -264,6 +286,8 @@ func TestDefinitionGroup_GetDefinitions_MultipleThread(t *testing.T) {
 
 // TestDefinitionGroup_NamesToIDs_MultipleThreads tests that NamesToIDs is thread-safe.
 func TestDefinitionGroup_NamesToIDs_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	wg := &sync.WaitGroup{}
@@ -291,6 +315,8 @@ func TestDefinitionGroup_NamesToIDs_MultipleThreads(t *testing.T) {
 
 // TestDefinitionGroup_IDs32ToIDs_MultipleThreads tests that IDs32ToIDs is thread-safe.
 func TestDefinitionGroup_IDs32ToIDs_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	defGroup := NewDefinitionGroup()
 
 	wg := &sync.WaitGroup{}

--- a/pkg/events/definition_test.go
+++ b/pkg/events/definition_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNewDefinition(t *testing.T) {
+	t.Parallel()
+
 	expectedDefinition := Definition{
 		name: "hooked_seq_ops2",
 		dependencies: Dependencies{
@@ -46,6 +48,8 @@ func TestNewDefinition(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		evt  Definition
@@ -98,7 +102,11 @@ func TestAdd(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := Core.Add(test.evt.GetID32Bit(), test.evt)
 			if err != nil {
 				assert.ErrorContains(t, err, test.err)

--- a/pkg/events/derive/derive_test.go
+++ b/pkg/events/derive/derive_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func Test_DeriveEvent(t *testing.T) {
+	t.Parallel()
+
 	testEventID := events.ID(1)
 	failEventID := events.ID(11)
 	deriveEventID := events.ID(12)
@@ -67,7 +69,11 @@ func Test_DeriveEvent(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			derived, errors := mockDerivationTable.DeriveEvent(tc.event)
 			assert.Equal(t, tc.expectedDerived, derived)
 			assert.Equal(t, tc.expectedErrors, errors)
@@ -297,6 +303,8 @@ func TestDeriveMultipleEvents(t *testing.T) {
 }
 
 func TestNewEvent(t *testing.T) {
+	t.Parallel()
+
 	baseEvent := getTestEvent()
 	skeleton := deriveBase{
 		Name: "test_derive",
@@ -336,7 +344,11 @@ func TestNewEvent(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
 			evt, err := buildDerivedEvent(&baseEvent, skeleton, testCase.Args)
 			if testCase.ExpectError {
 				assert.Error(t, err)

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -344,7 +344,11 @@ func TestSymbolsCollisionArgsGenerator_FindSOCollision(t *testing.T) {
 	}
 
 	for _, filterTestCase := range filtersTestCases {
+		filterTestCase := filterTestCase
+
 		t.Run(filterTestCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			for _, testCase := range testCases {
 				t.Run(testCase.name, func(t *testing.T) {
 					mockLoader := initLoaderMock(false)
@@ -394,7 +398,11 @@ func TestSymbolsCollisionArgsGenerator_deriveArgs(t *testing.T) {
 	pid := 1
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			mockLoader := initLoaderMock(false)
 			gen := initSOCollisionsEventGenerator(
 				mockLoader,
@@ -452,7 +460,11 @@ func TestSymbolsCollision(t *testing.T) {
 	pid := 1
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			mockLoader := initLoaderMock(false)
 
 			// Prepare mocked filters for the existing test cases

--- a/pkg/events/derive/symbols_loaded_test.go
+++ b/pkg/events/derive/symbols_loaded_test.go
@@ -165,12 +165,15 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 
 	t.Run("Happy flow", func(t *testing.T) {
 		for _, testCase := range happyFlowTestCases {
-			t.Run(testCase.name, func(t *testing.T) {
-				errChan := setMockLogger(logger.DebugLevel)
-				defer logger.SetLogger(baseLogger)
+			testCase := testCase
 
-				mockLoader := initLoaderMock(false)
-				mockLoader.addSOSymbols(testCase.loadingSO)
+			errChan := setMockLogger(logger.DebugLevel)
+			mockLoader := initLoaderMock(false)
+			mockLoader.addSOSymbols(testCase.loadingSO)
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
 				gen := initSymbolsLoadedEventGenerator(mockLoader, testCase.watchedSymbols, testCase.whitelistedLibs)
 				eventArgs, err := gen.deriveArgs(generateSOLoadedEvent(pid, testCase.loadingSO.info))
 				assert.Empty(t, errChan)
@@ -187,6 +190,8 @@ func TestDeriveSharedObjectExportWatchedSymbols(t *testing.T) {
 					assert.Len(t, eventArgs, 0)
 				}
 			})
+
+			logger.SetLogger(baseLogger)
 		}
 	})
 

--- a/pkg/events/ftrace_test.go
+++ b/pkg/events/ftrace_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestGetFtraceFlags(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Parse flags", func(t *testing.T) {
 		testCases := []struct {
 			name          string
@@ -23,13 +25,21 @@ func TestGetFtraceFlags(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			flags := getFtraceFlags(testCase.ftraceParts, &testCase.index)
-			assert.Equal(t, testCase.expectedFlags, flags)
+			testCase := testCase
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				flags := getFtraceFlags(testCase.ftraceParts, &testCase.index)
+				assert.Equal(t, testCase.expectedFlags, flags)
+			})
 		}
 	})
 }
 
 func TestGetCallback(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Parse callback", func(t *testing.T) {
 		testCases := []struct {
 			name             string
@@ -44,13 +54,21 @@ func TestGetCallback(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			flags := getCallback(testCase.ftraceParts)
-			assert.Equal(t, testCase.expectedCallback, flags)
+			testCase := testCase
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				flags := getCallback(testCase.ftraceParts)
+				assert.Equal(t, testCase.expectedCallback, flags)
+			})
 		}
 	})
 }
 
 func TestFetchTrampAndCallback(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Parse tramp and callback", func(t *testing.T) {
 		testCases := []struct {
 			name             string
@@ -77,6 +95,8 @@ func TestFetchTrampAndCallback(t *testing.T) {
 }
 
 func TestSplitCallback(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Split callback", func(t *testing.T) {
 		testCases := []struct {
 			name             string
@@ -95,10 +115,16 @@ func TestSplitCallback(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			funcName, offset, owner := splitCallback(testCase.callback)
-			assert.Equal(t, testCase.expectedFuncName, funcName)
-			assert.Equal(t, testCase.expectedOffset, offset)
-			assert.Equal(t, testCase.expectedOwner, owner)
+			testCase := testCase
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				funcName, offset, owner := splitCallback(testCase.callback)
+				assert.Equal(t, testCase.expectedFuncName, funcName)
+				assert.Equal(t, testCase.expectedOffset, offset)
+				assert.Equal(t, testCase.expectedOwner, owner)
+			})
 		}
 	})
 }

--- a/pkg/events/parse/params_test.go
+++ b/pkg/events/parse/params_test.go
@@ -9,7 +9,11 @@ import (
 )
 
 func TestArgVal(t *testing.T) {
+	t.Parallel()
+
 	t.Run("int32", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			name          string
 			arg           trace.Argument
@@ -52,7 +56,11 @@ func TestArgVal(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
+
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
 				val, err := ArgVal[int32](e.Args, tt.name)
 				if tt.errorMessage != "" {
@@ -67,6 +75,8 @@ func TestArgVal(t *testing.T) {
 	})
 
 	t.Run("string", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			name          string
 			arg           trace.Argument
@@ -109,7 +119,11 @@ func TestArgVal(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
+
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
 				val, err := ArgVal[string](e.Args, tt.name)
 				if tt.errorMessage != "" {
@@ -124,6 +138,8 @@ func TestArgVal(t *testing.T) {
 	})
 
 	t.Run("uint64", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			name          string
 			arg           trace.Argument
@@ -166,7 +182,11 @@ func TestArgVal(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
+
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
 				val, err := ArgVal[uint64](e.Args, tt.name)
 				if tt.errorMessage != "" {
@@ -181,6 +201,8 @@ func TestArgVal(t *testing.T) {
 	})
 
 	t.Run("uint32", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			name          string
 			arg           trace.Argument
@@ -223,7 +245,11 @@ func TestArgVal(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
+
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
 				val, err := ArgVal[uint32](e.Args, tt.name)
 				if tt.errorMessage != "" {
@@ -238,6 +264,8 @@ func TestArgVal(t *testing.T) {
 	})
 
 	t.Run("[]string", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			name          string
 			arg           trace.Argument
@@ -280,7 +308,11 @@ func TestArgVal(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
+
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
 				val, err := ArgVal[[]string](e.Args, tt.name)
 				if tt.errorMessage != "" {
@@ -295,6 +327,8 @@ func TestArgVal(t *testing.T) {
 	})
 
 	t.Run("[]uint64", func(t *testing.T) {
+		t.Parallel()
+
 		tests := []struct {
 			name          string
 			arg           trace.Argument
@@ -337,7 +371,11 @@ func TestArgVal(t *testing.T) {
 		}
 
 		for _, tt := range tests {
+			tt := tt
+
 			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
 				e := trace.Event{Args: []trace.Argument{tt.arg}}
 				val, err := ArgVal[[]uint64](e.Args, tt.name)
 				if tt.errorMessage != "" {

--- a/pkg/events/parse_args_test.go
+++ b/pkg/events/parse_args_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func TestParseArgs(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Parse setsockopt value", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name         string
 			args         []trace.Argument
@@ -98,20 +102,28 @@ func TestParseArgs(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			event := trace.Event{
-				EventID: int(Setsockopt),
-				Args:    testCase.args,
-			}
-			err := ParseArgs(&event)
-			require.NoError(t, err)
-			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(&event, expArg.Name)
-				assert.Equal(t, expArg, *arg)
-			}
+			testCase := testCase
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				event := trace.Event{
+					EventID: int(Setsockopt),
+					Args:    testCase.args,
+				}
+				err := ParseArgs(&event)
+				require.NoError(t, err)
+				for _, expArg := range testCase.expectedArgs {
+					arg := GetArg(&event, expArg.Name)
+					assert.Equal(t, expArg, *arg)
+				}
+			})
 		}
 	})
 
 	t.Run("Parse getsockopt value", func(t *testing.T) {
+		t.Parallel()
+
 		testCases := []struct {
 			name         string
 			args         []trace.Argument
@@ -176,16 +188,22 @@ func TestParseArgs(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			event := &trace.Event{
-				EventID: int(Getsockopt),
-				Args:    testCase.args,
-			}
-			err := ParseArgs(event)
-			require.NoError(t, err)
-			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
-				assert.Equal(t, expArg, *arg)
-			}
+			testCase := testCase
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				event := &trace.Event{
+					EventID: int(Getsockopt),
+					Args:    testCase.args,
+				}
+				err := ParseArgs(event)
+				require.NoError(t, err)
+				for _, expArg := range testCase.expectedArgs {
+					arg := GetArg(event, expArg.Name)
+					assert.Equal(t, expArg, *arg)
+				}
+			})
 		}
 	})
 }

--- a/pkg/events/queue/queue_mem_list_test.go
+++ b/pkg/events/queue/queue_mem_list_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestEnqueueDequeue(t *testing.T) {
+	t.Parallel()
+
 	q := NewEventQueueMem(1024)
 	wg := sync.WaitGroup{}
 	wg.Add(1)

--- a/pkg/events/sorting/sorting_test.go
+++ b/pkg/events/sorting/sorting_test.go
@@ -30,6 +30,8 @@ func (e sortableEventsList) Swap(i, j int) {
 }
 
 func TestEventsChronologicalSorter_addEvent(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		events                []trace.Event
 		expectedCpuQueuesLens map[int]int
@@ -88,7 +90,11 @@ func TestEventsChronologicalSorter_addEvent(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			errChan := make(chan error)
 			newSorter, err := InitEventSorter()
 			require.NoError(t, err)
@@ -130,6 +136,8 @@ type sorterTestCase struct {
 }
 
 func TestEventsChronologicalSorter_Start(t *testing.T) {
+	t.Parallel()
+
 	sendingInterval := 100 * time.Millisecond
 	testCases := []sorterTestCase{
 		{
@@ -255,7 +263,11 @@ func TestEventsChronologicalSorter_Start(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			outputChan := make(chan *trace.Event)
 			fatalErrorsChan := make(chan error)
 			errChan := make(chan error)

--- a/pkg/events/trigger/context_test.go
+++ b/pkg/events/trigger/context_test.go
@@ -51,6 +51,8 @@ func EventsMatch(t *testing.T, expected, actual trace.Event) {
 }
 
 func TestStore(t *testing.T) {
+	t.Parallel()
+
 	e := NewFakeTriggerEvent()
 	c := trigger.NewContext()
 
@@ -60,6 +62,8 @@ func TestStore(t *testing.T) {
 }
 
 func TestLoad(t *testing.T) {
+	t.Parallel()
+
 	e := NewFakeTriggerEvent()
 	c := trigger.NewContext()
 
@@ -72,6 +76,8 @@ func TestLoad(t *testing.T) {
 
 // TestStoreAndLoad_MultipleThreads tests that the context store is thread safe.
 func TestStoreAndLoad_MultipleThreads(t *testing.T) {
+	t.Parallel()
+
 	c := trigger.NewContext()
 
 	wg := sync.WaitGroup{}
@@ -95,6 +101,8 @@ func TestStoreAndLoad_MultipleThreads(t *testing.T) {
 }
 
 func TestContext_Apply(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name          string
 		invokingEvent trace.Event
@@ -209,7 +217,11 @@ func TestContext_Apply(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			triggerContexts := trigger.NewContext()
 			triggerContexts.Store(tc.invokingEvent)
 			out, err := triggerContexts.Apply(tc.inputEvent)

--- a/pkg/filters/filters_test.go
+++ b/pkg/filters/filters_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestBoolFilter(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name         string
 		expressions  []string
@@ -67,7 +69,11 @@ func TestBoolFilter(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := filters.NewBoolFilter()
 			for _, expr := range tc.expressions {
 				err := filter.Parse(expr)
@@ -87,6 +93,8 @@ func TestBoolFilter(t *testing.T) {
 }
 
 func TestIntFilter(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name        string
 		expressions []string
@@ -122,7 +130,11 @@ func TestIntFilter(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := filters.NewIntFilter()
 			for _, expr := range tc.expressions {
 				err := filter.Parse(expr)
@@ -138,6 +150,8 @@ func TestIntFilter(t *testing.T) {
 }
 
 func TestUIntFilter(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name        string
 		expressions []string
@@ -181,7 +195,11 @@ func TestUIntFilter(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := filters.NewUIntFilter()
 			for _, expr := range tc.expressions {
 				err := filter.Parse(expr)
@@ -197,6 +215,8 @@ func TestUIntFilter(t *testing.T) {
 }
 
 func TestStringFilter(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name        string
 		expressions []string
@@ -310,7 +330,11 @@ func TestStringFilter(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter := filters.NewStringFilter()
 			for _, expr := range tc.expressions {
 				err := filter.Parse(expr)

--- a/pkg/filters/sets/sets_test.go
+++ b/pkg/filters/sets/sets_test.go
@@ -23,6 +23,8 @@ func RandStringRunes(n int, prefixes []string) string {
 }
 
 func Test_PrefixSet(t *testing.T) {
+	t.Parallel()
+
 	prefixes := sets.NewPrefixSet()
 	put := []string{
 		"bruh",
@@ -52,6 +54,8 @@ func Test_PrefixSet(t *testing.T) {
 }
 
 func Test_SuffixSet(t *testing.T) {
+	t.Parallel()
+
 	suffixes := sets.NewSuffixSet()
 	put := []string{
 		"bruh",

--- a/pkg/policy/v1beta1/policy_file_test.go
+++ b/pkg/policy/v1beta1/policy_file_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPolicyValidate(t *testing.T) {
+	t.Parallel()
+
 	fakeSigEventDefinition := events.NewDefinition(
 		0,
 		events.Sys32Undefined,
@@ -488,7 +490,11 @@ func TestPolicyValidate(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.testName, func(t *testing.T) {
+			t.Parallel()
+
 			err := test.policy.Validate()
 			if test.expectedError != nil {
 				assert.ErrorContains(t, err, test.expectedError.Error())

--- a/pkg/server/grpc/event_data_test.go
+++ b/pkg/server/grpc/event_data_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func Test_getEventData(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		args        []trace.Argument
@@ -629,7 +631,11 @@ func Test_getEventData(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			id := int(events.CommitCreds)
 			if tt.syscall {
 				id = int(events.Ptrace)

--- a/pkg/server/grpc/server_test.go
+++ b/pkg/server/grpc/server_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	t.Parallel()
+
 	tempDir, err := os.MkdirTemp("", "tracee-tests")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/grpc/tracee_test.go
+++ b/pkg/server/grpc/tracee_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func Test_convertEventWithProcessContext(t *testing.T) {
+	t.Parallel()
+
 	unixTime := int(time.Now().UnixNano())
 
 	traceEvent := trace.Event{
@@ -56,6 +58,8 @@ func Test_convertEventWithProcessContext(t *testing.T) {
 }
 
 func Test_convertEventWithStackaddresses(t *testing.T) {
+	t.Parallel()
+
 	traceEvent := trace.Event{
 		StackAddresses: []uint64{1, 2, 3},
 	}
@@ -75,6 +79,8 @@ func Test_convertEventWithStackaddresses(t *testing.T) {
 }
 
 func Test_convertEventWithContainerContext(t *testing.T) {
+	t.Parallel()
+
 	traceEvent := trace.Event{
 		Container: trace.Container{
 			ID:          "containerID",
@@ -94,6 +100,8 @@ func Test_convertEventWithContainerContext(t *testing.T) {
 }
 
 func Test_convertEventWithK8sContext(t *testing.T) {
+	t.Parallel()
+
 	traceEvent := trace.Event{
 		Kubernetes: trace.Kubernetes{
 			PodName:      "podName",
@@ -111,6 +119,8 @@ func Test_convertEventWithK8sContext(t *testing.T) {
 }
 
 func Test_convertEventWithThreat(t *testing.T) {
+	t.Parallel()
+
 	traceEvent := trace.Event{
 		Metadata: &trace.Metadata{
 			Description: "An attempt to abuse the Docker UNIX ..",

--- a/pkg/server/http/server_test.go
+++ b/pkg/server/http/server_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestServer(t *testing.T) {
+	t.Parallel()
+
 	httpServer := New("")
 
 	httpServer.EnableMetricsEndpoint()

--- a/pkg/signatures/celsig/config_test.go
+++ b/pkg/signatures/celsig/config_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNewConfigFromFile(t *testing.T) {
+	t.Parallel()
+
 	config, err := celsig.NewConfigFromFile("testdata/rules/anti_debugging_ptraceme.yml")
 	require.NoError(t, err)
 	assert.Equal(t, celsig.SignaturesConfig{

--- a/pkg/signatures/celsig/signature_test.go
+++ b/pkg/signatures/celsig/signature_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestSignature_GetSelectedEvents(t *testing.T) {
+	t.Parallel()
+
 	signature, err := celsig.NewSignature(celsig.SignatureConfig{
 		Metadata: detect.SignatureMetadata{
 			ID:   "TRC-2",
@@ -39,6 +41,8 @@ func TestSignature_GetSelectedEvents(t *testing.T) {
 }
 
 func TestSignature_OnEvent(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name    string
 		config  celsig.SignatureConfig
@@ -201,7 +205,11 @@ input.sockaddrArg('addr').sin_addr == "216.58.215.110"`,
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			signature, err := celsig.NewSignature(tc.config)
 			require.NoError(t, err)
 			holder := &signaturestest.FindingsHolder{}

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestEngine_ConsumeSources(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name              string
 		inputEvent        protocol.Event
@@ -386,6 +388,8 @@ func TestEngine_ConsumeSources(t *testing.T) {
 }
 
 func TestEngine_GetSelectedEvents(t *testing.T) {
+	t.Parallel()
+
 	sigs := []detect.Signature{
 		&signature.FakeSignature{
 			FakeGetSelectedEvents: func() ([]detect.SignatureEventSelector, error) {
@@ -447,6 +451,8 @@ func TestEngine_GetSelectedEvents(t *testing.T) {
 }
 
 func TestEngine_LoadSignature(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name          string
 		signatures    []detect.Signature

--- a/pkg/signatures/regosig/aio_test.go
+++ b/pkg/signatures/regosig/aio_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestAio_GetMetadata(t *testing.T) {
+	t.Parallel()
+
 	sig, err := regosig.NewAIO(map[string]string{
 		"test_boolean.rego": testRegoCodeBoolean,
 		"test_object.rego":  testRegoCodeObject,
@@ -33,6 +35,8 @@ func TestAio_GetMetadata(t *testing.T) {
 }
 
 func TestAio_GetSelectedEvents(t *testing.T) {
+	t.Parallel()
+
 	sig, err := regosig.NewAIO(map[string]string{
 		"test_boolean.rego": testRegoCodeBoolean,
 		"test_object.rego":  testRegoCodeObject,
@@ -61,6 +65,8 @@ func TestAio_GetSelectedEvents(t *testing.T) {
 }
 
 func TestAio_OnEvent(t *testing.T) {
+	t.Parallel()
+
 	options := []struct {
 		target  string
 		partial bool
@@ -84,7 +90,11 @@ func TestAio_OnEvent(t *testing.T) {
 	}
 
 	for _, tc := range options {
+		tc := tc
+
 		t.Run(fmt.Sprintf("target=%s,partial=%t", tc.target, tc.partial), func(t *testing.T) {
+			t.Parallel()
+
 			AioOnEventSpec(t, tc.target, tc.partial)
 		})
 	}
@@ -265,7 +275,11 @@ func AioOnEventSpec(t *testing.T, target string, partial bool) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			sig, err := regosig.NewAIO(tc.modules,
 				regosig.OPATarget(target),
 				regosig.OPAPartial(partial),
@@ -288,6 +302,8 @@ func AioOnEventSpec(t *testing.T, target string, partial bool) {
 }
 
 func TestAio_OnSignal(t *testing.T) {
+	t.Parallel()
+
 	sig, err := regosig.NewAIO(map[string]string{})
 	require.NoError(t, err)
 	err = sig.OnSignal(os.Kill)

--- a/pkg/signatures/regosig/traceerego_test.go
+++ b/pkg/signatures/regosig/traceerego_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestRegoSignature_GetMetadata(t *testing.T) {
+	t.Parallel()
+
 	sig, err := regosig.NewRegoSignature(compile.TargetRego, false, testRegoCodeBoolean)
 	require.NoError(t, err)
 
@@ -42,6 +44,8 @@ func TestRegoSignature_GetMetadata(t *testing.T) {
 }
 
 func TestRegoSignature_GetSelectedEvents(t *testing.T) {
+	t.Parallel()
+
 	sig, err := regosig.NewRegoSignature(compile.TargetRego, false, testRegoCodeBoolean)
 	require.NoError(t, err)
 	events, err := sig.GetSelectedEvents()
@@ -55,6 +59,8 @@ func TestRegoSignature_GetSelectedEvents(t *testing.T) {
 }
 
 func TestRegoSignature_OnEvent(t *testing.T) {
+	t.Parallel()
+
 	options := []struct {
 		target  string
 		partial bool
@@ -78,7 +84,11 @@ func TestRegoSignature_OnEvent(t *testing.T) {
 	}
 
 	for _, tc := range options {
+		tc := tc
+
 		t.Run(fmt.Sprintf("target=%s,partial=%t", tc.target, tc.partial), func(t *testing.T) {
+			t.Parallel()
+
 			OnEventSpec(t, tc.target, tc.partial)
 		})
 	}
@@ -343,7 +353,11 @@ func OnEventSpec(t *testing.T, target string, partial bool) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			sig, err := regosig.NewRegoSignature(target, partial, tc.regoCode)
 			require.NoError(t, err)
 
@@ -364,6 +378,8 @@ func OnEventSpec(t *testing.T, target string, partial bool) {
 }
 
 func TestRegoSignature_OnSignal(t *testing.T) {
+	t.Parallel()
+
 	sig, err := regosig.NewRegoSignature(compile.TargetRego, false, testRegoCodeBoolean)
 	require.NoError(t, err)
 	err = sig.OnSignal(os.Kill)

--- a/pkg/signatures/signature/signature_test.go
+++ b/pkg/signatures/signature/signature_test.go
@@ -20,6 +20,8 @@ const (
 )
 
 func TestFindByEventName(t *testing.T) {
+	t.Parallel()
+
 	sigs, err := Find(compile.TargetRego, false, []string{exampleRulesDir}, []string{"anti_debugging"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sigs))
@@ -41,6 +43,8 @@ func TestFindByEventName(t *testing.T) {
 }
 
 func TestFindByRuleID(t *testing.T) {
+	t.Parallel()
+
 	sigs, err := Find(compile.TargetRego, false, []string{exampleRulesDir}, []string{"TRC-2"}, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sigs))
@@ -62,6 +66,8 @@ func TestFindByRuleID(t *testing.T) {
 }
 
 func Test_isHelper(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input    string
 		expected bool
@@ -79,7 +85,11 @@ func Test_isHelper(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
 			actual := isHelper(tc.input)
 			assert.Equal(t, tc.expected, actual)
 		})
@@ -87,6 +97,8 @@ func Test_isHelper(t *testing.T) {
 }
 
 func Test_findRegoSigs(t *testing.T) {
+	t.Parallel()
+
 	tRoot, err := os.MkdirTemp(os.TempDir(), "sample-***")
 	require.NoError(t, err)
 	tDir, err := os.MkdirTemp(tRoot, "sample2-***")
@@ -150,6 +162,8 @@ func copyExampleSig(exampleName, destDir string) error {
 }
 
 func Test_isRegoFile(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		input    string
 		expected bool
@@ -163,7 +177,11 @@ func Test_isRegoFile(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
 			actual := isHelper(tc.input)
 			assert.Equal(t, tc.expected, actual)
 		})

--- a/pkg/streams/streams_test.go
+++ b/pkg/streams/streams_test.go
@@ -24,6 +24,8 @@ var (
 )
 
 func TestStreamManager(t *testing.T) {
+	t.Parallel()
+
 	var (
 		stream1Count int
 		stream2Count int
@@ -103,6 +105,8 @@ func TestStreamManager(t *testing.T) {
 }
 
 func Test_shouldIgnorePolicy(t *testing.T) {
+	t.Parallel()
+
 	sm := NewStreamsManager()
 
 	tests := []struct {
@@ -150,7 +154,11 @@ func Test_shouldIgnorePolicy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
+
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			stream := sm.Subscribe(tt.policyMask, 0)
 			assert.Equal(t, tt.expected, stream.shouldIgnorePolicy(tt.event))
 		})

--- a/pkg/utils/proc/ns_test.go
+++ b/pkg/utils/proc/ns_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestExtractNSFromLink(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name          string
 		link          string
@@ -35,7 +37,11 @@ func TestExtractNSFromLink(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
 			ns, err := extractNSFromLink(testCase.link)
 			if testCase.expectedError {
 				assert.Error(t, err)

--- a/pkg/utils/sharedobjs/host_symbols_loader_test.go
+++ b/pkg/utils/sharedobjs/host_symbols_loader_test.go
@@ -44,7 +44,11 @@ var testDynamicSymbols = &dynamicSymbols{
 }
 
 func TestHostSharedObjectSymbolsLoader_GetDynamicSymbols(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Happy flow", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -63,6 +67,8 @@ func TestHostSharedObjectSymbolsLoader_GetDynamicSymbols(t *testing.T) {
 	})
 
 	t.Run("Sad flow", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -78,7 +84,11 @@ func TestHostSharedObjectSymbolsLoader_GetDynamicSymbols(t *testing.T) {
 }
 
 func TestHostSharedObjectSymbolsLoader_GetExportedSymbols(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Happy flow", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -97,6 +107,8 @@ func TestHostSharedObjectSymbolsLoader_GetExportedSymbols(t *testing.T) {
 	})
 
 	t.Run("Sad flow", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -112,7 +124,11 @@ func TestHostSharedObjectSymbolsLoader_GetExportedSymbols(t *testing.T) {
 }
 
 func TestHostSharedObjectSymbolsLoader_GetImportedSymbols(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Happy flow", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -131,6 +147,8 @@ func TestHostSharedObjectSymbolsLoader_GetImportedSymbols(t *testing.T) {
 	})
 
 	t.Run("Sad flow", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -146,7 +164,11 @@ func TestHostSharedObjectSymbolsLoader_GetImportedSymbols(t *testing.T) {
 }
 
 func TestHostSharedObjectSymbolsLoader_loadSOSymbols(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Cached SO", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -165,6 +187,8 @@ func TestHostSharedObjectSymbolsLoader_loadSOSymbols(t *testing.T) {
 	})
 
 	t.Run("Uncached non existing SO", func(t *testing.T) {
+		t.Parallel()
+
 		failLoadingFunc := func(path string) (*dynamicSymbols, error) {
 			return nil, errors.New("no SO")
 		}
@@ -185,6 +209,8 @@ func TestHostSharedObjectSymbolsLoader_loadSOSymbols(t *testing.T) {
 	})
 
 	t.Run("Uncached existing SO", func(t *testing.T) {
+		t.Parallel()
+
 		cachedSymbols := make(map[ObjInfo]*dynamicSymbols)
 		cache := soCacheMock{
 			add: func(obj ObjInfo, dynamicSymbols *dynamicSymbols) {
@@ -207,6 +233,8 @@ func TestHostSharedObjectSymbolsLoader_loadSOSymbols(t *testing.T) {
 }
 
 func TestParseDynamicSymbols(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name          string
 		Input         []elf.Symbol
@@ -267,7 +295,11 @@ func TestParseDynamicSymbols(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
+
 		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
 			dynamicSymbols := parseDynamicSymbols(testCase.Input)
 			assert.Equal(t, fmt.Sprint(testCase.ExpecteResult.Imported), fmt.Sprint(dynamicSymbols.Imported))
 			assert.Equal(t, fmt.Sprint(testCase.ExpecteResult.Exported), fmt.Sprint(dynamicSymbols.Exported))

--- a/signatures/golang/anti_debugging_ptraceme_test.go
+++ b/signatures/golang/anti_debugging_ptraceme_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAntiDebuggingPtraceme(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -84,7 +86,11 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := AntiDebuggingPtraceme{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/aslr_inspection_test.go
+++ b/signatures/golang/aslr_inspection_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAslrInspection(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestAslrInspection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := AslrInspection{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/cgroup_notify_on_release_modification_test.go
+++ b/signatures/golang/cgroup_notify_on_release_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCgroupNotifyOnReleaseModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := CgroupNotifyOnReleaseModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/cgroup_release_agent_modification_test.go
+++ b/signatures/golang/cgroup_release_agent_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCgroupReleaseAgentModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -189,7 +191,11 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := CgroupReleaseAgentModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/core_pattern_modification_test.go
+++ b/signatures/golang/core_pattern_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCorePatternModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestCorePatternModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := CorePatternModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/default_loader_modification_test.go
+++ b/signatures/golang/default_loader_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDefaultLoaderModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -189,7 +191,11 @@ func TestDefaultLoaderModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := DefaultLoaderModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/disk_mount_test.go
+++ b/signatures/golang/disk_mount_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDiskMount(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -113,7 +115,11 @@ func TestDiskMount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := DiskMount{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/docker_abuse_test.go
+++ b/signatures/golang/docker_abuse_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDockerAbuse(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -196,7 +198,11 @@ func TestDockerAbuse(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := DockerAbuse{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/dropped_executable_test.go
+++ b/signatures/golang/dropped_executable_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDroppedExecutable(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestDroppedExecutable(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := DroppedExecutable{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/dynamic_code_loading_test.go
+++ b/signatures/golang/dynamic_code_loading_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDynamicCodeLoading(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -84,7 +86,11 @@ func TestDynamicCodeLoading(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := DynamicCodeLoading{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/fileless_execution_test.go
+++ b/signatures/golang/fileless_execution_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestFilelessExecution(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -84,7 +86,11 @@ func TestFilelessExecution(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := FilelessExecution{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/hidden_file_created_test.go
+++ b/signatures/golang/hidden_file_created_test.go
@@ -125,7 +125,11 @@ func TestHiddenFileCreated(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := HiddenFileCreated{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/illegitimate_shell_test.go
+++ b/signatures/golang/illegitimate_shell_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestIllegitimateShell(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -105,7 +107,11 @@ func TestIllegitimateShell(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := IllegitimateShell{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/k8s_service_account_token_test.go
+++ b/signatures/golang/k8s_service_account_token_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestK8SServiceAccountToken(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -153,7 +155,11 @@ func TestK8SServiceAccountToken(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := K8SServiceAccountToken{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/kernel_module_loading_test.go
+++ b/signatures/golang/kernel_module_loading_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestKernelModuleLoading(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -115,7 +117,11 @@ func TestKernelModuleLoading(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := KernelModuleLoading{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/kubernetes_api_connection_test.go
+++ b/signatures/golang/kubernetes_api_connection_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestK8sApiConnection(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -130,7 +132,11 @@ func TestK8sApiConnection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 
 			sig := &K8sApiConnection{}

--- a/signatures/golang/kubernetes_certificate_theft_attempt_test.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestKubernetesCertificateTheftAttempt(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -217,7 +219,11 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := KubernetesCertificateTheftAttempt{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/ld_preload_test.go
+++ b/signatures/golang/ld_preload_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestLdPreload(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -271,7 +273,11 @@ func TestLdPreload(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := LdPreload{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/proc_fops_hooking_test.go
+++ b/signatures/golang/proc_fops_hooking_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProcFopsHooking(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -93,7 +95,11 @@ func TestProcFopsHooking(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := ProcFopsHooking{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/proc_kcore_read_test.go
+++ b/signatures/golang/proc_kcore_read_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProcKcoreRead(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestProcKcoreRead(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := ProcKcoreRead{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/proc_mem_access_test.go
+++ b/signatures/golang/proc_mem_access_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProcMemAccess(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestProcMemAccess(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := ProcMemAccess{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/proc_mem_code_injection_test.go
+++ b/signatures/golang/proc_mem_code_injection_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProcMemCodeInjection(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestProcMemCodeInjection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := ProcMemCodeInjection{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/process_vm_write_code_injection_test.go
+++ b/signatures/golang/process_vm_write_code_injection_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestProcessVmWriteCodeInjection(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -87,7 +89,11 @@ func TestProcessVmWriteCodeInjection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := ProcessVmWriteCodeInjection{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/ptrace_code_injection_test.go
+++ b/signatures/golang/ptrace_code_injection_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPtraceCodeInjection(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -131,7 +133,11 @@ func TestPtraceCodeInjection(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := PtraceCodeInjection{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/rcd_modification_test.go
+++ b/signatures/golang/rcd_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRcdModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -359,7 +361,11 @@ func TestRcdModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := RcdModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/sched_debug_recon_test.go
+++ b/signatures/golang/sched_debug_recon_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSchedDebugRecon(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestSchedDebugRecon(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := SchedDebugRecon{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/scheduled_task_modification_test.go
+++ b/signatures/golang/scheduled_task_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestScheduledTaskModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -359,7 +361,11 @@ func TestScheduledTaskModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := ScheduledTaskModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/stdio_over_socket_test.go
+++ b/signatures/golang/stdio_over_socket_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestStdioOverSocket(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -238,7 +240,11 @@ func TestStdioOverSocket(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := StdioOverSocket{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/sudoers_modification_test.go
+++ b/signatures/golang/sudoers_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSudoersModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -295,7 +297,11 @@ func TestSudoersModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := SudoersModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/syscall_table_hooking_test.go
+++ b/signatures/golang/syscall_table_hooking_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSyscallTableHooking(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -96,7 +98,11 @@ func TestSyscallTableHooking(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := SyscallTableHooking{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/signatures/golang/system_request_key_config_modification_test.go
+++ b/signatures/golang/system_request_key_config_modification_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSystemRequestKeyConfigModification(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		Name     string
 		Events   []trace.Event
@@ -125,7 +127,11 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
+
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
 			holder := signaturestest.FindingsHolder{}
 			sig := SystemRequestKeyConfigModification{}
 			sig.Init(detect.SignatureContext{Callback: holder.OnFinding})

--- a/tests/integration/exec_test.go
+++ b/tests/integration/exec_test.go
@@ -10,6 +10,8 @@ import (
 
 // Test_ParseCmd tests the parseCmd function
 func Test_ParseCmd(t *testing.T) {
+	t.Parallel()
+
 	tt := []struct {
 		input          string
 		expectedCmd    string
@@ -55,14 +57,20 @@ func Test_ParseCmd(t *testing.T) {
 	}
 
 	for _, tc := range tt {
-		cmd, args, err := testutils.ParseCmd(tc.input)
+		tc := tc
 
-		if err == nil {
-			assert.Equal(t, tc.expectedCmd, cmd)
-			assert.Len(t, args, len(tc.expectedArgs))
-			assert.Equal(t, tc.expectedArgs, args)
-		} else if err.Error() != tc.expectedErrMsg {
-			t.Errorf("For input \"%s\", expected error message \"%s\", but got \"%s\"", tc.input, tc.expectedErrMsg, err)
-		}
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			cmd, args, err := testutils.ParseCmd(tc.input)
+
+			if err == nil {
+				assert.Equal(t, tc.expectedCmd, cmd)
+				assert.Len(t, args, len(tc.expectedArgs))
+				assert.Equal(t, tc.expectedArgs, args)
+			} else if err.Error() != tc.expectedErrMsg {
+				t.Errorf("For input \"%s\", expected error message \"%s\", but got \"%s\"", tc.input, tc.expectedErrMsg, err)
+			}
+		})
 	}
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func Test_InitNamespacesEvent(t *testing.T) {
+	t.Parallel()
+
 	assureIsRoot(t)
 
 	procNamespaces := [...]string{"mnt", "cgroup", "pid", "pid_for_children", "time", "time_for_children", "user", "ipc", "net", "uts"}

--- a/tests/integration/syscaller/cmd/syscall_test.go
+++ b/tests/integration/syscaller/cmd/syscall_test.go
@@ -15,6 +15,8 @@ import (
 
 // Test_callsys tests the callsys function
 func Test_callsys(t *testing.T) {
+	t.Parallel()
+
 	// SYS_READ and SYS_CLOSE are syscalls that, considering this environment,
 	// should not return an error when called with zeroed arguments
 	syscalls := []events.ID{events.Read, events.Close}
@@ -32,6 +34,8 @@ func Test_callsys(t *testing.T) {
 
 // Test_changeOwnComm tests the changeOwnComm function
 func Test_changeOwnComm(t *testing.T) {
+	t.Parallel()
+
 	testutils.PinProccessToCPU()
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/tests/perftests/metrics_test.go
+++ b/tests/perftests/metrics_test.go
@@ -97,6 +97,8 @@ func checkIfPprofExist() error {
 
 // TestMetricsExist tests if the metrics endpoint returns all metrics.
 func TestMetricsandPprofExist(t *testing.T) {
+	t.Parallel()
+
 	if !testutils.IsSudoCmdAvailableForThisUser() {
 		t.Skip("skipping: sudo command is not available for this user")
 	}

--- a/types/protocol/protocol_test.go
+++ b/types/protocol/protocol_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestEvent_SetHeader(t *testing.T) {
+	t.Parallel()
+
 	evt := Event{
 		Headers: EventHeaders{},
 		Payload: "blah",


### PR DESCRIPTION
### 1. Explain what the PR does

a2ec86e38 **chore(test): enhance tests using t.Parallel()**

```
Utilize t.Parallel() in unit tests to enable concurrent execution. This
takes advantage of multiple CPU cores, reducing the overall test suite
runtime.

Critically, this practice elevates the detection of insidious race
conditions and state leakages—issues that often remain concealed during
serial test execution.
```

9b6d344bd **chore(Makefile): enable '-shuffle on' for random**

```
By using '-shuffle on' we can run the tests in a random order, which
helps us to find any unintentional inter-test dependencies or state
leakages.
```

### 2. Explain how to test it

`make test-unit`
`make test-types`
`sudo make test-integration`

### 3. Other comments

Currently, the use of t.Parallel() doesn't affect the performance of the tests (slight difference):

```
main:
make test-unit  43,27s user 11,96s system 320% cpu 17,249 total

PR:
make test-unit  43,74s user 11,34s system 325% cpu 16,944 total
```