### PR TITLE
feat(events): create access_remote_vm event

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,6 +70,7 @@ env:
     PROCTREE_DATA_SOURCE
     DNS_DATA_SOURCE
     WRITABLE_DATA_SOURCE
+    ACCESS_REMOTE_VM
 jobs:
   #
   # DOC VERIFICATION
@@ -326,6 +327,7 @@ jobs:
       - generate-matrix
     runs-on: "github-self-hosted_ami-${{ matrix.ami }}_${{ github.event.number }}-${{ github.run_id }}_${{ matrix.sufix }}"
     strategy:
+      fail-fast: false
       matrix:
         include: ${{fromJson(needs.generate-matrix.outputs.matrix01)}}
     env:

--- a/docs/docs/events/builtin/extra/access_remote_vm.md
+++ b/docs/docs/events/builtin/extra/access_remote_vm.md
@@ -1,0 +1,34 @@
+# access_remote_vm
+
+## Intro
+access_remote_vm - gain access to the virtual memory of a separate process through the use of the procfs mem file.
+
+## Description
+This event marks access attempt of a process to the virtual memory of another process using the procfs mem file associated with that specific process (/proc/<pid>/mem).
+It is a more elaborated event than the `security_file_open` of the mem file.
+
+## Arguments
+* `remote_pid`: `int`[K] - PID of the process the memory area belongs to.
+* `start_address`: `void *`[K] - Start address of the operation.
+* `gup_flags`: `unsigned int`[K] - Flags for get_user_pages operation.
+* `vm_flags`: `unsigned long`[K] - Virtual memory flags.
+* `mapped.path`: `const char*`[K] - Path of the mapped file, or the name of memory area if no file is mapped.
+* `mapped.device_id`: `dev_t`[K,OPT] - Device ID of the mapped file.
+* `mapped.inode_number`: `unsigned long`[K,OPT] - Inode number of the mapped file.
+* `mapped.ctime`: `unsigned long`[K,OPT] - Creation time of the mapped file.
+
+## Hooks
+### get_user_pages_remote
+#### Type
+kprobe + kretprobe
+#### Purpose
+The main function that implements the access to the virtual memory area of the other process.
+
+### generic_access_phys
+#### Type
+kprobe
+#### Purpose
+A fallback function, implementing the `access` method of the `vma_operations` struct for most of the vmas. It is used to access special memory areas.
+
+## Related Events
+`security_file_open`,`security_mmap_file`,`vfs_write`,`vfs_writev`,`vfs_read`,`vfs_readv`

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/fluent-forward-go v0.2.1
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.6.0-libbpf-1.3
-	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231123142329-37c4b843a539
+	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231127142843-5e798c565c08
 	github.com/aquasecurity/tracee/api v0.0.0-20231222010915-0f73aad36da9
 	github.com/aquasecurity/tracee/types v0.0.0-20231231104405-a33891f29d17
 	github.com/containerd/containerd v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/aquasecurity/libbpfgo v0.6.0-libbpf-1.3 h1:mhDe1mAZR80LjnsCnteS+R2/Ee
 github.com/aquasecurity/libbpfgo v0.6.0-libbpf-1.3/go.mod h1:0rEApF1YBHGuZ4C8OYI9q5oDBVpgqtRqYATePl9mCDk=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231123142329-37c4b843a539 h1:axIHZ3la2/wcqMYO9TUyKO/lMGYizEKyNIodbwQBOkE=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231123142329-37c4b843a539/go.mod h1:1fGKke5pgH4xYvZ7HqDbLSi/R5zfRFH2K+c9kLp9L34=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231127142843-5e798c565c08 h1:hlnYuC6sWi3yYi9HNsHLemDfbf6F787GCAkP7kwnqBc=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231127142843-5e798c565c08/go.mod h1:1fGKke5pgH4xYvZ7HqDbLSi/R5zfRFH2K+c9kLp9L34=
 github.com/aquasecurity/tracee/api v0.0.0-20231222010915-0f73aad36da9 h1:1y+/rhVRNZK8s/ZyqXhtqjVLbKs/F9jPjBUn9jcujQs=
 github.com/aquasecurity/tracee/api v0.0.0-20231222010915-0f73aad36da9/go.mod h1:QJG2PABXucOsFVO85tQsKxV4c1GUhcjww/Kw+Wv7Y/c=
 github.com/aquasecurity/tracee/types v0.0.0-20231231104405-a33891f29d17 h1:tgcl7BuyBLDng+47KKhyOB9gdsq3V9dKoapNyRDchwg=

