### PR TITLE
docs: merge tracee policies and filtering

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -22,7 +22,7 @@
         1. [Golang signatures](../docs/events/custom/golang.md)
         
     1. Let other tools to **CONSUME** detection events:
-        1. [Filters](../docs/filters/filtering.md)
+        1. [Filters](../docs/policies/filtering.md)
     
     1. **ENFORCE**
         1. Work in Progress

--- a/docs/docs/events/overview.md
+++ b/docs/docs/events/overview.md
@@ -6,13 +6,15 @@ This section documents all of the different events that Tracee exposes.
 
 Tracee uses eBPF technology to tap into your system and give you access to hundreds of events that help you understand how your system behaves. The events can be specified either through CLI with [filters] or with [policies].
 
-eg:
+### Using the CLI
 
 Tracing `execve` events with [filters]:
 
 ```console
 tracee --events execve
 ```
+
+### Through the Tracee Helm Chart installation
 
 Tracing `execve` events with [policies]:
 
@@ -38,81 +40,6 @@ tracee --policies sample_policy.yaml
 
 If no event is passed with [filters] or [policies], tracee will start with a set of default events.
 Below a list of tracee default events.
-
-### Default events
-
-Name   | Sets                              |
--------|-----------------------------------|
-stdio_over_socket | [signatures default] |
-k8s_api_connection |[signatures default] |
-aslr_inspection | [signatures default] |
-proc_mem_code_injection | [signatures default] |
-docker_abuse | [signatures default] |
-scheduled_task_mod | [signatures default] |
-ld_preload | [signatures default] |
-cgroup_notify_on_release | [signatures default] |
-default_loader_mod | [signatures default] |
-sudoers_modification | [signatures default] |
-sched_debug_recon | [signatures default] |
-system_request_key_mod | [signatures default] |
-cgroup_release_agent | [signatures default] |
-rcd_modification | [signatures default] |
-core_pattern_modification | [signatures default] |
-proc_kcore_read | [signatures default] |
-proc_mem_access | [signatures default] |
-hidden_file_created | [signatures default] |
-anti_debugging | [signatures default] |
-ptrace_code_injection | [signatures default] |
-process_vm_write_inject | [signatures default] |
-disk_mount | [signatures default] |
-dynamic_code_loading | [signatures default] |
-fileless_execution | [signatures default] |
-illegitimate_shell  | [signatures default] |
-kernel_module_loading | [signatures default] |
-k8s_cert_theft | [signatures default] |
-proc_fops_hooking | [signatures default] |
-syscall_hooking | [signatures default] |
-dropped_executable | [signatures default] |
-creat | [default syscalls fs fs_file_ops] |
-chmod | [default syscalls fs fs_file_attr] |
-fchmod | [default syscalls fs fs_file_attr] |
-chown | [default syscalls fs fs_file_attr] |
-fchown | [default syscalls fs fs_file_attr] |
-lchown | [default syscalls fs fs_file_attr]|
-ptrace | [default syscalls proc] |
-setuid | [default syscalls proc proc_ids] |
-setgid | [default syscalls proc proc_ids] |
-setpgid | [default syscalls proc proc_ids] |
-setsid | [default syscalls proc proc_ids] |
-setreuid | [default syscalls proc proc_ids] |
-setregid | [default syscalls proc proc_ids] |
-setresuid | [default syscalls proc proc_ids] |
-setresgid | [default syscalls proc proc_ids] |
-setfsuid | [default syscalls proc proc_ids] |
-setfsgid | [default syscalls proc proc_ids] |
-init_module | [default syscalls system system_module] | 
-fchownat | [default syscalls fs fs_file_attr] |
-fchmodat | [default syscalls fs fs_file_attr] |
-setns | [default syscalls proc] |
-process_vm_readv | [default syscalls proc] |
-process_vm_writev | [default syscalls proc] |
-finit_module | [default syscalls system system_module] |
-memfd_create | [default syscalls fs fs_file_ops] |
-move_mount | [default syscalls fs] |
-sched_process_exec | [default proc] |
-security_inode_unlink | [default lsm_hooks fs fs_file_ops] |
-security_socket_connect | [default lsm_hooks net net_sock] |
-security_socket_accept | [default lsm_hooks net net_sock] |
-security_socket_bind | [default lsm_hooks net net_sock] |
-security_sb_mount | [default lsm_hooks fs] |
-container_create | [default containers] |
-container_remove | [default containers] |
-net_packet_icmp | [default network_events] |
-net_packet_icmpv6 | [default network_events] |
-net_packet_dns_request | [default network_events] |
-net_packet_dns_response | [default network_events] |
-net_packet_http_request | [default network_events] |
-net_packet_http_response | [default network_events] |
 
 ### Sets
 

