### PR TITLE
handle 32-bit socketcall syscall

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/fluent-forward-go v0.2.1
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2
-	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f
+	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231123142329-37c4b843a539
 	github.com/aquasecurity/tracee/api v0.0.0-20231013014739-b32a168ee6a8
 	github.com/aquasecurity/tracee/types v0.0.0-20231123143520-9a6b89efc320
 	github.com/containerd/containerd v1.7.0
@@ -28,7 +28,7 @@ require (
 	github.com/urfave/cli/v2 v2.3.0
 	go.uber.org/goleak v1.2.1
 	go.uber.org/zap v1.25.0
-	golang.org/x/sys v0.13.0
+	golang.org/x/sys v0.14.0
 	google.golang.org/grpc v1.58.3
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVb
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2 h1:Yywi9wC3GPDOgR8wr6P9geY2qvFqKxH5sctMOssw+MQ=
 github.com/aquasecurity/libbpfgo v0.5.0-libbpf-1.2/go.mod h1:0rEApF1YBHGuZ4C8OYI9q5oDBVpgqtRqYATePl9mCDk=
-github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f h1:l127H3NqJBmw+XMt+haBOeZIrBppuw7TJz26cWMI9kY=
-github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20230321190037-f591a2c5734f/go.mod h1:j/TQLmsZpOIdF3CnJODzYngG4yu1YoDCoRMELxkQSSA=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231123142329-37c4b843a539 h1:axIHZ3la2/wcqMYO9TUyKO/lMGYizEKyNIodbwQBOkE=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20231123142329-37c4b843a539/go.mod h1:1fGKke5pgH4xYvZ7HqDbLSi/R5zfRFH2K+c9kLp9L34=
 github.com/aquasecurity/tracee/api v0.0.0-20231013014739-b32a168ee6a8 h1:NGzPDvQofEG04CoPZjSSRoFMxnSd3Brh39BY1dmdyZM=
 github.com/aquasecurity/tracee/api v0.0.0-20231013014739-b32a168ee6a8/go.mod h1:l1W65+m4KGg2i61fiPaQ/o4OQCrNtNnkPTEdysF5Zpw=
 github.com/aquasecurity/tracee/types v0.0.0-20231123143520-9a6b89efc320 h1:p98V5N6wwG1TLpHGSeUsXbC96XdkdJDhRkcMo+xxXNE=
@@ -645,8 +645,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=

--- a/pkg/ebpf/c/common/arch.h
+++ b/pkg/ebpf/c/common/arch.h
@@ -181,6 +181,8 @@ statfunc struct pt_regs *get_task_pt_regs(struct task_struct *task)
     #define SYSCALL_LANDLOCK_RESTRICT_SELF 446
     #define SYSCALL_PROCESS_MRELEASE       448
 
+    #define SYSCALL_SOCKETCALL 473 // x86 only
+
 #elif defined(bpf_target_arm64)
     #define SYSCALL_READ                   63
     #define SYSCALL_WRITE                  64

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1031,9 +1031,9 @@ func (t *Tracee) populateBPFMaps() error {
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
-	for eventDefID, eventDefinition := range events.Core.GetDefinitions() {
+	for _, eventDefinition := range events.Core.GetDefinitions() {
 		id32BitU32 := uint32(eventDefinition.GetID32Bit()) // ID32Bit is int32
-		idU32 := uint32(eventDefID)                        // ID is int32
+		idU32 := uint32(eventDefinition.GetID())           // ID is int32
 		err := sys32to64BPFMap.Update(unsafe.Pointer(&id32BitU32), unsafe.Pointer(&idU32))
 		if err != nil {
 			return errfmt.WrapError(err)

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -112,6 +112,13 @@ func ParseArgs(event *trace.Event) error {
 				parseOrEmptyString(optArg, prctlOptionArgument, err)
 			}
 		}
+	case Socketcall:
+		if callArg := GetArg(event, "call"); callArg != nil {
+			if call, isInt32 := callArg.Value.(int32); isInt32 {
+				socketcallArgument, err := helpers.ParseSocketcallCall(uint64(call))
+				parseOrEmptyString(callArg, socketcallArgument, err)
+			}
+		}
 	case Socket:
 		if domArg := GetArg(event, "domain"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {


### PR DESCRIPTION
Close: #3676 

### 1. Explain what the PR does

26475aa08 **feat(events): parse call arg for socketcall**
59158d596 **chore: libbpfgo/helpers bump**
ebdd28521 **fix(ebpf): handle x86 32-bit socketcall syscall**
7d3d3852d **fix(ebpf): 32-bit syscall numbers**


59158d596 **chore: libbpfgo/helpers bump**

```
Brings in the latest libbpfgo/helpers addition: ParseSocketcallCall().
```


ebdd28521 **fix(ebpf): handle x86 32-bit socketcall syscall**

```
The Linux kernel version determines x86 32-bit compatibility: older
versions use 'socketcall' syscall for socket functions (like socket,
bind, connect), while newer versions use individual syscalls directly.

These changes were also tested on an arm64 running an armhf binary.

Context: #3676
```

### 2. Explain how to test it

#### Use this event emitter

Build it for 64 and 32 bits:

`gcc conntest.c -o conntest64`
`gcc -m32 conntest.c -o conntest32`

<details>

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <unistd.h>
#include <arpa/inet.h>
#include <sys/types.h>
#include <sys/socket.h>
#include <fcntl.h>

int main() {
    int ret;
    int dummy_fd1, dummy_fd2;
    int sockfd;
    int listen_sock, client_sock;
    struct sockaddr_in server_addr;
    socklen_t addr_len;

    // Open dummy file descriptors to consume 3 and 4
    dummy_fd1 = open("/dev/null", O_RDONLY);
    if (dummy_fd1 < 0) {
        perror("Failed to open dummy file descriptor 1");
        exit(EXIT_FAILURE);
    }

    dummy_fd2 = open("/dev/null", O_RDONLY);
    if (dummy_fd2 < 0) {
        perror("Failed to open dummy file descriptor 2");
        exit(EXIT_FAILURE);
    }

    // Initialize server_addr
    memset(&server_addr, 0, sizeof(server_addr));
    server_addr.sin_family = AF_INET;
    server_addr.sin_port = htons(8080);
    server_addr.sin_addr.s_addr = htonl(INADDR_ANY);

    // Create socket
    sockfd = socket(AF_INET, SOCK_STREAM, 0);
    if (sockfd < 0) {
        perror("Socket creation failed");
        exit(EXIT_FAILURE);
    }

    int optval = 1;
    ret = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
    if (ret < 0) {
        perror("Setsockopt failed");
        exit(EXIT_FAILURE);
    }

    // Bind socket
    ret = bind(sockfd, (struct sockaddr *) &server_addr, sizeof(server_addr));
    if (ret < 0) {
        perror("Bind failed");
        exit(EXIT_FAILURE);
    }

    // Connect socket
    ret = connect(sockfd, (struct sockaddr *) &server_addr, sizeof(server_addr));
    if (ret < 0) {
        perror("Connect failed");
        exit(EXIT_FAILURE);
    }

    // Create listening socket
    listen_sock = socket(AF_INET, SOCK_STREAM, 0);
    if (listen_sock < 0) {
        perror("Socket creation failed");
        exit(EXIT_FAILURE);
    }

    // Bind listening socket
    memset(&server_addr, 0, sizeof(server_addr));
    server_addr.sin_family = AF_INET;
    server_addr.sin_port = htons(9090);
    server_addr.sin_addr.s_addr = htonl(INADDR_ANY);

    ret = bind(listen_sock, (struct sockaddr *) &server_addr, sizeof(server_addr));
    if (ret < 0) {
        perror("Bind failed");
        close(listen_sock);
        exit(EXIT_FAILURE);
    }

    // Listen on listening socket
    ret = listen(listen_sock, 5);
    if (ret < 0) {
        perror("Listen failed");
        close(listen_sock);
        exit(EXIT_FAILURE);
    }

    // Accept a connection
    addr_len = sizeof(server_addr);
    client_sock = accept(listen_sock, (struct sockaddr *) &server_addr, &addr_len);
    if (client_sock < 0) {
        perror("Accept failed");
        close(listen_sock);
        exit(EXIT_FAILURE);
    }

    close(client_sock);
    close(listen_sock);
    close(sockfd);

    close(dummy_fd1);
    close(dummy_fd2);

    return 0;
}
```

</details>

#### Run tracee

`sudo ./dist/tracee-ebpf -s comm=conntest32,conntest64 -e 'socketcall,socket,setsockopt,bind,connect,listen,accept,security_socket_*' --capabilities bypass=true`

#### Run `conntest*`

- Output for 64 bits

```
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
13:24:42:256495  1000   conntest64       226645  226645  0                security_socket_create    family: AF_INET, type: SOCK_STREAM, protocol: 0, kern: 0
13:24:42:256486  1000   conntest64       226645  226645  5                socket                    domain: AF_INET, type: SOCK_STREAM, protocol: 0
13:24:42:256740  1000   conntest64       226645  226645  0                security_socket_setsoc... sockfd: 5, level: SOL_SOCKET, optname: SO_REUSEADDR, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:0]
13:24:42:256734  1000   conntest64       226645  226645  0                setsockopt                sockfd: 5, level: SOL_SOCKET, optname: SO_REUSEADDR, optval: 0x7ffc880b8264, optlen: 4
13:24:42:256863  1000   conntest64       226645  226645  0                security_socket_bind      sockfd: 5, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:8080]
13:24:42:256857  1000   conntest64       226645  226645  0                bind                      sockfd: 5, addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:8080], addrlen: 16
13:24:42:256932  1000   conntest64       226645  226645  0                security_socket_connect   sockfd: 5, remote_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:8080]
13:24:42:256926  1000   conntest64       226645  226645  0                connect                   sockfd: 5, addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:8080], addrlen: 16
13:24:42:257121  1000   conntest64       226645  226645  0                security_socket_create    family: AF_INET, type: SOCK_STREAM, protocol: 0, kern: 0
13:24:42:257117  1000   conntest64       226645  226645  6                socket                    domain: AF_INET, type: SOCK_STREAM, protocol: 0
13:24:42:257183  1000   conntest64       226645  226645  0                security_socket_bind      sockfd: 6, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090]
13:24:42:257179  1000   conntest64       226645  226645  0                bind                      sockfd: 6, addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090], addrlen: 16
13:24:42:257240  1000   conntest64       226645  226645  0                security_socket_listen    sockfd: 6, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090], backlog: 5
13:24:42:257235  1000   conntest64       226645  226645  0                listen                    sockfd: 6, backlog: 5
13:24:42:257352  1000   conntest64       226645  226645  0                security_socket_accept    sockfd: 6, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090]
13:24:42:257331  1000   conntest64       226645  226645  7                accept                    sockfd: 6, addr: map[sa_family:AF_INET sin_addr:127.0.0.1 sin_port:58454], addrlen: 0x7ffc880b8260
```

- Output for 32 bits (on kernels which make use of socketcall)

```
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
13:27:36:200148  1000   conntest32       230968  230968  0                security_socket_create    family: AF_INET, type: SOCK_STREAM, protocol: 0, kern: 0
13:27:36:200145  1000   conntest32       230968  230968  5                socketcall                call: SYS_SOCKET, args: 0xffb38fd0
13:27:36:200170  1000   conntest32       230968  230968  0                security_socket_setsoc... sockfd: 5, level: SOL_SOCKET, optname: SO_REUSEADDR, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:0]
13:27:36:200168  1000   conntest32       230968  230968  0                socketcall                call: SYS_SETSOCKOPT, args: 0xffb38fa8
13:27:36:200180  1000   conntest32       230968  230968  0                security_socket_bind      sockfd: 5, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:8080]
13:27:36:200179  1000   conntest32       230968  230968  0                socketcall                call: SYS_BIND, args: 0xffb38fc4
13:27:36:200192  1000   conntest32       230968  230968  0                security_socket_connect   sockfd: 5, remote_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:8080]
13:27:36:200190  1000   conntest32       230968  230968  0                socketcall                call: SYS_CONNECT, args: 0xffb38fd0
13:27:36:200245  1000   conntest32       230968  230968  0                security_socket_create    family: AF_INET, type: SOCK_STREAM, protocol: 0, kern: 0
13:27:36:200244  1000   conntest32       230968  230968  6                socketcall                call: SYS_SOCKET, args: 0xffb38fd0
13:27:36:200256  1000   conntest32       230968  230968  0                security_socket_bind      sockfd: 6, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090]
13:27:36:200254  1000   conntest32       230968  230968  0                socketcall                call: SYS_BIND, args: 0xffb38fc4
13:27:36:200265  1000   conntest32       230968  230968  0                security_socket_listen    sockfd: 6, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090], backlog: 5
13:27:36:200263  1000   conntest32       230968  230968  0                socketcall                call: SYS_LISTEN, args: 0xffb38fd4
13:27:36:200275  1000   conntest32       230968  230968  0                security_socket_accept    sockfd: 6, local_addr: map[sa_family:AF_INET sin_addr:0.0.0.0 sin_port:9090]
13:27:36:200273  1000   conntest32       230968  230968  7                socketcall                call: SYS_ACCEPT, args: 0xffb38fd0
```

### 3. Other comments