--- a/pkg/cmd/initialize/callbacks.go
+++ b/pkg/cmd/initialize/callbacks.go
@@ -24,7 +24,7 @@ var (
 	// 3. %s = check_map_func_compatibility (function name)
 	// 4. %x = offset (ignored in this check)
 	// 5. %s = No such file or directory
-	libbpfgoKprobePerfEventRegexp = regexp.MustCompile(`libbpf:.*prog '(?:trace_check_map_func_compatibility|trace_utimes_common)'.*failed to create kprobe.*perf event: No such file or directory`)
+	libbpfgoKprobePerfEventRegexp = regexp.MustCompile(`libbpf:.*prog '(?:trace_check_map_func_compatibility|trace_utimes_common|trace_generic_access_phys)'.*failed to create kprobe.*perf event: No such file or directory`)
 
 	// triggered by: libbpf/src/libbpf.c->bpf_program__attach_fd()
 	// "libbpf: prog '%s': failed to attach to %s: %s\n"

--- a/pkg/ebpf/c/common/arguments.h
+++ b/pkg/ebpf/c/common/arguments.h
@@ -42,6 +42,7 @@ statfunc int load_args(args_t *args, u32 event_id)
     args->args[3] = saved_args->args[3];
     args->args[4] = saved_args->args[4];
     args->args[5] = saved_args->args[5];
+    args->args[6] = saved_args->args[6];
 
     return 0;
 }

--- a/pkg/ebpf/c/common/consts.h
+++ b/pkg/ebpf/c/common/consts.h
@@ -20,6 +20,8 @@
 #define MAX_SYS_CALL_TABLE_SIZE 500
 #define MAX_MEM_DUMP_SIZE   127
 
+#define MAX_VMA_ITERATIONS 20
+
 
 #define MAX_STR_ARR_ELEM      38 // TODO: turn this into global variables set w/ libbpfgo
 #define MAX_ARGS_STR_ARR_ELEM 15

--- a/pkg/ebpf/c/common/memory.h
+++ b/pkg/ebpf/c/common/memory.h
@@ -4,6 +4,7 @@
 #include <vmlinux.h>
 
 #include <common/common.h>
+#include <common/ksymbols.h>
 
 // PROTOTYPES
 
@@ -12,7 +13,11 @@ statfunc unsigned long get_arg_start_from_mm(struct mm_struct *);
 statfunc unsigned long get_arg_end_from_mm(struct mm_struct *);
 statfunc unsigned long get_env_start_from_mm(struct mm_struct *);
 statfunc unsigned long get_env_end_from_mm(struct mm_struct *);
+statfunc struct task_struct *get_owner_task_from_mm(struct mm_struct *);
+statfunc struct file *get_mapped_file_from_vma(struct vm_area_struct *);
+statfunc struct mount *real_mount(struct vfsmount *);
 statfunc unsigned long get_vma_flags(struct vm_area_struct *);
+statfunc int get_vma_location(struct vm_area_struct *, size_t, char *);
 
 // FUNCTIONS
 
@@ -41,6 +46,16 @@ statfunc unsigned long get_env_end_from_mm(struct mm_struct *mm)
     return BPF_CORE_READ(mm, env_end);
 }
 
