### PR TITLE
chore(workflow): add kernel v6.5 to kernel tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -293,6 +293,13 @@ jobs:
           - job_name: "Lunar 6.2"
             architecture: "aarch64"
             runner: "github-self-hosted_ami-0c0d64eea6367efd8_${{ github.event.number }}-${{ github.run_id }}_arm64c"
+          # MANTIC 6.5
+          - job_name: "Mantic 6.5"
+            architecture: "x86_64"
+            runner: "github-self-hosted_ami-0564e75d9605addaf_${{ github.event.number }}-${{ github.run_id }}_x64c"
+          - job_name: "Mantic 6.5"
+            architecture: "aarch64"
+            runner: "github-self-hosted_ami-028acebc5083c4840_${{ github.event.number }}-${{ github.run_id }}_arm64c"
     env:
       HOME: "/tmp/root"
       GOPATH: "/tmp/go"

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -4300,8 +4300,13 @@ int BPF_KPROBE(trace_security_file_permission)
     if (fops == NULL)
         return 0;
 
+    unsigned long iterate_addr = 0;
     unsigned long iterate_shared_addr = (unsigned long) BPF_CORE_READ(fops, iterate_shared);
-    unsigned long iterate_addr = (unsigned long) BPF_CORE_READ(fops, iterate);
+
+    // iterate() removed by commit 3e3271549670 at v6.5-rc4
+    if (bpf_core_field_exists(fops->iterate))
+        iterate_addr = (unsigned long) BPF_CORE_READ(fops, iterate);
+
     if (iterate_addr == 0 && iterate_shared_addr == 0)
         return 0;
 


### PR DESCRIPTION
commit 22374afc8 (HEAD -> add-mantic-to-workflow, rafaeldtinoco/add-mantic-t>
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Thu Oct 19 14:44:09 2023

    fix(events): fix hooked_proc_fops evt in v6.5+
    
    Fixes: #3573
    
    Reported-by: Jeff Wooldridge (provided patch suggestion)
    Signed-off-by: Rafael David Tinoco <rafaeldtinoco@gmail.com>

commit 2eb2bf1d5
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Thu Oct 19 11:27:50 2023

    chore(workflow): add kernel v6.5 to kernel tests