### PR TITLE
fix(initialize): do not fail kconfig options

### DIFF
--- a/docs/docs/deep-dive/os-info.md
+++ b/docs/docs/deep-dive/os-info.md
@@ -76,13 +76,15 @@ Tracee needs access to kconfig file (/proc/config.gz OR /boot/config-$(uname -r)
 2. Provide kconfig variables to its eBPF counter-part (so eBPF program take decisions)
 
 !!! Warning
-    Tracee **should NOT fail** when it cannot find a kconfig file:
+    Tracee **should NOT fail** when it cannot find a kconfig file or needed options:
     
+    - **missing kconfig file**
+
     ```console
     sudo ./dist/tracee --log debug --scope uid=1000 --scope pid=new --events execve
     ```
 
-    ```text
+    ```json
     {"level":"debug","ts":1670976875.7735798,"msg":"osinfo","VERSION":"\"20.04.5 LTS (Focal Fossa)\"","ID":"ubuntu","ID_LIKE":"debian","PRETTY_NAME":"\"Ubuntu 20.04.5 LTS\"","VERSION_ID":"\"20.04\"","VERSION_CODENAME":"focal","KERNEL_RELEASE":"5.4.0-91-generic","ARCH":"x86_64","pkg":"urfave","file":"urfave.go","line":53}
     ...
     {"level":"warn","ts":1670976875.7762284,"msg":"KConfig: could not check enabled kconfig features","error":"could not read /boot/config-5.4.0-91-generic: stat /boot/config-5.4.0-91-generic: no such file or directory"}
@@ -92,8 +94,14 @@ Tracee needs access to kconfig file (/proc/config.gz OR /boot/config-$(uname -r)
     TIME             UID    COMM             PID     TID     RET              EVENT                ARGS
     ...
     ```
+
+    - **missing kconfig options**
+
+    ```json
+    {"level":"warn","ts":1698759121.4432194,"msg":"KConfig: could not detect kconfig options","options":[...]}
+    ```
     
-    but do have in mind it is assuming some things from the host environment and
+    But do have in mind it is assuming some things from the host environment and
     its behavior might have inconsistencies.
     
     If you are running tracee in an environment that does not have a kconfig file
@@ -129,4 +137,4 @@ TIME             UID    COMM             PID     TID     RET              EVENT 
 
 !!! Attention
     In case no kconfig file is found, tracee takes some decisions blindly and
-    it may give you unexpected errors. Example:
+    it may give you unexpected errors.

--- a/pkg/cmd/initialize/kernelconfig.go
+++ b/pkg/cmd/initialize/kernelconfig.go
@@ -3,7 +3,6 @@ package initialize
 import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 
-	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -20,9 +19,11 @@ func KernelConfig() (*helpers.KernelConfig, error) {
 	kernelConfig.AddNeeded(helpers.CONFIG_BPF_SYSCALL, helpers.BUILTIN)
 	kernelConfig.AddNeeded(helpers.CONFIG_KPROBE_EVENTS, helpers.BUILTIN)
 	kernelConfig.AddNeeded(helpers.CONFIG_BPF_EVENTS, helpers.BUILTIN)
-	missing := kernelConfig.CheckMissing() // do fail if we found os-release file and it is not enough
+	missing := kernelConfig.CheckMissing()
 	if len(missing) > 0 {
-		return nil, errfmt.Errorf("missing kernel configuration options: %s", missing)
+		// do not fail if there are missing options, let it fail later by trying
+		logger.Warnw("KConfig: could not detect kconfig options", "options", missing)
 	}
+
 	return kernelConfig, nil
 }


### PR DESCRIPTION
Close: #3637 

### 1. Explain what the PR does

8a45f7a95590a51f2104ba530e438fa9f5a65ee0 **fix(initialize): do not fail kconfig options**

```
When initializing, we should not fail if the kernel config options
are not found. Let it fail if the option is required further down
the line.
```

### 2. Explain how to test it


### 3. Other comments

