### PR TITLE
fix(ebpf): use ts as fd_arg_path_map key

### DIFF
--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -108,7 +108,7 @@ BPF_PROG_ARRAY(sys_exit_submit_tail, MAX_EVENT_ID);                // store prog
 BPF_PROG_ARRAY(sys_enter_init_tail, MAX_EVENT_ID);                 // store program for performing syscall tracking logic in sys_enter
 BPF_PROG_ARRAY(sys_exit_init_tail, MAX_EVENT_ID);                  // store program for performing syscall tracking logic in sys_exits
 BPF_STACK_TRACE(stack_addresses, MAX_STACK_ADDRESSES);             // store stack traces
-BPF_LRU_HASH(fd_arg_path_map, fd_arg_task_t, fd_arg_path_t, 1024); // store fds paths by task
+BPF_LRU_HASH(fd_arg_path_map, u64, fd_arg_path_t, 1024);           // store fds paths by timestamp
 BPF_LRU_HASH(bpf_attach_map, u32, bpf_used_helpers_t, 1024);       // holds bpf prog info
 BPF_LRU_HASH(bpf_attach_tmp_map, u32, bpf_used_helpers_t, 1024);   // temporarily hold bpf_used_helpers_t
 BPF_LRU_HASH(bpf_prog_load_map, u32, void *, 1024);                // store bpf prog aux pointer between bpf_check and security_bpf_prog

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -183,12 +183,6 @@ typedef struct syscall_data {
     unsigned long ret; // Syscall ret val. May be used by syscall exit tail calls.
 } syscall_data_t;
 
-typedef struct fd_arg_task {
-    u32 pid;
-    u32 tid;
-    int fd;
-} fd_arg_task_t;
-
 #define MAX_CACHED_PATH_SIZE 64
 
 typedef struct fd_arg_path {

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -694,8 +694,9 @@ func (t *Tracee) parseArguments(e *trace.Event) error {
 		if err != nil {
 			return errfmt.WrapError(err)
 		}
+
 		if t.config.Output.ParseArgumentsFDs {
-			return events.ParseArgsFDs(e, t.FDArgPathMap)
+			return events.ParseArgsFDs(e, uint64(t.getOrigEvtTimestamp(e)), t.FDArgPathMap)
 		}
 	}
 

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -349,6 +349,18 @@ func (t *Tracee) normalizeEventCtxTimes(event *trace.Event) error {
 	return nil
 }
 
+// getOrigEvtTimestamp returns the original timestamp of the event.
+// To be used only when the event timestamp was normalized via normalizeEventCtxTimes.
+func (t *Tracee) getOrigEvtTimestamp(event *trace.Event) int {
+	if t.config.Output.RelativeTime {
+		// if the time was normalized relative to tracee start time, add the start time back
+		return event.Timestamp + int(t.startTime)
+	}
+
+	// if the time was normalized to "wall" time, subtract the boot time
+	return event.Timestamp - int(t.bootTime)
+}
+
 // processSchedProcessFork processes a sched_process_fork event by normalizing the start time.
 func (t *Tracee) processSchedProcessFork(event *trace.Event) error {
 	return t.normalizeEventArgTime(event, "start_time")


### PR DESCRIPTION
Close: #3609 

### 1. Explain what the PR does

9588651fb **fix(ebpf): use ts as fd_arg_path_map key**

```
A race condition has been reported when sequential open/close calls
cause the same FD (part of the map key) to be reused, therefore causing
value corruption.

The fd_arg_path_map continues as BPF_LRU_HASH just to avoid the need to
delete entries in userland even though the map is not used as a LRU
anymore - just as "oldest inserted", since there are no subsequent
accesses to update the LRU status of any entry.

P.S.: Another solution would be to use the inode number as part of the
key, but this value would not be available in the event at decode stage.
```

### 2. Explain how to test it

`sudo ./dist/tracee -s comm=openclose -e 'openat,close' -o option:parse-arguments-fds --capabilities bypass=true`

```
sudo ./dist/tracee -s comm=openclose -e 'openat,close' -o option:parse-arguments-fds --capabilities bypass=true
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
15:06:30:629712  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: /etc/ld.so.cache, flags: O_RDONLY|O_CLOEXEC, mode: 0
15:06:30:629748  1000   openclose        131340  131340  0                close                     fd: 3=/etc/ld.so.cache
15:06:30:629783  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: /usr/lib/libc.so.6, flags: O_RDONLY|O_CLOEXEC, mode: 0
15:06:30:629876  1000   openclose        131340  131340  0                close                     fd: 3=/usr/lib/libc.so.6
15:06:30:630163  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_2088142222.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630269  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_2088142222.txt
15:06:30:630298  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1423438580.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630331  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1423438580.txt
15:06:30:630344  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1290108987.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630372  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1290108987.txt
15:06:30:630384  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1633928993.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630413  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1633928993.txt
15:06:30:630426  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_939221181.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630459  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_939221181.txt
15:06:30:630472  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_73418372.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630500  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_73418372.txt
15:06:30:630513  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1706344463.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630542  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1706344463.txt
15:06:30:630558  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1477295567.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630588  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1477295567.txt
15:06:30:630601  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1347454283.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630629  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1347454283.txt
15:06:30:630642  1000   openclose        131340  131340  3                openat                    dirfd: -100, pathname: file_1857739312.txt, flags: O_WRONLY|O_CREAT|O_TRUNC, mode: 438
15:06:30:630674  1000   openclose        131340  131340  0                close                     fd: 3=/home/gg/oc/file_1857739312.txt
^C
End of events stream
Stats: {EventCount:{value:24} EventsFiltered:{value:0} NetCapCount:{value:0} BPFLogsCount:{value:0} ErrorCount:{value:0} LostEvCount:{value:0} LostWrCount:{value:0} LostNtCapCount:{value:0} LostBPFLogsCount:{value:0}}
```

Trigger the events by the PoC provided by @lclin56 in: https://github.com/aquasecurity/tracee/issues/3609#issuecomment-1780741104

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
