### PR TITLE
Silence missing event

### DIFF
--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -320,25 +320,5 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 		}
 	}
 
-	if len(policies.Map()) == 0 {
-		// if nothing was set, let us consider it as a single default policy
-		eventFilter := eventFilter{
-			Equal:    []string{},
-			NotEqual: []string{},
-		}
-
-		var err error
-		newPolicy := policy.NewPolicy()
-		newPolicy.EventsToTrace, err = prepareEventsToTrace(eventFilter, eventsNameToID)
-		if err != nil {
-			return nil, err
-		}
-
-		err = policies.Add(newPolicy)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return policies, nil
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -955,6 +955,7 @@ func (t *Tracee) checkUnavailableKSymbols(eventsState map[events.ID]events.Event
 // missing, it will cancel their event with informative error message.
 func (t *Tracee) validateKallsymsDependencies() {
 	unavKSymbols := t.checkUnavailableKSymbols(t.eventsState)
+	depsToCancel := make(map[events.ID]string)
 
 	// Cancel events with unavailable symbols dependencies
 	for eventToCancel, missingDepSyms := range unavKSymbols {
@@ -965,6 +966,27 @@ func (t *Tracee) validateKallsymsDependencies() {
 		)
 
 		delete(t.eventsState, eventToCancel)
+
+		// Find all events that depend on eventToCancel
+		for eventID := range t.eventsState {
+			depsIDs := events.Core.GetDefinitionByID(eventID).GetDependencies().GetIDs()
+			for _, depID := range depsIDs {
+				if depID == eventToCancel {
+					depsToCancel[eventID] = eventNameToCancel
+				}
+			}
+		}
+
+		// Cancel all events that require eventToCancel
+		for eventID, depEventName := range depsToCancel {
+			logger.Errorw(
+				"Event canceled because it depends on an previously canceled event",
+				"event", events.Core.GetDefinitionByID(eventID).GetName(),
+				"dependency", depEventName,
+			)
+
+			delete(t.eventsState, eventID)
+		}
 	}
 }
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -960,7 +960,7 @@ func (t *Tracee) validateKallsymsDependencies() {
 	// Cancel events with unavailable symbols dependencies
 	for eventToCancel, missingDepSyms := range unavKSymbols {
 		eventNameToCancel := events.Core.GetDefinitionByID(eventToCancel).GetName()
-		logger.Errorw(
+		logger.Debugw(
 			"Event canceled because of missing kernel symbol dependency",
 			"missing symbols", missingDepSyms, "event", eventNameToCancel,
 		)
@@ -979,7 +979,7 @@ func (t *Tracee) validateKallsymsDependencies() {
 
 		// Cancel all events that require eventToCancel
 		for eventID, depEventName := range depsToCancel {
-			logger.Errorw(
+			logger.Debugw(
 				"Event canceled because it depends on an previously canceled event",
 				"event", events.Core.GetDefinitionByID(eventID).GetName(),
 				"dependency", depEventName,


### PR DESCRIPTION
Close: #3397
Context: #3562

### 1. Explain what the PR does

257f36ac47cb78550ddeed5379403b043aef6a43 **fix(ebpf): change error to debug level**
58504464e **fix(ebpf): cancel dependencies of the canceled one**
4db6a48ab **chore(flags): remove leftover**


257f36ac47cb78550ddeed5379403b043aef6a43 **fix(ebpf): change error to debug level**

```
Some GKE kernels lack the CONFIG_KALLSYMS_ALL enabled, so this level
change is to silence the error related to missing kernel symbols. This
is a workaround until the 'sys_call_table' address can be retrieved
from the kernel in a way other than using '/proc/kallsyms' (see #3397).
At that point, the level should be changed back to 'error' again.
```


58504464e **fix(ebpf): cancel dependencies of the canceled one**

```
Context: #3495
https://github.com/aquasecurity/tracee/actions/runs/6475371851/job/17582516454#step:5:42
```


4db6a48ab **chore(flags): remove leftover**

```
After the changes of #3262, at this stage, policies.Map() length is
always greater than 0.
```

### 2. Explain how to test it

### 3. Other comments