### PR TITLE
proctree + datasource fixes and adjustments

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -382,13 +382,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	// Initialize Process Tree (if enabled)
 
 	if t.config.ProcTree.Source != proctree.SourceNone {
-		err = capabilities.GetInstance().Specific(
-			func() error {
-				t.processTree, err = proctree.NewProcessTree(ctx, t.config.ProcTree)
-				return err
-			},
-			cap.DAC_READ_SEARCH,
-		)
+		t.processTree, err = proctree.NewProcessTree(ctx, t.config.ProcTree)
 		if err != nil {
 			return errfmt.WrapError(err)
 		}

--- a/pkg/proctree/datasource.go
+++ b/pkg/proctree/datasource.go
@@ -118,7 +118,7 @@ func (ptds *DataSource) exportProcessInfo(
 		}
 		threadInfo := thread.GetInfo()
 		if threadInfo.IsAliveAt(queryTime) {
-			aliveThreads[threadInfo.GetPid()] = threadHash
+			aliveThreads[threadInfo.GetTid()] = threadHash
 		}
 	}
 

--- a/pkg/proctree/datasource.go
+++ b/pkg/proctree/datasource.go
@@ -9,7 +9,6 @@ import (
 )
 
 // DataSource is an implementation to detect.Datasource interface, enveloping the ProcessTree type.
-// It exposes all the relevant information of the tree using the interface methods.
 type DataSource struct {
 	procTree *ProcessTree
 }
@@ -18,6 +17,45 @@ func NewDataSource(processTree *ProcessTree) *DataSource {
 	return &DataSource{procTree: processTree}
 }
 
