### PR TITLE
fix: fail to parse container-id of TAS (cloud-founry) garden applicat…

### DIFF
--- a/pkg/containers/runtime/runtime.go
+++ b/pkg/containers/runtime/runtime.go
@@ -43,6 +43,7 @@ const (
 	Containerd
 	Crio
 	Podman
+	Garden
 )
 
 var runtimeStringMap = map[RuntimeId]string{
@@ -51,6 +52,7 @@ var runtimeStringMap = map[RuntimeId]string{
 	Containerd: "containerd",
 	Crio:       "crio",
 	Podman:     "podman",
+	Garden:     "garden",
 }
 
 func (runtime RuntimeId) String() string {
@@ -69,6 +71,9 @@ func FromString(str string) RuntimeId {
 		return Podman
 	case "containerd":
 		return Containerd
+	case "garden":
+		return Garden
+
 	default:
 		return Unknown
 	}


### PR DESCRIPTION
…ions

The regex check does not match.
It should match the following patterns:

ca94fb1d-8d1e-42f9-529c-a8af
e660266c-de34-45e9-6102-d881

fix: #3584

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
