### PR TITLE
chore: rename Context to EventContext

### DIFF
--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -44,45 +44,45 @@ func (decoder *EbpfDecoder) ReadAmountBytes() int {
 	return decoder.cursor
 }
 
-// DecodeContext translates data from the decoder buffer, starting from the decoder cursor, to bufferdecoder.Context struct.
-func (decoder *EbpfDecoder) DecodeContext(ctx *Context) error {
+// DecodeContext translates data from the decoder buffer, starting from the decoder cursor, to bufferdecoder.EventContext struct.
+func (decoder *EbpfDecoder) DecodeContext(eCtx *EventContext) error {
 	offset := decoder.cursor
-	if len(decoder.buffer[offset:]) < ctx.GetSizeBytes() {
-		return errfmt.Errorf("context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), ctx.GetSizeBytes())
+	if len(decoder.buffer[offset:]) < eCtx.GetSizeBytes() {
+		return errfmt.Errorf("context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), eCtx.GetSizeBytes())
 	}
 
 	// event_context start
-	ctx.Ts = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+8])
+	eCtx.Ts = binary.LittleEndian.Uint64(decoder.buffer[offset : offset+8])
 
 	// task_context start
-	ctx.StartTime = binary.LittleEndian.Uint64(decoder.buffer[offset+8 : offset+16])
-	ctx.CgroupID = binary.LittleEndian.Uint64(decoder.buffer[offset+16 : offset+24])
-	ctx.Pid = binary.LittleEndian.Uint32(decoder.buffer[offset+24 : offset+28])
-	ctx.Tid = binary.LittleEndian.Uint32(decoder.buffer[offset+28 : offset+32])
-	ctx.Ppid = binary.LittleEndian.Uint32(decoder.buffer[offset+32 : offset+36])
-	ctx.HostPid = binary.LittleEndian.Uint32(decoder.buffer[offset+36 : offset+40])
-	ctx.HostTid = binary.LittleEndian.Uint32(decoder.buffer[offset+40 : offset+44])
-	ctx.HostPpid = binary.LittleEndian.Uint32(decoder.buffer[offset+44 : offset+48])
-	ctx.Uid = binary.LittleEndian.Uint32(decoder.buffer[offset+48 : offset+52])
-	ctx.MntID = binary.LittleEndian.Uint32(decoder.buffer[offset+52 : offset+56])
-	ctx.PidID = binary.LittleEndian.Uint32(decoder.buffer[offset+56 : offset+60])
-	_ = copy(ctx.Comm[:], decoder.buffer[offset+60:offset+76])
-	_ = copy(ctx.UtsName[:], decoder.buffer[offset+76:offset+92])
-	ctx.Flags = binary.LittleEndian.Uint32(decoder.buffer[offset+92 : offset+96])
-	ctx.LeaderStartTime = binary.LittleEndian.Uint64(decoder.buffer[offset+96 : offset+104])
-	ctx.ParentStartTime = binary.LittleEndian.Uint64(decoder.buffer[offset+104 : offset+112])
+	eCtx.StartTime = binary.LittleEndian.Uint64(decoder.buffer[offset+8 : offset+16])
+	eCtx.CgroupID = binary.LittleEndian.Uint64(decoder.buffer[offset+16 : offset+24])
+	eCtx.Pid = binary.LittleEndian.Uint32(decoder.buffer[offset+24 : offset+28])
+	eCtx.Tid = binary.LittleEndian.Uint32(decoder.buffer[offset+28 : offset+32])
+	eCtx.Ppid = binary.LittleEndian.Uint32(decoder.buffer[offset+32 : offset+36])
+	eCtx.HostPid = binary.LittleEndian.Uint32(decoder.buffer[offset+36 : offset+40])
+	eCtx.HostTid = binary.LittleEndian.Uint32(decoder.buffer[offset+40 : offset+44])
+	eCtx.HostPpid = binary.LittleEndian.Uint32(decoder.buffer[offset+44 : offset+48])
+	eCtx.Uid = binary.LittleEndian.Uint32(decoder.buffer[offset+48 : offset+52])
+	eCtx.MntID = binary.LittleEndian.Uint32(decoder.buffer[offset+52 : offset+56])
+	eCtx.PidID = binary.LittleEndian.Uint32(decoder.buffer[offset+56 : offset+60])
+	_ = copy(eCtx.Comm[:], decoder.buffer[offset+60:offset+76])
+	_ = copy(eCtx.UtsName[:], decoder.buffer[offset+76:offset+92])
+	eCtx.Flags = binary.LittleEndian.Uint32(decoder.buffer[offset+92 : offset+96])
+	eCtx.LeaderStartTime = binary.LittleEndian.Uint64(decoder.buffer[offset+96 : offset+104])
+	eCtx.ParentStartTime = binary.LittleEndian.Uint64(decoder.buffer[offset+104 : offset+112])
 	// task_context end
 
-	ctx.EventID = events.ID(int32(binary.LittleEndian.Uint32(decoder.buffer[offset+112 : offset+116])))
-	ctx.Syscall = int32(binary.LittleEndian.Uint32(decoder.buffer[offset+116 : offset+120]))
-	ctx.MatchedPolicies = binary.LittleEndian.Uint64(decoder.buffer[offset+120 : offset+128])
-	ctx.Retval = int64(binary.LittleEndian.Uint64(decoder.buffer[offset+128 : offset+136]))
-	ctx.StackID = binary.LittleEndian.Uint32(decoder.buffer[offset+136 : offset+140])
-	ctx.ProcessorId = binary.LittleEndian.Uint16(decoder.buffer[offset+140 : offset+142])
+	eCtx.EventID = events.ID(int32(binary.LittleEndian.Uint32(decoder.buffer[offset+112 : offset+116])))
+	eCtx.Syscall = int32(binary.LittleEndian.Uint32(decoder.buffer[offset+116 : offset+120]))
+	eCtx.MatchedPolicies = binary.LittleEndian.Uint64(decoder.buffer[offset+120 : offset+128])
+	eCtx.Retval = int64(binary.LittleEndian.Uint64(decoder.buffer[offset+128 : offset+136]))
+	eCtx.StackID = binary.LittleEndian.Uint32(decoder.buffer[offset+136 : offset+140])
+	eCtx.ProcessorId = binary.LittleEndian.Uint16(decoder.buffer[offset+140 : offset+142])
 	// 2 byte padding
 	// event_context end
 
-	decoder.cursor += ctx.GetSizeBytes()
+	decoder.cursor += eCtx.GetSizeBytes()
 	return nil
 }
 

--- a/pkg/bufferdecoder/decoder_test.go
+++ b/pkg/bufferdecoder/decoder_test.go
@@ -14,7 +14,7 @@ func TestDecodeContext(t *testing.T) {
 	t.Parallel()
 
 	buf := new(bytes.Buffer)
-	ctxExpected := Context{
+	eCtxExpected := EventContext{
 		Ts:          11,
 		CgroupID:    22,
 		ProcessorId: 5,
@@ -33,21 +33,21 @@ func TestDecodeContext(t *testing.T) {
 		Retval:      0,
 		StackID:     0,
 	}
-	err := binary.Write(buf, binary.LittleEndian, ctxExpected)
+	err := binary.Write(buf, binary.LittleEndian, eCtxExpected)
 	assert.Equal(t, nil, err)
-	var ctxObtained Context
+	var eCtxObtained EventContext
 	rawData := buf.Bytes()
 	d := New(rawData)
 	cursorBefore := d.cursor
-	err = d.DecodeContext(&ctxObtained)
+	err = d.DecodeContext(&eCtxObtained)
 	cursorAfter := d.cursor
 
 	// checking no error
 	assert.Equal(t, nil, err)
 	// checking decoding succeeded correctly
-	assert.Equal(t, ctxExpected, ctxObtained)
+	assert.Equal(t, eCtxExpected, eCtxObtained)
 	// checking decoder cursor on buffer moved appropriately
-	assert.Equal(t, int(ctxExpected.GetSizeBytes()), cursorAfter-cursorBefore)
+	assert.Equal(t, int(eCtxExpected.GetSizeBytes()), cursorAfter-cursorBefore)
 }
 
 func TestDecodeUint8(t *testing.T) {
@@ -489,9 +489,9 @@ func TestDecodeMprotectWriteMeta(t *testing.T) {
 }
 
 func BenchmarkDecodeContext(*testing.B) {
-	var ctx Context
+	var eCtx EventContext
 	/*
-		s := Context{
+		eCtx := EventContext{
 			Ts:          11,
 			ProcessorId: 32,
 			CgroupID:    22,
@@ -521,13 +521,13 @@ func BenchmarkDecodeContext(*testing.B) {
 		0, 0, 0}
 	for i := 0; i < 100; i++ {
 		decoder := New(buffer)
-		decoder.DecodeContext(&ctx)
+		decoder.DecodeContext(&eCtx)
 	}
 }
 func BenchmarkBinaryContext(*testing.B) {
-	var ctx Context
+	var eCtx EventContext
 	/*
-		s := Context{
+		eCtx := EventContext{
 			Ts:       11,
 			CgroupID: 22,
 			ProcessorId: 432,
@@ -558,7 +558,7 @@ func BenchmarkBinaryContext(*testing.B) {
 		0, 0, 0}
 	for i := 0; i < 100; i++ {
 		binBuf := bytes.NewBuffer(buffer)
-		binary.Read(binBuf, binary.LittleEndian, &ctx)
+		binary.Read(binBuf, binary.LittleEndian, &eCtx)
 	}
 }
 

--- a/pkg/bufferdecoder/protocol.go
+++ b/pkg/bufferdecoder/protocol.go
@@ -18,12 +18,13 @@ const (
 
 // PLEASE NOTE, YOU MUST UPDATE THE DECODER IF ANY CHANGE TO THIS STRUCT IS DONE.
 
-// Context struct contains common metadata that is collected for all types of events
-// it is used to unmarshal binary data and therefore should match (bit by bit) to the `context_t` struct in the ebpf code.
-// NOTE: Integers want to be aligned in memory, so if changing the format of this struct
-// keep the 1-byte 'Argnum' as the final parameter before the padding (if padding is needed).
-type Context struct {
-	Ts              uint64
+// EventContext contains common metadata that is collected for all types of events.
+//
+// NOTE: Use pahole to ensure this struct reflects the `event_context“ struct in the eBPF code.
+type EventContext struct {
+	Ts uint64
+
+	// task_context start
 	StartTime       uint64
 	CgroupID        uint64
 	Pid             uint32
@@ -40,6 +41,8 @@ type Context struct {
 	Flags           uint32
 	LeaderStartTime uint64
 	ParentStartTime uint64
+	// task_context end
+
 	EventID         events.ID // int32
 	Syscall         int32
 	MatchedPolicies uint64
@@ -49,7 +52,7 @@ type Context struct {
 	_               [2]byte // padding
 }
 
-func (Context) GetSizeBytes() int {
+func (EventContext) GetSizeBytes() int {
 	return 144
 }
 

--- a/pkg/bufferdecoder/protocol_test.go
+++ b/pkg/bufferdecoder/protocol_test.go
@@ -17,7 +17,7 @@ import (
 func TestContextSize(t *testing.T) {
 	t.Parallel()
 
-	var v Context
+	var v EventContext
 	size := int(unsafe.Sizeof(v))
 	assert.Equal(t, size, int(v.GetSizeBytes()))
 }

--- a/pkg/ebpf/events_pipeline_bench_test.go
+++ b/pkg/ebpf/events_pipeline_bench_test.go
@@ -32,7 +32,7 @@ func BenchmarkGetEventFromPool(b *testing.B) {
 		evtPool.Put(evtPool.New())
 	}
 
-	ctx := bufferdecoder.Context{}
+	eCtx := bufferdecoder.EventContext{}
 	containerData := trace.Container{}
 	kubernetesData := trace.Kubernetes{}
 	eventDefinition := events.Definition{}
@@ -42,7 +42,7 @@ func BenchmarkGetEventFromPool(b *testing.B) {
 	syscall := ""
 	argnum := uint8(0)
 
-	decodeChan := make(chan *bufferdecoder.Context, 10000)
+	decodeChan := make(chan *bufferdecoder.EventContext, 10000)
 	processChan := make(chan *trace.Event, 10000)
 	deriveChan := make(chan *trace.Event)
 	engineChan := make(chan *trace.Event)
@@ -58,7 +58,7 @@ func BenchmarkGetEventFromPool(b *testing.B) {
 		defer wg.Done()
 		for i := 0; i < b.N; i++ {
 			for j := 0; j < decodeEvts; j++ {
-				decodeChan <- &ctx
+				decodeChan <- &eCtx
 			}
 		}
 	}()
@@ -185,7 +185,7 @@ func BenchmarkGetEventFromPool(b *testing.B) {
 // BenchmarkNewEventObject is a benchmark of using a new Event object for each event,
 // which simulates, with caveats, the way the pipeline works.
 func BenchmarkNewEventObject(b *testing.B) {
-	ctx := bufferdecoder.Context{}
+	eCtx := bufferdecoder.EventContext{}
 	containerData := trace.Container{}
 	kubernetesData := trace.Kubernetes{}
 	eventDefinition := events.Definition{}
@@ -195,7 +195,7 @@ func BenchmarkNewEventObject(b *testing.B) {
 	syscall := ""
 	argnum := uint8(0)
 
-	decodeChan := make(chan *bufferdecoder.Context, 10000)
+	decodeChan := make(chan *bufferdecoder.EventContext, 10000)
 	processChan := make(chan *trace.Event, 10000)
 	deriveChan := make(chan *trace.Event)
 	engineChan := make(chan *trace.Event)
@@ -211,7 +211,7 @@ func BenchmarkNewEventObject(b *testing.B) {
 		defer wg.Done()
 		for i := 0; i < b.N; i++ {
 			for j := 0; j < decodeEvts; j++ {
-				decodeChan <- &ctx
+				decodeChan <- &eCtx
 			}
 		}
 	}()


### PR DESCRIPTION
### 1. Explain what the PR does

00ffa33 **chore: rename Context to EventContext**

```
It aligns with the name of the type in the ebpf land, `event_context`
avoiding confusion with the `context.Context` type.
It also updates the respective comments.
```

### 2. Explain how to test it


### 3. Other comments

