### PR TITLE
chore(workflow): remove cosign from snapshot release

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -25,10 +25,10 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v2.0.2'
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@main
+      #   with:
+      #     cosign-release: 'v2.0.2'
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:
@@ -48,10 +48,11 @@ jobs:
           docker image tag tracee:latest aquasec/tracee:x86_64-dev
           docker image push aquasec/tracee:x86_64-dev
         shell: bash
-      - name: Sign Docker image
-        run: |
-          cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:x86_64-dev)
-        shell: bash
+      # Disabled to avoid generating too many sigstore cosign signatures
+      # - name: Sign Docker image
+      #   run: |
+      #     cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:x86_64-dev)
+      #   shell: bash
   release-snapshot-aarch64:
     name: Release Snapshot (aarch64)
     needs: [ release-snapshot-x86_64 ]
@@ -66,10 +67,10 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v2.0.2'
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@main
+      #   with:
+      #     cosign-release: 'v2.0.2'
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:
@@ -89,10 +90,11 @@ jobs:
           docker image tag tracee:latest aquasec/tracee:aarch64-dev
           docker image push aquasec/tracee:aarch64-dev
         shell: bash
-      - name: Sign Docker image
-        run: |
-          cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:aarch64-dev)
-        shell: bash
+      # Disabled to avoid generating too many sigstore cosign signatures
+      # - name: Sign Docker image
+      #   run: |
+      #     cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:aarch64-dev)
+      #   shell: bash
   release-snapshot:
     name: Release Snapshot
     needs: [release-snapshot-x86_64, release-snapshot-aarch64]
@@ -107,10 +109,10 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@main
-        with:
-          cosign-release: 'v2.0.2'
+      # - name: Install Cosign
+      #   uses: sigstore/cosign-installer@main
+      #   with:
+      #     cosign-release: 'v2.0.2'
       - name: Login to docker.io registry
         uses: docker/login-action@v2
         with:
@@ -124,7 +126,8 @@ jobs:
             aquasec/tracee:aarch64-dev
           docker manifest push aquasec/tracee:dev
         shell: bash
-      - name: Sign Docker image
-        run: |
-          cosign sign -y aquasec/tracee:dev
-        shell: bash
+      # Disabled to avoid generating too many sigstore cosign signatures
+      # - name: Sign Docker image
+      #   run: |
+      #     cosign sign -y aquasec/tracee:dev
+      #   shell: bash


### PR DESCRIPTION
- avoid too many sigstore cosign signatures because of daily runs.
