### PR TITLE
fix: webhook template should support sprig funcs

### DIFF
--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
 	"time"
 
 	forward "github.com/IBM/fluent-forward-go/fluent/client"
+	"github.com/Masterminds/sprig/v3"
 
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -644,7 +646,10 @@ func (ws *webhookEventPrinter) Init() error {
 
 	gotemplate := getParameterValue(parameters, "gotemplate", "")
 	if gotemplate != "" {
-		tmpl, err := template.ParseFiles(gotemplate)
+		tmpl, err := template.New(filepath.Base(gotemplate)).
+			Funcs(sprig.TxtFuncMap()).
+			ParseFiles(gotemplate)
+
 		if err != nil {
 			return errfmt.WrapError(err)
 		}


### PR DESCRIPTION

### 1. Explain what the PR does

Fix https://github.com/aquasecurity/tracee/issues/3717

This PR adds support to Sprig's funcs for webhook templates.

### 2. Explain how to test it

create a `test.tmpl` with:
```
{
  "hostname": "{{ .HostName }}",
  "message": "Signature name: \"{{ .Metadata.Properties.signatureName }}\" description:\n{{ .Metadata.Description }}",
  "severity": "{{ .Metadata.Properties.Severity }}",
  "time": "{{ dateInZone "2006-01-02T15:04:05Z" (now) "UTC" }}",
  "tags": {
    "category": "{{ .Metadata.Properties.Category }}",
    "external_id": "{{ .Metadata.Properties.external_id }}",
    "signature_id": "{{ .Metadata.Properties.signatureId }}"
  }
}
```

```
sudo ./dist/tracee -e anti_debugging -o webhook:http://localhost:8080?gotemplate=test.tmpl
```

Tracee wouldn't boot if the parse failed before. 

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
