### PR TITLE
fix(go.mod): remove types replacement leftover

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
-	github.com/aquasecurity/tracee/types v0.0.0-20230929172705-29c9b630aeed
+	github.com/aquasecurity/tracee/types v0.0.0-20231003114440-68aa961e8bef
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v23.0.5+incompatible
 	github.com/golang/protobuf v1.5.3

--- a/go.mod
+++ b/go.mod
@@ -173,5 +173,3 @@ require (
 )
 
 replace github.com/kubernetes/cri-api => k8s.io/cri-api v0.23.5-rc.0
-
-replace github.com/aquasecurity/tracee/types v0.0.0-20230929172705-29c9b630aeed => ./types

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
 github.com/aquasecurity/tracee/types v0.0.0-20230929172705-29c9b630aeed h1:d8ehyRJFP5qS0zfTss65UC2SoF7WX+/4+UcTL/73x9M=
 github.com/aquasecurity/tracee/types v0.0.0-20230929172705-29c9b630aeed/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
+github.com/aquasecurity/tracee/types v0.0.0-20231003114440-68aa961e8bef h1:RT9bbv7OzMaG2969xjnH77K+5CuHoWpd0halZH/v2CI=
+github.com/aquasecurity/tracee/types v0.0.0-20231003114440-68aa961e8bef/go.mod h1:sorAC3uGSNB/b8A9PjG1MSbENl81dR7azTSj+HclE+A=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=


### PR DESCRIPTION
commit 544b2cdfe introduced a types replacement, removing it.