+statfunc struct task_struct *get_owner_task_from_mm(struct mm_struct *mm)
+{
+    return BPF_CORE_READ(mm, owner);
+}
+
+statfunc struct file *get_mapped_file_from_vma(struct vm_area_struct *vma)
+{
+    return BPF_CORE_READ(vma, vm_file);
+}
+
 statfunc unsigned long get_vma_flags(struct vm_area_struct *vma)
 {
     return BPF_CORE_READ(vma, vm_flags);
@@ -49,6 +64,66 @@ statfunc unsigned long get_vma_flags(struct vm_area_struct *vma)
 statfunc struct mount *real_mount(struct vfsmount *mnt)
 {
     return container_of(mnt, struct mount, mnt);
+}
+
+// NOTE: The function below use "special_mapping_vmops" and "legacy_special_mapping_vmops"
+// symbols. Ensure these symbols are available when invoking this function.
+
+// Returns true if the specified Virtual Memory Area (VMA) is a special mapping, such as
+// [vdso]. Returns false otherwise.
+statfunc bool is_special_mapping(struct vm_area_struct *vma)
+{
+    char special_mapping_vmops_symbol[22] = "special_mapping_vmops";
+    char legacy_special_mapping_vmops_symbol[29] = "legacy_special_mapping_vmops";
+
+    void *special_mapping_vmops_addr = get_symbol_addr(special_mapping_vmops_symbol);
+    void *legacy_special_mapping_vmops_addr = get_symbol_addr(legacy_special_mapping_vmops_symbol);
+
+    const struct vm_operations_struct *vm_ops = BPF_CORE_READ(vma, vm_ops);
+
+    if (!vm_ops)
+        return false;
+
+    if (vm_ops == special_mapping_vmops_addr || vm_ops == legacy_special_mapping_vmops_addr)
+        return true;
+
+    return false;
+}
+
+// Returns the descriptive name of the specified Virtual Memory Area (VMA). This function
+// identifies special VMAs like [stack], [heap], and [vdso]. It does not resolve VMAs
+// mapped to files; such VMAs require alternative methods for detail retrieval.
+statfunc int get_vma_location(struct vm_area_struct *vma, size_t max_len, char *location)
+{
+    // Avoid buffer overflow and satisfy the verifier.
+    if (max_len < 7) {
+        return 0;
+    }
+
+    struct mm_struct *vm_mm = BPF_CORE_READ(vma, vm_mm);
+
+    if (vm_mm) {
+        u64 start_stack = BPF_CORE_READ(vm_mm, start_stack);
+        u64 start_brk = BPF_CORE_READ(vm_mm, start_brk);
+        u64 brk = BPF_CORE_READ(vm_mm, brk);
+        u64 vm_start = BPF_CORE_READ(vma, vm_start);
+        u64 vm_end = BPF_CORE_READ(vma, vm_end);
+
+        if (vm_start <= start_stack && vm_end >= start_stack) {
+            __builtin_memcpy(location, "[stack]", 7);
+
+        } else if (vm_start <= brk && vm_end >= start_brk) {
+            __builtin_memcpy(location, "[heap]", 6);
+
+        } else if (is_special_mapping(vma)) {
+            struct vm_special_mapping *special_mapping = BPF_CORE_READ(vma, vm_private_data);
+            const char *name = BPF_CORE_READ(special_mapping, name);
+            if (name)
+                bpf_probe_read_str(location, max_len, name);
+        }
+    }
+
+    return 0;
 }
 
 #endif

--- a/pkg/ebpf/c/common/probes.h
+++ b/pkg/ebpf/c/common/probes.h
@@ -11,13 +11,13 @@
 #include <common/filtering.h>
 
 #if defined(bpf_target_x86)
-#define PT_REGS_PARM7(ctx) \
-      ({ \
-          unsigned long reg; \
-          unsigned long *sp = (unsigned long *) PT_REGS_SP(ctx); \
-          bpf_core_read(&reg, sizeof(unsigned long), sp + 1); \
-          reg; \
-      })
+    #define PT_REGS_PARM7(ctx)                                                                     \
+        ({                                                                                         \
+            unsigned long reg;                                                                     \
+            unsigned long *sp = (unsigned long *) PT_REGS_SP(ctx);                                 \
+            bpf_core_read(&reg, sizeof(unsigned long), sp + 1);                                    \
+            reg;                                                                                   \
+        })
 
 #endif // bpf_target_x86
 

--- a/pkg/ebpf/c/common/probes.h
+++ b/pkg/ebpf/c/common/probes.h
@@ -21,12 +21,14 @@
             return 0;                                                                              \
                                                                                                    \
         args_t args = {};                                                                          \
+        unsigned long *sp = (unsigned long *) PT_REGS_SP(ctx);                                     \
         args.args[0] = PT_REGS_PARM1(ctx);                                                         \
         args.args[1] = PT_REGS_PARM2(ctx);                                                         \
         args.args[2] = PT_REGS_PARM3(ctx);                                                         \
         args.args[3] = PT_REGS_PARM4(ctx);                                                         \
         args.args[4] = PT_REGS_PARM5(ctx);                                                         \
         args.args[5] = PT_REGS_PARM6(ctx);                                                         \
+        bpf_core_read(&args.args[6], sizeof(unsigned long), sp + 1);                               \
                                                                                                    \
         return save_args(&args, id);                                                               \
     }

--- a/pkg/ebpf/c/common/probes.h
+++ b/pkg/ebpf/c/common/probes.h
@@ -19,7 +19,7 @@
             unsigned long __reg;                                                                   \
             unsigned long *__sp = (unsigned long *) PT_REGS_SP(ctx);                               \
             bpf_core_read(&__reg, sizeof(unsigned long), __sp + 1);                                \
-            reg;                                                                                   \
+            __reg;                                                                                   \
         })
     #pragma GCC diagnostic pop
 

--- a/pkg/ebpf/c/common/probes.h
+++ b/pkg/ebpf/c/common/probes.h
@@ -11,13 +11,17 @@
 #include <common/filtering.h>
 
 #if defined(bpf_target_x86)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmacro-redefined"
+    // Redefine the PT_REGS_PARM7 from __unsupported__ to use the stack to get the argument
     #define PT_REGS_PARM7(ctx)                                                                     \
         ({                                                                                         \
-            unsigned long reg;                                                                     \
-            unsigned long *sp = (unsigned long *) PT_REGS_SP(ctx);                                 \
-            bpf_core_read(&reg, sizeof(unsigned long), sp + 1);                                    \
+            unsigned long __reg;                                                                   \
+            unsigned long *__sp = (unsigned long *) PT_REGS_SP(ctx);                               \
+            bpf_core_read(&__reg, sizeof(unsigned long), __sp + 1);                                \
             reg;                                                                                   \
         })
+    #pragma GCC diagnostic pop
 
 #endif // bpf_target_x86
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4966,6 +4966,132 @@ int BPF_KPROBE(trace_ret_exec_binprm2)
     return events_perf_submit(&p, PROCESS_EXECUTION_FAILED, ret);
 }
 
