### PR TITLE
Handle structured config file

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -98,8 +98,8 @@ func main() {
 				Usage:   "process tree options. run '--proctree help' for more info.",
 			},
 			&cli.StringSliceFlag{
-				Name:  "crs",
-				Usage: "define connected container runtimes. run '--crs help' for more info.",
+				Name:  "cri",
+				Usage: "define connected container runtimes. run '--cri help' for more info.",
 				Value: cli.NewStringSlice(),
 			},
 			&cli.IntFlag{

--- a/cmd/tracee/cmd/man.go
+++ b/cmd/tracee/cmd/man.go
@@ -80,11 +80,11 @@ var configCmd = &cobra.Command{
 }
 
 var containersCmd = &cobra.Command{
-	Use:     "crs",
+	Use:     "cri",
 	Aliases: []string{},
 	Short:   "containers flag help",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runManForFlag("crs")
+		return runManForFlag("cri")
 	},
 }
 

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -158,11 +158,11 @@ func initCmd() error {
 	}
 
 	rootCmd.Flags().StringArray(
-		"crs",
+		"cri",
 		[]string{},
 		"<runtime:socket>\t\t\tDefine connected container runtimes",
 	)
-	err = viper.BindPFlag("crs", rootCmd.Flags().Lookup("crs"))
+	err = viper.BindPFlag("cri", rootCmd.Flags().Lookup("cri"))
 	if err != nil {
 		return errfmt.WrapError(err)
 	}

--- a/deploy/helm/tracee/templates/tracee-config.yaml
+++ b/deploy/helm/tracee/templates/tracee-config.yaml
@@ -30,8 +30,8 @@ data:
     capabilities:
       {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.config.crs }}
-    crs:
+    {{- with .Values.config.cri }}
+    cri:
       {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.config.rego }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -71,7 +71,7 @@ config:
   installPath: ""
   signaturesDir: ""
   capabilities: []
-  crs: []
+  cri: []
   rego: []
   cache:
     - cache-type=mem

--- a/docs/docs/config/kubernetes.md
+++ b/docs/docs/config/kubernetes.md
@@ -17,20 +17,22 @@ metadata:
 data:
   config.yaml: |-
     cache:
-      - cache-type=mem
-      - mem-cache-size=512
+        type: mem
+        size: 512
     perf-buffer-size: 1024
-    containers: true
     healthz: false
     metrics: true
     pprof: false
     pyroscope: false
     listen-addr: :3366
     log:
-        - info
+        level: info
     output:
-        - json
-        - option:parse-arguments
+        options:
+            parse-arguments: true
+        json:
+            files:
+                - stdout
 ```
 
 ## Customizing

--- a/docs/docs/config/overview.md
+++ b/docs/docs/config/overview.md
@@ -31,6 +31,15 @@ log:
     - aggregate
 ```
 
+Or in a structured format:
+
+```yaml
+log:
+    level: debug
+    aggregate:
+        enabled: true
+```
+
 ## Reserved Flags
 
 There are a few flags that are reserved for the CLI and cannot be set through the configuration file. These include:
@@ -40,8 +49,9 @@ There are a few flags that are reserved for the CLI and cannot be set through th
 
 To help you get started with configuring Tracee using the `--config` flag, we've provided two example configuration files in the `examples/config` directory of the Tracee repository:
 
-- `examples/config/global_config.json`: This file contains an example configuration in JSON format.
-- `examples/config/global_config.yaml`: This file contains the same example configuration as global_config.json, but in YAML format.
+- `examples/config/global_config.yaml`: This file contains an example configuration in YAML format.
+- `examples/config/global_config_cli.yaml`: This file contains the same example configuration as global_config.yaml, but using cli flags (not structured).
+- `examples/config/global_config.json`: This file contains the same example configuration as global_config_cli.yaml, but in JSON format.
 
 These example files demonstrate how you can set various configuration options using the `--config` flag. You can use these files as a starting point for your own configuration, or as a reference for the available configuration options.
 

--- a/docs/docs/deep-dive/caching-events.md
+++ b/docs/docs/deep-dive/caching-events.md
@@ -44,7 +44,7 @@ sudo ./dist/tracee \
     -o format:json \
     -o option:parse-arguments \
     -trace container \
-    --crs docker:/var/run/docker.sock
+    --cri docker:/var/run/docker.sock
 ```
 
 !!! Attention

--- a/docs/docs/flags/containers.1.md
+++ b/docs/docs/flags/containers.1.md
@@ -1,17 +1,17 @@
 ---
-title: TRACEE-CRS
+title: TRACEE-CRI
 section: 1
-header: Tracee CRS Flag Manual
+header: Tracee CRI Flag Manual
 date: 2023/10
 ...
 
 ## NAME
 
-tracee **\-\-crs** - Select container runtimes to connect to for container events enrichment
+tracee **\-\-cri** - Select container runtimes to connect to for container events enrichment
 
 ## SYNOPSIS
 
-tracee **\-\-crs** <[crio|containerd|docker|podman]:socket\> [**\-\-crs** ...] ...
+tracee **\-\-cri** <[crio|containerd|docker|podman]:socket\> [**\-\-cri** ...] ...
 
 ## DESCRIPTION
 
@@ -22,7 +22,7 @@ By default, if no flag is passed, Tracee will automatically detect installed run
 3. **CRI-O**:      `/var/run/crio/crio.sock`
 4. **Podman**:     `/var/run/podman/podman.sock`
 
-If runtimes are specified using the **\-\-crs** flag, only the ones passed through the flags will be connected to through the provided socket file path.
+If runtimes are specified using the **\-\-cri** flag, only the ones passed through the flags will be connected to through the provided socket file path.
 
 Supported runtimes are:
 
@@ -36,7 +36,7 @@ Supported runtimes are:
 - To connect to CRI-O using the socket file path `/var/run/crio/crio.sock`, use the following flag:
 
   ```console
