### PR TITLE
fix(ebpf): disable PrintSyscallTable as default

### DIFF
--- a/deploy/helm/tracee/templates/tracee-policies.yaml
+++ b/deploy/helm/tracee/templates/tracee-policies.yaml
@@ -45,5 +45,5 @@ data:
         - event: kernel_module_loading
         - event: k8s_cert_theft
         - event: proc_fops_hooking
-        - event: syscall_hooking
+        # - event: syscall_hooking
         - event: dropped_executable

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -47,7 +47,7 @@ data:
         - event: kernel_module_loading
         - event: k8s_cert_theft
         - event: proc_fops_hooking
-        - event: syscall_hooking
+        # - event: syscall_hooking
         - event: dropped_executable
 ---
 apiVersion: v1

--- a/docs/docs/events/overview.md
+++ b/docs/docs/events/overview.md
@@ -71,7 +71,7 @@ illegitimate_shell  | [signatures default] |
 kernel_module_loading | [signatures default] |
 k8s_cert_theft | [signatures default] |
 proc_fops_hooking | [signatures default] |
-syscall_hooking | [signatures default] |
+syscall_hooking | [signatures] |
 dropped_executable | [signatures default] |
 creat | [default syscalls fs fs_file_ops] |
 chmod | [default syscalls fs fs_file_attr] |

--- a/examples/policies/signature_events.yaml
+++ b/examples/policies/signature_events.yaml
@@ -36,5 +36,5 @@ spec:
     - event: kernel_module_loading  
     - event: k8s_cert_theft 
     - event: proc_fops_hooking      
-    - event: syscall_hooking
+    # - event: syscall_hooking
     - event: dropped_executable

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -157,18 +157,19 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	var policies *policy.Policies
 
 	if len(policyFlags) > 0 {
-		policies, err = createPoliciesFromPolicyFiles(policyFlags)
+		policies, err = createPoliciesFromPolicyFiles(policyFlags, config.EvtsToDisable)
 		if err != nil {
 			return runner, err
 		}
 	} else {
-		policies, err = createPoliciesFromCLIFlags(scopeFlags, eventFlags)
+		policies, err = createPoliciesFromCLIFlags(scopeFlags, eventFlags, config.EvtsToDisable)
 		if err != nil {
 			return runner, err
 		}
 	}
 
 	cfg.Policies = policies
+	cfg.EventsToDisable = config.EvtsToDisable // updated by Policies creation
 
 	// Output command line flags
 	output, err := flags.PrepareOutput(viper.GetStringSlice("output"), true)

--- a/pkg/cmd/cobra/helper.go
+++ b/pkg/cmd/cobra/helper.go
@@ -6,7 +6,10 @@ import (
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
 )
 
