### PR TITLE
probes: improve probes by having specific getters

### DIFF
--- a/pkg/ebpf/probes/cgroup.go
+++ b/pkg/ebpf/probes/cgroup.go
@@ -39,6 +39,10 @@ func NewCgroupProbe(a bpf.BPFAttachType, progName string) *CgroupProbe {
 	}
 }
 
+func (p *CgroupProbe) GetProgramName() string {
+	return p.programName
+}
+
 func (p *CgroupProbe) attach(module *bpf.Module, args ...interface{}) error {
 	var cgroups *cgroup.Cgroups
 

--- a/pkg/ebpf/probes/uprobe.go
+++ b/pkg/ebpf/probes/uprobe.go
@@ -31,6 +31,22 @@ func NewUprobe(evtName string, progName string, binPath string, symName string) 
 	}
 }
 
+func (p *Uprobe) GetEventName() string {
+	return p.eventName
+}
+
+func (p *Uprobe) GetProgramName() string {
+	return p.programName
+}
+
+func (p *Uprobe) GetBinaryPath() string {
+	return p.binaryPath
+}
+
+func (p *Uprobe) GetSymbolName() string {
+	return p.symbolName
+}
+
 func (p *Uprobe) attach(module *bpf.Module, args ...interface{}) error {
 	var link *bpf.BPFLink
 


### PR DESCRIPTION
One may debug self loaded function by using:

```
$ sudo ./dist/tracee --log debug --log filter:'msg=self loaded program' --output json --output option:parse-arguments --events do_init_module,ftrace_hook
```

For example:

```json
{"L":"DEBUG","T":"2023-11-27T02:18:44.440-0300","M":"self loaded program","event":"do_init_module","program":"trace_do_init_module","origin":"ebpf:pkg/ebpf/tracee.go:1569","calls":"(*Tracee).getSelfLoadedPrograms.func1() < (*Tracee).getSelfLoadedPrograms() < (*Tracee).invokeInitEvents() < (*Tracee).processEvents()"}
{"L":"DEBUG","T":"2023-11-27T02:18:44.440-0300","M":"self loaded program","event":"do_init_module","program":"trace_ret_do_init_module","origin":"ebpf:pkg/ebpf/tracee.go:1569","calls":"(*Tracee).getSelfLoadedPrograms.func1() < (*Tracee).getSelfLoadedPrograms() < (*Tracee).invokeInitEvents() < (*Tracee).processEvents()"}
```