### PR TITLE
fix: cap_capable should parse arguments

### DIFF
--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -70,12 +70,11 @@ func ParseArgs(event *trace.Event) error {
 				}
 			}
 		}
-		if ID(event.EventID) == CapCapable {
-			if capArg := GetArg(event, "cap"); capArg != nil {
-				if capability, isInt32 := capArg.Value.(int32); isInt32 {
-					capabilityFlagArgument, err := helpers.ParseCapability(uint64(capability))
-					parseOrEmptyString(capArg, capabilityFlagArgument, err)
-				}
+	case CapCapable:
+		if capArg := GetArg(event, "cap"); capArg != nil {
+			if capability, isInt32 := capArg.Value.(int32); isInt32 {
+				capabilityFlagArgument, err := helpers.ParseCapability(uint64(capability))
+				parseOrEmptyString(capArg, capabilityFlagArgument, err)
 			}
 		}
 	case SecurityMmapFile, DoMmap:


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

When choosing output option parse-arguments, cap_capable event didn't show the capability string.
This PR fixes it.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
