### PR TITLE
chore(events): rename syscall hooking arguments

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -10381,10 +10381,10 @@ var CoreEvents = map[ID]Definition{
 		},
 		sets: []string{},
 		params: []trace.ArgMeta{
-			{Type: "const char*", Name: "syscall_name"},
-			{Type: "const char*", Name: "hooked.address"},
-			{Type: "const char*", Name: "hooked.function_name"},
-			{Type: "const char*", Name: "hooked.owner"},
+			{Type: "const char*", Name: "syscall"},
+			{Type: "const char*", Name: "address"},
+			{Type: "const char*", Name: "function"},
+			{Type: "const char*", Name: "owner"},
 		},
 	},
 	DebugfsCreateDir: {


### PR DESCRIPTION
After merging the syscall hooking changes, the E2E signature needs fixing (which Im providing) and then I realized the argument names contained "." (which isn't something used in any other event so far). I changed the names and I'm providing fixes to the e2e tests (with signature and signature test changes as well).