### PR TITLE
fix(event): fix hooked_syscall privilege in older kernels

### DIFF
--- a/pkg/ebpf/hooked_syscall_table.go
+++ b/pkg/ebpf/hooked_syscall_table.go
@@ -9,6 +9,7 @@ import (
 
 	bpf "github.com/aquasecurity/libbpfgo"
 
+	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/derive"
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -44,7 +45,12 @@ func (t *Tracee) hookedSyscallTableRoutine(ctx gocontext.Context) {
 		return
 	}
 
-	if err := t.populateExpectedSyscallTableArray(expectedSyscallTableMap); err != nil {
+	err = capabilities.GetInstance().EBPF(
+		func() error {
+			return t.populateExpectedSyscallTableArray(expectedSyscallTableMap)
+		},
+	)
+	if err != nil {
 		logger.Errorw("Error populating expected syscall table array: " + err.Error())
 		return
 	}


### PR DESCRIPTION
Fixes: #3595
