### PR TITLE
fix(event): make sure parent points to a real process

### DIFF
--- a/pkg/ebpf/c/common/task.h
+++ b/pkg/ebpf/c/common/task.h
@@ -138,6 +138,11 @@ statfunc char *get_task_uts_name(struct task_struct *task)
     return BPF_CORE_READ(uts_ns, name.nodename);
 }
 
+statfunc u32 get_task_pid(struct task_struct *task)
+{
+    return BPF_CORE_READ(task, pid);
+}
+
 statfunc u32 get_task_ppid(struct task_struct *task)
 {
     struct task_struct *parent = BPF_CORE_READ(task, real_parent);


### PR DESCRIPTION
Both, process tree AND the event context should have "parent" pointing to a real task and not a potential thread. Event context still had it pointing to the real parent and not what is being called "up parent".
