### PR TITLE
Improve performance of exec-hash

### DIFF
--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -80,7 +80,7 @@ config:
       stackAddresses: false
       execEnv: false
       relativeTime: true
-      execHash: false
+      execHash: dev-inode
       sortEvents: false
 
 defaultPolicy: true

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -56,7 +56,7 @@ data:
             stack-addresses: false
             exec-env: false
             relative-time: true
-            exec-hash: false
+            exec-hash: dev-inode
             sort-events: false
 ---
 # Source: tracee/templates/role.yaml

--- a/docs/docs/flags/output.1.md
+++ b/docs/docs/flags/output.1.md
@@ -11,7 +11,7 @@ tracee **\-\-output** - Control how and where output is printed
 
 ## SYNOPSIS
 
-tracee **\-\-output** <format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,parse-arguments-fds,sort-events} ...
+tracee **\-\-output** <format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash={pathname,dev-inode,digest-inode},parse-arguments,parse-arguments-fds,sort-events} ...
 
 
 ## DESCRIPTION
@@ -48,7 +48,10 @@ Other options:
   - **exec-env**: When tracing execve/execveat, show the environment variables that were used for execution.
   - **relative-time**: Use relative timestamp instead of wall timestamp for events.
   - **exec-hash**: When tracing some file related events, show the file hash (sha256).
-    - Affected events: sched_process_exec, shared_object_loaded
+    - Affected events: *sched_process_exec*, *shared_object_loaded*
+    - **pathname** option recalculates the file hash if the inode's creation time (ctime) differs, which can occur in different namespaces even for identical pathnames.
+    - **dev-inode** option generally offers better performance compared to the **pathname** option, as it bypasses the need for recalculation by associating the creation time (ctime) with the device (dev) and inode pair.
+    - **digest-inode**" option is the most efficient, as it keys the hash to a pair consisting of the container image digest and inode. This approach, however, necessitates container enrichment.
   - **parse-arguments**: Do not show raw machine-readable values for event arguments. Instead, parse them into human-readable strings.
   - **parse-arguments-fds**: Enable parse-arguments and enrich file descriptors (fds) with their file path translation. This can cause pipeline slowdowns.
   - **sort-events**: Enable sorting events before passing them to the output. This may decrease the overall program efficiency.

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -134,7 +134,7 @@ output:
         stack-addresses: true
         exec-env: false
         relative-time: true
-        exec-hash: false
+        exec-hash: dev-inode
         parse-arguments: true
         sort-events: false
 

--- a/docs/docs/outputs/output-options.md
+++ b/docs/docs/outputs/output-options.md
@@ -48,8 +48,9 @@ Available options:
     ```
     output:
         options:
-            exec-hash: true
+            exec-hash: dev-inode
     ```
+
 5. **relative-time**
 
     The `relative-time` output option enables relative timestamp instead of wall timestamp for events.

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -92,7 +92,7 @@ output:
         stack-addresses: false
         exec-env: true
         relative-time: true
-        exec-hash: true
+        exec-hash: dev-inode
         parse-arguments: true
         parse-arguments-fds: true
         sort-events: true

--- a/docs/man/output.1
+++ b/docs/man/output.1
@@ -24,7 +24,7 @@ tracee \f[B]--output\f[R] - Control how and where output is printed
 tracee \f[B]--output\f[R] <format[:file,\&...]> |
 gotemplate=template[:file,\&...]
 | forward:url | webhook:url |
-option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,parse-arguments-fds,sort-events}
+option:{stack-addresses,exec-env,relative-time,exec-hash={pathname,dev-inode,digest-inode},parse-arguments,parse-arguments-fds,sort-events}
 \&...
 .SS DESCRIPTION
 .PP
@@ -90,7 +90,21 @@ timestamp for events.
 file hash (sha256).
 .RS 2
 .IP \[bu] 2