+// Submit "access_remote_vm" event for the given vma and info.
+statfunc int submit_access_remote_vm(program_data_t *p,
+                                     struct vm_area_struct *vma,
+                                     void *address,
+                                     unsigned int gup_flags)
+{
+    unsigned long vm_flags = get_vma_flags(vma);
+    struct mm_struct *mm = BPF_CORE_READ(vma, vm_mm);
+    file_info_t file_info = {};
+
+    char location[64] = {0};
+
+    // Get mapped memory information
+    struct file *file = get_mapped_file_from_vma(vma);
+    file_info = get_file_info(file);
+
+    // If there is no file that is mapped to the vma, try to get memory location name instead.
+    if (!file_info.pathname_p)
+        get_vma_location(vma, sizeof(location), location);
+
+    struct task_struct *task = get_owner_task_from_mm(mm);
+    u32 pid = get_task_host_tgid(task);
+
+    save_to_submit_buf(&p->event->args_buf, &pid, sizeof(u32), 0);
+    save_to_submit_buf(&p->event->args_buf, &address, sizeof(void *), 1);
+    save_to_submit_buf(&p->event->args_buf, &gup_flags, sizeof(unsigned int), 2);
+    save_to_submit_buf(&p->event->args_buf, &vm_flags, sizeof(unsigned long), 3);
+    if (file_info.pathname_p != NULL) {
+        save_str_to_buf(&p->event->args_buf, file_info.pathname_p, 4);
+        save_to_submit_buf(&p->event->args_buf, &file_info.id.device, sizeof(dev_t), 5);
+        save_to_submit_buf(&p->event->args_buf, &file_info.id.inode, sizeof(unsigned long), 6);
+        save_to_submit_buf(&p->event->args_buf, &file_info.id.ctime, sizeof(u64), 7);
+    } else {
+        save_str_to_buf(&p->event->args_buf, location, 4);
+    }
+
+    return events_perf_submit(p, ACCESS_REMOTE_VM, 0);
+}
+
+SEC("kprobe/generic_access_phys")
+int BPF_KPROBE(trace_generic_access_phys)
+{
+    program_data_t p = {};
+    if (!init_program_data(&p, ctx))
+        return 0;
+
+    if (!should_trace(&p))
+        return 0;
+
+    struct vm_area_struct *vma = (struct vm_area_struct *) PT_REGS_PARM1(ctx);
+    unsigned long addr = (unsigned long) PT_REGS_PARM2(ctx);
+    int write = (int) PT_REGS_PARM5(ctx);
+
+    return submit_access_remote_vm(&p, vma, (void *) addr, write);
+}
+
+SEC("kprobe/get_user_pages_remote")
+TRACE_ENT_FUNC(get_user_pages_remote, ACCESS_REMOTE_VM);
+
+// The "get_user_pages_remote" function has changed in kernel 6.5.
+// The part of finding the relevant vma was extracted to the new function
+// "get_user_page_vma_remote", leaving the logic of finding the relevant pages in this function. The
+// vma is what interest us in the ACCESS_REMOTE_VM, so this probe should only be used for kernels
+// prior to 6.5.
+SEC("kretprobe/get_user_pages_remote")
+int BPF_KPROBE(trace_ret_get_user_pages_remote)
+{
+    args_t saved_args;
+    if (load_args(&saved_args, ACCESS_REMOTE_VM) != 0) {
+        // missed entry or not traced
+        return 0;
+    }
+    del_args(ACCESS_REMOTE_VM);
+
+    program_data_t p = {};
+    if (!init_program_data(&p, ctx))
+        return 0;
+
+    if (!should_trace(&p))
+        return 0;
+
+    int ret_val = PT_REGS_RC(ctx);
+    // If the page cannot be pinned the return code would be <= 0, this could mean that
+    // the page is a memory mapped page, for example. In this case, the access to that
+    // page has to be done through "vma->vm_ops->access", which we trace for most cases
+    // (all normal cases) using generic_access_phys. Let the flow continue so it would be
+    // traced there.
+    if (ret_val <= 0)
+        return 0;
+
+    unsigned long address;
+    unsigned int gup_flags;
+    struct vm_area_struct **vmas;
+    struct vm_area_struct *vma = NULL;
+    unsigned long vm_flags = 0;
+    file_info_t file_info = {};
+
+    // The first argument of the function was removed in kernel version 5.9.
+    // We need to adjust the arguments retrival to the kernels to avoid misinformation.
+    // In kernel 5.9 the type bpf_iter_seq_array_map_info was added. By checking
+    // its existence, we can determine the current kernel version.
+    if (!bpf_core_type_exists(struct bpf_iter_seq_array_map_info)) { // kernel version < 5.9
+        address = (unsigned long) saved_args.args[2];
+        gup_flags = (unsigned int) saved_args.args[4];
+        vmas = (struct vm_area_struct **) saved_args.args[6];
+    } else { // kernel version >= 5.9
+        address = (unsigned long) saved_args.args[1];
+        gup_flags = (unsigned int) saved_args.args[3];
+        vmas = (struct vm_area_struct **) saved_args.args[5];
+    }
+
+    // Without a vma we can't get enough information for the event. Moreover, this will
+    // filter out the calls for it from the execve flow.
+    if (!vmas)
+        return 0;
+
+    // In the flow of interest, via the access_remote_vm function, the logic iterate over
+    // the pages 1 by 1. This means that 1 and only 1 vma would be resolved here if the
+    // function succeed.
+    bpf_core_read(&vma, sizeof(void *), vmas);
+    if (!vma)
+        return 0;
+
+    return submit_access_remote_vm(&p, vma, (void *) address, gup_flags);
+}
+
 // clang-format off
 
 // Network Packets (works from ~5.2 and beyond)

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5093,10 +5093,36 @@ int BPF_KPROBE(trace_ret_get_user_pages_remote)
 }
 
 // Callback function for bpf_find_vma