--- a/docs/docs/events/overview.md
+++ b/docs/docs/events/overview.md
@@ -6,9 +6,9 @@ This section documents all of the different events that Tracee exposes.
 
 Tracee uses eBPF technology to tap into your system and give you access to hundreds of events that help you understand how your system behaves. The events can be specified either through CLI with [filters] or with [policies].
 
-## Tracee Kubernetes Manifest
+## Tracee Kubernetes
 
-Events are specified in the Policy provided to the Tracee Kubernetes installation. The Policy can be edited as specified within the Policies section of the [documentation](../policies/index.md)
+Events are through the Tracee Policy in the Kubernetes installation. The Policy can be edited as specified within the `Policies` section of the [documentation](../policies/index.md)
 
 ## Tracee CLI Commands
 

--- a/docs/docs/events/overview.md
+++ b/docs/docs/events/overview.md
@@ -6,7 +6,11 @@ This section documents all of the different events that Tracee exposes.
 
 Tracee uses eBPF technology to tap into your system and give you access to hundreds of events that help you understand how your system behaves. The events can be specified either through CLI with [filters] or with [policies].
 
-### Using the CLI
+## Tracee Kubernetes Manifest
+
+Events are specified in the Policy provided to the Tracee Kubernetes installation. The Policy can be edited as specified within the Policies section of the [documentation](../policies/index.md)
+
+## Tracee CLI Commands
 
 Tracing `execve` events with [filters]:
 
@@ -14,7 +18,7 @@ Tracing `execve` events with [filters]:
 tracee --events execve
 ```
 
-### Through the Tracee Helm Chart installation
+## Tracee Policy File
 
 Tracing `execve` events with [policies]:
 

--- a/docs/docs/policies/filtering.md
+++ b/docs/docs/policies/filtering.md
@@ -1,4 +1,4 @@
-# Applying filters with Tracee CLI
+# How to filter Events through the Tracee CLI
 
 This section showcases how to trace events through the Tracee CLI by applying filters.
 

--- a/docs/docs/policies/filtering.md
+++ b/docs/docs/policies/filtering.md
@@ -1,4 +1,6 @@
-# Tracing Event Filtering
+# Tracing Events through the Tracee CLI by applying filters
+
+This section showcases how to trace events through the Tracee CLI by applying filters.
 
 ```console
 ./dist/tracee man

--- a/docs/docs/policies/filtering.md
+++ b/docs/docs/policies/filtering.md
@@ -1,4 +1,4 @@
-# Tracing Events through the Tracee CLI by applying filters
+# Applying filters with Tracee CLI
 
 This section showcases how to trace events through the Tracee CLI by applying filters.
 

--- a/docs/docs/policies/index.md
+++ b/docs/docs/policies/index.md
@@ -1,3 +1,5 @@
+# Overview 
+
 In this section you can find the reference documentation for Tracee's policies.
 
 Policies are YAML manifests that allow you to define how Tracee should respond to different events. This is done through rules in the policy. A rule takes in one or several events. Additionally, events can be filtered to specific resources. If Tracee detects the event, it will respond with an action. 
