### PR TITLE
chore(tests): re-enable 'trace events from pid 1'

### DIFF
--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -566,39 +566,39 @@ func Test_EventFilters(t *testing.T) {
 			useSyscaller: false,
 			test:         ExpectAnyOfEach,
 		},
-		// {
-		// 	name: "pid: trace events from pid 1",
-		// 	policyFiles: []policyFileWithID{
-		// 		{
-		// 			id: 1,
-		// 			policyFile: v1beta1.PolicyFile{
-		// 				Metadata: v1beta1.Metadata{
-		// 					Name: "pid-1",
-		// 				},
-		// 				Spec: v1beta1.PolicySpec{
-		// 					Scope: []string{
-		// 						"pid=1",
-		// 					},
-		// 					DefaultActions: []string{"log"},
-		// 					Rules:          []v1beta1.Rule{},
-		// 				},
-		// 			},
-		// 		},
-		// 	},
-		// 	cmdEvents: []cmdEvents{
-		// 		newCmdEvents(
-		// 			"kill -SIGHUP 1", // reloads the complete daemon configuration
-		// 			1*time.Second,
-		// 			[]trace.Event{
-		// 				expectEvent(anyHost, "init", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
-		// 				expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
-		// 			},
-		// 			[]string{},
-		// 		),
-		// 	},
-		// 	useSyscaller: false,
-		// 	test:         ExpectAnyOfEach,
-		// },
+		{
+			name: "pid: trace events from pid 1",
+			policyFiles: []policyFileWithID{
+				{
+					id: 1,
+					policyFile: v1beta1.PolicyFile{
+						Metadata: v1beta1.Metadata{
+							Name: "pid-1",
+						},
+						Spec: v1beta1.PolicySpec{
+							Scope: []string{
+								"pid=1",
+							},
+							DefaultActions: []string{"log"},
+							Rules:          []v1beta1.Rule{},
+						},
+					},
+				},
+			},
+			cmdEvents: []cmdEvents{
+				newCmdEvents(
+					"kill -SIGHUP 1", // reloads the complete daemon configuration
+					1*time.Second,
+					[]trace.Event{
+						expectEvent(anyHost, "init", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
+						expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
+					},
+					[]string{},
+				),
+			},
+			useSyscaller: false,
+			test:         ExpectAnyOfEach,
+		},
 		{
 			name: "uid: comm: trace uid 0 from ls command",
 			policyFiles: []policyFileWithID{
@@ -1659,9 +1659,7 @@ func Test_EventFilters(t *testing.T) {
 					case <-ctx.Done():
 						return
 					case evt := <-stream.ReceiveEvents():
-						buf.mu.Lock()
-						buf.events = append(buf.events, evt)
-						buf.mu.Unlock()
+						buf.addEvent(evt)
 					}
 				}
 			}(ctx)

--- a/tests/integration/syscaller/cmd/syscall_test.go
+++ b/tests/integration/syscaller/cmd/syscall_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"syscall"
@@ -10,13 +11,24 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/tests/testutils"
 )
 
-// Test_callsys tests the callsys function
-func Test_callsys(t *testing.T) {
-	t.Parallel()
+var newComm = "test-comm"
 
+func init() {
+	runtime.GOMAXPROCS(1) // force tests to run in a single thread
+
+	// This is to make sure that all threads will have the comm changed to the
+	// expected value. It's indeed a hack, but it's the best that can be done to
+	// have an unit test for changeOwnComm.
+	err := changeOwnComm(newComm)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to change comm: %v", err))
+	}
+}
+
+// Test_callsys tests the callsys function.
+func Test_callsys(t *testing.T) {
 	// SYS_READ and SYS_CLOSE are syscalls that, considering this environment,
 	// should not return an error when called with zeroed arguments
 	syscalls := []events.ID{events.Read, events.Close}
@@ -29,37 +41,18 @@ func Test_callsys(t *testing.T) {
 	// should return an error when called with zeroed arguments
 	syscalls = []events.ID{events.Write}
 	err := callsys(syscalls)[0]
-	assert.Equal(t, syscall.Errno(9), err)
+	assert.Equal(t, syscall.EBADF, err)
 }
 
-// Test_changeOwnComm tests the changeOwnComm function
+// Test_changeOwnComm tests the changeOwnComm function results.
+// changeOwnComm is run in init() so all tests will run with the comm changed.
 func Test_changeOwnComm(t *testing.T) {
-	t.Parallel()
-
-	testutils.PinProccessToCPU()
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	pid, _, _ := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
-	if pid == 0 { // child
-		newComm := "test-comm"
-		// test changing the comm to a valid string
-		err := changeOwnComm(newComm)
-		require.NoError(t, err, "Unexpected error")
+	curComm, err := os.ReadFile("/proc/self/comm")
+	require.NoError(t, err, "Failed to read comm")
 
-		// double check that the comm was changed
-		curComm, err := os.ReadFile("/proc/self/comm")
-		require.NoError(t, err, "Readfile failed")
-
-		curComm = curComm[:len(curComm)-1] // remove the trailing newline
-		assert.Equal(t, newComm, string(curComm), "comm was not changed")
-
-		syscall.Exit(0)
-	}
-
-	// parent
-	assert.NotEqual(t, -1, pid, "Fork failed")
-
-	_, err := syscall.Wait4(int(pid), nil, 0, nil)
-	assert.NoError(t, err, "Wait4 failed")
+	curComm = curComm[:len(curComm)-1] // remove the trailing newline
+	assert.Equal(t, newComm, string(curComm), "Comm was not changed to the expected value")
 }


### PR DESCRIPTION
Close: #3440 

### 1. Explain what the PR does

538e6be62 **chore(tests): re-enable 'trace events from pid 1'**

```
This re-enables 'pid 1 trace events' since it was unable to be
reproduced. If it happens again, hopefully with the use of a shuffle
seed it can be reproduced.

During analysis, another issue was detected with Test_changeOwnComm. The
raw fork is not safe at all, even with all the precautions taken, which
is why it was removed and the test takes place in the same thread now.
Additional measures were taken to prevent the goroutine from escaping
the OS thread: calling runtime.GOMAXPROCS(1) and changeOwnComm()
from init().

This also removes leftover code (eventOutput, waitForTraceeOutput).
```

### 2. Explain how to test it


### 3. Other comments