-static long kprobe_vma_callback(struct task_struct *task, struct vm_area_struct *vma, void *callback_ctx) {
+statfunc long kprobe_vma_callback(struct task_struct *task, struct vm_area_struct *vma, void *callback_ctx) {
     struct vm_area_struct **out_vma = (struct vm_area_struct **)callback_ctx;
     if (vma)
         *out_vma = vma;
+    return 0;
+}
+
+typedef struct vma_iteration_ctx {
+    program_data_t *p;
+    struct task_struct *task;
+    u64 addr;
+    u64 len;
+    unsigned int gup_flags;
+} vma_iteration_ctx_t;
+
+statfunc long iterate_submit_access_remote_vm(u32 index, void *ctx) {
+    vma_iteration_ctx_t *iter_ctx = (vma_iteration_ctx_t *)ctx;
+    struct vm_area_struct *vma;
+    int ret = bpf_find_vma(iter_ctx->task, iter_ctx->addr, (void *)kprobe_vma_callback, (void *)&vma, 0);
+    if (ret != 0)
+        return 1;
+
+    submit_access_remote_vm(iter_ctx->p, vma, (void *) iter_ctx->addr, iter_ctx->gup_flags);
+    u64 vm_end = BPF_CORE_READ(vma, vm_end);
+    u64 len_in_vma = vm_end - iter_ctx->addr;
+    len_in_vma += 1; // Range access include last byte - addresses range of 0-4 consist of 5 bytes.
+    if (iter_ctx->len <= len_in_vma)
+        return 1;
+    iter_ctx->addr += len_in_vma;
+    iter_ctx->len -= len_in_vma;
     return 0;
 }
 
@@ -5112,18 +5138,16 @@ int BPF_KPROBE(trace_access_remote_vm)
 	
 	if (!should_submit(ACCESS_REMOTE_VM, p.event))
         return 0;
-	
-	struct vm_area_struct *vma;
+
 	struct mm_struct *mm = (struct mm_struct *)PT_REGS_PARM1(ctx);
-	struct task_struct *task = get_owner_task_from_mm(mm);
-	u64 addr = (u64)PT_REGS_PARM2(ctx);
-	unsigned int gup_flags = (unsigned int)PT_REGS_PARM5(ctx);
+	vma_iteration_ctx_t vma_iteration_ctx = {};
+	vma_iteration_ctx.task = get_owner_task_from_mm(mm);
+	vma_iteration_ctx.addr = (u64)PT_REGS_PARM2(ctx);
+	vma_iteration_ctx.len = (u64)PT_REGS_PARM4(ctx);
+	vma_iteration_ctx.gup_flags = (unsigned int)PT_REGS_PARM5(ctx);
+	vma_iteration_ctx.p = &p;
 
-	int ret = bpf_find_vma(task, addr, (void *)kprobe_vma_callback, (void *)&vma, 0);
-    if (ret != 0)
-        return 0;
-
-	return submit_access_remote_vm(&p, vma, (void *) addr, gup_flags);
+    return bpf_loop(MAX_VMA_ITERATIONS, (void *)iterate_submit_access_remote_vm, &vma_iteration_ctx, 0);
 }
 
 // clang-format off

--- a/pkg/ebpf/c/tracee.h
+++ b/pkg/ebpf/c/tracee.h
@@ -62,5 +62,7 @@ statfunc int capture_file_write(struct pt_regs *, u32, bool);
 statfunc bool filter_file_read_capture(program_data_t *, struct file *, io_data_t, off_t);
 statfunc int capture_file_read(struct pt_regs *, u32, bool);
 statfunc struct pipe_buffer *get_last_write_pipe_buffer(struct pipe_inode_info *);
+statfunc int
+submit_access_remote_vm(program_data_t *, struct vm_area_struct *, void *, unsigned int);
 
 #endif

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -136,7 +136,7 @@ enum signal_event_id_e
 };
 
 typedef struct args {
-    unsigned long args[6];
+    unsigned long args[7];
 } args_t;
 
 enum argument_type_e

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -123,6 +123,7 @@ enum event_id_e
     HIDDEN_KERNEL_MODULE_SEEKER,
     MODULE_LOAD,
     MODULE_FREE,