-Affected events: sched_process_exec, shared_object_loaded
+Affected events: \f[I]sched_process_exec\f[R],
+\f[I]shared_object_loaded\f[R]
+.IP \[bu] 2
+\f[B]pathname\f[R] option recalculates the file hash if the inode\[cq]s
+creation time (ctime) differs, which can occur in different namespaces
+even for identical pathnames.
+.IP \[bu] 2
+\f[B]dev-inode\f[R] option generally offers better performance compared
+to the \f[B]pathname\f[R] option, as it bypasses the need for
+recalculation by associating the creation time (ctime) with the device
+(dev) and inode pair.
+.IP \[bu] 2
+\f[B]digest-inode\f[R]\[rq] option is the most efficient, as it keys the
+hash to a pair consisting of the container image digest and inode.
+This approach, however, necessitates container enrichment.
 .RE
 .IP \[bu] 2
 \f[B]parse-arguments\f[R]: Do not show raw machine-readable values for

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -126,7 +126,7 @@ output:
     #     stack-addresses: true
     #     exec-env: false
     #     relative-time: true
-    #     exec-hash: false
+    #     exec-hash: dev-inode
     #     parse-arguments: true
     #     sort-events: false
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/kubernetes/cri-api v0.27.1
 	github.com/mennanov/fmutils v0.2.0
+	github.com/minio/sha256-simd v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/open-policy-agent/opa v0.52.0
 	github.com/prometheus/client_golang v1.16.0
@@ -64,6 +65,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
+github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -307,6 +309,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/mennanov/fmutils v0.2.0 h1:Hw/iuQPdKtiB2B9YYh+NX8iv7U7eQu1rICPjr8NvxSo=
 github.com/mennanov/fmutils v0.2.0/go.mod h1:DE+qeI9Xy5s1GA4trgq8H26jr5DgJ4a9+0D1DPVCqyk=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
