### PR TITLE
fix(containers): parse cont id of cloud-foundry garden apps

### DIFF
--- a/pkg/containers/runtime/runtime.go
+++ b/pkg/containers/runtime/runtime.go
@@ -43,6 +43,7 @@ const (
 	Containerd
 	Crio
 	Podman
+	Garden
 )
 
 var runtimeStringMap = map[RuntimeId]string{
@@ -51,6 +52,7 @@ var runtimeStringMap = map[RuntimeId]string{
 	Containerd: "containerd",
 	Crio:       "crio",
 	Podman:     "podman",
+	Garden:     "garden", // there is no enricher (yet ?) for garden
 }
 
 func (runtime RuntimeId) String() string {
@@ -69,6 +71,9 @@ func FromString(str string) RuntimeId {
 		return Podman
 	case "containerd":
 		return Containerd
+	case "garden":
+		return Garden
+
 	default:
 		return Unknown
 	}


### PR DESCRIPTION
The regex should match the following patterns:

ca94fb1d-8d1e-42f9-529c-a8af
e660266c-de34-45e9-6102-d881

Fixes: #3584