+    ACCESS_REMOTE_VM,
     MAX_EVENT_ID,
 };
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -283,10 +283,27 @@ typedef struct {
 struct signal_struct {
     atomic_t live;
 };
+typedef unsigned long vm_flags_t;
+
+struct vm_special_mapping {
+    const char *name;
+};
 
 struct vm_area_struct {
-    long unsigned int vm_flags;
+    union {
+        struct {
+            unsigned long vm_start;
+            unsigned long vm_end;
+        };
+    };
+    struct mm_struct *vm_mm;
+    union {
+        const vm_flags_t vm_flags;
+        vm_flags_t __vm_flags;
+    };
     struct file *vm_file;
+    void *vm_private_data;
+    const struct vm_operations_struct *vm_ops;
 };
 
 typedef unsigned int __kernel_gid32_t;
@@ -638,9 +655,13 @@ struct mm_struct {
     struct {
         long unsigned int arg_start;
         long unsigned int arg_end;
+        long unsigned int start_brk;
+        long unsigned int brk;
+        long unsigned int start_stack;
         long unsigned int env_start;
         long unsigned int env_end;
     };
+    struct task_struct *owner;
 };
 
 struct vfsmount {
@@ -1228,6 +1249,9 @@ struct icmp6hdr {
         struct icmpv6_nd_advt u_nd_advt;
         struct icmpv6_nd_ra u_nd_ra;
     } icmp6_dataun;
+};
+
+struct bpf_iter_seq_array_map_info {
 };
 
 #pragma clang attribute pop

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -215,6 +215,9 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		SignalSchedProcessFork:     NewTraceProbe(RawTracepoint, "sched:sched_process_fork", "sched_process_fork_signal"),
 		SignalSchedProcessExec:     NewTraceProbe(RawTracepoint, "sched:sched_process_exec", "sched_process_exec_signal"),
 		SignalSchedProcessExit:     NewTraceProbe(RawTracepoint, "sched:sched_process_exit", "sched_process_exit_signal"),
+		GetUserPagesRemote:         NewTraceProbe(KProbe, "get_user_pages_remote", "trace_get_user_pages_remote"),
+		GetUserPagesRemoteRet:      NewTraceProbe(KretProbe, "get_user_pages_remote", "trace_ret_get_user_pages_remote"),
+		GenericAccessPhys:          NewTraceProbe(KProbe, "generic_access_phys", "trace_generic_access_phys"),
 	}
 
 	if !netEnabled {

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -218,6 +218,7 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		GetUserPagesRemote:         NewTraceProbe(KProbe, "get_user_pages_remote", "trace_get_user_pages_remote"),
 		GetUserPagesRemoteRet:      NewTraceProbe(KretProbe, "get_user_pages_remote", "trace_ret_get_user_pages_remote"),
 		GenericAccessPhys:          NewTraceProbe(KProbe, "generic_access_phys", "trace_generic_access_phys"),
+		AccessRemoteVm:             NewTraceProbe(KProbe, "access_remote_vm", "trace_access_remote_vm"),
 	}
 
 	if !netEnabled {

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -132,4 +132,7 @@ const (
 	SignalSchedProcessFork
 	SignalSchedProcessExec
 	SignalSchedProcessExit
+	GetUserPagesRemote
+	GetUserPagesRemoteRet
+	GenericAccessPhys
 )

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -135,4 +135,5 @@ const (
 	GetUserPagesRemote
 	GetUserPagesRemoteRet
 	GenericAccessPhys
+	AccessRemoteVm
 )

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -105,6 +105,7 @@ const (
 	HiddenKernelModuleSeeker
 	ModuleLoad
 	ModuleFree
+	AccessRemoteVm
 	MaxCommonID
 )
 
@@ -11274,6 +11275,33 @@ var CoreEvents = map[ID]Definition{
 			{Type: "u32", Name: "leader_hash"},
 			{Type: "long", Name: "exit_code"},
 			{Type: "bool", Name: "process_group_exit"},
+		},
+	},
+	AccessRemoteVm: {
+		id:      AccessRemoteVm,
+		id32Bit: Sys32Undefined,
+		name:    "access_remote_vm",
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.GetUserPagesRemote, required: true, relevantKernels: []KernelDependency{{version: "6.4", comparison: OlderEquals}}},
+				{handle: probes.GetUserPagesRemoteRet, required: true, relevantKernels: []KernelDependency{{version: "6.4", comparison: OlderEquals}}},
+				{handle: probes.GenericAccessPhys, required: false}, // Exist if CONFIG_HAVE_IOREMAP_PROT
+			},
+			kSymbols: []KSymbol{
+				{symbol: "special_mapping_vmops", required: false},
+				{symbol: "legacy_special_mapping_vmops", required: false},
+			},
+		},
+		sets: []string{},
+		params: []trace.ArgMeta{
+			{Type: "int", Name: "remote_pid"},
+			{Type: "void *", Name: "start_address"},
+			{Type: "unsigned int", Name: "gup_flags"},
+			{Type: "unsigned long", Name: "vm_flags"},
+			{Type: "const char*", Name: "mapped.path"},
+			{Type: "dev_t", Name: "mapped.device_id"},
+			{Type: "unsigned long", Name: "mapped.inode_number"},
+			{Type: "unsigned long", Name: "mapped.ctime"},
 		},
 	},
 	//

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11285,7 +11285,8 @@ var CoreEvents = map[ID]Definition{
 			probes: []Probe{
 				{handle: probes.GetUserPagesRemote, required: true, relevantKernels: []KernelDependency{{version: "6.4", comparison: OlderEquals}}},
 				{handle: probes.GetUserPagesRemoteRet, required: true, relevantKernels: []KernelDependency{{version: "6.4", comparison: OlderEquals}}},
-				{handle: probes.GenericAccessPhys, required: false}, // Exist if CONFIG_HAVE_IOREMAP_PROT
+				{handle: probes.GenericAccessPhys, required: false, relevantKernels: []KernelDependency{{version: "6.4", comparison: OlderEquals}}}, // Exist if CONFIG_HAVE_IOREMAP_PROT
+				{handle: probes.AccessRemoteVm, required: true, relevantKernels: []KernelDependency{{version: "6.4", comparison: Newer}}},
 			},
 			kSymbols: []KSymbol{
 				{symbol: "special_mapping_vmops", required: false},

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -277,6 +277,22 @@ func ParseArgs(event *trace.Event) error {
 				helpersArg.Value = parsedHelpersList
 			}
 		}
+	case AccessRemoteVm:
+		if gupFlagsArg := GetArg(event, "gup_flags"); gupFlagsArg != nil {
+			if gupFlags, isUint := gupFlagsArg.Value.(uint32); isUint {
+				parsedGupFlags, err := helpers.ParseGUPFlagsCurrentOS(uint64(gupFlags))
+				if err != nil {
+					return err
+				}
+				parseOrEmptyString(gupFlagsArg, parsedGupFlags, nil)
+			}
+		}
+		if vmFlagsArg := GetArg(event, "vm_flags"); vmFlagsArg != nil {
+			if vmFlags, isUint64 := vmFlagsArg.Value.(uint64); isUint64 {
+				parsedVmFlags := helpers.ParseVmFlags(vmFlags)
+				parseOrEmptyString(vmFlagsArg, parsedVmFlags, nil)
+			}
+		}
 	}
 
 	return nil

