### PR TITLE
Network: add net_tcp_connect event with DNS support

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -588,8 +588,6 @@ struct msghdr {
 
 typedef s64 ktime_t;
 
-typedef unsigned int sk_buff_data_t;
-
 struct sk_buff {
     __u16 network_header;
     union {

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -588,18 +588,15 @@ struct msghdr {
 
 typedef s64 ktime_t;
 
+typedef unsigned int sk_buff_data_t;
+
 struct sk_buff {
-    __u16 transport_header;
     __u16 network_header;
     union {
         ktime_t tstamp;
         u64 skb_mstamp_ns;
     };
     unsigned char *head;
-    unsigned char *data;
-    u32 len;
-    u16 mac_len;
-    u16 hdr_len;
 };
 
 struct linux_binprm {

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -478,8 +478,9 @@ struct alloc_context {
 };
 
 struct socket {
-    struct sock *sk;
+    short type;
     struct file *file;
+    struct sock *sk;
 };
 
 typedef struct {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -661,8 +661,16 @@ func (t *Tracee) initDerivationTable() error {
 				),
 			},
 		},
+		events.SecuritySocketConnect: {
+			events.NetTCPConnect: {
+				Enabled: shouldSubmit(events.NetTCPConnect),
+				DeriveFunction: derive.NetTCPConnect(
+					t.dnsCache,
+				),
+			},
+		},
 		//
-		// Network Derivations
+		// Network Packet Derivations
 		//
 		events.NetPacketIPBase: {
 			events.NetPacketIPv4: {

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -9811,6 +9811,7 @@ var CoreEvents = map[ID]Definition{
 		sets: []string{"default", "lsm_hooks", "net", "net_sock"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "sockfd"},
+			{Type: "int", Name: "type"},
 			{Type: "struct sockaddr*", Name: "remote_addr"},
 		},
 	},

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -122,6 +122,7 @@ const (
 	NetPacketHTTPRequest
 	NetPacketHTTPResponse
 	MaxUserNetID
+	NetTCPConnect
 	InitNamespaces
 	ContainerCreate
 	ContainerRemove
@@ -9813,6 +9814,23 @@ var CoreEvents = map[ID]Definition{
 			{Type: "struct sockaddr*", Name: "remote_addr"},
 		},
 	},
+	NetTCPConnect: {
+		id:      NetTCPConnect,
+		id32Bit: Sys32Undefined,
+		name:    "net_tcp_connect",
+		version: NewVersion(1, 0, 0),
+		dependencies: Dependencies{
+			ids: []ID{
+				SecuritySocketConnect,
+			},
+		},
+		sets: []string{"default", "flows"},
+		params: []trace.ArgMeta{
+			{Type: "const char*", Name: "dst"},
+			{Type: "int", Name: "dst_port"},
+			{Type: "const char **", Name: "dst_dns"},
+		},
+	},
 	SecuritySocketAccept: {
 		id:      SecuritySocketAccept,
 		id32Bit: Sys32Undefined,
@@ -9833,6 +9851,7 @@ var CoreEvents = map[ID]Definition{
 			{Type: "struct sockaddr*", Name: "local_addr"},
 		},
 	},
+	// TODO: NetTCPAccept ? Problem: we don't have the remote address in current security_socket_accept
 	SecuritySocketBind: {
 		id:      SecuritySocketBind,
 		id32Bit: Sys32Undefined,

--- a/pkg/events/derive/net_tcp.go
+++ b/pkg/events/derive/net_tcp.go
@@ -1,0 +1,106 @@
+package derive
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/aquasecurity/tracee/pkg/dnscache"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+func NetTCPConnect(cache *dnscache.DNSCache) DeriveFunction {
+	return deriveSingleEvent(events.NetTCPConnect, deriveNetTCPConnectArgs(cache))
+}
+
+func deriveNetTCPConnectArgs(cache *dnscache.DNSCache) deriveArgsFunction {
+	return func(event trace.Event) ([]interface{}, error) {
+		dstIP, dstPort, err := pickIpAndPort(event, "remote_addr")
+		if err != nil {
+			logger.Debugw("error picking address", "error", err)
+			return nil, nil
+		}
+		if dstIP == "" {
+			return nil, nil
+		}
+
+		// Check if DNS cache is enabled
+		results := []string{}
+		if cache != nil {
+			query, err := cache.Get(dstIP)
+			if err != nil {
+				switch err {
+				case dnscache.ErrDNSRecordNotFound, dnscache.ErrDNSRecordExpired:
+					results = []string{}
+					goto allGood
+				}
+				logger.Debugw("ip lookup error", "ip", dstIP, "error", err)
+				return nil, nil
+			}
+			results = query.DNSResults()
+		}
+
+	allGood:
+		return []interface{}{
+			dstIP,
+			dstPort,
+			results,
+		}, nil
+	}
+}
+
+// pickIpAndPort returns the IP address and port from the event's sockaddr field.
+func pickIpAndPort(event trace.Event, fieldName string) (string, int, error) {
+	var err error
+	// e.g: sockaddr: map[sa_family:AF_INET sin_addr:10.10.11.2 sin_port:1234]
+
+	sockaddr, err := parse.ArgVal[map[string]string](event.Args, fieldName)
+	if err != nil {
+		return "", 0, errfmt.WrapError(err)
+	}
+	if sockaddr == nil {
+		return "", 0, errfmt.WrapError(errors.New("remote_addr not found"))
+	}
+
+	var addr string
+	var port int
+
+	family, ok := sockaddr["sa_family"]
+	if !ok {
+		return "", 0, errfmt.WrapError(errors.New("missing field sa_family"))
+	}
+	switch family {
+	case "AF_INET":
+		addr, port, err = getAddrAndPort("sin_addr", "sin_port", sockaddr)
+		if err != nil {
+			return "", 0, errfmt.WrapError(err)
+		}
+	case "AF_INET6":
+		addr, port, err = getAddrAndPort("sin6_addr", "sin6_port", sockaddr)
+		if err != nil {
+			return "", 0, errfmt.WrapError(err)
+		}
+	default:
+		return "", 0, nil
+	}
+
+	return addr, port, nil
+}
+
+// getAddrAndPort returns the address and port from sockaddr for IPv4 or IPv6.
+func getAddrAndPort(a, p string, sockaddr map[string]string) (string, int, error) {
+	for _, key := range []string{a, p} {
+		if _, ok := sockaddr[key]; !ok {
+			return "", 0, errfmt.WrapError(errors.New("missing field " + key))
+		}
+	}
+	addr := sockaddr[a]
+	port, err := strconv.Atoi(sockaddr[p])
+	if err != nil {
+		return "", 0, errfmt.WrapError(err)
+	}
+	return addr, port, nil
+}

--- a/pkg/events/derive/net_tcp.go
+++ b/pkg/events/derive/net_tcp.go
@@ -57,6 +57,16 @@ func pickIpAndPort(event trace.Event, fieldName string) (string, int, error) {
 	var err error
 	// e.g: sockaddr: map[sa_family:AF_INET sin_addr:10.10.11.2 sin_port:1234]
 
+	// Check if socket is a TCP socket.
+	sType, err := parse.ArgVal[string](event.Args, "type")
+	if err != nil {
+		return "", 0, errfmt.WrapError(err)
+	}
+	if sType != "SOCK_STREAM" {
+		return "", 0, nil
+	}
+
+	// Get sockaddr field.
 	sockaddr, err := parse.ArgVal[map[string]string](event.Args, fieldName)
 	if err != nil {
 		return "", 0, errfmt.WrapError(err)

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -132,7 +132,7 @@ func ParseArgs(event *trace.Event) error {
 				parseOrEmptyString(typeArg, socketTypeArgument, err)
 			}
 		}
-	case SecuritySocketCreate:
+	case SecuritySocketCreate, SecuritySocketConnect:
 		if domArg := GetArg(event, "family"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				socketDomainArgument, err := helpers.ParseSocketDomainArgument(uint64(dom))


### PR DESCRIPTION
commit c3bb180a4 (HEAD -> network-connection)
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Wed Dec 6 23:34:58 2023

    feature(event): make net_tcp_connect report only TCP

commit 8d476c907
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Dec 5 23:43:18 2023

    feature(event): add net_tcp_connect event with dns support
    
    - create new set called "flows" to represent network flows.

commit cb3525fdf
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Dec 5 23:39:30 2023

    chore(ebpf): improve readability for security_socket_connect
    
    Opportunistic code change with no logic changes.

commit 8f40dc58e
Author: Rafael David Tinoco <rafaeldtinoco@gmail.com>
Date:   Tue Dec 5 16:09:29 2023

    fix(network): important fix to how header pointers are calculated
    
    The network L3 header pointer should always be calculated as:
    
    - header pointer + network header offset
    
    no matter if during ingress or egress.
    
    Considering sk_buff overall structure, it holds pointers to:
    
                                     ---------------
                                    | sk_buff       |
                                     ---------------
        ,---------------------------  + head
       /          ,-----------------  + data
      /          /      ,-----------  + tail
     |          |      |            , + end
     |          |      |           |
     v          v      v           v
      -----------------------------------------------
     | headroom | data |  tailroom | skb_shared_info |
      -----------------------------------------------
                                    + [page frag]
                                    + [page frag]
                                    + [page frag]
                                    + [page frag]       ---------
                                    + frag_list    --> | sk_buff |
                                                        ---------
    
    Ingress: Headroom is often unused, allowing for header prepending without
    reallocating. The data segment holds all packet data and headers. Tailroom,
    typically unused, provides space for possible data addition.
    
    Egress: Headroom is utilized for adding necessary headers as packets move up
    the network stack. The data starts with payload or higher-layer data, with
    headers added during processing. Tailroom, less used, offers space for
    potential data appending at the end.