### PR TITLE
Allow default policy customization

### DIFF
--- a/deploy/helm/tracee/templates/tracee-policies.yaml
+++ b/deploy/helm/tracee/templates/tracee-policies.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "tracee.labels" . | nindent 4 }}
 data:
+  {{- if .Values.defaultPolicy }}
+  default.yaml:
+    {{- toYaml .Values.defaultPolicy | nindent 4 }}
+  {{- else }}
   default.yaml: |-
     apiVersion: tracee.aquasec.com/v1beta1
     kind: Policy
@@ -87,3 +91,4 @@ data:
         - event: net_packet_dns_response
         - event: net_packet_http_request
         - event: net_packet_http_response
+  {{- end }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -56,6 +56,8 @@ affinity: {}
 
 webhook: ""
 
+defaultPolicy: {}
+
 traceeConfig: {}
 
 config:


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3516


This PR adds a new option to helm to allow the customization of the default policy. The work on this PR is done in the commit https://github.com/aquasecurity/tracee/commit/8f97f471553b3c6a195540c1a96d89bcc3ee95ea the previous commit is from the PR https://github.com/aquasecurity/tracee/pull/3619, which is a depedency.
### 2. Explain how to test it

```
# create your k8s cluster
helm install tracee ./deploy/helm/tracee --set-file defaultPolicy=/path/to/policy
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
