### PR TITLE
bugfix(ebpf): avoid errors upon hash calc fail

### DIFF
--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -36,7 +37,7 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 ) {
 	// path should be absolute, except, for example, memfd_create files
 	if mountNSAbsolutePath == "" || mountNSAbsolutePath[0] != '/' {
-		return "", errfmt.Errorf("file path is not absolute in its container mount point")
+		return "", ErrNonAbsolutePath
 	}
 
 	// Current process has already died, try to access the root fs from another
@@ -73,8 +74,10 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 		}
 	}
 
-	return "", errfmt.Errorf(
-		"has no access to container fs - no living task of mountns %d",
-		mountNS,
-	)
+	return "", ErrContainerFSUnreachable
 }
+
+var (
+	ErrContainerFSUnreachable = errors.New("container file system is unreachable in mount namespace because there are not living children")
+	ErrNonAbsolutePath        = errors.New("file path is not absolute in its container mount point")
+)


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Avoid creating errors upon errors in hash calculations from known reasons.
This includes memfd files, and race conditions in container FS access

Fix #3732

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