@@ -7,7 +9,7 @@ Lastly, policies require a scope. The scope details which resources the policy a
 
 You can load multiple (up to 64) policies into Tracee using the --policy flag providing a path to the policy file.
 
-Following is a sample policy:
+Following is a sample policy for the Tracee Kubernetes usage:
 
 ```yaml
 apiVersion: tracee.aquasec.com/v1beta1
@@ -46,6 +48,17 @@ While specifying event filters is optional, policies must have the `name`, `desc
     Note that currently only one rule can be defined per any event type in a policy
 
 More information about defining a scope and the available filters can be found in the next sections.
+
+## Tracee Kubernetes Policy configuration
+
+Through Querying the Tracee Configmap, users can access the default configuration and apply changes:
+```console
+kubectl edit ds/tracee -n tracee-system
+```
+
+## Tracee CLI Policy configuration
+
+Applying Tracee Policies in the CLI is further detailed within the [filtering section.](./filtering)
 
 ## Video Content
 

--- a/docs/docs/policies/index.md
+++ b/docs/docs/policies/index.md
@@ -9,7 +9,7 @@ Lastly, policies require a scope. The scope details which resources the policy a
 
 You can load multiple (up to 64) policies into Tracee using the --policy flag providing a path to the policy file.
 
-Following is a sample policy for the Tracee Kubernetes usage:
+Following is a sample policy:
 
 ```yaml
 apiVersion: tracee.aquasec.com/v1beta1
@@ -51,14 +51,22 @@ More information about defining a scope and the available filters can be found i
 
 ## Tracee Kubernetes Policy configuration
 
-Through Querying the Tracee Configmap, users can access the default configuration and apply changes:
+Through Querying the Tracee Configmap which is part of the Daemonset, users can access the default policy and apply changes:
 ```console
 kubectl edit ds/tracee -n tracee-system
 ```
 
 ## Tracee CLI Policy configuration
 
-Applying Tracee Policies in the CLI is further detailed within the [filtering section.](./filtering)
+There are multiple ways Tracee can be configured in the CLI. 
+
+### Tracee Config
+
+The first one is through providing the Tracee Policy as a Tracee Config File as detailed in the [`Config` section of the documentation.](../config/overview/)
+
+### Tracee CLI Flags
+
+Alternatively, Tracee can be configured by applying [filters.](./filtering)
 
 ## Video Content
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -566,19 +566,19 @@ nav:
                 - Overview: docs/policies/index.md
                 - Scopes: docs/policies/scopes.md
                 - Rules: docs/policies/rules.md
-          - Filters:
-                - Filtering: docs/filters/filtering.md
-                - Flags Manuals:
-                      - scope: docs/flags/scope.1.md
-                      - events: docs/flags/events.1.md
-                      - output: docs/flags/output.1.md
-                      - capture: docs/flags/capture.1.md
-                      - config: docs/flags/config.1.md
-                      - crs: docs/flags/containers.1.md
-                      - rego: docs/flags/rego.1.md
-                      - cache: docs/flags/cache.1.md
-                      - capabilities: docs/flags/capabilities.1.md
-                      - log: docs/flags/log.1.md
+                - CLI Configuration: 
+                      - Overview: docs/policies/filtering.md
+                      - Flags Manuals:
+                            - scope: docs/flags/scope.1.md
+                            - events: docs/flags/events.1.md
+                            - output: docs/flags/output.1.md
+                            - capture: docs/flags/capture.1.md
+                            - config: docs/flags/config.1.md
+                            - crs: docs/flags/containers.1.md
+                            - rego: docs/flags/rego.1.md
+                            - cache: docs/flags/cache.1.md
+                            - capabilities: docs/flags/capabilities.1.md
+                            - log: docs/flags/log.1.md
           - Outputs:
                 - Output Formats: docs/outputs/output-formats.md
                 - Output Options: docs/outputs/output-options.md


### PR DESCRIPTION
Based on the following issue: https://github.com/aquasecurity/tracee/issues/3607
Merging the policies and filtering section of the docs