### PR TITLE
fix(proctree): register processors correctly

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,9 +59,9 @@ env:
     DNS
     HTTP
   INSTTESTS: >
-    HOOKED_SYSCALL
     VFS_WRITE
     FILE_MODIFICATION
+    HOOKED_SYSCALL
     SECURITY_INODE_RENAME
     BPF_ATTACH
     CONTAINERS_DATA_SOURCE
@@ -294,9 +294,9 @@ jobs:
           if [[ "${{ matrix.arch }}" == "aarch64" ]]; then
             echo "TESTS=${{ env.ARM64_TESTS }}" >> $GITHUB_ENV
           fi
-      - name: "Kernel Test"
-        run: ./tests/e2e-kernel-test.sh
-      - name: "Network Test"
-        run: ./tests/e2e-net-test.sh
       - name: "Instrumentation Test"
         run: ./tests/e2e-inst-test.sh
+      - name: "Network Test"
+        run: ./tests/e2e-net-test.sh
+      - name: "Kernel Test"
+        run: ./tests/e2e-kernel-test.sh

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ help:
 	@echo "    $$ make e2e-net-signatures       # build ./dist/e2e-net-signatures"
 	@echo "    $$ make e2e-inst-signatures      # build ./dist/e2e-inst-signatures"
 	@echo "    $$ make tracee                   # build ./dist/tracee"
-	@echo "    $$ make tracee-operator			# build ./dist/tracee-operator"
+	@echo "    $$ make tracee-operator          # build ./dist/tracee-operator"
 	@echo ""
 	@echo "# clean"
 	@echo ""


### PR DESCRIPTION
- procTreeForkProcessor, procTreeExecProcessor and procTreeExitProcessor should be registered when source "events" (or "both") is picked.

- any proctree enriching processor should be registered if at least one source is available (which means the process tree is enabled).

- there is one (for now at least) processor that is always registered (cleanup).