-  --crs crio:/var/run/crio/crio.sock
+  --cri crio:/var/run/crio/crio.sock
   ```
 
 Please refer to the [documentation](../integrating/container-engines.md) for more information on container events enrichment.

--- a/docs/man/containers.1
+++ b/docs/man/containers.1
@@ -14,16 +14,16 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "TRACEE-CRS" "1" "2023/10" "" "Tracee CRS Flag Manual"
+.TH "TRACEE-CRI" "1" "2023/10" "" "Tracee CRI Flag Manual"
 .hy
 .SS NAME
 .PP
-tracee \f[B]--crs\f[R] - Select container runtimes to connect to for
+tracee \f[B]--cri\f[R] - Select container runtimes to connect to for
 container events enrichment
 .SS SYNOPSIS
 .PP
-tracee \f[B]--crs\f[R] <[crio|containerd|docker|podman]:socket>
-[\f[B]--crs\f[R] \&...]
+tracee \f[B]--cri\f[R] <[crio|containerd|docker|podman]:socket>
+[\f[B]--cri\f[R] \&...]
 \&...
 .SS DESCRIPTION
 .PP
@@ -39,7 +39,7 @@ for the following paths:
 .IP "4." 3
 \f[B]Podman\f[R]: \f[V]/var/run/podman/podman.sock\f[R]
 .PP
-If runtimes are specified using the \f[B]--crs\f[R] flag, only the ones
+If runtimes are specified using the \f[B]--cri\f[R] flag, only the ones
 passed through the flags will be connected to through the provided
 socket file path.
 .PP
@@ -60,7 +60,7 @@ To connect to CRI-O using the socket file path
 .IP
 .nf
 \f[C]
---crs crio:/var/run/crio/crio.sock
+--cri crio:/var/run/crio/crio.sock
 \f[R]
 .fi
 .RE

--- a/examples/config/global_config.json
+++ b/examples/config/global_config.json
@@ -7,7 +7,7 @@
         "none"
     ],
     "capabilities": [],
-    "crs": [],
+    "cri": [],
     "healthz": false,
     "install-path": "/tmp/tracee",
     "listen-addr": ":3366",

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -1,10 +1,37 @@
 blob-perf-buffer-size: 1024
 cache:
-    - none
+    # - none # cache-type={none,mem}
+    - cache-type=none
+    # - mem-cache-size=556
+# cache:
+    # type: mem
+    # size: 256
 proctree:
-    - none
-capabilities: []
-crs: []
+    # - source=events
+    source: events
+    cache:
+        process: 8192
+        thread: 4096
+capabilities:
+    # - bypass=false
+    # - add=cap_kill,cap_syslog
+    bypass: true
+    add:
+        - cap_sys_admin
+        - cap_syslog
+    drop:
+        - cap_chown
+crs:
+    - containerd:/var/run/containerd/containerd.sock
+    - docker:/var/run/docker.sock
+    - runtime:
+        name: containerd
+        socket: /var/run/containerd/containerd.sock
+    - runtime:
+        name: docker
+        socket: /var/run/docker.sock
+
+
 healthz: false
 install-path: /tmp/tracee
 listen-addr: :3366
@@ -13,8 +40,24 @@ log:
 metrics: false
 output:
     - json
+    # - webhook:HTTP://localhost:8080?timeout=5s
+# output-structured:
+#     - webhook:
+#         name: webhook1
+#         host: http://localhost
+#         port: 8000
+#         timeout: 5s
+#     - webhook:
+#         name: webhook2
+#         host: http://localhost
+#         port: 9000
+#         timeout: 5s
 perf-buffer-size: 1024
 pprof: false
 pyroscope: false
-rego: []
+rego:
+    # - partial-eval
+    - aio
+    # partial-eval: true
+    # aio: true
 signatures-dir: ""

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -111,11 +111,15 @@ output:
     #         host: localhost
     #         port: 8000
     #         timeout: 5s
+    #         gotemplate: /path/to/template/test.tmpl
+    #         content-type: application/json
     #     - webhook2:
     #         protocol: http
     #         host: localhost
     #         port: 9000
     #         timeout: 3s
+    #         gotemplate: /path/to/template/test.tmpl
+    #         content-type: application/json
 
     # options:
     #     none: false

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -1,63 +1,135 @@
 blob-perf-buffer-size: 1024
 cache:
-    # - none # cache-type={none,mem}
-    - cache-type=none
-    # - mem-cache-size=556
-# cache:
-    # type: mem
-    # size: 256
-proctree:
-    # - source=events
-    source: events
-    cache:
-        process: 8192
-        thread: 4096
-capabilities:
-    # - bypass=false
-    # - add=cap_kill,cap_syslog
-    bypass: true
-    add:
-        - cap_sys_admin
-        - cap_syslog
-    drop:
-        - cap_chown
-crs:
-    - containerd:/var/run/containerd/containerd.sock
-    - docker:/var/run/docker.sock
-    - runtime:
-        name: containerd
-        socket: /var/run/containerd/containerd.sock
-    - runtime:
-        name: docker
-        socket: /var/run/docker.sock
+    type: none
+    # size: 1024
 
+proctree:
+    source: none
+    # cache:
+    #     process: 8192
+    #     thread: 4096
+
+capabilities:
+    bypass: false
+    # add:
+    #     - cap_sys_admin
+    #     - cap_syslog
+    # drop:
+    #     - cap_chown
+
+crs:
+    # - runtime:
+    #     name: containerd
+    #     socket: /var/run/containerd/containerd.sock
+    # - runtime:
+    #     name: docker
+    #     socket: /var/run/docker.sock
 
 healthz: false
 install-path: /tmp/tracee
 listen-addr: :3366
 log:
-    - info
+    level: info
+    # file: "/path/to/log/file.log"
+    # aggregate:
+    #     enabled: true
+    #     flush-interval: "5s"
+    # filters:
+    #     libbpf: false
+    #     in:
+    #     msg:
+    #         - SampleMessage1
+    #         - SampleMessage2
+    #     pkg:
+    #         - package1
+    #         - package2
+    #     file:
+    #         - file1.go
+    #         - file2.go
+    #     level:
+    #         - warn
+    #         - error
+    #     regex:
+    #         - ^pattern1
+    #         - ^pattern2
+    #     out:
+    #     msg:
+    #         - ExcludedMessage1
+    #     pkg:
+    #         - excludedPackage
+    #     file:
+    #         - excludedFile.go
+    #     level:
+    #         - debug
+    #     regex:
+    #         - ^excludedPattern
+
 metrics: false
 output:
-    - json
-    # - webhook:HTTP://localhost:8080?timeout=5s
-# output-structured:
-#     - webhook:
-#         name: webhook1
-#         host: http://localhost
-#         port: 8000
-#         timeout: 5s
-#     - webhook:
-#         name: webhook2
-#         host: http://localhost
-#         port: 9000
-#         timeout: 5s
+    json:
+        files:
+            - stdout
+
+    # table:
+    #     files:
+    #         - /path/to/table1.out
+    #         - /path/to/table2.out
+
+    # table-verbose:
+    #     files:
+    #         - stdout
+
+    # gob:
+    #     files:
+    #     - /path/to/gob1.out
+
+    # gotemplate:
+    #     template: /path/to/my_template1.tmpl
+    #     files:
+    #         - /path/to/output1.out
+    #         - /path/to/output2.out
+
+    # forward:
+    #     - forward1:
+    #         protocol: tcp
+    #         user: user
+    #         password: pass
+    #         host: 127.0.0.1
+    #         port: 24224
+    #         tag: tracee1
+    #     - forward2:
+    #         protocol: udp
+    #         user: user
+    #         password: pass
+    #         host: 127.0.0.1
+    #         port: 24225
+    #         tag: tracee2
+
+    # webhook:
+    #     - webhook1:
+    #         protocol: http
+    #         host: localhost
+    #         port: 8000
+    #         timeout: 5s
+    #     - webhook2:
+    #         protocol: http
+    #         host: localhost
+    #         port: 9000
+    #         timeout: 3s
+
+    # options:
+    #     none: false
+    #     stack-addresses: true
+    #     exec-env: false
+    #     relative-time: true
+    #     exec-hash: false
+    #     parse-arguments: true
+    #     sort-events: false
+
 perf-buffer-size: 1024
 pprof: false
 pyroscope: false
 rego:
-    # - partial-eval
-    - aio
     # partial-eval: true
     # aio: true
 signatures-dir: ""

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -17,7 +17,7 @@ capabilities:
     # drop:
     #     - cap_chown
 
-crs:
+cri:
     # - runtime:
     #     name: containerd
     #     socket: /var/run/containerd/containerd.sock

--- a/examples/config/global_config_cli.yaml
+++ b/examples/config/global_config_cli.yaml
@@ -5,7 +5,7 @@ proctree:
     - none
 capabilities: []
 containers: false
-crs: []
+cri: []
 healthz: false
 install-path: /tmp/tracee
 listen-addr: :3366

--- a/examples/config/global_config_cli.yaml
+++ b/examples/config/global_config_cli.yaml
@@ -1,0 +1,21 @@
+blob-perf-buffer-size: 1024
+cache:
+    - none
+proctree:
+    - none
+capabilities: []
+containers: false
+crs: []
+healthz: false
+install-path: /tmp/tracee
+listen-addr: :3366
+log:
+    - info
+metrics: false
+output:
+    - json
+perf-buffer-size: 1024
+pprof: false
+pyroscope: false
+rego: []
+signatures-dir: ""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -571,7 +571,7 @@ nav:
                       - output: docs/flags/output.1.md
                       - capture: docs/flags/capture.1.md
                       - config: docs/flags/config.1.md
-                      - crs: docs/flags/containers.1.md
+                      - cri: docs/flags/containers.1.md
                       - rego: docs/flags/rego.1.md
                       - cache: docs/flags/cache.1.md
                       - capabilities: docs/flags/capabilities.1.md

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -96,12 +96,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	// Container Runtime command line flags
 
 	if !cfg.NoContainersEnrich {
-		crsFlags, err := GetFlagsFromViper("crs")
+		criFlags, err := GetFlagsFromViper("cri")
 		if err != nil {
 			return runner, err
 		}
 
-		sockets, err := flags.PrepareContainers(crsFlags)
+		sockets, err := flags.PrepareContainers(criFlags)
 		if err != nil {
 			return runner, err
 		}

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -29,8 +29,14 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	// Log command line flags
 
 	// Logger initialization must be the first thing to be done,
-	// so all other packages can use it
-	logCfg, err := flags.PrepareLogger(viper.GetStringSlice("log"), true)
+	// so all other packages can use
+
+	logFlags, err := GetFlagsFromViper("log")
+	if err != nil {
+		return runner, err
+	}
+
+	logCfg, err := flags.PrepareLogger(logFlags, true)
 	if err != nil {
 		return runner, err
 	}
@@ -38,7 +44,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Rego command line flags
 
-	rego, err := flags.PrepareRego(viper.GetStringSlice("rego"))
+	regoFlags, err := GetFlagsFromViper("rego")
+	if err != nil {
+		return runner, err
+	}
+
+	rego, err := flags.PrepareRego(regoFlags)
 	if err != nil {
 		return runner, err
 	}
@@ -85,7 +96,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	// Container Runtime command line flags
 
 	if !cfg.NoContainersEnrich {
-		sockets, err := flags.PrepareContainers(viper.GetStringSlice("crs"))
+		crsFlags, err := GetFlagsFromViper("crs")
+		if err != nil {
+			return runner, err
+		}
+
+		sockets, err := flags.PrepareContainers(crsFlags)
 		if err != nil {
 			return runner, err
 		}
@@ -94,7 +110,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Cache command line flags
 
-	cache, err := flags.PrepareCache(viper.GetStringSlice("cache"))
+	cacheFlags, err := GetFlagsFromViper("cache")
+	if err != nil {
+		return runner, err
+	}
+
+	cache, err := flags.PrepareCache(cacheFlags)
 	if err != nil {
 		return runner, err
 	}
@@ -105,7 +126,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Process Tree command line flags
 
-	procTree, err := flags.PrepareProcTree(viper.GetStringSlice("proctree"))
+	procTreeFlags, err := GetFlagsFromViper("proctree")
+	if err != nil {
+		return runner, err
+	}
+
+	procTree, err := flags.PrepareProcTree(procTreeFlags)
 	if err != nil {
 		return runner, err
 	}
@@ -126,7 +152,12 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Capabilities command line flags
 
-	capsCfg, err := flags.PrepareCapabilities(viper.GetStringSlice("capabilities"))
+	capFlags, err := GetFlagsFromViper("capabilities")
+	if err != nil {
+		return runner, err
+	}
+
+	capsCfg, err := flags.PrepareCapabilities(capFlags)
 	if err != nil {
 		return runner, err
 	}
@@ -173,7 +204,13 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	cfg.Policies = policies
 
 	// Output command line flags
-	output, err := flags.PrepareOutput(viper.GetStringSlice("output"), true)
+
+	outputFlags, err := GetFlagsFromViper("output")
+	if err != nil {
+		return runner, err
+	}
+
+	output, err := flags.PrepareOutput(outputFlags, true)
 	if err != nil {
 		return runner, err
 	}

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -1,0 +1,475 @@
+package cobra
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+)
+
+type cliFlagger interface {
+	flags() []string
+}
+
+// GetFlagsFromViper returns a slice of flags from a given config key.
+// It relies on the fact that the config key is a viper.Gettable and that the
+// config value complies with the cliFlagger interface (when structured).
+func GetFlagsFromViper(key string) ([]string, error) {
+	var flagger cliFlagger
+	rawValue := viper.Get(key)
+
+	switch key {
+	case "cache":
+		flagger = &CacheConfig{}
+	case "rego":
+		flagger = &RegoConfig{}
+	case "proctree":
+		flagger = &ProcTreeConfig{}
+	case "capabilities":
+		flagger = &CapabilitiesConfig{}
+	case "crs":
+		switch v := rawValue.(type) {
+		case []string: // via cli
+			return getConfigFlags(rawValue, nil, "crs")
+		case []interface{}: // via config file
+			return getCRSConfigFlags(rawValue)
+		default:
+			return nil, errfmt.Errorf("unrecognized type %T for crs", v)
+		}
+	case "log":
+		flagger = &LogConfig{}
+	case "output":
+		flagger = &OutputConfig{}
+	default:
+		return nil, errfmt.Errorf("unrecognized key: %s", key)
+	}
+
+	return getConfigFlags(rawValue, flagger, key)
+}
+
+// getConfigFlags handles the given config key via viper.UnmarshalKey for both
+// structured and raw cli flags.
+func getConfigFlags(rawValue interface{}, flagger cliFlagger, key string) ([]string, error) {
+	switch v := rawValue.(type) {
+	// structured flags
+	case map[string]interface{}:
+		err := viper.UnmarshalKey(key, flagger)
+		if err != nil {
+			return nil, errfmt.WrapError(err)
+		}
+		return flagger.flags(), nil
+
+	// raw cli flags
+	case []interface{}, []string:
+		flags := make([]string, 0)
+		err := viper.UnmarshalKey(key, &flags)
+		if err != nil {
+			return nil, errfmt.WrapError(err)
+		}
+		return flags, nil
+
+	default:
+		return nil, errfmt.Errorf("unrecognized type %T for key %s", v, key)
+	}
+}
+
+// getCRSConfigFlags handles the crs config key, which is a special case.
+// For structured flags, it uses mapstructure to decode the config into a
+// CRSConfig struct. For raw cli flags, it returns the raw values as strings.
+func getCRSConfigFlags(rawValue interface{}) ([]string, error) {
+	rawValues, ok := rawValue.([]interface{})
+	if !ok {
+		return nil, errfmt.Errorf("unrecognized type %T for crs", rawValue)
+	}
+
+	flags := make([]string, 0)
+	flagger := &CRSConfig{}
+	for _, raw := range rawValues {
+		switch v := raw.(type) {
+		// raw cli flags
+		case string:
+			// crs:
+			//     - containerd:/var/run/containerd/containerd.sock
+			//     - docker:/var/run/docker.sock
+			flags = append(flags, v)
+
+		// structured flags
+		case map[string]interface{}:
+			// crs:
+			//     - runtime:
+			//         name: containerd
+			//         socket: /var/run/containerd/containerd.sock
+			//     - runtime:
+			//         name: docker
+			//         socket: /var/run/docker.sock
+			runtimeMap, exists := v["runtime"].(map[string]interface{})
+			if !exists {
+				return nil, errfmt.Errorf("runtime key not found or not a map")
+			}
+			if err := mapstructure.Decode(runtimeMap, flagger); err != nil {
+				return nil, errfmt.WrapError(err)
+			}
+			flags = append(flags, flagger.flags()...)
+
+		default:
+			return nil, errfmt.Errorf("unrecognized type %T for crs", v)
+		}
+	}
+
+	return flags, nil
+}
+
+//
+// config flag
+//
+
+type CacheConfig struct {
+	Type string `mapstructure:"type"`
+	Size int    `mapstructure:"size"`
+}
+
+func (c *CacheConfig) flags() []string {
+	flags := make([]string, 0)
+
+	if c.Type != "" {
+		flags = append(flags, fmt.Sprintf("cache-type=%s", c.Type))
+	}
+	if c.Size != 0 {
+		flags = append(flags, fmt.Sprintf("mem-cache-size=%d", c.Size))
+	}
+
+	return flags
+}
+
+//
+// rego flag
+//
+
+type RegoConfig struct {
+	PartialEval bool `mapstructure:"partial-eval"`
+	AIO         bool `mapstructure:"aio"`
+}
+
+func (c *RegoConfig) flags() []string {
+	flags := make([]string, 0)
+
+	if c.PartialEval {
+		flags = append(flags, "partial-eval")
+	}
+	if c.AIO {
+		flags = append(flags, "aio")
+	}
+
+	return flags
+}
+
+//
+// proctree flag
+//
+
+type ProcTreeConfig struct {
+	Source string              `mapstructure:"source"`
+	Cache  ProcTreeCacheConfig `mapstructure:"cache"`
+}
+
+type ProcTreeCacheConfig struct {
+	Process int `mapstructure:"process"`
+	Thread  int `mapstructure:"thread"`
+}
+
+func (c *ProcTreeConfig) flags() []string {
+	flags := make([]string, 0)
+
+	if c.Source != "" {
+		if c.Source == "none" {
+			flags = append(flags, "none")
+		} else {
+			flags = append(flags, fmt.Sprintf("source=%s", c.Source))
+		}
+	}
+	if c.Cache.Process != 0 {
+		flags = append(flags, fmt.Sprintf("process-cache=%d", c.Cache.Process))
+	}
+	if c.Cache.Thread != 0 {
+		flags = append(flags, fmt.Sprintf("thread-cache=%d", c.Cache.Thread))
+	}
+
+	return flags
+}
+
+//
+// capabilities flag
+//
+
+type CapabilitiesConfig struct {
+	Bypass bool     `mapstructure:"bypass"`
+	Add    []string `mapstructure:"add"`
+	Drop   []string `mapstructure:"drop"`
+}
+
+func (c *CapabilitiesConfig) flags() []string {
+	flags := make([]string, 0)
+
+	flags = append(flags, fmt.Sprintf("bypass=%v", c.Bypass))
+	for _, cap := range c.Add {
+		flags = append(flags, fmt.Sprintf("add=%s", cap))
+	}
+	for _, cap := range c.Drop {
+		flags = append(flags, fmt.Sprintf("drop=%s", cap))
+	}
+
+	return flags
+}
+
+//
+// crs flag
+//
+
+type CRSConfig struct {
+	Name   string `mapstructure:"name"`
+	Socket string `mapstructure:"socket"`
+}
+
+func (c *CRSConfig) flags() []string {
+	flags := make([]string, 0)
+
+	if c.Name != "" && c.Socket != "" {
+		flags = append(flags, fmt.Sprintf("%s:%s", c.Name, c.Socket))
+	}
+
+	return flags
+}
+
+//
+// log flag
+//
+
+type LogConfig struct {
+	Level     string             `mapstructure:"level"`
+	File      string             `mapstructure:"file"`
+	Aggregate LogAggregateConfig `mapstructure:"aggregate"`
+	Filters   LogFilterConfig    `mapstructure:"filters"`
+}
+
+func (c *LogConfig) flags() []string {
+	flags := []string{}
+
+	// level
+	if c.Level != "" {
+		flags = append(flags, c.Level)
+	}
+
+	// file
+	if c.File != "" {
+		flags = append(flags, fmt.Sprintf("file:%s", c.File))
+	}
+
+	// aggregate
+	if c.Aggregate.Enabled {
+		if c.Aggregate.FlushInterval == "" {
+			flags = append(flags, "aggregate")
+		} else {
+			flags = append(flags, fmt.Sprintf("aggregate:%s", c.Aggregate.FlushInterval))
+		}
+	}
+
+	// filters
+	if c.Filters.LibBPF {
+		flags = append(flags, "filter:libbpf")
+	}
+	flags = append(flags, getLogFilterAttrFlags(false, c.Filters.In)...)
+	flags = append(flags, getLogFilterAttrFlags(true, c.Filters.Out)...)
+
+	return flags
+}
+
+type LogAggregateConfig struct {
+	Enabled       bool   `mapstructure:"enabled"`
+	FlushInterval string `mapstructure:"flush-interval"`
+}
+
+type LogFilterConfig struct {
+	LibBPF bool                `mapstructure:"libbpf"`
+	In     LogFilterAttributes `mapstructure:"in"`
+	Out    LogFilterAttributes `mapstructure:"out"`
+}
+
+type LogFilterAttributes struct {
+	Msg   []string `mapstructure:"msg"`
+	Pkg   []string `mapstructure:"pkg"`
+	File  []string `mapstructure:"file"`
+	Level []string `mapstructure:"lvl"`
+	Regex []string `mapstructure:"regex"`
+}
+
+func getLogFilterAttrFlags(filterOut bool, attrs LogFilterAttributes) []string {
+	attrFlags := []string{}
+	suffix := ""
+
+	if filterOut {
+		suffix = "-out"
+	}
+
+	// msg
+	for _, msg := range attrs.Msg {
+		attrFlags = append(attrFlags, fmt.Sprintf("filter%s:msg=%s", suffix, msg))
+	}
+
+	// pkg
+	for _, pkg := range attrs.Pkg {
+		attrFlags = append(attrFlags, fmt.Sprintf("filter%s:pkg=%s", suffix, pkg))
+	}
+
+	// file
+	for _, file := range attrs.File {
+		attrFlags = append(attrFlags, fmt.Sprintf("filter%s:file=%s", suffix, file))
+	}
+
+	// level
+	for _, level := range attrs.Level {
+		attrFlags = append(attrFlags, fmt.Sprintf("filter%s:lvl=%s", suffix, level))
+	}
+
+	// regex
+	for _, regex := range attrs.Regex {
+		attrFlags = append(attrFlags, fmt.Sprintf("filter%s:regex=%s", suffix, regex))
+	}
+
+	return attrFlags
+}
+
+//
+// output flag
+//
+
+type OutputConfig struct {
+	Options      OutputOptsConfig               `mapstructure:"options"`
+	Table        OutputFormatConfig             `mapstructure:"table"`
+	TableVerbose OutputFormatConfig             `mapstructure:"table-verbose"`
+	JSON         OutputFormatConfig             `mapstructure:"json"`
+	Gob          OutputFormatConfig             `mapstructure:"gob"`
+	GoTemplate   OutputGoTemplateConfig         `mapstructure:"gotemplate"`
+	Forwards     map[string]OutputForwardConfig `mapstructure:"forward"`
+	Webhooks     map[string]OutputWebhookConfig `mapstructure:"webhook"`
+}
+
+func (c *OutputConfig) flags() []string {
+	flags := []string{}
+
+	// options flags
+	if c.Options.None {
+		flags = append(flags, "none")
+	}
+	if c.Options.StackAddresses {
+		flags = append(flags, "option:stack-addresses")
+	}
+	if c.Options.ExecEnv {
+		flags = append(flags, "option:exec-env")
+	}
+	if c.Options.RelativeTime {
+		flags = append(flags, "option:relative-time")
+	}
+	if c.Options.ExecHash {
+		flags = append(flags, "option:exec-hash")
+	}
+	if c.Options.ParseArguments {
+		flags = append(flags, "option:parse-arguments")
+	}
+	if c.Options.ParseArgumentsFDs {
+		flags = append(flags, "option:parse-arguments-fds")
+	}
+	if c.Options.SortEvents {
+		flags = append(flags, "option:sort-events")
+	}
+
+	// formats with files
+	formatFilesMap := map[string][]string{
+		"table":         c.Table.Files,
+		"table-verbose": c.TableVerbose.Files,
+		"json":          c.JSON.Files,
+		"gob":           c.Gob.Files,
+	}
+	for format, files := range formatFilesMap {
+		for _, file := range files {
+			flags = append(flags, fmt.Sprintf("%s:%s", format, file))
+		}
+	}
+
+	// gotemplate
+	if c.GoTemplate.Template != "" {
+		templateFlag := fmt.Sprintf("gotemplate=%s", c.GoTemplate.Template)
+		if len(c.GoTemplate.Files) > 0 {
+			templateFlag += ":" + strings.Join(c.GoTemplate.Files, ",")
+		}
+		flags = append(flags, templateFlag)
+	}
+
+	// forward
+	for forwardName, forward := range c.Forwards {
+		_ = forwardName
+		url := fmt.Sprintf("%s://", forward.Protocol)
+
+		if forward.User != "" && forward.Password != "" {
+			url += fmt.Sprintf("%s:%s@", forward.User, forward.Password)
+		}
+
+		url += fmt.Sprintf("%s:%d", forward.Host, forward.Port)
+
+		if forward.Tag != "" {
+			url += fmt.Sprintf("?tag=%s", forward.Tag)
+		}
+
+		flags = append(flags, fmt.Sprintf("forward:%s", url))
+	}
+
+	// webhook
+	for webhookName, webhook := range c.Webhooks {
+		_ = webhookName
+		url := fmt.Sprintf("%s://%s:%d", webhook.Protocol, webhook.Host, webhook.Port)
+		if webhook.Timeout != "" {
+			url += fmt.Sprintf("?timeout=%s", webhook.Timeout)
+		}
+		flags = append(flags, fmt.Sprintf("webhook:%s", url))
+	}
+
+	return flags
+}
+
+type OutputOptsConfig struct {
+	None              bool `mapstructure:"none"`
+	StackAddresses    bool `mapstructure:"stack-addresses"`
+	ExecEnv           bool `mapstructure:"exec-env"`
+	RelativeTime      bool `mapstructure:"relative-time"`
+	ExecHash          bool `mapstructure:"exec-hash"`
+	ParseArguments    bool `mapstructure:"parse-arguments"`
+	ParseArgumentsFDs bool `mapstructure:"parse-arguments-fds"`
+	SortEvents        bool `mapstructure:"sort-events"`
+}
+
+type OutputFormatConfig struct {
+	Files []string `mapstructure:"files"`
+}
+
+type OutputGoTemplateConfig struct {
+	Template string   `mapstructure:"template"`
+	Files    []string `mapstructure:"files"`
+}
+
+type OutputForwardConfig struct {
+	Protocol string `mapstructure:"protocol"`
+	User     string `mapstructure:"user"`
+	Password string `mapstructure:"password"`
+	Host     string `mapstructure:"host"`
+	Port     int    `mapstructure:"port"`
+	Tag      string `mapstructure:"tag"`
+}
+
+type OutputWebhookConfig struct {
+	Protocol string `mapstructure:"protocol"`
+	Host     string `mapstructure:"host"`
+	Port     int    `mapstructure:"port"`
+	Timeout  string `mapstructure:"timeout"`
+}

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -280,6 +280,7 @@ func (c *LogConfig) flags() []string {
 	if c.Filters.LibBPF {
 		flags = append(flags, "filter:libbpf")
 	}
+
 	flags = append(flags, getLogFilterAttrFlags(false, c.Filters.In)...)
 	flags = append(flags, getLogFilterAttrFlags(true, c.Filters.Out)...)
 
@@ -404,6 +405,7 @@ func (c *OutputConfig) flags() []string {
 		if len(c.GoTemplate.Files) > 0 {
 			templateFlag += ":" + strings.Join(c.GoTemplate.Files, ",")
 		}
+
 		flags = append(flags, templateFlag)
 	}
 
@@ -432,6 +434,13 @@ func (c *OutputConfig) flags() []string {
 		if webhook.Timeout != "" {
 			url += fmt.Sprintf("?timeout=%s", webhook.Timeout)
 		}
+		if webhook.GoTemplate != "" {
+			url += fmt.Sprintf("?gotemplate=%s", webhook.GoTemplate)
+		}
+		if webhook.ContentType != "" {
+			url += fmt.Sprintf("?contentType=%s", webhook.ContentType)
+		}
+
 		flags = append(flags, fmt.Sprintf("webhook:%s", url))
 	}
 
@@ -468,8 +477,10 @@ type OutputForwardConfig struct {
 }
 
 type OutputWebhookConfig struct {
-	Protocol string `mapstructure:"protocol"`
-	Host     string `mapstructure:"host"`
-	Port     int    `mapstructure:"port"`
-	Timeout  string `mapstructure:"timeout"`
+	Protocol    string `mapstructure:"protocol"`
+	Host        string `mapstructure:"host"`
+	Port        int    `mapstructure:"port"`
+	Timeout     string `mapstructure:"timeout"`
+	GoTemplate  string `mapstructure:"gotemplate"`
+	ContentType string `mapstructure:"content-type"`
 }

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -30,14 +30,14 @@ func GetFlagsFromViper(key string) ([]string, error) {
 		flagger = &ProcTreeConfig{}
 	case "capabilities":
 		flagger = &CapabilitiesConfig{}
-	case "crs":
+	case "cri":
 		switch v := rawValue.(type) {
 		case []string: // via cli
-			return getConfigFlags(rawValue, nil, "crs")
+			return getConfigFlags(rawValue, nil, "cri")
 		case []interface{}: // via config file
-			return getCRSConfigFlags(rawValue)
+			return getCRIConfigFlags(rawValue)
 		default:
-			return nil, errfmt.Errorf("unrecognized type %T for crs", v)
+			return nil, errfmt.Errorf("unrecognized type %T for cri", v)
 		}
 	case "log":
 		flagger = &LogConfig{}
@@ -76,29 +76,29 @@ func getConfigFlags(rawValue interface{}, flagger cliFlagger, key string) ([]str
 	}
 }
 
-// getCRSConfigFlags handles the crs config key, which is a special case.
+// getCRIConfigFlags handles the cri config key, which is a special case.
 // For structured flags, it uses mapstructure to decode the config into a
-// CRSConfig struct. For raw cli flags, it returns the raw values as strings.
-func getCRSConfigFlags(rawValue interface{}) ([]string, error) {
+// CRIConfig struct. For raw cli flags, it returns the raw values as strings.
+func getCRIConfigFlags(rawValue interface{}) ([]string, error) {
 	rawValues, ok := rawValue.([]interface{})
 	if !ok {
-		return nil, errfmt.Errorf("unrecognized type %T for crs", rawValue)
+		return nil, errfmt.Errorf("unrecognized type %T for cri", rawValue)
 	}
 
 	flags := make([]string, 0)
-	flagger := &CRSConfig{}
+	flagger := &CRIConfig{}
 	for _, raw := range rawValues {
 		switch v := raw.(type) {
 		// raw cli flags
 		case string:
-			// crs:
+			// cri:
 			//     - containerd:/var/run/containerd/containerd.sock
 			//     - docker:/var/run/docker.sock
 			flags = append(flags, v)
 
 		// structured flags
 		case map[string]interface{}:
-			// crs:
+			// cri:
 			//     - runtime:
 			//         name: containerd
 			//         socket: /var/run/containerd/containerd.sock
@@ -115,7 +115,7 @@ func getCRSConfigFlags(rawValue interface{}) ([]string, error) {
 			flags = append(flags, flagger.flags()...)
 
 		default:
-			return nil, errfmt.Errorf("unrecognized type %T for crs", v)
+			return nil, errfmt.Errorf("unrecognized type %T for cri", v)
 		}
 	}
 
@@ -225,15 +225,15 @@ func (c *CapabilitiesConfig) flags() []string {
 }
 
 //
-// crs flag
+// cri flag
 //
 
-type CRSConfig struct {
+type CRIConfig struct {
 	Name   string `mapstructure:"name"`
 	Socket string `mapstructure:"socket"`
 }
 
-func (c *CRSConfig) flags() []string {
+func (c *CRIConfig) flags() []string {
 	flags := make([]string, 0)
 
 	if c.Name != "" && c.Socket != "" {

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -354,11 +354,15 @@ output:
             host: localhost
             port: 8000
             timeout: 5s
+            gotemplate: /path/to/template1
+            content-type: application/json
         - webhook2:
             protocol: http
             host: localhost
             port: 9000
             timeout: 3s
+            gotemplate: /path/to/template2
+            content-type: application/ld+json
 `,
 			key: "output",
 			expectedFlags: []string{
@@ -376,8 +380,8 @@ output:
 				"gotemplate=template1:file3,file4",
 				"forward:tcp://user:pass@127.0.0.1:24224?tag=tracee1",
 				"forward:udp://user:pass@127.0.0.1:24225?tag=tracee2",
-				"webhook:http://localhost:8000?timeout=5s",
-				"webhook:http://localhost:9000?timeout=3s",
+				"webhook:http://localhost:8000?timeout=5s?gotemplate=/path/to/template1?contentType=application/json",
+				"webhook:http://localhost:9000?timeout=3s?gotemplate=/path/to/template2?contentType=application/ld+json",
 			},
 		},
 	}
