### PR TITLE
Integration Tests Fix

### DIFF
--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1859,7 +1859,7 @@ func runCmd(t *testing.T, cmd cmdEvents, expectedEvts int, actual *eventBuffer, 
 	pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
 	require.NoError(t, err)
 
-	waitForTraceeOutputEvents(t, actual, time.Now(), expectedEvts, failOnTimeout)
+	waitForTraceeOutputEvents(t, actual, expectedEvts, failOnTimeout)
 
 	return proc{
 		pid:          pid,
@@ -1893,7 +1893,7 @@ func runCmds(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscal
 		expectedEvts += len(cmd.evts)
 	}
 
-	waitForTraceeOutputEvents(t, actual, time.Now(), expectedEvts, failOnTimeout)
+	waitForTraceeOutputEvents(t, actual, expectedEvts, failOnTimeout)
 
 	return procs, expectedEvts
 }

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
@@ -68,6 +67,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"docker run -d --rm hello-world",
+					0,
 					10*time.Second, // give some time for the container to start (possibly downloading the image)
 					[]trace.Event{
 						expectEvent(anyHost, "hello", anyProcessorID, 1, 0, events.SchedProcessExec, orPolNames("container-event"), orPolIDs(1)),
@@ -101,9 +101,9 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				// no event expected
-				newCmdEvents("ls", 1*time.Second, []trace.Event{}, []string{}),
-				newCmdEvents("uname", 1*time.Second, []trace.Event{}, []string{}),
-				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("ls", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("uname", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("who", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
 			coolDown:     0,
@@ -130,8 +130,8 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				// no event expected
-				newCmdEvents("uname", 1*time.Second, []trace.Event{}, []string{}),
-				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("uname", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("who", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
 			coolDown:     0,
@@ -158,8 +158,8 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				// no event expected
-				newCmdEvents("uname", 1*time.Second, []trace.Event{}, []string{}),
-				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("uname", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("who", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
 			coolDown:     0,
@@ -198,6 +198,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ping -c1 0.0.0.0",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm_mntns_pidns_event"), orPolIDs(1)),
@@ -241,6 +242,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ping -c1 0.0.0.0",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm-event"), orPolIDs(1)),
@@ -280,6 +282,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ping -c1 0.0.0.0",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event"), orPolIDs(5)),
@@ -321,6 +324,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "integration.tes", // note that comm name is from the go test binary that runs the command
@@ -361,9 +365,9 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				// no event expected
-				newCmdEvents("ls", 1*time.Second, []trace.Event{}, []string{}),
-				newCmdEvents("uname", 1*time.Second, []trace.Event{}, []string{}),
-				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("ls", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("uname", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
+				newCmdEvents("who", 100*time.Millisecond, 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
 			coolDown:     0,
@@ -398,6 +402,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("comm-event-args"), orPolIDs(42), expectArg("pathname", "*integration")),
@@ -455,6 +460,7 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents("ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm-event-4"), orPolIDs(4)),
@@ -462,6 +468,7 @@ func Test_EventFilters(t *testing.T) {
 					[]string{},
 				),
 				newCmdEvents("uname",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "uname", testutils.CPUForTests, anyPID, 0, events.SchedProcessExit, orPolNames("comm-event-2"), orPolIDs(2)),
@@ -519,6 +526,7 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents("who",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("exec-event-1"), orPolIDs(1)),
@@ -526,6 +534,7 @@ func Test_EventFilters(t *testing.T) {
 					[]string{},
 				),
 				newCmdEvents("uname",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "uname", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("exec-event-2"), orPolIDs(2)),
@@ -557,7 +566,7 @@ func Test_EventFilters(t *testing.T) {
 								{
 									Event: "sched_switch",
 									Filters: []string{
-										"args.next_comm=systemd,init",
+										"args.next_comm=systemd",
 									},
 								},
 							},
@@ -567,18 +576,18 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"kill -SIGHUP 1", // reloads the complete daemon configuration
+					"kill -SIGUSR1 1", // systemd: try to reconnect to the D-Bus bus
+					500*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-args"), orPolIDs(1), expectArg("next_comm", "systemd")),
-						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-args"), orPolIDs(1), expectArg("next_comm", "init")),
 					},
 					[]string{},
 				),
 			},
 			useSyscaller: false,
-			coolDown:     2 * time.Second,
-			test:         ExpectAnyOfEvts,
+			coolDown:     1 * time.Second,
+			test:         ExpectAtLeastOneForEach,
 		},
 		{
 			name: "pid: trace events from pid 1",
@@ -594,24 +603,29 @@ func Test_EventFilters(t *testing.T) {
 								"pid=1",
 							},
 							DefaultActions: []string{"log"},
-							Rules:          []k8s.Rule{},
+							Rules: []k8s.Rule{
+								{
+									Event: "memfd_create,security_inode_unlink",
+								},
+							},
 						},
 					},
 				},
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"kill -SIGHUP 1", // reloads the complete daemon configuration
+					"kill -SIGHUP 1", // systemd: reloads the complete daemon configuration
+					500*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "init", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
-						expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, anyEventID, orPolNames("pid-1"), orPolIDs(1)),
+						expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, events.MemfdCreate, orPolNames("pid-1"), orPolIDs(1)),
+						expectEvent(anyHost, "systemd", anyProcessorID, 1, 0, events.SecurityInodeUnlink, orPolNames("pid-1"), orPolIDs(1)),
 					},
 					[]string{},
 				),
 			},
 			useSyscaller: false,
-			coolDown:     2 * time.Second,
+			coolDown:     1 * time.Second,
 			test:         ExpectAnyOfEvts,
 		},
 		{
@@ -637,6 +651,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("uid-0-comm"), orPolIDs(1)),
@@ -671,6 +686,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					100*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{}, // no events expected
 					[]string{},