--- a/tests/e2e-inst-signatures/e2e-access_remote_vm.go
+++ b/tests/e2e-inst-signatures/e2e-access_remote_vm.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	helpers2 "github.com/aquasecurity/libbpfgo/helpers"
-
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -14,17 +12,11 @@ import (
 
 type e2eAccessRemoteVm struct {
 	cb                    detect.SignatureHandler
-	osInfo                *helpers2.OSInfo
 	markUnsupportedKernel sync.Once
 }
 
 func (sig *e2eAccessRemoteVm) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	var err error
-	sig.osInfo, err = helpers2.GetOSInfo()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -42,7 +34,6 @@ func (sig *e2eAccessRemoteVm) GetMetadata() (detect.SignatureMetadata, error) {
 func (sig *e2eAccessRemoteVm) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{
 		{Source: "tracee", Name: "access_remote_vm"},
-		{Source: "tracee", Name: "sched_process_exec"},
 	}, nil
 }
 
@@ -53,29 +44,6 @@ func (sig *e2eAccessRemoteVm) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-	case "sched_process_exec":
-		// The event does not support kernel versions 6.5 and newer, so pass the test if run in such
-		// environment.
-		var err error
-		sig.markUnsupportedKernel.Do(
-			func() {
-				comp, err := sig.osInfo.CompareOSBaseKernelRelease("6.4")
-				if err != nil {
-					return
-				}
-				if comp == helpers2.KernelVersionOlder { // > V6.4
-					m, _ := sig.GetMetadata()
-
-					sig.cb(&detect.Finding{
-						SigMetadata: m,
-						Event:       event,
-					})
-				}
-			})
-		if err != nil {
-			return err
-		}
-
 	case "access_remote_vm":
 		remotePid, err := helpers.GetTraceeIntArgumentByName(eventObj, "remote_pid")
 		if err != nil {

--- a/tests/e2e-inst-signatures/e2e-access_remote_vm.go
+++ b/tests/e2e-inst-signatures/e2e-access_remote_vm.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	helpers2 "github.com/aquasecurity/libbpfgo/helpers"
+
+	"github.com/aquasecurity/tracee/signatures/helpers"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type e2eAccessRemoteVm struct {
+	cb                    detect.SignatureHandler
+	osInfo                *helpers2.OSInfo
+	markUnsupportedKernel sync.Once
+}
+
+func (sig *e2eAccessRemoteVm) Init(ctx detect.SignatureContext) error {
+	sig.cb = ctx.Callback
+	var err error
+	sig.osInfo, err = helpers2.GetOSInfo()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sig *e2eAccessRemoteVm) GetMetadata() (detect.SignatureMetadata, error) {
+	return detect.SignatureMetadata{
+		ID:          "ACCESS_REMOTE_VM",
+		EventName:   "ACCESS_REMOTE_VM",
+		Version:     "0.1.0",
+		Name:        "Access Remote VM Test",
+		Description: "Instrumentation events E2E Tests: Access Remote VM",
+		Tags:        []string{"e2e", "instrumentation"},
+	}, nil
+}
+
+func (sig *e2eAccessRemoteVm) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
+	return []detect.SignatureEventSelector{
+		{Source: "tracee", Name: "access_remote_vm"},
+		{Source: "tracee", Name: "sched_process_exec"},
+	}, nil
+}
+
+func (sig *e2eAccessRemoteVm) OnEvent(event protocol.Event) error {
+	eventObj, ok := event.Payload.(trace.Event)
+	if !ok {
+		return fmt.Errorf("failed to cast event's payload")
+	}
+
+	switch eventObj.EventName {
+	case "sched_process_exec":
+		// The event does not support kernel versions 6.5 and newer, so pass the test if run in such
+		// environment.
+		var err error
+		sig.markUnsupportedKernel.Do(
+			func() {
+				comp, err := sig.osInfo.CompareOSBaseKernelRelease("6.4")
+				if err != nil {
+					return
+				}
+				if comp == helpers2.KernelVersionOlder { // > V6.4
+					m, _ := sig.GetMetadata()
+
+					sig.cb(&detect.Finding{
+						SigMetadata: m,
+						Event:       event,
+					})
+				}
+			})
+		if err != nil {
+			return err
+		}
+
+	case "access_remote_vm":
+		remotePid, err := helpers.GetTraceeIntArgumentByName(eventObj, "remote_pid")
+		if err != nil {
+			return err
+		}
+
+		vmName, err := helpers.GetTraceeStringArgumentByName(eventObj, "mapped.path")
+		if err != nil {
+			return err
+		}
+
+		// check expected values from test for detection
+
+		if remotePid != eventObj.HostParentProcessID || vmName != "[stack]" {
+			return nil
+		}
+
+		m, _ := sig.GetMetadata()
+
+		sig.cb(&detect.Finding{
+			SigMetadata: m,
+			Event:       event,
+		})
+	}
+
+	return nil
+}
+
+func (sig *e2eAccessRemoteVm) OnSignal(s detect.Signal) error {
+	return nil
+}
+
+func (sig *e2eAccessRemoteVm) Close() {}

--- a/tests/e2e-inst-signatures/export.go
+++ b/tests/e2e-inst-signatures/export.go
@@ -17,6 +17,7 @@ var ExportedSignatures = []detect.Signature{
 	&e2eSignatureDerivation{},
 	&e2eDnsDataSource{},
 	&e2eWritableDatasourceSig{},
+	&e2eAccessRemoteVm{},
 }
 
 var ExportedDataSources = []detect.DataSource{

--- a/tests/e2e-inst-signatures/scripts/access_remote_vm.sh
+++ b/tests/e2e-inst-signatures/scripts/access_remote_vm.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+info_exit() {
+    echo -n "INFO: "
+    echo "$@"
+    exit 0
+}
+
+info() {
+    echo -n "INFO: "
+    echo "$@"
+}
+
+error_exit() {
+    echo -n "ERROR: "
+    echo "$@"
+    exit 1
+}
+
+this=$$
+info "Current process: $this"
+
+# Get the stack address from /proc/self/maps
+stack_address="0x"$(grep 'stack' /proc/$this/maps | awk '{split($1, range, "-"); print range[1]}')
+
+if [ -z "$stack_address" ]; then
+  error_exit "Failed to find the stack address in /proc/self/maps"
+fi
+
+info "Stack address: $stack_address"
+
+# Read from /proc/self/mem in given address
+read_mem_file() {
+  tail /proc/$this/mem -c +"$1" > /dev/null
+}
+
+# Call the function to read from the stack
+read_mem_file $((stack_address))

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -13,7 +13,7 @@ SCRIPT_TMP_DIR=/tmp
 TRACEE_TMP_DIR=/tmp/tracee
 
 # Default test to run if no other is given
-TESTS=${INSTTESTS:=VFS_WRITE}
+TESTS=${INSTTESTS:=ACCESS_REMOTE_VM}
 
 info_exit() {
     echo -n "INFO: "

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -137,7 +137,7 @@ for TEST in $TESTS; do
         --output option:parse-arguments \
         --log file:$SCRIPT_TMP_DIR/tracee-log-$$ \
         --signatures-dir "$SIG_DIR" \
-        --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer \
+        --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,tail \
         --dnscache enable \
         --grpc-listen-addr unix:/tmp/tracee.sock \
         --events "$TEST" &

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -140,7 +140,8 @@ for TEST in $TESTS; do
         --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,tail \
         --dnscache enable \
         --grpc-listen-addr unix:/tmp/tracee.sock \
-        --events "$TEST" &
+        --events "$TEST" \
+        --events access_remote_vm,security_file_open &
 
     # Wait tracee to start
 


### PR DESCRIPTION
### 1. Explain what the PR does

An event for accessing the memory of a process externally (can be the same process) by the mem file of the process in procfs.

789bd6940 **test(events): add e2e test to access_remote_vm**
fd6e01ad3 **feat(events): create access_remote_vm event**
0854a889e **feat(ebpf): support 7 arguments saving for kretprobe**
491ba0491 **feat(events): add probe relevance attribute**

Fix #3518 

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