+// Keys returns a list of supported keys by the DataSource.
+func (ptds *DataSource) Keys() []string {
+	return []string{"datasource.ProcKey", "datasource.ThreadKey", "datasource.LineageKey"}
+}
+
+// Schema returns the schema of the DataSource.
+func (ptds *DataSource) Schema() string {
+	schemaMap := map[string]string{
+		"process_info":    "datasource.ProcessInfo",
+		"thread_info":     "datasource.ThreadInfo",
+		"process_lineage": "datasource.ProcessLineage",
+	}
+	schema, _ := json.Marshal(schemaMap)
+	return string(schema)
+}
+
+// Version returns the version of the DataSource.
+func (ptds *DataSource) Version() uint {
+	return 1 // TODO: Change to semantic versioning
+}
+
+// Namespace returns the namespace of the DataSource.
+func (ptds *DataSource) Namespace() string {
+	return "tracee"
+}
+
+// ID returns the ID of the DataSource.
+func (ptds *DataSource) ID() string {
+	return "process_tree"
+}
+
+// Get retrieves information from DataSource based on the provided key.
+// It supports keys of the following types:
+//
+// - datasource.ProcKey (for process information retrieval)
+// - datasource.ThreadKey (for thread information retrieval)
+// - datasource.LineageKey (for process lineage information retrieval)
+//
+// and returns an error if the data isn't found.
 func (ptds *DataSource) Get(key interface{}) (map[string]interface{}, error) {
 	switch typedKey := key.(type) {
 	case datasource.ProcKey:
@@ -44,49 +82,22 @@ func (ptds *DataSource) Get(key interface{}) (map[string]interface{}, error) {
 		return map[string]interface{}{
 			"process_lineage": ptds.exportProcessLineage(process, typedKey.Time, typedKey.MaxDepth),
 		}, nil
-	default:
-		return nil, detect.ErrKeyNotSupported
 	}
+	return nil, detect.ErrKeyNotSupported
 }
 
-func (ptds *DataSource) Keys() []string {
-	return []string{"datasource.ProcKey", "datasource.ThreadKey", "datasource.LineageKey"}
-}
-
-func (ptds *DataSource) Schema() string {
-	schemaMap := map[string]string{
-		"process_info":    "datasource.ProcessInfo",
-		"thread_info":     "datasource.ThreadInfo",
-		"process_lineage": "datasource.ProcessLineage",
-	}
-	schema, _ := json.Marshal(schemaMap)
-	return string(schema)
-}
-
-func (ptds *DataSource) Version() uint {
-	return 1 // TODO: Change to semantic versioning
-}
-
-func (ptds *DataSource) Namespace() string {
-	return "tracee"
-}
-
-func (ptds *DataSource) ID() string {
-	return "process_tree"
-}
-
-// exportProcessInfo return a representation of the given Process information relevant to given time
-// as the expected datasource process structure.
+// exportProcessInfo returns information of the given Process at the given query time.
 func (ptds *DataSource) exportProcessInfo(
-	process *Process,
-	queryTime time.Time,
+	process *Process, queryTime time.Time,
 ) datasource.ProcessInfo {
+	// Pick the objects related to the process from the process tree.
 	info := process.GetInfo()
 	executable := process.GetExecutable()
 	interpreter := process.GetInterpreter()
 	interp := process.GetInterp()
 
-	existingChildren := make(map[int]uint32)
+	// Walk children hashes and discover the ones alive at the query time.
+	aliveChildren := make(map[int]uint32)
 	for _, childHash := range process.GetChildren() {
 		child, ok := ptds.procTree.GetProcessByHash(childHash)
 		if !ok {
@@ -94,11 +105,12 @@ func (ptds *DataSource) exportProcessInfo(
 		}
 		childInfo := child.GetInfo()
 		if childInfo.IsAliveAt(queryTime) {
-			existingChildren[childInfo.GetPid()] = childHash
+			aliveChildren[childInfo.GetPid()] = childHash
 		}
 	}
 
-	existingThreads := make(map[int]uint32)
+	// Walk thread hashes and discover the ones alive at the query time.
+	aliveThreads := make(map[int]uint32)
 	for _, threadHash := range process.GetThreads() {
 		thread, ok := ptds.procTree.GetThreadByHash(threadHash)
 		if !ok {
@@ -106,12 +118,14 @@ func (ptds *DataSource) exportProcessInfo(
 		}
 		threadInfo := thread.GetInfo()
 		if threadInfo.IsAliveAt(queryTime) {
-			existingThreads[threadInfo.GetPid()] = threadHash
+			aliveThreads[threadInfo.GetPid()] = threadHash
 		}
 	}
 
+	// Pick the process information from the process tree.
 	infoFeed := info.GetFeedAt(queryTime)
 
+	// Export the information as the expected datasource process structure.
 	return datasource.ProcessInfo{
 		EntityId:          process.GetHash(),
 		Pid:               infoFeed.Pid,
@@ -126,20 +140,21 @@ func (ptds *DataSource) exportProcessInfo(
 		ExecTime:          time.Unix(0, 0), // TODO: Add
 		ExitTime:          info.GetExitTime(),
 		ParentEntityId:    process.GetParentHash(),
-		ThreadsIds:        existingThreads,
-		ChildProcessesIds: existingChildren,
+		ThreadsIds:        aliveThreads,
+		ChildProcessesIds: aliveChildren,
 		IsAlive:           info.IsAliveAt(queryTime),
 	}
 }
 
-// exportThreadInfo return a representation of the given Thread information relevant to given time
-// as the expected datasource thread structure.
+// exportThreadInfo returns information of the given Thread at the given query time.
 func (ptds *DataSource) exportThreadInfo(
-	thread *Thread,
-	queryTime time.Time,
+	thread *Thread, queryTime time.Time,
 ) datasource.ThreadInfo {
+	// Pick the objects related to the thread from the process tree.
 	info := thread.GetInfo()
 	infoFeed := info.GetFeedAt(queryTime)
+
+	// Export the information as the expected datasource thread structure.
 	return datasource.ThreadInfo{
 		EntityId:  thread.GetHash(),
 		Tid:       infoFeed.Tid,
@@ -154,39 +169,51 @@ func (ptds *DataSource) exportThreadInfo(
 	}
 }
 
-// exportProcessLineage return a representation of the given Process information and up to a given
-// depth of its ancestors as the expected datasource process lineage structure.
-// The information of each struct is relevant to the fork time of its dependent from it.
+// exportProcessLineage returns the lineage of the given Process at the given query time. Lineage is
+// a slice of process information, starting from the given process and going up to the max depth.
 func (ptds *DataSource) exportProcessLineage(
-	process *Process,
-	queryTime time.Time,
-	maxDepth int,
+	process *Process, queryTime time.Time, maxDepth int,
 ) datasource.ProcessLineage {
-	lineage := datasource.ProcessLineage{
-		ptds.exportProcessInfo(process, queryTime),
-	}
-	currentProcess := process
 	var found bool
-	var iterationQueryTime time.Time
+	var start time.Time
+	var lineage datasource.ProcessLineage
+
+	// Pick the process information from the process tree and add it to the lineage.
+	lineage = append(lineage, ptds.exportProcessInfo(process, queryTime))
+
+	// Walk the process tree up (parents) to the max depth.
+
+	current := process
 	for depth := 0; depth < maxDepth; depth++ {
-		// We don't want to get parents processes which are not part of the container.
-		if currentProcess.GetInfo().GetNsPid() == 1 {
+		// If the current process is "init" stop the walk.
+		if current.GetInfo().GetNsPid() == 1 {
 			break
 		}
-		iterationQueryTime = currentProcess.GetInfo().GetStartTime()
-		currentProcess, found = ptds.procTree.GetProcessByHash(currentProcess.GetParentHash())
+
+		// Save the start time of the current process. The parent information
+		// will be obtained at this time, the time the current process was
+		// created, and not the query time.
+		start = current.GetInfo().GetStartTime()
+
+		// Get the parent process.
+		current, found = ptds.procTree.GetProcessByHash(current.GetParentHash())
 		if !found {
 			break
 		}
-		lineage = append(lineage, ptds.exportProcessInfo(currentProcess, iterationQueryTime))
+
+		// Add the parent process to the lineage.
+		lineage = append(lineage, ptds.exportProcessInfo(current, start))
 	}
+
 	return lineage
 }
 
-// exportFileInfo return a representation of the given FileInfo information relevant to given time
-// as the expected datasource file info structure.
+// exportFileInfo returns information of the given FileInfo at the given query time.
 func exportFileInfo(fileInfo *FileInfo, queryTime time.Time) datasource.FileInfo {
+	// Pick the objects related to the file from the process tree.
 	fileInfoFeed := fileInfo.GetFeedAt(queryTime)
+
+	// Export the information as the expected datasource file structure.
 	return datasource.FileInfo{
 		Path:   fileInfoFeed.Path,
 		Hash:   "", // TODO: Add

--- a/pkg/proctree/proctree_output.go
+++ b/pkg/proctree/proctree_output.go
@@ -85,9 +85,7 @@ func (pt *ProcessTree) String() string {
 	// Use tablewriter to print the tree in a table
 	newTable := func() *tablewriter.Table {
 		table := tablewriter.NewWriter(buffer)
-		table.SetHeader([]string{"Ppid", "Tid", "Pid", "Date", "Comm", "Children", "Threads"})
-		// uncomment to add "hash" and "start_time" to the table
-		// table.SetHeader([]string{"Ppid", "Tid", "Pid", "StartTime", "Hash", "CMD", "Children", "Threads"})
+		table.SetHeader([]string{"Ppid", "Tid", "Pid", "StartTime", "Hash", "Date", "CMD", "Children", "Threads"})
 		table.SetAutoWrapText(false)
 		table.SetRowLine(false)
 		table.SetAutoFormatHeaders(true)
@@ -124,9 +122,8 @@ func (pt *ProcessTree) String() string {
 		if len(execName) > 25 {
 			execName = execName[:20] + "..."
 		}
-		// uncomment to add "hash" and "start_time" to the table
-		// hashStr := fmt.Sprintf("%v", process.GetHash())
-		// startTime := fmt.Sprintf("%v", process.GetInfo().GetStartTimeNS())
+		hashStr := fmt.Sprintf("%v", process.GetHash())
+		startTime := fmt.Sprintf("%v", process.GetInfo().GetStartTimeNS())
 		tid := stringify(processFeed.Tid)
 		pid := stringify(processFeed.Pid)
 		ppid := stringify(processFeed.PPid)
@@ -136,8 +133,7 @@ func (pt *ProcessTree) String() string {
 		unsortedRows = append(unsortedRows,
 			[]string{
 				ppid, tid, pid,
-				// uncomment to add "hash" and "start_time" to the table
-				// startTime, hashStr,
+				startTime, hashStr,
 				date, execName,
 				getListOfChildrenPids(process),
 				getListOfThreadsTids(process),

--- a/pkg/proctree/proctree_procfs.go
+++ b/pkg/proctree/proctree_procfs.go
@@ -41,7 +41,7 @@ func (pt *ProcessTree) feedFromProcFSLoop() {
 func (pt *ProcessTree) FeedFromProcFSAsync(givenPid int) {
 	if pt.procfsChan == nil {
 		logger.Debugw("starting procfs proctree loop") // will tell if called more than once
-		pt.procfsChan = make(chan int, 100)
+		pt.procfsChan = make(chan int, 1000)
 		pt.feedFromProcFSLoop()
 	}
 	if pt.procfsOnce == nil {
@@ -64,7 +64,7 @@ func (pt *ProcessTree) FeedFromProcFS(givenPid int) error {
 	procDir := "/proc"
 
 	// If a PID is given, only deal with that process
-	if givenPid > 0 {
+	if givenPid != AllPIDs {
 		return dealWithProcFsEntry(pt, givenPid)
 	}
 
@@ -129,31 +129,59 @@ func dealWithProc(pt *ProcessTree, givenPid int) error {
 	if status.GetPid() != status.GetTgid() {
 		return errfmt.Errorf("invalid process") // sanity check (process, not thread)
 	}
-	if stat.StartTime == 0 {
-		return errfmt.Errorf("invalid start time")
+
+	name := status.GetName()
+	pid := status.GetPid()   // status: pid == tid
+	tgid := status.GetTgid() // status: tgid == pid
+	ppid := status.GetPPid()
+	nspid := status.GetNsPid()
+	nstgid := status.GetNsTgid()
+	nsppid := status.GetNsPPid()
+	start := stat.StartTime
+
+	// sanity checks
+	switch givenPid {
+	case 0, 1: // PID 0 and 1 are special
+	default:
+		if name == "" || pid == 0 || tgid == 0 || ppid == 0 {
+			return errfmt.Errorf("invalid process")
+		}
 	}
 
-	// given process (pid) hash
-	startTimeNs := utils.ClockTicksToNsSinceBootTime(stat.StartTime)
-	hash := utils.HashTaskID(uint32(status.GetPid()), startTimeNs)
+	// process hash
+	startTimeNs := utils.ClockTicksToNsSinceBootTime(start)
+	hash := utils.HashTaskID(uint32(pid), startTimeNs)
 
 	// update tree for the given process
 	process := pt.GetOrCreateProcessByHash(hash)
 	procInfo := process.GetInfo()
-	procInfo.SetFeed(
+
+	// check if the process info was already set (proctree might miss ppid and name)
+	switch givenPid {
+	case 0, 1: // PID 0 and 1 are special
+	default:
+		if procInfo.GetName() != "" && procInfo.GetPPid() != 0 {
+			return nil
+		}
+	}
+
+	procInfo.SetFeedAt(
 		TaskInfoFeed{
-			Name:        status.GetName(),
-			Tid:         int(status.GetPid()),    // status: pid == tid
-			Pid:         int(status.GetTgid()),   // status: tgid == pid
-			PPid:        int(status.GetPPid()),   // status: ppid == ppid
-			NsTid:       int(status.GetNsPid()),  // status: nspid == nspid
-			NsPid:       int(status.GetNsTgid()), // status: nstgid == nspid
-			NsPPid:      int(status.GetNsPPid()), // status: nsppid == nsppid
-			Uid:         -1,                      // do not change the parent UID
-			Gid:         -1,                      // do not change the parent GID
+			Name:        name,   // command name (add "procfs+" to debug if needed)
+			Tid:         pid,    // status: pid == tid
+			Pid:         tgid,   // status: tgid == pid
+			PPid:        ppid,   // status: ppid == ppid
+			NsTid:       nspid,  // status: nspid == nspid
+			NsPid:       nstgid, // status: nstgid == nspid
+			NsPPid:      nsppid, // status: nsppid == nsppid
+			Uid:         -1,     // do not change the parent uid
+			Gid:         -1,     // do not change the parent gid
 			StartTimeNS: startTimeNs,
 		},
+		utils.NsSinceBootTimeToTime(uint64(start)), // try to be the first changelog entry
 	)
+
+	// TODO: Update executable with information from /proc/<pid>/exe
 
 	// update given process parent (if exists)
 	parent, err := getProcessByPID(pt, status.GetPPid())
@@ -166,55 +194,74 @@ func dealWithProc(pt *ProcessTree, givenPid int) error {
 }
 
 // dealWithThread deals with a thread from procfs.
-func dealWithThread(pt *ProcessTree, pid int, tid int) error {
-	if pid <= 0 {
+func dealWithThread(pt *ProcessTree, givenPid int, givenTid int) error {
+	if givenPid <= 0 {
 		return errfmt.Errorf("invalid PID")
 	}
-	status, err := proc.NewThreadProcStatus(pid, tid)
+	status, err := proc.NewThreadProcStatus(givenPid, givenTid)
 	if err != nil {
 		return errfmt.Errorf("%v", err)
 	}
-	stat, err := proc.NewThreadProcStat(pid, tid)
+	stat, err := proc.NewThreadProcStat(givenPid, givenTid)
 	if err != nil {
 		return errfmt.Errorf("%v", err)
 	}
 
-	// thread
+	name := status.GetName()
+	pid := status.GetPid()   // status: pid == tid
+	tgid := status.GetTgid() // status: tgid == pid
+	ppid := status.GetPPid()
+	nspid := status.GetNsTgid()
+	nstgid := status.GetNsTgid()
+	nsppid := status.GetNsPPid()
+	start := stat.StartTime
 
-	threadTid := status.GetPid()   // status: pid == tid
-	threadPid := status.GetTgid()  // status: tgid == pid
-	threadPpid := status.GetPPid() // status: ppid == ppid
+	// sanity checks
+	if name == "" || pid == 0 || tgid == 0 || ppid == 0 {
+		return errfmt.Errorf("invalid thread")
+	}
 
-	threadStartTimeNs := utils.ClockTicksToNsSinceBootTime(stat.StartTime)
-	threadHash := utils.HashTaskID(uint32(threadTid), threadStartTimeNs)
-	thread := pt.GetOrCreateThreadByHash(threadHash)
+	// thread hash
+	startTimeNs := utils.ClockTicksToNsSinceBootTime(start)
+	hash := utils.HashTaskID(uint32(pid), startTimeNs)
+
+	// update tree for the given thread
+	thread := pt.GetOrCreateThreadByHash(hash)
 	threadInfo := thread.GetInfo()
-	threadInfo.SetFeed(
+
+	// check if the thread info was already set (proctree might miss ppid and name)
+	if threadInfo.GetName() != "" && threadInfo.GetPPid() != 0 {
+		return nil
+	}
+
+	threadInfo.SetFeedAt(
 		TaskInfoFeed{
-			Tid:         int(status.GetPid()),    // status: pid == tid
-			Pid:         int(status.GetTgid()),   // status: tgid == pid
-			PPid:        int(status.GetPPid()),   // status: ppid == ppid
-			NsTid:       int(status.GetNsPid()),  // status: nspid == nspid
-			NsPid:       int(status.GetNsTgid()), // status: nstgid == nspid
-			NsPPid:      int(status.GetNsPPid()), // status: nsppid == nsppid
-			Uid:         -1,                      // do not change the parent UID
-			Gid:         -1,                      // do not change the parent GID
-			StartTimeNS: threadStartTimeNs,
+			Name:        name,   // command name (add "procfs+" to debug if needed)
+			Tid:         pid,    // status: pid == tid
+			Pid:         tgid,   // status: tgid == pid
+			PPid:        ppid,   // status: ppid == ppid
+			NsTid:       nspid,  // status: nspid == nspid
+			NsPid:       nstgid, // status: nstgid == nspid
+			NsPPid:      nsppid, // status: nsppid == nsppid
+			Uid:         -1,     // do not change the parent uid
+			Gid:         -1,     // do not change the parent gid
+			StartTimeNS: startTimeNs,
 		},
+		utils.NsSinceBootTimeToTime(uint64(start)), // try to be the first changelog entry
 	)
 
 	// thread group leader (leader tid is the same as the thread's pid, so we can find it)
 
-	leader, err := getProcessByPID(pt, threadPid)
+	leader, err := getProcessByPID(pt, tgid)
 	if err == nil {
-		leader.AddThread(threadHash) // threads associated with the leader (not parent)
+		leader.AddThread(hash) // threads associated with the leader (not parent)
 		leaderHash := leader.GetHash()
 		thread.SetLeaderHash(leaderHash) // same
 	}
 
 	// parent (real process, parent of all threads)
 
-	parent, err := getProcessByPID(pt, threadPpid)
+	parent, err := getProcessByPID(pt, ppid)
 	if err == nil {
 		thread.SetParentHash(parent.GetHash()) // all threads have the same parent
 	}

--- a/pkg/proctree/taskinfo.go
+++ b/pkg/proctree/taskinfo.go
@@ -82,22 +82,22 @@ func (ti *TaskInfo) setFeedAt(feed TaskInfoFeed, targetTime time.Time) {
 	if feed.Name != "" {
 		ti.name.Set(feed.Name, targetTime)
 	}
-	if feed.Tid > 0 {
+	if feed.Tid >= 0 {
 		ti.tid = feed.Tid
 	}
-	if feed.Pid > 0 {
+	if feed.Pid >= 0 {
 		ti.pid = feed.Pid
 	}
-	if feed.PPid > 0 {
+	if feed.PPid >= 0 {
 		ti.pPid.Set(feed.PPid, targetTime)
 	}
-	if feed.NsTid > 0 {
+	if feed.NsTid >= 0 {
 		ti.nsTid = feed.NsTid
 	}
-	if feed.NsPid > 0 {
+	if feed.NsPid >= 0 {
 		ti.nsPid = feed.NsPid
 	}
-	if feed.NsPid > 0 {
+	if feed.NsPid >= 0 {
 		ti.nsPPid.Set(feed.NsPid, targetTime)
 	}
 	if feed.Uid >= 0 {


### PR DESCRIPTION
commit 559a649f8 (HEAD -> proctree-datasource-fixes, rafaeldtinoco/proctree-datasource-fixes)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Oct 6 10:31:41 2023

    fix(proctree): fix issues when updating from procfs
    
    - raise channel buffer due to initialization needs (all pids)
    - check if fields from stat and status are valid
    - take care of PIDs 0 and 1 in the right manner
    - only update nodes if they are incomplete in basic fields

commit 72d31d570
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Oct 6 10:28:43 2023

    fix(proctree): remove unused capabilities change
    
    The routing that is in charge of reading procfs is not the same as the
    one being called for initialization. Capabilities were being raised for
    no reason in the initialization.
    
    The loop in charge for reading PIDs from a channel and reading procfs,
    in order to update the process tree, can (or not) have the capabilities
    elevated in a later moment (if/when needed, for example, when
    /proc/pid/exe needs to be read).

commit b407883a4
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Oct 6 10:28:08 2023

    chore(proctree): keep important fields in the table all the time

commit 2e274ee4e
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Oct 6 10:23:48 2023

    fix(proctree): fix proctree feed in many places
    
    - only feed parent if it isn't found or is incomplete
    - only feed leader if it isn't found or is incomplete
    - always create process and thread nodes on exit (due to out-of-order)
    - uid and gid fields should be -1 for no changes

commit 3dc7c9187
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Fri Oct 6 10:22:12 2023

    fix(datasource): thread list is indexed by tid and not pid

commit 628d4269d
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Oct 3 15:23:16 2023

    chore(proctree): documentation and style changes

I'm not adding the test yet because it is not needed for the release. I have to adjust the test in order to add it as a github actions test (it works locally and I used it to provide these fixes, but needs to finish the automation).