+github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -639,6 +643,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/bucketscache/bucketscache.go
+++ b/pkg/bucketscache/bucketscache.go
@@ -21,7 +21,14 @@ func (c *BucketsCache) Init(bucketLimit int) {
 func (c *BucketsCache) GetBucket(key uint32) []uint32 {
 	c.bucketsMutex.RLock()
 	defer c.bucketsMutex.RUnlock()
-	return c.buckets[key]
+
+	if orig, ok := c.buckets[key]; ok {
+		b := make([]uint32, len(orig))
+		copy(b, orig)
+		return b
+	}
+
+	return nil
 }
 
 func (c *BucketsCache) GetBucketItem(key uint32, index int) (uint32, error) {

--- a/pkg/bucketscache/bucketscache_bench_test.go
+++ b/pkg/bucketscache/bucketscache_bench_test.go
@@ -1,0 +1,80 @@
+package bucketscache
+
+import (
+	"sync"
+	"testing"
+)
+
+type BucketsCacheWithOneLock struct {
+	bc BucketsCache
+}
+
+func (c *BucketsCacheWithOneLock) Init(bucketLimit int) {
+	c.bc.Init(bucketLimit)
+}
+
+func (c *BucketsCacheWithOneLock) addBucketItem(key uint32, value uint32, force bool) {
+	c.bc.bucketsMutex.Lock()
+	defer c.bc.bucketsMutex.Unlock()
+
+	b, exists := c.bc.buckets[key]
+	if !exists {
+		c.bc.buckets[key] = make([]uint32, 0, c.bc.bucketLimit)
+		b = c.bc.buckets[key]
+	}
+
+	if len(b) >= c.bc.bucketLimit {
+		if !force {
+			return
+		}
+		b[0] = value
+	} else {
+		c.bc.buckets[key] = append(b, value)
+	}
+}
+
+func BenchmarkAddBucketItemCurrent(b *testing.B) {
+	bc := &BucketsCache{}
+	bc.Init(100)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1000 * b.N)
+	for i := 0; i < 1000*b.N; i++ {
+		go func() {
+			<-start
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				bc.addBucketItem(uint32(j), uint32(j), false)
+			}
+		}()
+	}
+
+	b.ResetTimer() // Start timing after setup
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+}
+
+func BenchmarkAddBucketItemWithOneLock(b *testing.B) {
+	bc := &BucketsCacheWithOneLock{}
+	bc.Init(100)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1000 * b.N)
+	for i := 0; i < 1000*b.N; i++ {
+		go func() {
+			<-start
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				bc.addBucketItem(uint32(j), uint32(j), false)
+			}
+		}()
+	}
+
+	b.ResetTimer() // Start timing after setup
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+}

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -399,8 +399,8 @@ func (c *OutputConfig) flags() []string {
 	if c.Options.RelativeTime {
 		flags = append(flags, "option:relative-time")
 	}
-	if c.Options.ExecHash {
-		flags = append(flags, "option:exec-hash")
+	if c.Options.ExecHash != "" {
+		flags = append(flags, fmt.Sprintf("option:exec-hash=%s", c.Options.ExecHash))
 	}
 	if c.Options.ParseArguments {
 		flags = append(flags, "option:parse-arguments")
@@ -474,14 +474,14 @@ func (c *OutputConfig) flags() []string {
 }
 
 type OutputOptsConfig struct {
-	None              bool `mapstructure:"none"`
-	StackAddresses    bool `mapstructure:"stack-addresses"`
-	ExecEnv           bool `mapstructure:"exec-env"`
-	RelativeTime      bool `mapstructure:"relative-time"`
-	ExecHash          bool `mapstructure:"exec-hash"`
-	ParseArguments    bool `mapstructure:"parse-arguments"`
-	ParseArgumentsFDs bool `mapstructure:"parse-arguments-fds"`
-	SortEvents        bool `mapstructure:"sort-events"`
+	None              bool   `mapstructure:"none"`
+	StackAddresses    bool   `mapstructure:"stack-addresses"`
+	ExecEnv           bool   `mapstructure:"exec-env"`
+	RelativeTime      bool   `mapstructure:"relative-time"`
+	ExecHash          string `mapstructure:"exec-hash"`
+	ParseArguments    bool   `mapstructure:"parse-arguments"`
+	ParseArgumentsFDs bool   `mapstructure:"parse-arguments-fds"`
+	SortEvents        bool   `mapstructure:"sort-events"`
 }
 
 type OutputFormatConfig struct {

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -282,7 +282,7 @@ output:
     - option:stack-addresses
     - option:exec-env
     - option:relative-time
-    - option:exec-hash
+    - option:exec-hash=dev-inode
     - option:parse-arguments
     - option:parse-arguments-fds
     - option:sort-events
@@ -296,7 +296,7 @@ output:
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -314,7 +314,7 @@ output:
         stack-addresses: true
         exec-env: true
         relative-time: true
-        exec-hash: true
+        exec-hash: dev-inode
         parse-arguments: true
         parse-arguments-fds: true
         sort-events: true
@@ -369,7 +369,7 @@ output:
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -986,7 +986,7 @@ func TestOutputConfigFlags(t *testing.T) {
 					StackAddresses:    true,
 					ExecEnv:           true,
 					RelativeTime:      true,
-					ExecHash:          true,
+					ExecHash:          "dev-inode",
 					ParseArguments:    true,
 					ParseArgumentsFDs: true,
 					SortEvents:        true,
@@ -997,7 +997,7 @@ func TestOutputConfigFlags(t *testing.T) {
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -107,8 +107,6 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 		cfg.ExecEnv = true
 	case "relative-time":
 		cfg.RelativeTime = true
-	case "exec-hash":
-		cfg.CalcHashes = true
 	case "parse-arguments":
 		cfg.ParseArguments = true
 	case "parse-arguments-fds":
@@ -117,6 +115,29 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 	case "sort-events":
 		cfg.EventsSorting = true
 	default:
+		if strings.HasPrefix(option, "exec-hash") {
+			hashExecParts := strings.Split(option, "=")
+
+			if len(hashExecParts) == 2 {
+				hashExecOpt := hashExecParts[1]
+				switch hashExecOpt {
+				case "none":
+					cfg.CalcHashes = config.CalcHashesNone
+				case "pathname":
+					cfg.CalcHashes = config.CalcHashesPathname
+				case "dev-inode":
+					cfg.CalcHashes = config.CalcHashesDevInode
+				case "digest-inode":
+					cfg.CalcHashes = config.CalcHashesDigestInode
+				default:
+					goto invalidOption
+				}
+			}
+
+			return nil
+		}
+
+	invalidOption:
 		if newBinary {
 			// TODO: build man page
 			// return errfmt.Errorf("invalid output option: %s, see 'tracee-output' man page for more info", option)

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -325,14 +325,14 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "option exec-hash",
-			outputSlice: []string{"option:exec-hash"},
+			testName:    "option exec-hash=pathname",
+			outputSlice: []string{"option:exec-hash=pathname"},
 			expectedOutput: PrepareOutputResult{
 				PrinterConfigs: []config.PrinterConfig{
 					{Kind: "table", OutPath: "stdout"},
 				},
 				TraceeConfig: &config.OutputConfig{
-					CalcHashes:     true,
+					CalcHashes:     config.CalcHashesPathname,
 					ParseArguments: true,
 				},
 			},
@@ -382,7 +382,7 @@ func TestPrepareOutput(t *testing.T) {
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -395,7 +395,7 @@ func TestPrepareOutput(t *testing.T) {
 					StackAddresses:    true,
 					ExecEnv:           true,
 					RelativeTime:      true,
-					CalcHashes:        true,
+					CalcHashes:        config.CalcHashesDevInode,
 					ParseArguments:    true,
 					ParseArgumentsFDs: true,
 					EventsSorting:     true,
@@ -404,10 +404,10 @@ func TestPrepareOutput(t *testing.T) {
 		},
 	}
 	for _, testcase := range testCases {
-		testcase := testcase
+		// testcase := testcase
 
 		t.Run(testcase.testName, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 
 			output, err := PrepareOutput(testcase.outputSlice, false)
 			if err != nil {

--- a/pkg/cmd/flags/tracee_ebpf_output_test.go
+++ b/pkg/cmd/flags/tracee_ebpf_output_test.go
@@ -87,11 +87,11 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "option exec-hash",
-			outputSlice: []string{"option:exec-hash"},
+			testName:    "option exec-hash=pathname",
+			outputSlice: []string{"option:exec-hash=pathname"},
 			expectedOutput: PrepareOutputResult{
 				TraceeConfig: &config.OutputConfig{
-					CalcHashes:     true,
+					CalcHashes:     config.CalcHashesPathname,
 					ParseArguments: true,
 				},
 			},
@@ -132,7 +132,7 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=none",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -142,7 +142,7 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 					StackAddresses:    true,
 					ExecEnv:           true,
 					RelativeTime:      true,
-					CalcHashes:        true,
+					CalcHashes:        config.CalcHashesNone,
 					ParseArguments:    true,
 					ParseArgumentsFDs: true,
 					EventsSorting:     true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,11 +153,35 @@ type CapabilitiesConfig struct {
 // Output
 //
 
+type CalcHashesOption int
+
+const (
+	CalcHashesNone CalcHashesOption = iota
+	CalcHashesPathname
+	CalcHashesDevInode
+	CalcHashesDigestInode
+)
+
+func (c CalcHashesOption) String() string {
+	switch c {
+	case CalcHashesNone:
+		return "none"
+	case CalcHashesPathname:
+		return "pathname"
+	case CalcHashesDevInode:
+		return "dev-inode"
+	case CalcHashesDigestInode:
+		return "digest-inode"
+	default:
+		return "unknown"
+	}
+}
+
 type OutputConfig struct {
 	StackAddresses bool
 	ExecEnv        bool
 	RelativeTime   bool
-	CalcHashes     bool
+	CalcHashes     CalcHashesOption
 
 	ParseArguments    bool
 	ParseArgumentsFDs bool

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1569,6 +1569,7 @@ func (t *Tracee) getFileHash(filename string, ctime int64, mountNs int, containe
 		if err == nil {
 			hashInfoObj = fileExecInfo{ctime, hash}
 			t.fileHashes.Add(fileId, hashInfoObj)
+			fileHash = hash
 		}
 	}
 	return fileHash, nil

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -2,7 +2,6 @@ package ebpf
 
 import (
 	gocontext "context"
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"unsafe"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	miniosha "github.com/minio/sha256-simd"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
 	bpf "github.com/aquasecurity/libbpfgo"
@@ -1602,11 +1602,12 @@ func computeFileHashAtPath(fileName string) (string, error) {
 }
 
 func computeFileHash(file *os.File) (string, error) {
-	h := sha256.New()
+	h := miniosha.New()
 	_, err := io.Copy(h, file)
 	if err != nil {
 		return "", errfmt.WrapError(err)
 	}
+
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 

--- a/pkg/ebpf/tracee_bench_test.go
+++ b/pkg/ebpf/tracee_bench_test.go
@@ -1,0 +1,60 @@
+package ebpf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+)
+
+func computeFileHashOld(file *os.File) (string, error) {
+	h := sha256.New()
+
+	_, err := io.Copy(h, file)
+	if err != nil {
+		return "", errfmt.WrapError(err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func BenchmarkComputeFileHashOld(b *testing.B) {
+	file, err := os.Open("/usr/bin/uname")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := computeFileHashOld(file)
+		if err != nil {
+			b.Fatalf("Error computing file hash: %v", err)
+		}
+		// Reset the file pointer to the beginning for the next iteration
+		file.Seek(0, 0)
+	}
+}
+
+func BenchmarkComputeFileHashCurrent(b *testing.B) {
+	file, err := os.Open("/usr/bin/uname")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := computeFileHash(file)
+		if err != nil {
+			b.Fatalf("Error computing file hash: %v", err)
+		}
+		// Reset the file pointer to the beginning for the next iteration
+		file.Seek(0, 0)
+	}
+}


### PR DESCRIPTION
Close: #3734 
Close: #3745

### 1. Explain what the PR does

f24813f12 **feat(ebpf): expand exec-hash output option**
43f46089b **feat(ebpf): optimize computeFileHash**
e90ad8576 **fix(ebpf): fix getFileHash()**
7fcc7341b **fix(bucketscache): GetBucket was not thread safe**
4d04a15d4 **chore(bucketscache): add benchmark**


f24813f12 **feat(ebpf): expand exec-hash output option**

```
The user can now choose between the following options:

- none (default)
- pathname
- dev-inode
- digest-inode

'pathname' option recalculates the file hash if the inode's creation
time (ctime) differs, which can occur in different namespaces even for
identical pathnames.

'dev-inode' option generally offers better performance compared to the
pathname option, as it bypasses the need for recalculation by
associating the creation time (ctime) with the device (dev) and inode
pair.

'digest-inode' option is the most efficient, as it keys the hash to a
pair consisting of the container image digest and inode. This approach,
however, necessitates container enrichment.
```


43f46089b **feat(ebpf): optimize computeFileHash**

```
Improve the computeFileHash function, by using minio/sha256-simd.

Benchmarking indicates the current implementation is nearly three times
faster than the old version (21,311 ns/op vs. 61,857 ns/op) while
maintaining similar memory efficiency (33,040 B/op vs. 33,056 B/op) and
the same number of memory allocations per operation (5 allocs/op).

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/ebpf
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkComputeFileHashOld-20             19257             61857 ns/op           33056 B/op          5 allocs/op
BenchmarkComputeFileHashCurrent-20         56769             21311 ns/op           33040 B/op          5 allocs/op
```


e90ad8576 **fix(ebpf): fix getFileHash()**

```
First call to getFileHash() for a given filename was returning an
empty string.

Context: #3745
```


7fcc7341b **fix(bucketscache): GetBucket was not thread safe**

```
GetBucket was not thread safe since it was returning a reference to a
bucket instead of its copy.
```


4d04a15d4 **chore(bucketscache): add benchmark**

```
It demonstrate that the current algorithm of addBucketItem with multiple
lock/unlock) is optimal compared to a single lock/unlock.

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/bucketscache
cpu: 12th Gen Intel(R) Core(TM) i7-12700H
BenchmarkAddBucketItemCurrent-20                     464           2586038 ns/op           2118 B/op           5 allocs/op
BenchmarkAddBucketItemWithOneLock-20                 122           9461730 ns/op            424 B/op           1 allocs/op
```

### 2. Explain how to test it

### 3. Other comments
