### PR TITLE
refactor(engine): feed engine with signatures events

### DIFF
--- a/tests/e2e-inst-signatures/e2e-signature_derivation.go
+++ b/tests/e2e-inst-signatures/e2e-signature_derivation.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type e2eSignatureDerivation struct {
+	cb detect.SignatureHandler
+}
+
+func (sig *e2eSignatureDerivation) Init(ctx detect.SignatureContext) error {
+	sig.cb = ctx.Callback
+	return nil
+}
+
+func (sig *e2eSignatureDerivation) GetMetadata() (detect.SignatureMetadata, error) {
+	return detect.SignatureMetadata{
+		ID:          "SIGNATURE_DERIVATION",
+		EventName:   "SIGNATURE_DERIVATION",
+		Version:     "0.1.0",
+		Name:        "Signature Derivation Test",
+		Description: "Instrumentation events E2E Tests: Signature Derivation",
+		Tags:        []string{"e2e", "instrumentation"},
+	}, nil
+}
+
+func (sig *e2eSignatureDerivation) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
+	return []detect.SignatureEventSelector{
+		{Source: "tracee", Name: "FILE_MODIFICATION"},
+	}, nil
+}
+
+func (sig *e2eSignatureDerivation) OnEvent(event protocol.Event) error {
+	eventObj, ok := event.Payload.(trace.Event)
+	if !ok {
+		return fmt.Errorf("failed to cast event's payload")
+	}
+
+	switch eventObj.EventName {
+	case "FILE_MODIFICATION":
+		m, _ := sig.GetMetadata()
+
+		sig.cb(detect.Finding{
+			SigMetadata: m,
+			Event:       event,
+			Data:        map[string]interface{}{},
+		})
+	}
+
+	return nil
+}
+
+func (sig *e2eSignatureDerivation) OnSignal(s detect.Signal) error {
+	return nil
+}
+
+func (sig *e2eSignatureDerivation) Close() {}

--- a/tests/e2e-inst-signatures/export.go
+++ b/tests/e2e-inst-signatures/export.go
@@ -11,4 +11,5 @@ var ExportedSignatures = []detect.Signature{
 	&e2eBpfAttach{},
 	&e2eProcessTreeDataSource{},
 	&e2eHookedSyscall{},
+	&e2eSignatureDerivation{},
 }

--- a/tests/e2e-inst-signatures/scripts/signature_derivation.sh
+++ b/tests/e2e-inst-signatures/scripts/signature_derivation.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+exit_err() {
+    echo -n "ERROR: "
+    echo $@
+    exit 1
+}
+
+./tests/e2e-inst-signatures/scripts/file_modification.sh


### PR DESCRIPTION
Feed the signatures engine with its own output instead of feeding it to the output channel.
This allows signatures to use other signatures as their selector.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

cfa2e5dae **refactor(engine): feed engine with signatures events**

fix #3680

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