@@ -707,6 +723,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("event-fs"), orPolIDs(1)),
@@ -745,6 +762,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"docker run -d --rm hello-world",
+					0,
 					10*time.Second, // give some time for the container to start (possibly downloading the image)
 					[]trace.Event{
 						// using anyComm as some versions of dockerd may result in e.g. "dockerd" or "exe"
@@ -758,7 +776,7 @@ func Test_EventFilters(t *testing.T) {
 			test:         ExpectAllInOrderSequentially,
 		},
 		{
-			name: "trace new pids (should be empty)",
+			name: "pid: trace new (should be empty)",
 			policyFiles: []policyFileWithID{
 				{
 					id: 1,
@@ -779,7 +797,8 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"kill -SIGHUP 1", // reloads the complete daemon configuration
+					"kill -SIGUSR1 1", // systemd: try to reconnect to the D-Bus bus
+					500*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{}, // no events expected
 					[]string{},
@@ -811,6 +830,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64"), orPolIDs(64)),
@@ -860,6 +880,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64"), orPolIDs(64)),
@@ -908,6 +929,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64"), orPolIDs(64)),
@@ -916,6 +938,7 @@ func Test_EventFilters(t *testing.T) {
 				),
 				newCmdEvents(
 					"who",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-42"), orPolIDs(42)),
@@ -957,6 +980,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"bash -c ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "bash", // note that comm name is from the runner
@@ -996,6 +1020,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"bash -c '/usr/bin/tee /tmp/magic_write_test < <(echo 42)'",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "tee", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("comm-event"), orPolIDs(42)),
@@ -1129,6 +1154,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ping -c1 0.0.0.0",
+					100*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.NetPacketICMP, orPolNames("comm-event-3", "comm-event-5"), orPolIDs(3, 5)),
@@ -1192,6 +1218,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ping -c1 0.0.0.0",
+					100*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.Setuid, orPolNames("comm-event-5"), orPolIDs(5)),
@@ -1297,6 +1324,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ping -c1 0.0.0.0",
+					100*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ping", testutils.CPUForTests, anyPID, 0, events.SchedProcessExec, orPolNames("comm-event-7", "comm-event-9"), orPolIDs(7, 9)),
@@ -1351,6 +1379,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64", "comm-42"), orPolIDs(64, 42)),
@@ -1359,6 +1388,7 @@ func Test_EventFilters(t *testing.T) {
 				),
 				newCmdEvents(
 					"who",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-42"), orPolIDs(42)),
@@ -1407,6 +1437,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"ls",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "ls", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-64", "comm-42"), orPolIDs(64, 42)),
@@ -1415,6 +1446,7 @@ func Test_EventFilters(t *testing.T) {
 				),
 				newCmdEvents(
 					"who",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "who", testutils.CPUForTests, anyPID, 0, anyEventID, orPolNames("comm-42"), orPolIDs(42)),
@@ -1463,6 +1495,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"fakeprog1",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Read, orPolNames("comm-event"), orPolIDs(1)),
@@ -1500,6 +1533,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"fakeprog1",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Execve, orPolNames("event-pol-42"), orPolIDs(42)),
@@ -1565,6 +1599,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"fakeprog1",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Openat, orPolNames("comm-event-args-64"), orPolIDs(64),
@@ -1577,6 +1612,7 @@ func Test_EventFilters(t *testing.T) {
 				),
 				newCmdEvents(
 					"fakeprog2",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "fakeprog2", testutils.CPUForTests, anyPID, 0, events.Open, orPolNames("comm-event-args-42"), orPolIDs(42),
@@ -1643,6 +1679,7 @@ func Test_EventFilters(t *testing.T) {
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
 					"fakeprog1",
+					0,
 					1*time.Second,
 					[]trace.Event{
 						expectEvent(anyHost, "fakeprog1", testutils.CPUForTests, anyPID, 0, events.Openat, orPolNames("comm-event-retval-64"), orPolIDs(64),
@@ -1655,6 +1692,7 @@ func Test_EventFilters(t *testing.T) {
 				),
 				newCmdEvents(
 					"fakeprog2",
+					100*time.Millisecond,
 					1*time.Second,
 					[]trace.Event{}, // no events expected
 					[]string{},
@@ -1683,8 +1721,18 @@ func Test_EventFilters(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			// start tracee
-			trc := startTracee(ctx, t, config, nil, nil)
-			waitForTraceeStart(t, trc)
+			trc, err := startTracee(ctx, t, config, nil, nil)
+			if err != nil {
+				cancel()
+				t.Fatal(err)
+			}
+
+			t.Logf("  --- started tracee ---")
+			err = waitForTraceeStart(trc)
+			if err != nil {
+				cancel()
+				t.Fatal(err)
+			}
 
 			stream := trc.SubscribeAll()
 			defer trc.Unsubscribe(stream)
@@ -1702,12 +1750,26 @@ func Test_EventFilters(t *testing.T) {
 				}
 			}(ctx, buf)
 
+			failed := false
 			// run a test case and validate the results against the expected events
-			tc.test(t, tc.cmdEvents, buf, tc.useSyscaller)
+			err = tc.test(t, tc.cmdEvents, buf, tc.useSyscaller)
+			if err != nil {
+				t.Logf("Test %s failed: %v", t.Name(), err)
+				failed = true
+			}
 
-			// if we got here, the test passed, so we can stop tracee
 			cancel()
-			waitForTraceeStop(t, trc)
+			errStop := waitForTraceeStop(trc)
+			if errStop != nil {
+				t.Log(errStop)
+				failed = true
+			} else {
+				t.Logf("  --- stopped tracee ---")
+			}
+
+			if failed {
+				t.Fail()
+			}
 		})
 	}
 }
@@ -1734,20 +1796,22 @@ type testCase struct {
 	cmdEvents    []cmdEvents
 	useSyscaller bool
 	coolDown     time.Duration // cool down before running the test case
-	test         func(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool)
+	test         func(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) error
 }
 
 type cmdEvents struct {
 	runCmd  string
-	timeout time.Duration
+	waitFor time.Duration // time to wait before collecting events
+	timeout time.Duration // timeout for the command to run
 	evts    []trace.Event
 	sets    []string
 }
 
 // newCmdEvents is a helper function to create a cmdEvents
-func newCmdEvents(runCmd string, timeout time.Duration, evts []trace.Event, sets []string) cmdEvents {
+func newCmdEvents(runCmd string, waitFor, timeout time.Duration, evts []trace.Event, sets []string) cmdEvents {
 	return cmdEvents{
 		runCmd:  runCmd,
+		waitFor: waitFor,
 		timeout: timeout,
 		evts:    evts,
 		sets:    sets,
@@ -1845,7 +1909,7 @@ type proc struct {
 }
 
 // runCmd runs a command and returns a process
-func runCmd(t *testing.T, cmd cmdEvents, expectedEvts int, actual *eventBuffer, useSyscaller, failOnTimeout bool) proc {
+func runCmd(t *testing.T, cmd cmdEvents, expectedEvts int, actual *eventBuffer, useSyscaller, failOnTimeout bool) (proc, error) {
 	var (
 		pid int
 		err error
@@ -1855,24 +1919,30 @@ func runCmd(t *testing.T, cmd cmdEvents, expectedEvts int, actual *eventBuffer, 
 		formatCmdEvents(&cmd)
 	}
 
-	t.Logf("Running command: %s", cmd.runCmd)
+	t.Logf("  >>> running: %s", cmd.runCmd)
 	pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
-	require.NoError(t, err)
+	if err != nil {
+		return proc{}, err
+	}
 
-	waitForTraceeOutputEvents(t, actual, expectedEvts, failOnTimeout)
+	err = waitForTraceeOutputEvents(t, cmd.waitFor, actual, expectedEvts, failOnTimeout)
+	if err != nil {
+		return proc{}, err
+	}
 
 	return proc{
 		pid:          pid,
 		expectedEvts: expectedEvts,
-	}
+	}, nil
 }
 
 // runCmds runs a list of commands and returns a list of processes
 // It also returns the number of expected events from all processes
-func runCmds(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller, failOnTimeout bool) ([]proc, int) {
+func runCmds(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller, failOnTimeout bool) ([]proc, int, error) {
 	var (
-		procs        = make([]proc, 0)
-		expectedEvts int
+		procs          = make([]proc, 0)
+		expectedEvts   int
+		waitForAverage time.Duration
 	)
 
 	for _, cmd := range cmdEvents {
@@ -1885,17 +1955,26 @@ func runCmds(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscal
 			formatCmdEvents(&cmd)
 		}
 
-		t.Logf("Running command: %s", cmd.runCmd)
+		t.Logf("  >>> running: %s", cmd.runCmd)
 		pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
-		require.NoError(t, err)
+		if err != nil {
+			return nil, 0, err
+		}
 
 		procs = append(procs, proc{pid, len(cmd.evts)})
 		expectedEvts += len(cmd.evts)
+		waitForAverage += cmd.waitFor
+	}
+	if waitForAverage > 0 {
+		waitForAverage /= time.Duration(len(cmdEvents))
 	}
 
-	waitForTraceeOutputEvents(t, actual, expectedEvts, failOnTimeout)
+	err := waitForTraceeOutputEvents(t, waitForAverage, actual, expectedEvts, failOnTimeout)
+	if err != nil {
+		return nil, 0, err
+	}
 
-	return procs, expectedEvts
+	return procs, expectedEvts, nil
 }
 
 // formatCmdEvents formats given commands to be executed by syscaller helper tool
@@ -1967,8 +2046,10 @@ func pidToCheck(cmd string, actEvt trace.Event) int {
 }
 
 // assert that the given string slices are equal, ignoring order
-func assertUnorderedStringSlicesEqual(t *testing.T, expNames []string, actNames []string) {
-	assert.Equal(t, len(expNames), len(actNames))
+func assertUnorderedStringSlicesEqual(expNames []string, actNames []string) bool {
+	if len(expNames) != len(actNames) {
+		return false
+	}
 	sortedExpNames := make([]string, len(expNames))
 	copy(sortedExpNames, expNames)
 	sort.Strings(sortedExpNames)
@@ -1978,8 +2059,12 @@ func assertUnorderedStringSlicesEqual(t *testing.T, expNames []string, actNames 
 	sort.Strings(sortedActNames)
 
 	for i := range sortedExpNames {
-		assert.Equal(t, sortedExpNames[i], sortedActNames[i])
+		if sortedExpNames[i] != sortedActNames[i] {
+			return false
+		}
 	}
+
+	return true
 }
 
 // ExpectAtLeastOneForEach validates that at least one event from each command
@@ -1993,7 +2078,7 @@ func assertUnorderedStringSlicesEqual(t *testing.T, expNames []string, actNames 
 // This function is suitable when you want to ensure that each command has at
 // least one event in the actual events, regardless of the number of expected
 // events for each command.
-func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) error {
 	for _, cmd := range cmdEvents {
 		syscallsInSets := []string{}
 		checkSets := len(cmd.sets) > 0
@@ -2003,9 +2088,12 @@ func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 
 		actual.clear()
 		// first stage: run commands
-		proc := runCmd(t, cmd, len(cmd.evts), actual, useSyscaller, true)
+		proc, err := runCmd(t, cmd, len(cmd.evts), actual, useSyscaller, true)
+		if err != nil {
+			return err
+		}
 		if len(cmd.evts) == 0 && proc.expectedEvts > 0 {
-			t.Fatalf("expected no events for command %s, but got %d", cmd.runCmd, proc.expectedEvts)
+			return fmt.Errorf("expected no events for command %s, but got %d", cmd.runCmd, proc.expectedEvts)
 		}
 
 		actEvtsCopy := actual.getCopy()
@@ -2023,7 +2111,7 @@ func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 			checkPolicyName := len(expEvt.MatchedPolicies) > 0 && expEvt.MatchedPolicies[0] != anyPolicyName
 
 			if len(cmd.evts) > 0 && proc.expectedEvts == 0 {
-				t.Fatalf("expected events for command %s, but got none", cmd.runCmd)
+				return fmt.Errorf("expected events for command %s, but got none", cmd.runCmd)
 			}
 
 			for _, actEvt := range actEvtsCopy {
@@ -2077,7 +2165,9 @@ func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 				// check args
 				for _, expArg := range expEvt.Args {
 					actArg, err := helpers.GetTraceeArgumentByName(actEvt, expArg.Name, helpers.GetArgOps{DefaultArgs: false})
-					require.NoError(t, err)
+					if err != nil {
+						return err
+					}
 					switch v := expArg.Value.(type) {
 					case string:
 						actVal := actArg.Value.(string)
@@ -2103,9 +2193,13 @@ func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 				break
 			}
 			// evaluate found
-			require.True(t, found, "Event %+v:\nnot found in actual output:\n%+v", expEvt, actual.events)
+			if !found {
+				return fmt.Errorf("Event %+v:\nnot found in actual output:\n%+v", expEvt, actEvtsCopy)
+			}
 		}
 	}
+
+	return nil
 }
 
 // ExpectAnyOfEvts validates that at least one event from each command in
@@ -2116,10 +2210,10 @@ func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 //
 // This function is suitable when you expect any of a set of events to occur
 // and want to confirm that at least one of them happened.
-func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) error {
 	for _, cmd := range cmdEvents {
 		if len(cmd.evts) <= 1 {
-			t.Fatalf("ExpectAnyOfEvts test requires at least 2 expected events for command %s", cmd.runCmd)
+			return fmt.Errorf("ExpectAnyOfEvts test requires at least 2 expected events for command %s", cmd.runCmd)
 		}
 
 		syscallsInSets := []string{}
@@ -2130,7 +2224,10 @@ func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 
 		actual.clear()
 		// first stage: run commands
-		proc := runCmd(t, cmd, 1, actual, useSyscaller, true)
+		proc, err := runCmd(t, cmd, 1, actual, useSyscaller, true)
+		if err != nil {
+			return err
+		}
 
 		actEvtsCopy := actual.getCopy()
 
@@ -2147,7 +2244,7 @@ func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 			checkPolicyName := len(expEvt.MatchedPolicies) > 0 && expEvt.MatchedPolicies[0] != anyPolicyName
 
 			if len(cmd.evts) > 0 && proc.expectedEvts == 0 {
-				t.Fatalf("expected events for command %s, but got none", cmd.runCmd)
+				return fmt.Errorf("expected events for command %s, but got none", cmd.runCmd)
 			}
 
 			for _, actEvt := range actEvtsCopy {
@@ -2201,7 +2298,9 @@ func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 				// check args
 				for _, expArg := range expEvt.Args {
 					actArg, err := helpers.GetTraceeArgumentByName(actEvt, expArg.Name, helpers.GetArgOps{DefaultArgs: false})
-					require.NoError(t, err)
+					if err != nil {
+						return err
+					}
 					switch v := expArg.Value.(type) {
 					case string:
 						actVal := actArg.Value.(string)
@@ -2233,8 +2332,12 @@ func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 		}
 
 		// evaluate found
-		require.True(t, found, "None of the expected events\n%+v\nare in the actual output\n%+v\n", cmd.evts, actEvtsCopy)
+		if !found {
+			return fmt.Errorf("none of the expected events\n%+v\nare in the actual output\n%+v", cmd.evts, actEvtsCopy)
+		}
 	}
+
+	return nil
 }
 
 // ExpectAllEvtsEqualToOne validates that all events within a command match the
@@ -2243,20 +2346,23 @@ func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 //
 // This function is suitable for cases where each command should produce one
 // specific event, and all commands should match their respective events.
-func ExpectAllEvtsEqualToOne(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+func ExpectAllEvtsEqualToOne(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) error {
 	for _, cmd := range cmdEvents {
 		if len(cmd.evts) != 1 {
-			t.Fatalf("ExpectAllEvtsEqualToOne test requires exactly one event per command, but got %d events for command %s", len(cmd.evts), cmd.runCmd)
+			return fmt.Errorf("ExpectAllEvtsEqualToOne test requires exactly one event per command, but got %d events for command %s", len(cmd.evts), cmd.runCmd)
 		}
 
 		actual.clear()
 		// first stage: run commands
-		proc := runCmd(t, cmd, len(cmd.evts), actual, useSyscaller, true)
+		proc, err := runCmd(t, cmd, len(cmd.evts), actual, useSyscaller, true)
+		if err != nil {
+			return err
+		}
 
 		actEvtsCopy := actual.getCopy()
 
 		if proc.expectedEvts == 0 {
-			t.Fatalf("expected one event for command %s, but got none", cmd.runCmd)
+			return fmt.Errorf("expected one event for command %s, but got none", cmd.runCmd)
 		}
 		syscallsInSets := []string{}
 		checkSets := len(cmd.sets) > 0
@@ -2276,65 +2382,81 @@ func ExpectAllEvtsEqualToOne(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 			checkPolicyName := len(expEvt.MatchedPolicies) > 0 && expEvt.MatchedPolicies[0] != anyPolicyName
 
 			for _, actEvt := range actEvtsCopy {
-				if checkSets {
-					assert.Contains(t, syscallsInSets, actEvt.EventName, "event name in set")
+				if checkSets && !isInSets(actEvt.EventName, syscallsInSets) {
+					return fmt.Errorf("Event %s not found in sets %v", actEvt.EventName, cmd.sets)
 				}
 
-				if checkHost {
-					assert.Equal(t, expEvt.HostName, actEvt.HostName, "host name")
+				if checkHost && !assert.ObjectsAreEqual(expEvt.HostName, actEvt.HostName) {
+					return fmt.Errorf("Event %+v:\nhost name mismatch: expected %s, got %s", expEvt, expEvt.HostName, actEvt.HostName)
 				}
-				if checkComm {
-					assert.Equal(t, expEvt.ProcessName, actEvt.ProcessName, "comm")
+				if checkComm && !assert.ObjectsAreEqual(expEvt.ProcessName, actEvt.ProcessName) {
+					return fmt.Errorf("Event %+v:\ncomm mismatch: expected %s, got %s", expEvt, expEvt.ProcessName, actEvt.ProcessName)
 				}
-				if checkProcessorID {
-					assert.Equal(t, expEvt.ProcessorID, actEvt.ProcessorID, "processor id")
+				if checkProcessorID && !assert.ObjectsAreEqual(expEvt.ProcessorID, actEvt.ProcessorID) {
+					return fmt.Errorf("Event %+v:\nprocessor id mismatch: expected %d, got %d", expEvt, expEvt.ProcessorID, actEvt.ProcessorID)
 				}
 				if checkPID {
-					assert.Equal(t, expEvt.ProcessID, pidToCheck(cmd.runCmd, actEvt), "pid")
+					actPID := pidToCheck(cmd.runCmd, actEvt)
+					if !assert.ObjectsAreEqual(expEvt.ProcessID, actPID) {
+						return fmt.Errorf("Event %+v:\npid mismatch: expected %d, got %d", expEvt, expEvt.ProcessID, actPID)
+					}
 				}
-				if checkUID {
-					assert.Equal(t, expEvt.UserID, actEvt.UserID, "user id")
+				if checkUID && !assert.ObjectsAreEqual(expEvt.UserID, actEvt.UserID) {
+					return fmt.Errorf("Event %+v:\nuser id mismatch: expected %d, got %d", expEvt, expEvt.UserID, actEvt.UserID)
 				}
-				if checkEventID {
-					assert.Equal(t, expEvt.EventID, actEvt.EventID, "event id")
+				if checkEventID && !assert.ObjectsAreEqual(expEvt.EventID, actEvt.EventID) {
+					return fmt.Errorf("Event %+v:\nevent id mismatch: expected %d, got %d", expEvt, expEvt.EventID, actEvt.EventID)
 				}
-				if checkPolicy {
-					assert.Equal(t, expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser, "matched policies")
+				if checkPolicy && !assert.ObjectsAreEqual(expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser) {
+					return fmt.Errorf("Event %+v:\nmatched policies mismatch: expected %d, got %d", expEvt, expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser)
 				}
-				if checkPolicyName {
-					assertUnorderedStringSlicesEqual(t, expEvt.MatchedPolicies, actEvt.MatchedPolicies)
+				if checkPolicyName && !assertUnorderedStringSlicesEqual(expEvt.MatchedPolicies, actEvt.MatchedPolicies) {
+					return fmt.Errorf("Event %+v:\nmatched policies mismatch: expected %v, got %v", expEvt, expEvt.MatchedPolicies, actEvt.MatchedPolicies)
 				}
 
 				// check args
 				for _, expArg := range expEvt.Args {
 					actArg, err := helpers.GetTraceeArgumentByName(actEvt, expArg.Name, helpers.GetArgOps{DefaultArgs: false})
-					require.NoError(t, err)
+					if err != nil {
+						return err
+					}
 					switch v := expArg.Value.(type) {
 					case string:
 						actVal := actArg.Value.(string)
 						if strings.Contains(v, "*") {
 							v = strings.ReplaceAll(v, "*", "")
-							assert.Contains(t, actVal, v, "arg value")
+							if !strings.Contains(actVal, v) {
+								return fmt.Errorf("Event %+v:\narg value mismatch: expected %s, got %s", expEvt, v, actVal)
+							}
 						} else {
-							assert.Equal(t, v, actVal, "arg value")
+							if !assert.ObjectsAreEqual(v, actVal) {
+								return fmt.Errorf("Event %+v:\narg value mismatch: expected %s, got %s", expEvt, v, actVal)
+							}
 						}
 					default:
-						assert.Equal(t, v, actArg.Value, "arg value")
+						if !assert.ObjectsAreEqual(v, actArg.Value) {
+							return fmt.Errorf("Event %+v:\narg value mismatch: expected %v, got %v", expEvt, v, actArg.Value)
+						}
 					}
 				}
 			}
 		}
 	}
+
+	return nil
 }
 
 // ExpectAllInOrderSequentially validates that the actual events match the
 // expected events for each command, with events appearing in the same order.
-func ExpectAllInOrderSequentially(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+func ExpectAllInOrderSequentially(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) error {
 	// first stage: run commands
 	actual.clear()
-	procs, _ := runCmds(t, cmdEvents, actual, useSyscaller, true)
+	procs, _, err := runCmds(t, cmdEvents, actual, useSyscaller, true)
+	if err != nil {
+		return err
+	}
 	if len(procs) > len(cmdEvents) {
-		t.Fatalf("expected %d commands, but got %d", len(cmdEvents), len(procs))
+		return fmt.Errorf("expected %d commands, but got %d", len(cmdEvents), len(procs))
 	}
 
 	actEvtsCopy := actual.getCopy()
@@ -2351,8 +2473,8 @@ func ExpectAllInOrderSequentially(t *testing.T, cmdEvents []cmdEvents, actual *e
 		for evtIdx, expEvt := range cmd.evts {
 			actEvt := actEvtsCopy[cmdIdx*len(cmd.evts)+evtIdx]
 
-			if checkSets {
-				assert.Contains(t, syscallsInSets, actEvt.EventName, "event name in set")
+			if checkSets && !isInSets(actEvt.EventName, syscallsInSets) {
+				return fmt.Errorf("Event %s not found in sets %v", actEvt.EventName, cmd.sets)
 			}
 			checkHost := expEvt.HostName != anyHost
 			checkComm := expEvt.ProcessName != anyComm
@@ -2363,48 +2485,62 @@ func ExpectAllInOrderSequentially(t *testing.T, cmdEvents []cmdEvents, actual *e
 			checkPolicy := expEvt.MatchedPoliciesUser != anyPolicy
 			checkPolicyName := len(expEvt.MatchedPolicies) > 0 && expEvt.MatchedPolicies[0] != anyPolicyName
 
-			if checkHost {
-				assert.Equal(t, expEvt.HostName, actEvt.HostName, "host name")
+			if checkHost && !assert.ObjectsAreEqual(expEvt.HostName, actEvt.HostName) {
+				return fmt.Errorf("Event %+v:\nhost name mismatch: expected %s, got %s", expEvt, expEvt.HostName, actEvt.HostName)
 			}
-			if checkComm {
-				assert.Equal(t, expEvt.ProcessName, actEvt.ProcessName, "comm")
+			if checkComm && !assert.ObjectsAreEqual(expEvt.ProcessName, actEvt.ProcessName) {
+				return fmt.Errorf("Event %+v:\ncomm mismatch: expected %s, got %s", expEvt, expEvt.ProcessName, actEvt.ProcessName)
 			}
-			if checkProcessorID {
-				assert.Equal(t, expEvt.ProcessorID, actEvt.ProcessorID, "processor id")
+			if checkProcessorID && !assert.ObjectsAreEqual(expEvt.ProcessorID, actEvt.ProcessorID) {
+				return fmt.Errorf("Event %+v:\nprocessor id mismatch: expected %d, got %d", expEvt, expEvt.ProcessorID, actEvt.ProcessorID)
 			}
 			if checkPID {
-				assert.Equal(t, expEvt.ProcessID, pidToCheck(cmd.runCmd, actEvt), "pid")
+				actPID := pidToCheck(cmd.runCmd, actEvt)
+				if !assert.ObjectsAreEqual(expEvt.ProcessID, actPID) {
+					return fmt.Errorf("Event %+v:\npid mismatch: expected %d, got %d", expEvt, expEvt.ProcessID, actPID)
+				}
 			}
-			if checkUID {
-				assert.Equal(t, expEvt.UserID, actEvt.UserID, "user id")
+			if checkUID && !assert.ObjectsAreEqual(expEvt.UserID, actEvt.UserID) {
+				return fmt.Errorf("Event %+v:\nuser id mismatch: expected %d, got %d", expEvt, expEvt.UserID, actEvt.UserID)
 			}
-			if checkEventID {
-				assert.Equal(t, expEvt.EventID, actEvt.EventID, "event id")
+			if checkEventID && !assert.ObjectsAreEqual(expEvt.EventID, actEvt.EventID) {
+				return fmt.Errorf("Event %+v:\nevent id mismatch: expected %d, got %d", expEvt, expEvt.EventID, actEvt.EventID)
 			}
-			if checkPolicy {
-				assert.Equal(t, expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser, "matched policies")
+			if checkPolicy && !assert.ObjectsAreEqual(expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser) {
+				return fmt.Errorf("Event %+v:\nmatched policies mismatch: expected %d, got %d", expEvt, expEvt.MatchedPoliciesUser, actEvt.MatchedPoliciesUser)
 			}
-			if checkPolicyName {
-				assertUnorderedStringSlicesEqual(t, expEvt.MatchedPolicies, actEvt.MatchedPolicies)
+			if checkPolicyName && !assertUnorderedStringSlicesEqual(expEvt.MatchedPolicies, actEvt.MatchedPolicies) {
+				return fmt.Errorf("Event %+v:\nmatched policies mismatch: expected %v, got %v", expEvt, expEvt.MatchedPolicies, actEvt.MatchedPolicies)
 			}
 
 			// check args
 			for _, expArg := range expEvt.Args {
 				actArg, err := helpers.GetTraceeArgumentByName(actEvt, expArg.Name, helpers.GetArgOps{DefaultArgs: false})
-				require.NoError(t, err)
+				if err != nil {
+					return err
+				}
 				switch v := expArg.Value.(type) {
 				case string:
+					actVal := actArg.Value.(string)
 					if strings.Contains(v, "*") {
 						v = strings.ReplaceAll(v, "*", "")
-						assert.Contains(t, actArg.Value, v, "arg value")
+						if !strings.Contains(actVal, v) {
+							return fmt.Errorf("Event %+v:\narg value mismatch: expected %s, got %s", expEvt, v, actVal)
+						}
 					} else {
-						assert.Equal(t, v, actArg.Value, "arg value")
+						if !assert.ObjectsAreEqual(v, actArg.Value) {
+							return fmt.Errorf("Event %+v:\narg value mismatch: expected %s, got %s", expEvt, v, actVal)
+						}
 					}
 
 				default:
-					assert.Equal(t, v, actArg.Value, "arg value")
+					if !assert.ObjectsAreEqual(v, actArg.Value) {
+						return fmt.Errorf("Event %+v:\narg value mismatch: expected %v, got %v", expEvt, v, actArg.Value)
+					}
 				}
 			}
 		}
 	}
+
+	return nil
 }

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -76,7 +76,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "mntns/pidns: trace events only from mount/pid namespace 0",
@@ -105,7 +106,8 @@ func Test_EventFilters(t *testing.T) {
 				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "mntns: trace events from all mount namespaces but current",
@@ -132,7 +134,8 @@ func Test_EventFilters(t *testing.T) {
 				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "pidns: trace events from all pid namespaces but current",
@@ -159,7 +162,8 @@ func Test_EventFilters(t *testing.T) {
 				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: mntns: pidns: event: trace events set in a single policy from current pid/mount namespaces",
@@ -203,7 +207,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: trace events set in a single policy from ping command",
@@ -245,7 +250,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: trace events set in a single policy from ping command",
@@ -283,7 +289,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "event: args: trace event set in a specific policy with args pathname finishing with 'ls'",
@@ -323,7 +330,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "event: args: trace event set in a specific policy with args pathname starting with * wildcard",
@@ -358,7 +366,8 @@ func Test_EventFilters(t *testing.T) {
 				newCmdEvents("who", 1*time.Second, []trace.Event{}, []string{}),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: args: trace event set in a specific policy with args from ls command",
@@ -397,7 +406,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: trace events set in two specific policies from ls and uname commands",
@@ -460,7 +470,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "exec: event: trace events in separate policies from who and uname executable",
@@ -523,7 +534,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		// TODO: Add pid>0 pid<1000
 		// TODO: Add u>0 u!=1000
@@ -565,7 +577,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAnyOfEach,
+			coolDown:     2 * time.Second,
+			test:         ExpectAnyOfEvts,
 		},
 		{
 			name: "pid: trace events from pid 1",
@@ -598,7 +611,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAnyOfEach,
+			coolDown:     2 * time.Second,
+			test:         ExpectAnyOfEvts,
 		},
 		{
 			name: "uid: comm: trace uid 0 from ls command",
@@ -631,7 +645,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "uid: comm: trace only uid>0 from ls command (should be empty)",
@@ -662,7 +677,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: trace filesystem events from ls command",
@@ -699,7 +715,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "exec: event: trace only setns events from \"/usr/bin/dockerd\" executable",
@@ -737,7 +754,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "trace new pids (should be empty)",
@@ -768,7 +786,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: trace events set in a specific policy from ls command",
@@ -800,7 +819,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "comm: trace events set in a specific policy from ls command",
@@ -848,7 +868,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "comm: trace events set in a specific policy from ls and who commands",
@@ -903,7 +924,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "event: args: context: only security_file_open from \"execve\" syscall",
@@ -944,7 +966,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "comm: event: do a file write",
@@ -981,7 +1004,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 
 		// // TODO: add tests using signature events
@@ -1053,7 +1077,8 @@ func Test_EventFilters(t *testing.T) {
 		// 		),
 		// 	},
 		// 	useSyscaller: false,
-		// 	test:         ExpectAtLeastOneOfEach,
+		// 	coolDown: 0,
+		//  test: ExpectAtLeastOneOfEach,
 		// },
 
 		// events matched in multiple policies - intertwined workloads
@@ -1113,7 +1138,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: trace events from ping command in multiple policies",
@@ -1177,7 +1203,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: trace events from ping command in multiple policies",
@@ -1283,7 +1310,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: trace only events from from ls and who commands in multiple policies",
@@ -1339,7 +1367,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAllEqualTo,
+			coolDown:     0,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "comm: trace at least one event in multiple policies from ls and who commands",
@@ -1394,7 +1423,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: false,
-			test:         ExpectAtLeastOneOfEach,
+			coolDown:     0,
+			test:         ExpectAtLeastOneForEach,
 		},
 
 		// This uses the syscaller tool which emits the desired events from a desired comm,
@@ -1442,7 +1472,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: true,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "event: trace execve event set in a specific policy from fakeprog1 command",
@@ -1477,7 +1508,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: true,
-			test:         ExpectAtLeastOneOfEach,
+			coolDown:     0,
+			test:         ExpectAtLeastOneForEach,
 		},
 		{
 			name: "comm: event: args: trace event set in a specific policy with args from fakeprog1 and fakeprog2 commands",
@@ -1556,7 +1588,8 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: true,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 		{
 			name: "comm: event: retval: trace event set in a specific policy with retval from fakeprog1 and fakeprog2 commands",
@@ -1628,13 +1661,17 @@ func Test_EventFilters(t *testing.T) {
 				),
 			},
 			useSyscaller: true,
-			test:         ExpectAllInOrder,
+			coolDown:     0,
+			test:         ExpectAllInOrderSequentially,
 		},
 	}
 
 	// run tests cases
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
+			// wait for the previous test to cool down
+			coolDown(t, tc.coolDown)
+
 			// prepare tracee config
 			config := config.Config{
 				Policies: newPolicies(tc.policyFiles),
@@ -1653,8 +1690,8 @@ func Test_EventFilters(t *testing.T) {
 			defer trc.Unsubscribe(stream)
 
 			// start a goroutine to read events from the channel into the buffer
-			buf := &eventBuffer{}
-			go func(ctx context.Context) {
+			buf := newEventBuffer()
+			go func(ctx context.Context, buf *eventBuffer) {
 				for {
 					select {
 					case <-ctx.Done():
@@ -1663,7 +1700,7 @@ func Test_EventFilters(t *testing.T) {
 						buf.addEvent(evt)
 					}
 				}
-			}(ctx)
+			}(ctx, buf)
 
 			// run a test case and validate the results against the expected events
 			tc.test(t, tc.cmdEvents, buf, tc.useSyscaller)
@@ -1696,6 +1733,7 @@ type testCase struct {
 	policyFiles  []policyFileWithID
 	cmdEvents    []cmdEvents
 	useSyscaller bool
+	coolDown     time.Duration // cool down before running the test case
 	test         func(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool)
 }
 
@@ -1793,6 +1831,13 @@ func expectEvent(
 	}
 }
 
+func coolDown(t *testing.T, duration time.Duration) {
+	if duration > 0 {
+		t.Logf("Cooling down for %v", duration)
+		time.Sleep(duration)
+	}
+}
+
 // proc represents a process, with its pid and the number of events it should generate
 type proc struct {
 	pid          int
@@ -1800,7 +1845,7 @@ type proc struct {
 }
 
 // runCmd runs a command and returns a process
-func runCmd(t *testing.T, cmd cmdEvents, actual *eventBuffer, useSyscaller, failOnTimeout bool) proc {
+func runCmd(t *testing.T, cmd cmdEvents, expectedEvts int, actual *eventBuffer, useSyscaller, failOnTimeout bool) proc {
 	var (
 		pid int
 		err error
@@ -1809,14 +1854,16 @@ func runCmd(t *testing.T, cmd cmdEvents, actual *eventBuffer, useSyscaller, fail
 	if useSyscaller {
 		formatCmdEvents(&cmd)
 	}
+
+	t.Logf("Running command: %s", cmd.runCmd)
 	pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
 	require.NoError(t, err)
 
-	waitForTraceeOutputEvents(t, actual, time.Now(), len(cmd.evts), failOnTimeout)
+	waitForTraceeOutputEvents(t, actual, time.Now(), expectedEvts, failOnTimeout)
 
 	return proc{
 		pid:          pid,
-		expectedEvts: len(cmd.evts),
+		expectedEvts: expectedEvts,
 	}
 }
 
@@ -1837,6 +1884,8 @@ func runCmds(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscal
 		if useSyscaller {
 			formatCmdEvents(&cmd)
 		}
+
+		t.Logf("Running command: %s", cmd.runCmd)
 		pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
 		require.NoError(t, err)
 
@@ -1917,18 +1966,6 @@ func pidToCheck(cmd string, actEvt trace.Event) int {
 	return actEvt.ProcessID
 }
 
-// copyActualEvents returns a copy of the actual events
-// This is to avoid holding the lock while comparing the events (in nested loops)
-func copyActualEvents(actual *eventBuffer) []trace.Event {
-	var evts []trace.Event
-
-	actual.mu.Lock()
-	evts = append(evts, actual.events...)
-	actual.mu.Unlock()
-
-	return evts
-}
-
 // assert that the given string slices are equal, ignoring order
 func assertUnorderedStringSlicesEqual(t *testing.T, expNames []string, actNames []string) {
 	assert.Equal(t, len(expNames), len(actNames))
@@ -1945,26 +1982,36 @@ func assertUnorderedStringSlicesEqual(t *testing.T, expNames []string, actNames 
 	}
 }
 
-// ExpectAtLeastOneOfEach validates that at least one event from each command was captured
-func ExpectAtLeastOneOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
-	for _, exp := range cmdEvents {
+// ExpectAtLeastOneForEach validates that at least one event from each command
+// in 'cmdEvents' was captured in the actual events. It does not impose a minimum
+// expected event count and checks that at least one event from each command
+// (regardless of the number of expected events) is present in the actual events.
+// It continues searching for all expected events for each command and raises a
+// test failure only if none of the expected events for a command are found in
+// the actual events.
+//
+// This function is suitable when you want to ensure that each command has at
+// least one event in the actual events, regardless of the number of expected
+// events for each command.
+func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+	for _, cmd := range cmdEvents {
 		syscallsInSets := []string{}
-		checkSets := len(exp.sets) > 0
+		checkSets := len(cmd.sets) > 0
 		if checkSets {
-			syscallsInSets = getAllSyscallsInSets(exp.sets)
+			syscallsInSets = getAllSyscallsInSets(cmd.sets)
 		}
 
 		actual.clear()
 		// first stage: run commands
-		proc := runCmd(t, exp, actual, useSyscaller, true)
-		if len(exp.evts) == 0 && proc.expectedEvts > 0 {
-			t.Fatalf("expected no events for command %s, but got %d", exp.runCmd, proc.expectedEvts)
+		proc := runCmd(t, cmd, len(cmd.evts), actual, useSyscaller, true)
+		if len(cmd.evts) == 0 && proc.expectedEvts > 0 {
+			t.Fatalf("expected no events for command %s, but got %d", cmd.runCmd, proc.expectedEvts)
 		}
 
-		actEvtsCopy := copyActualEvents(actual)
+		actEvtsCopy := actual.getCopy()
 
 		// second stage: validate events
-		for _, expEvt := range exp.evts {
+		for _, expEvt := range cmd.evts {
 			found := false
 			checkHost := expEvt.HostName != anyHost
 			checkComm := expEvt.ProcessName != anyComm
@@ -1975,8 +2022,8 @@ func ExpectAtLeastOneOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBu
 			checkPolicy := expEvt.MatchedPoliciesUser != anyPolicy
 			checkPolicyName := len(expEvt.MatchedPolicies) > 0 && expEvt.MatchedPolicies[0] != anyPolicyName
 
-			if len(exp.evts) > 0 && proc.expectedEvts == 0 {
-				t.Fatalf("expected events for command %s, but got none", exp.runCmd)
+			if len(cmd.evts) > 0 && proc.expectedEvts == 0 {
+				t.Fatalf("expected events for command %s, but got none", cmd.runCmd)
 			}
 
 			for _, actEvt := range actEvtsCopy {
@@ -1993,7 +2040,7 @@ func ExpectAtLeastOneOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBu
 				if checkProcessorID && actEvt.ProcessorID != expEvt.ProcessorID {
 					continue
 				}
-				if checkPID && pidToCheck(exp.runCmd, actEvt) != expEvt.ProcessID {
+				if checkPID && pidToCheck(cmd.runCmd, actEvt) != expEvt.ProcessID {
 					continue
 				}
 				if checkPID && actEvt.ProcessID != expEvt.ProcessID {
@@ -2061,27 +2108,35 @@ func ExpectAtLeastOneOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBu
 	}
 }
 
-// ExpectAnyOfEach validates that at any event from each command was captured
-func ExpectAnyOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
-	for _, exp := range cmdEvents {
+// ExpectAnyOfEvts validates that at least one event from each command in
+// 'cmdEvents' was captured in the actual events. It requires a minimum of two
+// expected events for each command and stops searching as soon as it finds a
+// matching event. If any command does not have at least one matching event in
+// the actual events, it raises a test failure.
+//
+// This function is suitable when you expect any of a set of events to occur
+// and want to confirm that at least one of them happened.
+func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+	for _, cmd := range cmdEvents {
+		if len(cmd.evts) <= 1 {
+			t.Fatalf("ExpectAnyOfEvts test requires at least 2 expected events for command %s", cmd.runCmd)
+		}
+
 		syscallsInSets := []string{}
-		checkSets := len(exp.sets) > 0
+		checkSets := len(cmd.sets) > 0
 		if checkSets {
-			syscallsInSets = getAllSyscallsInSets(exp.sets)
+			syscallsInSets = getAllSyscallsInSets(cmd.sets)
 		}
 
 		actual.clear()
 		// first stage: run commands
-		proc := runCmd(t, exp, actual, useSyscaller, true)
-		if len(exp.evts) == 0 && proc.expectedEvts > 0 {
-			t.Fatalf("expected no events for command %s, but got %d", exp.runCmd, proc.expectedEvts)
-		}
+		proc := runCmd(t, cmd, 1, actual, useSyscaller, true)
 
-		actEvtsCopy := copyActualEvents(actual)
+		actEvtsCopy := actual.getCopy()
 
 		// second stage: validate events
 		found := false
-		for _, expEvt := range exp.evts {
+		for _, expEvt := range cmd.evts {
 			checkHost := expEvt.HostName != anyHost
 			checkComm := expEvt.ProcessName != anyComm
 			checkProcessorID := expEvt.ProcessorID != anyProcessorID
@@ -2091,8 +2146,8 @@ func ExpectAnyOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 			checkPolicy := expEvt.MatchedPoliciesUser != anyPolicy
 			checkPolicyName := len(expEvt.MatchedPolicies) > 0 && expEvt.MatchedPolicies[0] != anyPolicyName
 
-			if len(exp.evts) > 0 && proc.expectedEvts == 0 {
-				t.Fatalf("expected events for command %s, but got none", exp.runCmd)
+			if len(cmd.evts) > 0 && proc.expectedEvts == 0 {
+				t.Fatalf("expected events for command %s, but got none", cmd.runCmd)
 			}
 
 			for _, actEvt := range actEvtsCopy {
@@ -2109,7 +2164,7 @@ func ExpectAnyOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 				if checkProcessorID && actEvt.ProcessorID != expEvt.ProcessorID {
 					continue
 				}
-				if checkPID && pidToCheck(exp.runCmd, actEvt) != expEvt.ProcessID {
+				if checkPID && pidToCheck(cmd.runCmd, actEvt) != expEvt.ProcessID {
 					continue
 				}
 				if checkPID && actEvt.ProcessID != expEvt.ProcessID {
@@ -2178,33 +2233,39 @@ func ExpectAnyOfEach(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 		}
 
 		// evaluate found
-		require.True(t, found, "None of the expected events\n%+v\nare in the actual output\n%+v\n", exp.evts, actEvtsCopy)
+		require.True(t, found, "None of the expected events\n%+v\nare in the actual output\n%+v\n", cmd.evts, actEvtsCopy)
 	}
 }
 
-// ExpectAllEqualTo expects all events to be equal to the expected events
-func ExpectAllEqualTo(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
-	for _, exp := range cmdEvents {
-		if len(exp.evts) != 1 {
-			t.Fatalf("ExpectAllEqualTo test requires exactly one event per command")
+// ExpectAllEvtsEqualToOne validates that all events within a command match the
+// single expected event for each command. It enforces that each command's events
+// are exactly equal to the single expected event.
+//
+// This function is suitable for cases where each command should produce one
+// specific event, and all commands should match their respective events.
+func ExpectAllEvtsEqualToOne(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+	for _, cmd := range cmdEvents {
+		if len(cmd.evts) != 1 {
+			t.Fatalf("ExpectAllEvtsEqualToOne test requires exactly one event per command, but got %d events for command %s", len(cmd.evts), cmd.runCmd)
 		}
 
 		actual.clear()
 		// first stage: run commands
-		proc := runCmd(t, exp, actual, useSyscaller, true)
-		actEvtsCopy := copyActualEvents(actual)
+		proc := runCmd(t, cmd, len(cmd.evts), actual, useSyscaller, true)
+
+		actEvtsCopy := actual.getCopy()
 
 		if proc.expectedEvts == 0 {
-			t.Fatalf("expected one event for command %s, but got none", exp.runCmd)
+			t.Fatalf("expected one event for command %s, but got none", cmd.runCmd)
 		}
 		syscallsInSets := []string{}
-		checkSets := len(exp.sets) > 0
+		checkSets := len(cmd.sets) > 0
 		if checkSets {
-			syscallsInSets = getAllSyscallsInSets(exp.sets)
+			syscallsInSets = getAllSyscallsInSets(cmd.sets)
 		}
 
 		// second stage: validate events
-		for _, expEvt := range exp.evts {
+		for _, expEvt := range cmd.evts {
 			checkHost := expEvt.HostName != anyHost
 			checkComm := expEvt.ProcessName != anyComm
 			checkProcessorID := expEvt.ProcessorID != anyProcessorID
@@ -2229,7 +2290,7 @@ func ExpectAllEqualTo(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, 
 					assert.Equal(t, expEvt.ProcessorID, actEvt.ProcessorID, "processor id")
 				}
 				if checkPID {
-					assert.Equal(t, expEvt.ProcessID, pidToCheck(exp.runCmd, actEvt), "pid")
+					assert.Equal(t, expEvt.ProcessID, pidToCheck(cmd.runCmd, actEvt), "pid")
 				}
 				if checkUID {
 					assert.Equal(t, expEvt.UserID, actEvt.UserID, "user id")
@@ -2266,27 +2327,29 @@ func ExpectAllEqualTo(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, 
 	}
 }
 
-// ExpectAllInOrder expects all events to be equal to the expected events in the same order
-func ExpectAllInOrder(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
+// ExpectAllInOrderSequentially validates that the actual events match the
+// expected events for each command, with events appearing in the same order.
+func ExpectAllInOrderSequentially(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, useSyscaller bool) {
 	// first stage: run commands
 	actual.clear()
 	procs, _ := runCmds(t, cmdEvents, actual, useSyscaller, true)
 	if len(procs) > len(cmdEvents) {
 		t.Fatalf("expected %d commands, but got %d", len(cmdEvents), len(procs))
 	}
-	actEvtsCopy := copyActualEvents(actual)
+
+	actEvtsCopy := actual.getCopy()
 
 	// second stage: check events
-	for cmdIdx, exp := range cmdEvents {
+	for cmdIdx, cmd := range cmdEvents {
 		syscallsInSets := []string{}
-		checkSets := len(exp.sets) > 0
+		checkSets := len(cmd.sets) > 0
 		if checkSets {
-			syscallsInSets = getAllSyscallsInSets(exp.sets)
+			syscallsInSets = getAllSyscallsInSets(cmd.sets)
 		}
 
 		// compare the expected events with the actual events in the same order
-		for evtIdx, expEvt := range exp.evts {
-			actEvt := actEvtsCopy[cmdIdx*len(exp.evts)+evtIdx]
+		for evtIdx, expEvt := range cmd.evts {
+			actEvt := actEvtsCopy[cmdIdx*len(cmd.evts)+evtIdx]
 
 			if checkSets {
 				assert.Contains(t, syscallsInSets, actEvt.EventName, "event name in set")
@@ -2310,7 +2373,7 @@ func ExpectAllInOrder(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, 
 				assert.Equal(t, expEvt.ProcessorID, actEvt.ProcessorID, "processor id")
 			}
 			if checkPID {
-				assert.Equal(t, expEvt.ProcessID, pidToCheck(exp.runCmd, actEvt), "pid")
+				assert.Equal(t, expEvt.ProcessID, pidToCheck(cmd.runCmd, actEvt), "pid")
 			}
 			if checkUID {
 				assert.Equal(t, expEvt.UserID, actEvt.UserID, "user id")

--- a/tests/integration/syscaller/cmd/syscaller.go
+++ b/tests/integration/syscaller/cmd/syscaller.go
@@ -11,7 +11,11 @@ import (
 )
 
 func main() {
-	testutils.PinProccessToCPU()
+	err := testutils.PinProccessToCPU()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "PinProccessToCPU: %v\n", err)
+		os.Exit(1)
+	}
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -31,7 +35,7 @@ func main() {
 		syscallsToCall = append(syscallsToCall, events.ID(syscallNum))
 	}
 
-	err := changeOwnComm(callerComm)
+	err = changeOwnComm(callerComm)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -27,6 +27,12 @@ type eventBuffer struct {
 	events []trace.Event
 }
 
+func newEventBuffer() *eventBuffer {
+	return &eventBuffer{
+		events: make([]trace.Event, 0),
+	}
+}
+
 // addEvent adds an event to the eventBuffer
 func (b *eventBuffer) addEvent(evt trace.Event) {
 	b.mu.Lock()
@@ -40,7 +46,7 @@ func (b *eventBuffer) clear() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.events = b.events[:0]
+	b.events = make([]trace.Event, 0)
 }
 
 // len returns the number of events in the eventBuffer
@@ -49,6 +55,17 @@ func (b *eventBuffer) len() int {
 	defer b.mu.RUnlock()
 
 	return len(b.events)
+}
+
+// getCopy returns a copy of the eventBuffer events
+func (b *eventBuffer) getCopy() []trace.Event {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	evts := make([]trace.Event, len(b.events))
+	copy(evts, b.events)
+
+	return evts
 }
 
 // load tracee into memory with args

--- a/tests/testutils/cpu.go
+++ b/tests/testutils/cpu.go
@@ -7,7 +7,7 @@ import (
 const CPUForTests = 0 // CPU to pin test processes to
 
 // PinProccessToCPU pins the current process to a specific CPU
-func PinProccessToCPU(id ...int) {
+func PinProccessToCPU(id ...int) error {
 	if len(id) == 0 {
 		id = append(id, CPUForTests)
 	}
@@ -16,5 +16,6 @@ func PinProccessToCPU(id ...int) {
 	for _, i := range id {
 		cpuMask.Set(i)
 	}
-	_ = unix.SchedSetaffinity(0, &cpuMask)
+
+	return unix.SchedSetaffinity(0, &cpuMask)
 }

--- a/tests/testutils/errors.go
+++ b/tests/testutils/errors.go
@@ -52,6 +52,16 @@ func (e *commandFailed) Error() string {
 	return fmt.Sprintf("command '%s' failed with error: %s", e.command, e.err)
 }
 
+// failedToPinProcessToCPU is returned when a command fails to pin to a CPU.
+type failedToPinProcessToCPU struct {
+	command string
+	err     error
+}
+
+func (e *failedToPinProcessToCPU) Error() string {
+	return fmt.Sprintf("failed to pin command '%s' to CPU: %s", e.command, e.err)
+}
+
 // failedToParseCmd is returned when a command fails to parse.
 type failedToParseCmd struct {
 	command string

--- a/tests/testutils/exec.go
+++ b/tests/testutils/exec.go
@@ -49,7 +49,10 @@ func ParseCmd(fullCmd string) (string, []string, error) {
 
 // ExecPinnedCmdWithTimeout executes a cmd with a timeout and returns the PID of the process.
 func ExecPinnedCmdWithTimeout(command string, timeout time.Duration) (int, error) {
-	PinProccessToCPU()             // pin this goroutine to a specific CPU
+	err := PinProccessToCPU() // pin this goroutine to a specific CPU
+	if err != nil {
+		return 0, &failedToPinProcessToCPU{command: command, err: err}
+	}
 	runtime.LockOSThread()         // wire this goroutine to a specific OS thread
 	defer runtime.UnlockOSThread() // unlock the thread when we're done
 

--- a/tests/testutils/exec.go
+++ b/tests/testutils/exec.go
@@ -71,8 +71,11 @@ func ExecPinnedCmdWithTimeout(command string, timeout time.Duration) (int, error
 		cmdDone <- cmd.Wait() // wait for command to exit
 	}()
 
+	timeoutTicker := time.NewTicker(timeout)
+	defer timeoutTicker.Stop()
+
 	select {
-	case <-time.After(timeout):
+	case <-timeoutTicker.C:
 		err := cmd.Process.Kill()
 		if err != nil {
 			return pid, &failedToKillProcess{command: command, err: err}
@@ -117,7 +120,7 @@ func ExecCmdBgWithSudoAndCtx(ctx context.Context, command string) (int, chan err
 	wg.Add(1)
 	go func(pid *atomic.Int64) {
 		// Will make the command to inherit the current process' CPU affinity.
-		PinProccessToCPU()             // pin this goroutine to a specific CPU
+		_ = PinProccessToCPU()         // pin this goroutine to a specific CPU
 		runtime.LockOSThread()         // wire this goroutine to a specific OS thread
 		defer runtime.UnlockOSThread() // unlock the thread when we're done
 


### PR DESCRIPTION
Close: #3440
 
### 1. Explain what the PR does

a8d94ade2 **chore: bring some colour into tests life**
0650e6152 **fix(tests): on error stop tracee gracefully**
12228df2a **fix(tests): integration timeout handling**
d240add37 **chore(tests): integration changes**


0650e6152 **fix(tests): on error stop tracee gracefully**

```
Return all errors to the main test loop to check and abort the tracee
execution in the correct way.

This also:

- Introduces cmdEvents.waitFor duration as a guarantee before starting
  to collect events after executing a command.
- Changes the following tests to be certain of the events collected:
  . pid: trace events from pid 1
  . pid: event: args: trace event sched_switch with args from pid 0
  . pid: trace new (should be empty)
```


12228df2a **fix(tests): integration timeout handling**

```
Updated the Tracee integration tests to address a bug with the
time.After usage. Previously, at each iteration of the loop, the
time.After was reset whenever its corresponding select clause was
reached. This behavior resulted in the creation of a new timer on each
loop iteration without freeing the previous one, leading to a memory
leak.

The solution involved replacing time.After with a dedicated
timeoutTicker, ensuring consistent timeout handling without unnecessary
resource consumption.
```


d240add37 **chore(tests): integration changes**

```
- add coolDown to sleep before to run the next test.
- change runCmd to receive the number of expected events.
- ExpectAnyOfEvts (ExpectAnyOfEach before) now call runCmd passing 1 as
  expected events.
- eventBuffer.clear() now sets a new empty slice for it, instead of
  relying on the old underlying array.
- replaced copyActualEvents() with eventBuffer.getCopy().
- refactored test functions, improved comments and logs.
```

### 2. Explain how to test it


### 3. Other comments

