### PR TITLE
fix: enrichment for kind and minikube

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -43,6 +43,10 @@ spec:
           env:
             - name: LIBBPFGO_OSRELEASE_FILE
               value: /etc/os-release-host
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.config.healthz }}

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -108,6 +108,10 @@ spec:
         env:
           - name: LIBBPFGO_OSRELEASE_FILE
             value: /etc/os-release-host
+          - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
         readinessProbe:
           httpGet:
             path: /healthz

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/cgroup"
 	cruntime "github.com/aquasecurity/tracee/pkg/containers/runtime"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/k8s"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -210,7 +211,8 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 		return metadata, errfmt.Errorf("no containerId")
 	}
 
-	if info.Dead {
+	isMikubeOrKind := k8s.IsMinkube() || k8s.IsKind()
+	if info.Dead && !isMikubeOrKind {
 		return metadata, errfmt.Errorf("container already deleted")
 	}
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -1,0 +1,14 @@
+package k8s
+
+import (
+	"os"
+	"strings"
+)
+
+func IsMinkube() bool {
+	return strings.HasPrefix(os.Getenv("NODE_NAME"), "minikube")
+}
+
+func IsKind() bool {
+	return strings.HasPrefix(os.Getenv("NODE_NAME"), "kind")
+}


### PR DESCRIPTION
fix https://github.com/aquasecurity/tracee/issues/3593

The PR https://github.com/aquasecurity/tracee/pull/3325 introduced an optimization to avoid querying CRI on short live cgroups, this works well for all bigger gke platforms I tested (aws, azure, gke, digital ocean), but it doesn't work for minikube/kind, because the cgroup path is not accessible to a container https://github.com/aquasecurity/tracee/blob/main/pkg/containers/containers.go#L365-L374

As this is a special case for development tools only, I did a hack to not validate this whenever it is running on minikube or kind, so enrichment works. 

The PR uses the downward API to know the name of the node, if the name of the node is either minikube or kind it ignores the cgroup dead valiation. 