-func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, error) {
+func createPoliciesFromPolicyFiles(
+	policyFlags []string,
+	evtsToDisable map[string]struct{},
+) (*policy.Policies, error) {
 	policyFiles, err := v1beta1.PoliciesFromPaths(policyFlags)
 	if err != nil {
 		return nil, err
@@ -17,10 +20,13 @@ func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, erro
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(policyScopeMap, policyEventsMap, evtsToDisable, true)
 }
 
-func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Policies, error) {
+func createPoliciesFromCLIFlags(
+	scopeFlags, eventFlags []string,
+	evtsToDisable map[string]struct{},
+) (*policy.Policies, error) {
 	policyScopeMap, err := flags.PrepareScopeMapFromFlags(scopeFlags)
 	if err != nil {
 		return nil, err
@@ -31,5 +37,5 @@ func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Polici
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(policyScopeMap, policyEventsMap, evtsToDisable, true)
 }

--- a/pkg/cmd/flags/filter.go
+++ b/pkg/cmd/flags/filter.go
@@ -193,7 +193,7 @@ func prepareEventsToTrace(
 	for disableName := range eventsToDisable {
 		disableId, ok := events.Core.GetDefinitionIDByName(disableName)
 		if !ok {
-			logger.Errorw("Event name to be removed for tracing not found", "event", disableName)
+			logger.Debugw("Event name to be removed for tracing not found", "event", disableName)
 		} else {
 			delete(idToName, disableId)
 		}
@@ -211,7 +211,7 @@ func prepareEventsToTrace(
 			for _, reqId := range depIds {
 				if reqId == disableId {
 					delete(idToName, defId)
-					logger.Warnw("Event removed from events to trace", "id", defId, "name", defName, "requires", disableName)
+					logger.Debugw("Event removed from events to trace", "id", defId, "name", defName, "requires", disableName)
 				}
 			}
 		}

--- a/pkg/cmd/flags/filter_test.go
+++ b/pkg/cmd/flags/filter_test.go
@@ -87,7 +87,8 @@ func TestFilter_prepareEventsToTrace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			res, err := prepareEventsToTrace(tc.eventFilter, eventsNameToID)
+			evtsToDisable := map[string]struct{}{}
+			res, err := prepareEventsToTrace(tc.eventFilter, eventsNameToID, evtsToDisable)
 			if tc.expectedErr != nil {
 				assert.Equal(t, err.Error(), tc.expectedErr.Error())
 			} else {

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -325,25 +325,5 @@ func CreatePolicies(
 		}
 	}
 
-	if len(policies.Map()) == 0 {
-		// if nothing was set, let us consider it as a single default policy
-		eventFilter := eventFilter{
-			Equal:    []string{},
-			NotEqual: []string{},
-		}
-
-		var err error
-		newPolicy := policy.NewPolicy()
-		newPolicy.EventsToTrace, err = prepareEventsToTrace(eventFilter, eventsNameToID, evtsToDisable)
-		if err != nil {
-			return nil, err
-		}
-
-		err = policies.Add(newPolicy)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return policies, nil
 }

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -101,7 +101,12 @@ func PrepareFilterMapsFromPolicies(policies []v1beta1.PolicyFile) (PolicyScopeMa
 }
 
 // CreatePolicies creates a Policies object from the scope and events maps.
-func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMap, newBinary bool) (*policy.Policies, error) {
+func CreatePolicies(
+	policyScopeMap PolicyScopeMap,
+	policyEventsMap PolicyEventMap,
+	evtsToDisable map[string]struct{},
+	newBinary bool,
+) (*policy.Policies, error) {
 	eventsNameToID := events.Core.NamesToIDs()
 	// remove internal events since they shouldn't be accessible by users
 	for event, id := range eventsNameToID {
@@ -309,7 +314,7 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 		}
 
 		var err error
-		p.EventsToTrace, err = prepareEventsToTrace(eventFilter, eventsNameToID)
+		p.EventsToTrace, err = prepareEventsToTrace(eventFilter, eventsNameToID, evtsToDisable)
 		if err != nil {
 			return nil, err
 		}
@@ -329,7 +334,7 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 
 		var err error
 		newPolicy := policy.NewPolicy()
-		newPolicy.EventsToTrace, err = prepareEventsToTrace(eventFilter, eventsNameToID)
+		newPolicy.EventsToTrace, err = prepareEventsToTrace(eventFilter, eventsNameToID, evtsToDisable)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -2075,7 +2075,8 @@ func TestCreatePolicies(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			_, err = CreatePolicies(policyScopeMap, policyEventsMap, false)
+			evtsToDisable := map[string]struct{}{}
+			_, err = CreatePolicies(policyScopeMap, policyEventsMap, evtsToDisable, false)
 			if tc.expectPolicyErr != nil {
 				assert.ErrorContains(t, err, tc.expectPolicyErr.Error())
 			} else {

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -119,12 +119,13 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 		return runner, err
 	}
 
-	policies, err := flags.CreatePolicies(policyScopeMap, policyEventsMap, false)
+	policies, err := flags.CreatePolicies(policyScopeMap, policyEventsMap, config.EvtsToDisable, false)
 	if err != nil {
 		return runner, err
 	}
 
 	cfg.Policies = policies
+	cfg.EventsToDisable = config.EvtsToDisable // updated by Policies creation
 
 	broadcast, err := printer.NewBroadcast(output.PrinterConfigs, cmd.GetContainerMode(cfg))
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,8 +14,13 @@ import (
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
 )
 
+// Events to be disabled if not explicitly required in a policy.
+// This map is updated by Policies creation and used further to actually disable the events.
+var EvtsToDisable = map[string]struct{}{}
+
 // Config is a struct containing user defined configuration of tracee
 type Config struct {
+	EventsToDisable    map[string]struct{} // hard-coded events to disable when not required
 	Policies           *policy.Policies
 	Capture            *CaptureConfig
 	Capabilities       *CapabilitiesConfig

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,14 @@ import (
 
 // Events to be disabled if not explicitly required in a policy.
 // This map is updated by Policies creation and used further to actually disable the events.
-var EvtsToDisable = map[string]struct{}{}
+var EvtsToDisable = map[string]struct{}{
+	// Some GKE kernel lacks CONFIG_KALLSYMS_ALL enabled, so to silence the
+	// error of missing kernel symbols, events are being disabled when
+	// syscall_hooking is not required by the user.
+	// This is a workaround until the 'sys_call_table' address can be retrieved
+	// from the kernel in a different way than '/proc/kallsyms'. See #3397.
+	"syscall_hooking": {},
+}
 
 // Config is a struct containing user defined configuration of tracee
 type Config struct {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -276,12 +276,12 @@ func New(cfg config.Config) (*Tracee, error) {
 	for evt := range t.config.EventsToDisable {
 		evtId, ok := events.Core.GetDefinitionIDByName(evt)
 		if !ok {
-			logger.Errorw("Event name to disable was not found", "name", evt)
+			logger.Debugw("Event name to disable was not found", "name", evt)
 			continue
 		}
 
 		delete(t.eventsState, evtId)
-		logger.Warnw("Event disabled", "id", evtId, "name", evt)
+		logger.Debugw("Event disabled", "id", evtId, "name", evt)
 	}
 
 	// Handle all essential events dependencies

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -271,6 +271,19 @@ func New(cfg config.Config) (*Tracee, error) {
 		}
 	}
 
+	// Disable events that were set to be disabled
+
+	for evt := range t.config.EventsToDisable {
+		evtId, ok := events.Core.GetDefinitionIDByName(evt)
+		if !ok {
+			logger.Errorw("Event name to disable was not found", "name", evt)
+			continue
+		}
+
+		delete(t.eventsState, evtId)
+		logger.Warnw("Event disabled", "id", evtId, "name", evt)
+	}
+
 	// Handle all essential events dependencies
 
 	for id, state := range t.eventsState {

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1730,7 +1730,8 @@ func newPolicies(polsFilesID []policyFileWithID) *policy.Policies {
 		panic(err)
 	}
 
-	policies, err := flags.CreatePolicies(policyScopeMap, policyEventMap, true)
+	evtsToDisable := map[string]struct{}{}
+	policies, err := flags.CreatePolicies(policyScopeMap, policyEventMap, evtsToDisable, true)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Close: #3397 

### 1. Explain what the PR does

e91f15a48 **chore: change logger levels to debug**
286dff204 **fix(ebpf): cancel dependencies of the canceled one**
19381ad93 **chore(flags): remove leftover**
ab97d721b **fix: disable syscall_hooking**
2e200fdbd **fix(ebpf): set events to be disabled by default**


286dff204 **fix(ebpf): cancel dependencies of the canceled one**

```
Context: #3495
https://github.com/aquasecurity/tracee/actions/runs/6475371851/job/17582516454#step:5:42
```


19381ad93 **chore(flags): remove leftover**

```
After the changes of #3262, at this stage, policies.Map() length is
always greater than 0.
```


ab97d721b **fix: disable syscall_hooking**

```
This is a temporary fix to silence error messages from GKE kernel.
```


2e200fdbd **fix(ebpf): set events to be disabled by default**

```
EvtsToDisable is a hardcoded map of events (key: string) to be disabled
by default. It allows to turn off events that may be causing unwanted
side effects or can't have their ID predicted (e.g. signature events).

If the user sets such an event on the policy, it will be removed from
the list of disabled events and the event will be enabled as usual.
```


### 2. Explain how to test it

When setting `syscall_hooking`, if the symbol `AAAsys_call_table` is not found we see the error.

```
sudo ./dist/tracee -l debug -l filter:pkg=ebpf -s comm=who -e syscall_hooking
{"L":"ERROR","T":"2023-10-16T09:02:20.154-0300","M":"Event canceled because of missing kernel symbol dependency","missing symbols":["AAAsys_call_table"],"event":"print_syscall_table"}
{"L":"ERROR","T":"2023-10-16T09:02:20.154-0300","M":"Event canceled because it depends on an previously canceled event","event":"hooked_syscalls","dependency":"print_syscall_table"}
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
^C
```

Even with the symbol not found, if `syscall_hooking` is NOT required by the user, we don't receive the error any more, just a debug log concerning the disabling.

```
sudo ./dist/tracee -l debug -l filter:pkg=ebpf -s comm=who                   
{"L":"DEBUG","T":"2023-10-16T09:02:43.476-0300","M":"Event disabled","id":6028,"name":"syscall_hooking","origin":"ebpf:pkg/ebpf/tracee.go:284","calls":"New() < Runner.Run() < glob..func4() < (*Command).execute() < (*Command).ExecuteC() < (*Command).Execute() < Execute() < main()"}
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
^C
```

### 3. Other comments