@@ -1063,19 +1067,21 @@ func TestOutputConfigFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "test webhook with timeout",
+			name: "test webhook with all fields",
 			config: OutputConfig{
 				Webhooks: map[string]OutputWebhookConfig{
 					"example3": {
-						Protocol: "http",
-						Host:     "webhook.com",
-						Port:     9090,
-						Timeout:  "5s",
+						Protocol:    "http",
+						Host:        "webhook.com",
+						Port:        9090,
+						Timeout:     "5s",
+						GoTemplate:  "/path/to/template1",
+						ContentType: "application/json",
 					},
 				},
 			},
 			expected: []string{
-				"webhook:http://webhook.com:9090?timeout=5s",
+				"webhook:http://webhook.com:9090?timeout=5s?gotemplate=/path/to/template1?contentType=application/json",
 			},
 		},
 		{

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -146,24 +146,24 @@ capabilities:
 			},
 		},
 		{
-			name: "Test crs configuration (cli flags)",
+			name: "Test cri configuration (cli flags)",
 			yamlContent: `
-crs:
+cri:
     - test1:/var/run/test1.sock
     - test2:/var/run/test2.sock
 `,
-			key: "crs",
+			key: "cri",
 			expectedFlags: []string{
 				"test1:/var/run/test1.sock",
 				"test2:/var/run/test2.sock",
 			},
 		},
 		{
-			name: "Test crs configuration (structured flags)",
+			name: "Test cri configuration (structured flags)",
 			// test1: /var/run/test1.sock
 			// test2: /var/run/test2.sock
 			yamlContent: `
-crs:
+cri:
     - runtime:
         name: test1
         socket: /var/run/test1.sock
@@ -171,7 +171,7 @@ crs:
         name: test2
         socket: /var/run/test2.sock
 `,
-			key: "crs",
+			key: "cri",
 			expectedFlags: []string{
 				"test1:/var/run/test1.sock",
 				"test2:/var/run/test2.sock",
@@ -737,20 +737,20 @@ func TestCapabilitiesConfigFlags(t *testing.T) {
 }
 
 //
-// crs
+// cri
 //
 
-func TestCRSConfigFlag(t *testing.T) {
+func TestCRIConfigFlag(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
-		config   CRSConfig
+		config   CRIConfig
 		expected []string
 	}{
 		{
 			name: "empty config",
-			config: CRSConfig{
+			config: CRIConfig{
 				Name:   "",
 				Socket: "",
 			},
@@ -758,7 +758,7 @@ func TestCRSConfigFlag(t *testing.T) {
 		},
 		{
 			name: "valid config",
-			config: CRSConfig{
+			config: CRIConfig{
 				Name:   "testName",
 				Socket: "/var/run/socket.sock",
 			},

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -1,0 +1,1139 @@
+package cobra
+
+import (
+	"log"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetFlagsFromViper tests the GetFlagsFromViper function using a global
+// viper instance. It tests all keys that are supported by the function for
+// both structured and cli flags.
+func TestGetFlagsFromViper(t *testing.T) {
+	// Cannot run in parallel because of the global viper instance
+
+	tests := []struct {
+		name          string
+		yamlContent   string
+		key           string
+		expectedFlags []string
+	}{
+		{
+			name: "Test cache configuration (cli flags)",
+			yamlContent: `
+cache:
+    - cache-type=mem
+    - mem-cache-size=556
+`,
+			key: "cache",
+			expectedFlags: []string{
+				"cache-type=mem",
+				"mem-cache-size=556",
+			},
+		},
+		{
+			name: "Test cache configuration (structured flags)",
+			yamlContent: `
+cache:
+    type: mem
+    size: 1024
+`,
+			key: "cache",
+			expectedFlags: []string{
+				"cache-type=mem",
+				"mem-cache-size=1024",
+			},
+		},
+		{
+			name: "Test rego configuration (cli flags)",
+			yamlContent: `
+rego:
+    - partial-eval
+    - aio
+`,
+			key: "rego",
+			expectedFlags: []string{
+				"partial-eval",
+				"aio",
+			},
+		},
+		{
+			name: "Test rego configuration (structured flags)",
+			yamlContent: `
+rego:
+    partial-eval: true
+    aio: true
+`,
+			key: "rego",
+			expectedFlags: []string{
+				"partial-eval",
+				"aio",
+			},
+		},
+		{
+			name: "Test proctree configuration (cli flags)",
+			yamlContent: `
+proctree:
+    - source=events
+    - process-cache=8192
+    - thread-cache=4096
+`,
+			key: "proctree",
+			expectedFlags: []string{
+				"source=events",
+				"process-cache=8192",
+				"thread-cache=4096",
+			},
+		},
+		{
+			name: "Test proctree configuration (structured flags)",
+			yamlContent: `
+proctree:
+    source: events
+    cache:
+        process: 8192
+        thread: 4096
+`,
+			key: "proctree",
+			expectedFlags: []string{
+				"source=events",
+				"process-cache=8192",
+				"thread-cache=4096",
+			},
+		},
+		{
+			name: "Test capabilities configuration (cli flags)",
+			yamlContent: `
+capabilities:
+    - bypass=false
+    - add=CAP_NET_ADMIN
+    - add=CAP_SYS_ADMIN
+    - drop=CAP_NET_RAW
+    - drop=CAP_DAC_OVERRIDE
+`,
+			key: "capabilities",
+			expectedFlags: []string{
+				"bypass=false",
+				"add=CAP_NET_ADMIN",
+				"add=CAP_SYS_ADMIN",
+				"drop=CAP_NET_RAW",
+				"drop=CAP_DAC_OVERRIDE",
+			},
+		},
+		{
+			name: "Test capabilities configuration (structured flags)",
+			yamlContent: `
+capabilities:
+    bypass: false
+    add:
+        - CAP_NET_ADMIN
+        - CAP_SYS_ADMIN
+    drop:
+        - CAP_NET_RAW
+        - CAP_DAC_OVERRIDE
+`,
+			key: "capabilities",
+			expectedFlags: []string{
+				"bypass=false",
+				"add=CAP_NET_ADMIN",
+				"add=CAP_SYS_ADMIN",
+				"drop=CAP_NET_RAW",
+				"drop=CAP_DAC_OVERRIDE",
+			},
+		},
+		{
+			name: "Test crs configuration (cli flags)",
+			yamlContent: `
+crs:
+    - test1:/var/run/test1.sock
+    - test2:/var/run/test2.sock
+`,
+			key: "crs",
+			expectedFlags: []string{
+				"test1:/var/run/test1.sock",
+				"test2:/var/run/test2.sock",
+			},
+		},
+		{
+			name: "Test crs configuration (structured flags)",
+			// test1: /var/run/test1.sock
+			// test2: /var/run/test2.sock
+			yamlContent: `
+crs:
+    - runtime:
+        name: test1
+        socket: /var/run/test1.sock
+    - runtime:
+        name: test2
+        socket: /var/run/test2.sock
+`,
+			key: "crs",
+			expectedFlags: []string{
+				"test1:/var/run/test1.sock",
+				"test2:/var/run/test2.sock",
+			},
+		},
+		{
+			name: "Test log configuration (cli flags)",
+			yamlContent: `
+log:
+    - debug
+    - file:/var/log/test.log
+    - aggregate:5s
+    - filter:libbpf
+    - filter:msg=msg1
+    - filter:pkg=pkg1
+    - filter:pkg=pkg2
+    - filter:file=file1
+    - filter:lvl=info
+    - filter:regex=^regex.*
+    - filter-out:msg=msg1
+    - filter-out:pkg=pkg1
+    - filter-out:file=file1
+    - filter-out:file=file2
+    - filter-out:lvl=info
+    - filter-out:regex=^regex.*
+`,
+			key: "log",
+			expectedFlags: []string{
+				"debug",
+				"file:/var/log/test.log",
+				"aggregate:5s",
+				"filter:libbpf",
+				"filter:msg=msg1",
+				"filter:pkg=pkg1",
+				"filter:pkg=pkg2",
+				"filter:file=file1",
+				"filter:lvl=info",
+				"filter:regex=^regex.*",
+				"filter-out:msg=msg1",
+				"filter-out:pkg=pkg1",
+				"filter-out:file=file1",
+				"filter-out:file=file2",
+				"filter-out:lvl=info",
+				"filter-out:regex=^regex.*",
+			},
+		},
+		{
+			name: "Test log configuration (structured flags)",
+			yamlContent: `
+log:
+    level: debug
+    file: /var/log/test.log
+    aggregate:
+        enabled: true
+        flush-interval: 5s
+    filters:
+        libbpf: true
+        in:
+            msg:
+                - msg1
+            pkg:
+                - pkg1
+                - pkg2
+            file:
+                - file1
+            lvl:
+                - info
+            regex:
+                - ^regex.*
+        out:
+            msg:
+                - msg1
+            pkg:
+                - pkg1
+            file:
+                - file1
+                - file2
+            lvl:
+                - info
+            regex:
+                - ^regex.*
+`,
+			key: "log",
+			expectedFlags: []string{
+				"debug",
+				"file:/var/log/test.log",
+				"aggregate:5s",
+				"filter:libbpf",
+				"filter:msg=msg1",
+				"filter:pkg=pkg1",
+				"filter:pkg=pkg2",
+				"filter:file=file1",
+				"filter:lvl=info",
+				"filter:regex=^regex.*",
+				"filter-out:msg=msg1",
+				"filter-out:pkg=pkg1",
+				"filter-out:file=file1",
+				"filter-out:file=file2",
+				"filter-out:lvl=info",
+				"filter-out:regex=^regex.*",
+			},
+		},
+		{
+			name: "Test output configuration (cli flags)",
+			yamlContent: `
+output:
+    - none
+    - option:stack-addresses
+    - option:exec-env
+    - option:relative-time
+    - option:exec-hash
+    - option:parse-arguments
+    - option:parse-arguments-fds
+    - option:sort-events
+    - table:file1
+    - json:file2    
+    - gotemplate=template1:file3,file4    
+`,
+			key: "output",
+			expectedFlags: []string{
+				"none",
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+				"table:file1",
+				"json:file2",
+				"gotemplate=template1:file3,file4",
+			},
+		},
+		{
+			name: "Test output configuration (structured flags)",
+			yamlContent: `
+output:
+    options:
+        none: false
+        stack-addresses: true
+        exec-env: true
+        relative-time: true
+        exec-hash: true
+        parse-arguments: true
+        parse-arguments-fds: true
+        sort-events: true
+    table:
+        files:
+            - file1
+    table-verbose:
+        files:
+            - stdout
+    json:
+        files:
+            - /path/to/json1.out
+    gob: # this won't be present since it does not have any files
+    gotemplate:
+        template: template1
+        files:
+            - file3
+            - file4
+    forward:
+        - forward1:
+            protocol: tcp
+            user: user
+            password: pass
+            host: 127.0.0.1
+            port: 24224
+            tag: tracee1
+        - forward2:
+            protocol: udp
+            user: user
+            password: pass
+            host: 127.0.0.1
+            port: 24225
+            tag: tracee2
+    webhook:
+        - webhook1:
+            protocol: http
+            host: localhost
+            port: 8000
+            timeout: 5s
+        - webhook2:
+            protocol: http
+            host: localhost
+            port: 9000
+            timeout: 3s
+`,
+			key: "output",
+			expectedFlags: []string{
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+				"table:file1",
+				"table-verbose:stdout",
+				"json:/path/to/json1.out",
+				// gob is not present since it does not have any files
+				"gotemplate=template1:file3,file4",
+				"forward:tcp://user:pass@127.0.0.1:24224?tag=tracee1",
+				"forward:udp://user:pass@127.0.0.1:24225?tag=tracee2",
+				"webhook:http://localhost:8000?timeout=5s",
+				"webhook:http://localhost:9000?timeout=3s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Cannot run in parallel because of the global viper instance
+
+			viper.Reset() // Reset viper's state for each test case
+			viper.SetConfigType("yaml")
+			if err := viper.ReadConfig(strings.NewReader(tt.yamlContent)); err != nil {
+				t.Fatalf("Error setting up viper: %v", err)
+			}
+
+			flags, err := GetFlagsFromViper(tt.key)
+			assert.NoError(t, err)
+
+			if len(flags) != len(tt.expectedFlags) {
+				log.Printf("Expected %+v", tt.expectedFlags)
+				log.Printf("Got %+v", flags)
+				t.Fatalf("Expected %d flags, got %d flags", len(tt.expectedFlags), len(flags))
+			}
+
+			if !slicesEqualIgnoreOrder(flags, tt.expectedFlags) {
+				t.Errorf("Expected %v, got %v", tt.expectedFlags, flags)
+			}
+		})
+	}
+}
+
+//
+// cache
+//
+
+func TestCacheConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   CacheConfig
+		expected []string
+	}{
+		{
+			name:     "empty config",
+			config:   CacheConfig{},
+			expected: []string{},
+		},
+		{
+			name: "only type",
+			config: CacheConfig{
+				Type: "none",
+			},
+			expected: []string{
+				"cache-type=none",
+			},
+		},
+		{
+			name: "both type and size",
+			config: CacheConfig{
+				Type: "mem",
+				Size: 1024,
+			},
+			expected: []string{
+				"cache-type=mem",
+				"mem-cache-size=1024",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags := tt.config.flags()
+			if !slicesEqualIgnoreOrder(flags, tt.expected) {
+				t.Errorf("flags() = %v, want %v", flags, tt.expected)
+			}
+		})
+	}
+}
+
+//
+// rego
+//
+
+func TestRegoConfigFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   RegoConfig
+		expected []string
+	}{
+		{
+			name:     "empty config",
+			config:   RegoConfig{},
+			expected: []string{},
+		},
+		{
+			name: "both partial-eval and aio",
+			config: RegoConfig{
+				PartialEval: true,
+				AIO:         true,
+			},
+			expected: []string{
+				"partial-eval",
+				"aio",
+			},
+		},
+		{
+			name: "only partial-eval",
+			config: RegoConfig{
+				PartialEval: true,
+			},
+			expected: []string{
+				"partial-eval",
+			},
+		},
+		{
+			name: "only aio",
+			config: RegoConfig{
+				AIO: true,
+			},
+			expected: []string{
+				"aio",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags := tt.config.flags()
+			if !slicesEqualIgnoreOrder(flags, tt.expected) {
+				t.Errorf("flags() = %v, want %v", flags, tt.expected)
+			}
+		})
+	}
+}
+
+//
+// proctree
+//
+
+func TestProcTreeConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   ProcTreeConfig
+		expected []string
+	}{
+		{
+			name: "empty config",
+			config: ProcTreeConfig{
+				Source: "",
+				Cache:  ProcTreeCacheConfig{},
+			},
+			expected: []string{},
+		},
+		{
+			name: "only source set",
+			config: ProcTreeConfig{
+				Source: "events",
+				Cache:  ProcTreeCacheConfig{},
+			},
+			expected: []string{
+				"source=events",
+			},
+		},
+		{
+			name: "only process cache set",
+			config: ProcTreeConfig{
+				Source: "",
+				Cache: ProcTreeCacheConfig{
+					Process: 8192,
+				},
+			},
+			expected: []string{
+				"process-cache=8192",
+			},
+		},
+		{
+			name: "only thread cache set",
+			config: ProcTreeConfig{
+				Source: "",
+				Cache: ProcTreeCacheConfig{
+					Thread: 4096,
+				},
+			},
+			expected: []string{
+				"thread-cache=4096",
+			},
+		},
+		{
+			name: "both cache values set",
+			config: ProcTreeConfig{
+				Source: "",
+				Cache: ProcTreeCacheConfig{
+					Process: 8192,
+					Thread:  4096,
+				},
+			},
+			expected: []string{
+				"process-cache=8192",
+				"thread-cache=4096",
+			},
+		},
+		{
+			name: "all fields set",
+			config: ProcTreeConfig{
+				Source: "events",
+				Cache: ProcTreeCacheConfig{
+					Process: 8192,
+					Thread:  4096,
+				},
+			},
+			expected: []string{
+				"source=events",
+				"process-cache=8192",
+				"thread-cache=4096",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.config.flags()
+			if !slicesEqualIgnoreOrder(got, tt.expected) {
+				t.Errorf("flags() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+//
+// capabilities
+//
+
+func TestCapabilitiesConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   CapabilitiesConfig
+		expected []string
+	}{
+		{
+			name: "empty config",
+			config: CapabilitiesConfig{
+				Bypass: false,
+				Add:    nil,
+				Drop:   nil,
+			},
+			expected: []string{
+				"bypass=false",
+			},
+		},
+		{
+			name: "bypass true",
+			config: CapabilitiesConfig{
+				Bypass: true,
+				Add:    nil,
+				Drop:   nil,
+			},
+			expected: []string{
+				"bypass=true",
+			},
+		},
+		{
+			name: "only add capabilities",
+			config: CapabilitiesConfig{
+				Bypass: false,
+				Add: []string{
+					"CAP_NET_ADMIN",
+					"CAP_SYS_ADMIN",
+				},
+				Drop: nil,
+			},
+			expected: []string{
+				"bypass=false",
+				"add=CAP_NET_ADMIN",
+				"add=CAP_SYS_ADMIN",
+			},
+		},
+		{
+			name: "only drop capabilities",
+			config: CapabilitiesConfig{
+				Bypass: false,
+				Add:    nil,
+				Drop: []string{
+					"CAP_NET_RAW",
+					"CAP_DAC_OVERRIDE",
+				},
+			},
+			expected: []string{
+				"bypass=false",
+				"drop=CAP_NET_RAW",
+				"drop=CAP_DAC_OVERRIDE",
+			},
+		},
+		{
+			name: "add and drop capabilities",
+			config: CapabilitiesConfig{
+				Bypass: false,
+				Add: []string{
+					"CAP_NET_ADMIN",
+				},
+				Drop: []string{
+					"CAP_NET_RAW",
+				},
+			},
+			expected: []string{
+				"bypass=false",
+				"add=CAP_NET_ADMIN",
+				"drop=CAP_NET_RAW",
+			},
+		},
+		{
+			name: "bypass with capabilities",
+			config: CapabilitiesConfig{
+				Bypass: true,
+				Add: []string{
+					"CAP_NET_ADMIN",
+				},
+				Drop: []string{
+					"CAP_NET_RAW",
+				},
+			},
+			expected: []string{
+				"bypass=true",
+				"add=CAP_NET_ADMIN",
+				"drop=CAP_NET_RAW",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.config.flags()
+			if !slicesEqualIgnoreOrder(got, tt.expected) {
+				t.Errorf("flags() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+//
+// crs
+//
+
+func TestCRSConfigFlag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   CRSConfig
+		expected []string
+	}{
+		{
+			name: "empty config",
+			config: CRSConfig{
+				Name:   "",
+				Socket: "",
+			},
+			expected: []string{},
+		},
+		{
+			name: "valid config",
+			config: CRSConfig{
+				Name:   "testName",
+				Socket: "/var/run/socket.sock",
+			},
+			expected: []string{
+				"testName:/var/run/socket.sock",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.config.flags()
+			if len(got) != len(tt.expected) {
+				t.Errorf("flags() = %v, want %v", got, tt.expected)
+			}
+			if len(got) > 0 && got[0] != tt.expected[0] {
+				t.Errorf("flags() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+//
+// log
+//
+
+func TestLogConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   LogConfig
+		expected []string
+	}{
+		{
+			name: "empty config",
+			config: LogConfig{
+				Level: "",
+				File:  "",
+			},
+			expected: []string{},
+		},
+		{
+			name: "level only",
+			config: LogConfig{
+				Level: "debug",
+			},
+			expected: []string{
+				"debug",
+			},
+		},
+		{
+			name: "file only",
+			config: LogConfig{
+				File: "/var/log/test.log",
+			},
+			expected: []string{
+				"file:/var/log/test.log",
+			},
+		},
+		{
+			name: "aggregate only",
+			config: LogConfig{
+				Aggregate: LogAggregateConfig{
+					Enabled:       true,
+					FlushInterval: "",
+				},
+			},
+			expected: []string{
+				"aggregate",
+			},
+		},
+		{
+			name: "aggregate with interval",
+			config: LogConfig{
+				Aggregate: LogAggregateConfig{
+					Enabled:       true,
+					FlushInterval: "5s",
+				},
+			},
+			expected: []string{
+				"aggregate:5s",
+			},
+		},
+		{
+			name: "filters with libbpf",
+			config: LogConfig{
+				Filters: LogFilterConfig{
+					LibBPF: true,
+				},
+			},
+			expected: []string{
+				"filter:libbpf",
+			},
+		},
+		{
+			name: "filters with attributes",
+			config: LogConfig{
+				Filters: LogFilterConfig{
+					In: LogFilterAttributes{
+						Msg: []string{
+							"msg1",
+							"msg2",
+						},
+						Pkg: []string{
+							"pkg1",
+						},
+						File: []string{
+							"file1",
+							"file2",
+						},
+						Level: []string{
+							"lvl1",
+						},
+						Regex: []string{
+							"^test.*",
+						},
+					},
+				},
+			},
+			expected: []string{
+				"filter:msg=msg1",
+				"filter:msg=msg2",
+				"filter:pkg=pkg1",
+				"filter:file=file1",
+				"filter:file=file2",
+				"filter:lvl=lvl1",
+				"filter:regex=^test.*",
+			},
+		},
+		{
+			name: "all flags",
+			config: LogConfig{
+				Level: "debug",
+				File:  "/var/log/test.log",
+				Aggregate: LogAggregateConfig{
+					Enabled:       true,
+					FlushInterval: "10s",
+				},
+				Filters: LogFilterConfig{
+					LibBPF: true,
+					In: LogFilterAttributes{
+						Msg:   []string{"msg1"},
+						Pkg:   []string{"pkg1", "pkg2"},
+						File:  []string{"file1"},
+						Level: []string{"lvl1", "lvl2"},
+						Regex: []string{"^regex.*"},
+					},
+					Out: LogFilterAttributes{
+						Msg:   []string{"msg1"},
+						Pkg:   []string{"pkg1"},
+						File:  []string{"file1", "file2"},
+						Level: []string{"lvl1"},
+						Regex: []string{"^regex.*"},
+					},
+				},
+			},
+			expected: []string{
+				"debug",
+				"file:/var/log/test.log",
+				"aggregate:10s",
+				"filter:libbpf",
+				"filter:msg=msg1",
+				"filter:pkg=pkg1",
+				"filter:pkg=pkg2",
+				"filter:file=file1",
+				"filter:lvl=lvl1",
+				"filter:lvl=lvl2",
+				"filter:regex=^regex.*",
+				"filter-out:msg=msg1",
+				"filter-out:pkg=pkg1",
+				"filter-out:file=file1",
+				"filter-out:file=file2",
+				"filter-out:lvl=lvl1",
+				"filter-out:regex=^regex.*",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.config.flags()
+
+			if !slicesEqualIgnoreOrder(got, tt.expected) {
+				t.Errorf("flags() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+//
+// output
+//
+
+func TestOutputConfigFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   OutputConfig
+		expected []string
+	}{
+		{
+			name:     "empty config",
+			config:   OutputConfig{},
+			expected: []string{},
+		},
+		{
+			name: "options set",
+			config: OutputConfig{
+				Options: OutputOptsConfig{
+					None:              true,
+					StackAddresses:    true,
+					ExecEnv:           true,
+					RelativeTime:      true,
+					ExecHash:          true,
+					ParseArguments:    true,
+					ParseArgumentsFDs: true,
+					SortEvents:        true,
+				},
+			},
+			expected: []string{
+				"none",
+				"option:stack-addresses",
+				"option:exec-env",
+				"option:relative-time",
+				"option:exec-hash",
+				"option:parse-arguments",
+				"option:parse-arguments-fds",
+				"option:sort-events",
+			},
+		},
+		{
+			name: "formats set",
+			config: OutputConfig{
+				Table: OutputFormatConfig{
+					Files: []string{"file1"},
+				},
+				JSON: OutputFormatConfig{
+					Files: []string{"file2"},
+				},
+			},
+			expected: []string{
+				"table:file1",
+				"json:file2",
+			},
+		},
+		{
+			name: "gotemplate set",
+			config: OutputConfig{
+				GoTemplate: OutputGoTemplateConfig{
+					Template: "template1",
+					Files:    []string{"file3", "file4"},
+				},
+			},
+			expected: []string{
+				"gotemplate=template1:file3,file4",
+			},
+		},
+		{
+			name: "test forward with tag",
+			config: OutputConfig{
+				Forwards: map[string]OutputForwardConfig{
+					"example1": {
+						Protocol: "tcp",
+						User:     "",
+						Password: "",
+						Host:     "example.com",
+						Port:     8080,
+						Tag:      "sample",
+					},
+				},
+			},
+			expected: []string{
+				"forward:tcp://example.com:8080?tag=sample",
+			},
+		},
+		{
+			name: "test forward with user and password",
+			config: OutputConfig{
+				Forwards: map[string]OutputForwardConfig{
+					"example2": {
+						Protocol: "tcp",
+						User:     "user123",
+						Password: "pass123",
+						Host:     "secure.com",
+						Port:     443,
+						Tag:      "",
+					},
+				},
+			},
+			expected: []string{
+				"forward:tcp://user123:pass123@secure.com:443",
+			},
+		},
+		{
+			name: "test webhook with timeout",
+			config: OutputConfig{
+				Webhooks: map[string]OutputWebhookConfig{
+					"example3": {
+						Protocol: "http",
+						Host:     "webhook.com",
+						Port:     9090,
+						Timeout:  "5s",
+					},
+				},
+			},
+			expected: []string{
+				"webhook:http://webhook.com:9090?timeout=5s",
+			},
+		},
+		{
+			name: "test combined forward and webhook",
+			config: OutputConfig{
+				Forwards: map[string]OutputForwardConfig{
+					"example4": {
+						Protocol: "http",
+						User:     "",
+						Password: "",
+						Host:     "combined.com",
+						Port:     8000,
+						Tag:      "taggy",
+					},
+				},
+				Webhooks: map[string]OutputWebhookConfig{
+					"example5": {
+						Protocol: "http",
+						Host:     "hooky.com",
+						Port:     8088,
+						Timeout:  "10s",
+					},
+				},
+			},
+			expected: []string{
+				"forward:http://combined.com:8000?tag=taggy",
+				"webhook:http://hooky.com:8088?timeout=10s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.config.flags()
+			if !slicesEqualIgnoreOrder(got, tt.expected) {
+				t.Errorf("flags() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// slicesEqualIgnoreOrder compares two string slices, ignoring order
+func slicesEqualIgnoreOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	sort.Strings(a)
+	sort.Strings(b)
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/cmd/flags/containers.go
+++ b/pkg/cmd/flags/containers.go
@@ -27,7 +27,7 @@ Supported runtimes are:
 4. Podman     (podman)
 
 Example:
-  --crs crio:/var/run/crio/crio.sock
+  --cri crio:/var/run/crio/crio.sock
 `
 }
 
@@ -63,7 +63,7 @@ func PrepareContainers(containerFlags []string) (runtime.Sockets, error) {
 		containerRuntime := parts[0]
 
 		if !contains(supportedRuntimes, containerRuntime) {
-			return sockets, errfmt.Errorf("provided unsupported container runtime (see --crs help for supported runtimes)")
+			return sockets, errfmt.Errorf("provided unsupported container runtime (see --cri help for supported runtimes)")
 		}
 
 		socket := parts[1]

--- a/pkg/cmd/flags/help.go
+++ b/pkg/cmd/flags/help.go
@@ -11,7 +11,7 @@ import (
 // It is used only by the old binary (tracee-ebpf).
 func PrintAndExitIfHelp(ctx *cli.Context) {
 	keys := []string{
-		"crs",
+		"cri",
 		"cache",
 		"proctree",
 		"capture",
@@ -48,7 +48,7 @@ func GetHelpString(key string) string {
 	switch key {
 	case "config":
 		return configHelp()
-	case "crs":
+	case "cri":
 		return containersHelp()
 	case "cache":
 		return cacheHelp()

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -64,7 +64,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 	// Container Runtime command line flags
 
 	if !cfg.NoContainersEnrich {
-		sockets, err := flags.PrepareContainers(c.StringSlice("crs"))
+		sockets, err := flags.PrepareContainers(c.StringSlice("cri"))
 		if err != nil {
 			return runner, err
 		}


### PR DESCRIPTION
Close: #3182 

### 1. Explain what the PR does

d3f9ba9fb **chore(config): add gotemplate and content-type**
86c120975 **chore!: change crs flag/key to cri**
d1532749d **feat(docs): update docs for structured config file**
9092b9941 **feat(cobra): add parser for structured config file**


d3f9ba9fb **chore(config): add gotemplate and content-type**

```
Since #3622, webhooks can be configured with a gotemplate and a
content-type. This commit adds these two fields to the config file.
```


86c120975 **chore!: change crs flag/key to cri**

```
BREAKING CHANGE: change crs flag to cri
```


d1532749d **feat(docs): update docs for structured config file**

```
This also changes the default config file to be a structured YAML file
and adds a new example config file 'global_config_cli.yaml'  that uses
the CLI format.
```


9092b9941 **feat(cobra): add parser for structured config file**

```
This commit adds a parser for a structured config file using viper.

Now, the config file can be written in a more structured way, like:

cache:
    type: mem
    size: 1024

The old way (cli flags) is still supported.

cache:
    - cache-type=mem
    - mem-cache-size=556
```

### 2. Explain how to test it

`sudo ./dist/tracee --config ./examples/config/global_config.yaml`
`sudo ./dist/tracee --config ./examples/config/global_config_cli.yaml`

### 3. Other comments
