### PR TITLE
Improve performance of exec-hash

### DIFF
--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -80,7 +80,7 @@ config:
       stackAddresses: false
       execEnv: false
       relativeTime: true
-      execHash: false
+      execHash: dev-inode
       sortEvents: false
 
 defaultPolicy: true

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -56,7 +56,7 @@ data:
             stack-addresses: false
             exec-env: false
             relative-time: true
-            exec-hash: false
+            exec-hash: dev-inode
             sort-events: false
 ---
 # Source: tracee/templates/role.yaml

--- a/docs/docs/flags/output.1.md
+++ b/docs/docs/flags/output.1.md
@@ -11,7 +11,7 @@ tracee **\-\-output** - Control how and where output is printed
 
 ## SYNOPSIS
 
-tracee **\-\-output** <format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,parse-arguments-fds,sort-events} ...
+tracee **\-\-output** <format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash={inode,dev-inode,digest-inode},parse-arguments,parse-arguments-fds,sort-events} ...
 
 
 ## DESCRIPTION
@@ -48,7 +48,10 @@ Other options:
   - **exec-env**: When tracing execve/execveat, show the environment variables that were used for execution.
   - **relative-time**: Use relative timestamp instead of wall timestamp for events.
   - **exec-hash**: When tracing some file related events, show the file hash (sha256).
-    - Affected events: sched_process_exec, shared_object_loaded
+    - Affected events: *sched_process_exec*, *shared_object_loaded*
+    - **inode** option recalculates the file hash if the inode's creation time (ctime) differs, which can occur in different namespaces even for identical inode. This option is performant, but not recommended and should only be used if container enrichment can't be enabled for digest-inode, and if performance is preffered over correctness.
+    - **dev-inode** option generally offers better performance compared to the **inode** option, as it bypasses the need for recalculation by associating the creation time (ctime) with the device (dev) and inode pair. It's recommended if correctness is preffered over performance without container enrichment.
+    - **digest-inode**" option is the most efficient, as it keys the hash to a pair consisting of the container image digest and inode. This approach, however, necessitates container enrichment.
   - **parse-arguments**: Do not show raw machine-readable values for event arguments. Instead, parse them into human-readable strings.
   - **parse-arguments-fds**: Enable parse-arguments and enrich file descriptors (fds) with their file path translation. This can cause pipeline slowdowns.
   - **sort-events**: Enable sorting events before passing them to the output. This may decrease the overall program efficiency.

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -134,7 +134,7 @@ output:
         stack-addresses: true
         exec-env: false
         relative-time: true
-        exec-hash: false
+        exec-hash: dev-inode
         parse-arguments: true
         sort-events: false
 

--- a/docs/docs/outputs/output-options.md
+++ b/docs/docs/outputs/output-options.md
@@ -48,8 +48,9 @@ Available options:
     ```
     output:
         options:
-            exec-hash: true
+            exec-hash: dev-inode
     ```
+
 5. **relative-time**
 
     The `relative-time` output option enables relative timestamp instead of wall timestamp for events.

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -92,7 +92,7 @@ output:
         stack-addresses: false
         exec-env: true
         relative-time: true
-        exec-hash: true
+        exec-hash: dev-inode
         parse-arguments: true
         parse-arguments-fds: true
         sort-events: true

--- a/docs/man/output.1
+++ b/docs/man/output.1
@@ -24,7 +24,7 @@ tracee \f[B]--output\f[R] - Control how and where output is printed
 tracee \f[B]--output\f[R] <format[:file,\&...]> |
 gotemplate=template[:file,\&...]
 | forward:url | webhook:url |
-option:{stack-addresses,exec-env,relative-time,exec-hash,parse-arguments,parse-arguments-fds,sort-events}
+option:{stack-addresses,exec-env,relative-time,exec-hash={inode,dev-inode,digest-inode},parse-arguments,parse-arguments-fds,sort-events}
 \&...
 .SS DESCRIPTION
 .PP
@@ -90,7 +90,24 @@ timestamp for events.
 file hash (sha256).
 .RS 2
 .IP \[bu] 2
-Affected events: sched_process_exec, shared_object_loaded
+Affected events: \f[I]sched_process_exec\f[R],
+\f[I]shared_object_loaded\f[R]
+.IP \[bu] 2
+\f[B]inode\f[R] option recalculates the file hash if the inode\[cq]s
+creation time (ctime) differs, which can occur in different namespaces
+even for identical inodes. This option is performant, but not recommended
+and should only be used if container enrichment can't be enabled for digest-inode,
+and if performance is preffered over correctness.
+.IP \[bu] 2
+\f[B]dev-inode\f[R] option generally offers better performance compared
+to the \f[B]inode\f[R] option, as it bypasses the need for
+recalculation by associating the creation time (ctime) with the device
+(dev) and inode pair. It's recommended if correctness is preffered over
+performance without container enrichment enabled.
+.IP \[bu] 2
+\f[B]digest-inode\f[R]\[rq] option is the most efficient, as it keys the
+hash to a pair consisting of the container image digest and inode.
+This approach, however, necessitates container enrichment.
 .RE
 .IP \[bu] 2
 \f[B]parse-arguments\f[R]: Do not show raw machine-readable values for

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -126,7 +126,7 @@ output:
     #     stack-addresses: true
     #     exec-env: false
     #     relative-time: true
-    #     exec-hash: false
+    #     exec-hash: dev-inode
     #     parse-arguments: true
     #     sort-events: false
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.2
 	github.com/kubernetes/cri-api v0.27.1
 	github.com/mennanov/fmutils v0.2.0
+	github.com/minio/sha256-simd v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/open-policy-agent/opa v0.52.0
 	github.com/prometheus/client_golang v1.16.0
@@ -64,6 +65,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.3 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
+github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -307,6 +309,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/mennanov/fmutils v0.2.0 h1:Hw/iuQPdKtiB2B9YYh+NX8iv7U7eQu1rICPjr8NvxSo=
 github.com/mennanov/fmutils v0.2.0/go.mod h1:DE+qeI9Xy5s1GA4trgq8H26jr5DgJ4a9+0D1DPVCqyk=
 github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
+github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
@@ -639,6 +643,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/bucketscache/bucketscache.go
+++ b/pkg/bucketscache/bucketscache.go
@@ -21,7 +21,14 @@ func (c *BucketsCache) Init(bucketLimit int) {
 func (c *BucketsCache) GetBucket(key uint32) []uint32 {
 	c.bucketsMutex.RLock()
 	defer c.bucketsMutex.RUnlock()
-	return c.buckets[key]
+
+	if orig, ok := c.buckets[key]; ok {
+		b := make([]uint32, len(orig))
+		copy(b, orig)
+		return b
+	}
+
+	return nil
 }
 
 func (c *BucketsCache) GetBucketItem(key uint32, index int) (uint32, error) {

--- a/pkg/bucketscache/bucketscache_bench_test.go
+++ b/pkg/bucketscache/bucketscache_bench_test.go
@@ -1,0 +1,80 @@
+package bucketscache
+
+import (
+	"sync"
+	"testing"
+)
+
+type BucketsCacheWithOneLock struct {
+	bc BucketsCache
+}
+
+func (c *BucketsCacheWithOneLock) Init(bucketLimit int) {
+	c.bc.Init(bucketLimit)
+}
+
+func (c *BucketsCacheWithOneLock) addBucketItem(key uint32, value uint32, force bool) {
+	c.bc.bucketsMutex.Lock()
+	defer c.bc.bucketsMutex.Unlock()
+
+	b, exists := c.bc.buckets[key]
+	if !exists {
+		c.bc.buckets[key] = make([]uint32, 0, c.bc.bucketLimit)
+		b = c.bc.buckets[key]
+	}
+
+	if len(b) >= c.bc.bucketLimit {
+		if !force {
+			return
+		}
+		b[0] = value
+	} else {
+		c.bc.buckets[key] = append(b, value)
+	}
+}
+
+func BenchmarkAddBucketItemCurrent(b *testing.B) {
+	bc := &BucketsCache{}
+	bc.Init(100)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1000 * b.N)
+	for i := 0; i < 1000*b.N; i++ {
+		go func() {
+			<-start
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				bc.addBucketItem(uint32(j), uint32(j), false)
+			}
+		}()
+	}
+
+	b.ResetTimer() // Start timing after setup
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+}
+
+func BenchmarkAddBucketItemWithOneLock(b *testing.B) {
+	bc := &BucketsCacheWithOneLock{}
+	bc.Init(100)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1000 * b.N)
+	for i := 0; i < 1000*b.N; i++ {
+		go func() {
+			<-start
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				bc.addBucketItem(uint32(j), uint32(j), false)
+			}
+		}()
+	}
+
+	b.ResetTimer() // Start timing after setup
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+}

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -399,8 +399,8 @@ func (c *OutputConfig) flags() []string {
 	if c.Options.RelativeTime {
 		flags = append(flags, "option:relative-time")
 	}
-	if c.Options.ExecHash {
-		flags = append(flags, "option:exec-hash")
+	if c.Options.ExecHash != "" {
+		flags = append(flags, fmt.Sprintf("option:exec-hash=%s", c.Options.ExecHash))
 	}
 	if c.Options.ParseArguments {
 		flags = append(flags, "option:parse-arguments")
@@ -474,14 +474,14 @@ func (c *OutputConfig) flags() []string {
 }
 
 type OutputOptsConfig struct {
-	None              bool `mapstructure:"none"`
-	StackAddresses    bool `mapstructure:"stack-addresses"`
-	ExecEnv           bool `mapstructure:"exec-env"`
-	RelativeTime      bool `mapstructure:"relative-time"`
-	ExecHash          bool `mapstructure:"exec-hash"`
-	ParseArguments    bool `mapstructure:"parse-arguments"`
-	ParseArgumentsFDs bool `mapstructure:"parse-arguments-fds"`
-	SortEvents        bool `mapstructure:"sort-events"`
+	None              bool   `mapstructure:"none"`
+	StackAddresses    bool   `mapstructure:"stack-addresses"`
+	ExecEnv           bool   `mapstructure:"exec-env"`
+	RelativeTime      bool   `mapstructure:"relative-time"`
+	ExecHash          string `mapstructure:"exec-hash"`
+	ParseArguments    bool   `mapstructure:"parse-arguments"`
+	ParseArgumentsFDs bool   `mapstructure:"parse-arguments-fds"`
+	SortEvents        bool   `mapstructure:"sort-events"`
 }
 
 type OutputFormatConfig struct {

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -282,7 +282,7 @@ output:
     - option:stack-addresses
     - option:exec-env
     - option:relative-time
-    - option:exec-hash
+    - option:exec-hash=dev-inode
     - option:parse-arguments
     - option:parse-arguments-fds
     - option:sort-events
@@ -296,7 +296,7 @@ output:
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -314,7 +314,7 @@ output:
         stack-addresses: true
         exec-env: true
         relative-time: true
-        exec-hash: true
+        exec-hash: dev-inode
         parse-arguments: true
         parse-arguments-fds: true
         sort-events: true
@@ -369,7 +369,7 @@ output:
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -986,7 +986,7 @@ func TestOutputConfigFlags(t *testing.T) {
 					StackAddresses:    true,
 					ExecEnv:           true,
 					RelativeTime:      true,
-					ExecHash:          true,
+					ExecHash:          "dev-inode",
 					ParseArguments:    true,
 					ParseArgumentsFDs: true,
 					SortEvents:        true,
@@ -997,7 +997,7 @@ func TestOutputConfigFlags(t *testing.T) {
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -103,8 +103,6 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 		cfg.ExecEnv = true
 	case "relative-time":
 		cfg.RelativeTime = true
-	case "exec-hash":
-		cfg.CalcHashes = true
 	case "parse-arguments":
 		cfg.ParseArguments = true
 	case "parse-arguments-fds":
@@ -113,6 +111,31 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 	case "sort-events":
 		cfg.EventsSorting = true
 	default:
+		if strings.HasPrefix(option, "exec-hash=") {
+			hashExecParts := strings.Split(option, "=")
+
+			if len(hashExecParts) == 2 {
+				hashExecOpt := hashExecParts[1]
+				switch hashExecOpt {
+				case "none":
+					cfg.CalcHashes = config.CalcHashesNone
+				case "inode":
+					cfg.CalcHashes = config.CalcHashesInode
+				case "dev-inode":
+					cfg.CalcHashes = config.CalcHashesDevInode
+				case "digest-inode":
+					cfg.CalcHashes = config.CalcHashesDigestInode
+				default:
+					goto invalidOption
+				}
+			}
+
+			return nil
+		} else {
+			goto invalidOption
+		}
+
+	invalidOption:
 		if newBinary {
 			return errfmt.Errorf("invalid output option: %s, run 'man output' for more info", option)
 		}

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -325,17 +325,22 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "option exec-hash",
-			outputSlice: []string{"option:exec-hash"},
+			testName:    "option exec-hash=inode",
+			outputSlice: []string{"option:exec-hash=inode"},
 			expectedOutput: PrepareOutputResult{
 				PrinterConfigs: []config.PrinterConfig{
 					{Kind: "table", OutPath: "stdout"},
 				},
 				TraceeConfig: &config.OutputConfig{
-					CalcHashes:     true,
+					CalcHashes:     config.CalcHashesInode,
 					ParseArguments: true,
 				},
 			},
+		},
+		{
+			testName:      "option exec-hash invalid",
+			outputSlice:   []string{"option:exec-hash=notvalid"},
+			expectedError: errors.New("invalid output option: exec-hash=notvalid, use '--output help' for more info"),
 		},
 		{
 			testName:    "option parse-arguments",
@@ -382,7 +387,7 @@ func TestPrepareOutput(t *testing.T) {
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=dev-inode",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -395,7 +400,7 @@ func TestPrepareOutput(t *testing.T) {
 					StackAddresses:    true,
 					ExecEnv:           true,
 					RelativeTime:      true,
-					CalcHashes:        true,
+					CalcHashes:        config.CalcHashesDevInode,
 					ParseArguments:    true,
 					ParseArgumentsFDs: true,
 					EventsSorting:     true,
@@ -404,10 +409,10 @@ func TestPrepareOutput(t *testing.T) {
 		},
 	}
 	for _, testcase := range testCases {
-		testcase := testcase
+		// testcase := testcase
 
 		t.Run(testcase.testName, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 
 			output, err := PrepareOutput(testcase.outputSlice, false)
 			if err != nil {

--- a/pkg/cmd/flags/tracee_ebpf_output_test.go
+++ b/pkg/cmd/flags/tracee_ebpf_output_test.go
@@ -87,11 +87,11 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "option exec-hash",
-			outputSlice: []string{"option:exec-hash"},
+			testName:    "option exec-hash=inode",
+			outputSlice: []string{"option:exec-hash=inode"},
 			expectedOutput: PrepareOutputResult{
 				TraceeConfig: &config.OutputConfig{
-					CalcHashes:     true,
+					CalcHashes:     config.CalcHashesInode,
 					ParseArguments: true,
 				},
 			},
@@ -132,7 +132,7 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 				"option:stack-addresses",
 				"option:exec-env",
 				"option:relative-time",
-				"option:exec-hash",
+				"option:exec-hash=none",
 				"option:parse-arguments",
 				"option:parse-arguments-fds",
 				"option:sort-events",
@@ -142,7 +142,7 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 					StackAddresses:    true,
 					ExecEnv:           true,
 					RelativeTime:      true,
-					CalcHashes:        true,
+					CalcHashes:        config.CalcHashesNone,
 					ParseArguments:    true,
 					ParseArgumentsFDs: true,
 					EventsSorting:     true,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,11 +153,35 @@ type CapabilitiesConfig struct {
 // Output
 //
 
+type CalcHashesOption int
+
+const (
+	CalcHashesNone CalcHashesOption = iota
+	CalcHashesInode
+	CalcHashesDevInode
+	CalcHashesDigestInode
+)
+
+func (c CalcHashesOption) String() string {
+	switch c {
+	case CalcHashesNone:
+		return "none"
+	case CalcHashesInode:
+		return "pathname"
+	case CalcHashesDevInode:
+		return "dev-inode"
+	case CalcHashesDigestInode:
+		return "digest-inode"
+	default:
+		return "unknown"
+	}
+}
+
 type OutputConfig struct {
 	StackAddresses bool
 	ExecEnv        bool
 	RelativeTime   bool
-	CalcHashes     bool
+	CalcHashes     CalcHashesOption
 
 	ParseArguments    bool
 	ParseArgumentsFDs bool

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -11,10 +11,12 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/containers"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/filehash"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -121,8 +123,9 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 	} else {
 		t.pidsInMntns.AddBucketItem(uint32(event.MountNS), uint32(event.HostProcessID))
 	}
+
 	// capture executed files
-	if t.config.Capture.Exec || t.config.Output.CalcHashes {
+	if t.config.Capture.Exec || t.config.Output.CalcHashes != config.CalcHashesNone {
 		filePath, err := parse.ArgVal[string](event.Args, "pathname")
 		if err != nil {
 			return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
@@ -147,6 +150,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 			if containerId == "" {
 				containerId = "host"
 			}
+
 			capturedFileID := fmt.Sprintf("%s:%s", containerId, filePath)
 			// capture exec'ed files ?
 			if t.config.Capture.Exec {
@@ -177,8 +181,23 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 				}
 			}
 			// check exec'ed hash ?
-			if t.config.Output.CalcHashes {
-				err := t.addHashArg(event, filePath, castedSourceFileCtime)
+			if t.config.Output.CalcHashes != config.CalcHashesNone {
+				dev, err := parse.ArgVal[uint32](event.Args, "dev")
+				if err != nil {
+					return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
+				}
+				ino, err := parse.ArgVal[uint64](event.Args, "inode")
+				if err != nil {
+					return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
+				}
+
+				fileKey := filehash.NewKey(filePath, event.MountNS,
+					filehash.WithDevice(dev),
+					filehash.WithInode(ino, castedSourceFileCtime),
+					filehash.WithDigest(event.Container.ImageDigest),
+				)
+
+				err = t.addHashArg(event, &fileKey)
 				if err != nil {
 					return err
 				}
@@ -366,32 +385,34 @@ func (t *Tracee) normalizeEventArgTime(event *trace.Event, argName string) error
 }
 
 // addHashArg calculate file hash (in a best-effort efficiency manner) and add it as an argument
-func (t *Tracee) addHashArg(event *trace.Event, fileName string, ctime int64) error {
-	if t.config.Output.CalcHashes {
-		// Currently Tracee does not support hash calculation of memfd files
-		if strings.HasPrefix(fileName, "memfd") {
-			return nil
-		}
-		hash, err := t.getFileHash(fileName, ctime, event.MountNS, event.ContainerID)
-
-		event.Args = append(
-			event.Args, trace.Argument{
-				ArgMeta: trace.ArgMeta{Name: "sha256", Type: "const char*"},
-				Value:   hash,
-			},
-		)
-		event.ArgsNum++
-
-		// Container FS unreachable can happen because of race condition on any system,
-		// so there is no reason to return an error on it
-		if errors.Is(err, containers.ErrContainerFSUnreachable) {
-			logger.Debugw("failed to calculate hash", "error", err, "mount NS", event.MountNS)
-			err = nil
-		}
-
-		return err
+func (t *Tracee) addHashArg(event *trace.Event, fileKey *filehash.Key) error {
+	// Currently Tracee does not support hash calculation of memfd files
+	if strings.HasPrefix(fileKey.Pathname(), "memfd") {
+		return nil
 	}
-	return nil
+
+	hashArg := trace.Argument{
+		ArgMeta: trace.ArgMeta{Name: "sha256", Type: "const char*"},
+	}
+
+	hash, err := t.fileHashes.Get(fileKey)
+	if hash == "" {
+		hashArg.Value = nil
+	} else {
+		hashArg.Value = hash
+	}
+
+	event.Args = append(event.Args, hashArg)
+	event.ArgsNum++
+
+	// Container FS unreachable can happen because of race condition on any system,
+	// so there is no reason to return an error on it
+	if errors.Is(err, containers.ErrContainerFSUnreachable) {
+		logger.Debugw("failed to calculate hash", "error", err, "mount NS", event.MountNS)
+		err = nil
+	}
+
+	return err
 }
 
 func (t *Tracee) processSharedObjectLoaded(event *trace.Event) error {
@@ -405,6 +426,28 @@ func (t *Tracee) processSharedObjectLoaded(event *trace.Event) error {
 		logger.Debugw("Error parsing argument", "error", err)
 		return nil
 	}
+	dev, err := parse.ArgVal[uint32](event.Args, "dev")
+	if err != nil {
+		return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
+	}
+	ino, err := parse.ArgVal[uint64](event.Args, "inode")
+	if err != nil {
+		return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
+	}
 
-	return t.addHashArg(event, filePath, int64(fileCtime))
+	containerId := event.Container.ID
+	if containerId == "" {
+		containerId = "host"
+	}
+	if t.config.Output.CalcHashes != config.CalcHashesNone {
+		fileKey := filehash.NewKey(filePath, event.MountNS,
+			filehash.WithDevice(dev),
+			filehash.WithInode(ino, int64(fileCtime)),
+			filehash.WithDigest(event.Container.ImageDigest),
+		)
+
+		return t.addHashArg(event, &fileKey)
+	}
+
+	return nil
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -2,7 +2,6 @@ package ebpf
 
 import (
 	gocontext "context"
-	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -15,6 +14,7 @@ import (
 	"unsafe"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	miniosha "github.com/minio/sha256-simd"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
 	bpf "github.com/aquasecurity/libbpfgo"
@@ -1629,11 +1629,12 @@ func computeFileHashAtPath(fileName string) (string, error) {
 }
 
 func computeFileHash(file *os.File) (string, error) {
-	h := sha256.New()
+	h := miniosha.New()
 	_, err := io.Copy(h, file)
 	if err != nil {
 		return "", errfmt.WrapError(err)
 	}
+
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1596,6 +1596,7 @@ func (t *Tracee) getFileHash(filename string, ctime int64, mountNs int, containe
 		if err == nil {
 			hashInfoObj = fileExecInfo{ctime, hash}
 			t.fileHashes.Add(fileId, hashInfoObj)
+			fileHash = hash
 		}
 	}
 	return fileHash, nil

--- a/pkg/ebpf/tracee_bench_test.go
+++ b/pkg/ebpf/tracee_bench_test.go
@@ -1,0 +1,60 @@
+package ebpf
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+)
+
+func computeFileHashOld(file *os.File) (string, error) {
+	h := sha256.New()
+
+	_, err := io.Copy(h, file)
+	if err != nil {
+		return "", errfmt.WrapError(err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func BenchmarkComputeFileHashOld(b *testing.B) {
+	file, err := os.Open("/usr/bin/uname")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := computeFileHashOld(file)
+		if err != nil {
+			b.Fatalf("Error computing file hash: %v", err)
+		}
+		// Reset the file pointer to the beginning for the next iteration
+		file.Seek(0, 0)
+	}
+}
+
+func BenchmarkComputeFileHashCurrent(b *testing.B) {
+	file, err := os.Open("/usr/bin/uname")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer file.Close()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := computeFileHash(file)
+		if err != nil {
+			b.Fatalf("Error computing file hash: %v", err)
+		}
+		// Reset the file pointer to the beginning for the next iteration
+		file.Seek(0, 0)
+	}
+}

--- a/pkg/filehash/cache.go
+++ b/pkg/filehash/cache.go
@@ -1,0 +1,93 @@
+package filehash
+
+import (
+	"fmt"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/config"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+var onceHashCapsAdd sync.Once // capabilities for exec hash enabled only once
+
+type hashInfo struct {
+	lastCtime int64
+	hash      string
+}
+
+type pathResolver interface {
+	GetHostAbsPath(absolutePath string, mountNS int) (string, error)
+}
+
+type Cache struct {
+	execHashMode config.CalcHashesOption
+	hashes       *lru.Cache[string, hashInfo]
+	resolver     pathResolver
+}
+
+// NewCache creates a new cache for storing sha256 hashes with associated files.
+// In order to meet multiple performance and correctness needs, the cache can operate in multiple modes.
+//
+//   - inode: recalculates the file hash if the inode's creation time (ctime) differs. The option is performant, but not necessarily correct.
+//   - dev-inode: generally offers better performance compared to the inode option, as it bypasses the need
+//     for recalculation by associating the creation time (ctime) with the device (dev) and inode pair. It's recommended if correctnes
+//     is preffered over performance without container enrichment.
+//   - digest-inode: is the most efficient, as it keys the hash to a pair consisting of the container image digest and inode.
+//     This approach, however, necessitates container enrichment.
+func NewCache(mode config.CalcHashesOption, resolver pathResolver) (*Cache, error) {
+	hashes, err := lru.New[string, hashInfo](1024)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create exechash cache: %v", err)
+	}
+	return &Cache{
+		execHashMode: mode,
+		hashes:       hashes,
+		resolver:     resolver,
+	}, nil
+}
+
+// Get returns a hash from the cache. It attempts to retrieve info from the key based on the mode initially given to the cache.
+func (c *Cache) Get(k *Key) (string, error) {
+	onceHashCapsAdd.Do(
+		func() {
+			logger.Infow("enabled cap.SYS_PTRACE")
+			err := capabilities.GetInstance().BaseRingAdd(cap.SYS_PTRACE)
+			if err != nil {
+				logger.Errorw("error adding cap.SYS_PTRACE to base ring", "error", err)
+			}
+		},
+	)
+
+	key, err := getKeyByExecHashMode(k, c.execHashMode)
+	if err != nil {
+		return "", err
+	}
+
+	if key == "" {
+		return "", fmt.Errorf("empty key given")
+	}
+
+	var fileHash string
+	hashInfoObj, ok := c.hashes.Get(key)
+	if ok && hashInfoObj.lastCtime == k.ctime {
+		fileHash = hashInfoObj.hash
+	} else {
+		sourceFilePath, err := c.resolver.GetHostAbsPath(k.filePath, k.mountNS)
+		if err != nil {
+			return "", err
+		}
+
+		hash, err := ComputeFileHashAtPath(sourceFilePath)
+		if err == nil {
+			hashInfoObj = hashInfo{k.ctime, hash}
+			c.hashes.Add(key, hashInfoObj)
+			fileHash = hash
+		}
+	}
+
+	return fileHash, nil
+}

--- a/pkg/filehash/hash.go
+++ b/pkg/filehash/hash.go
@@ -1,9 +1,11 @@
 package filehash
 
 import (
+	"bytes"
 	"encoding/hex"
 	"io"
 	"os"
+	"sync"
 
 	miniosha "github.com/minio/sha256-simd"
 
@@ -26,9 +28,23 @@ func ComputeFileHashAtPath(path string) (string, error) {
 	return ComputeFileHash(f)
 }
 
+// Preallocate a copy buffer for use between hash computations.
+// This reduces allocations and garbage collection which would happen
+// from using io.Copy.
+var (
+	hashBuffer        = make([]byte, 1024*32)
+	hashBufferWrapper = bytes.NewBuffer(hashBuffer)
+	bufferMutex       = new(sync.Mutex) // add a mutex to prevent concurrent calls deleting the buffer
+)
+
+// ComputeFileHashAtPath attempts to calculate the sha256 hash of a file
+// (the file must already be opened).
 func ComputeFileHash(file *os.File) (string, error) {
+	bufferMutex.Lock()
+	defer bufferMutex.Unlock()
+	hashBufferWrapper.Reset()
 	h := miniosha.New()
-	_, err := io.Copy(h, file)
+	_, err := io.CopyBuffer(h, file, hashBuffer)
 	if err != nil {
 		return "", errfmt.WrapError(err)
 	}

--- a/pkg/filehash/hash.go
+++ b/pkg/filehash/hash.go
@@ -1,0 +1,37 @@
+package filehash
+
+import (
+	"encoding/hex"
+	"io"
+	"os"
+
+	miniosha "github.com/minio/sha256-simd"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+// ComputeFileHashAtPath attempts to open a file at a path and calculate its
+// sha256 hash.
+func ComputeFileHashAtPath(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", errfmt.WrapError(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logger.Errorw("Closing file", "error", err)
+		}
+	}()
+	return ComputeFileHash(f)
+}
+
+func ComputeFileHash(file *os.File) (string, error) {
+	h := miniosha.New()
+	_, err := io.Copy(h, file)
+	if err != nil {
+		return "", errfmt.WrapError(err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/filehash/hash_bench_test.go
+++ b/pkg/filehash/hash_bench_test.go
@@ -1,25 +1,11 @@
-package ebpf
+package filehash_test
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"io"
 	"os"
 	"testing"
 
-	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/filehash"
 )
-
-func computeFileHashOld(file *os.File) (string, error) {
-	h := sha256.New()
-
-	_, err := io.Copy(h, file)
-	if err != nil {
-		return "", errfmt.WrapError(err)
-	}
-
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
 
 func BenchmarkComputeFileHashOld(b *testing.B) {
 	file, err := os.Open("/usr/bin/uname")
@@ -50,7 +36,7 @@ func BenchmarkComputeFileHashCurrent(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := computeFileHash(file)
+		_, err := filehash.ComputeFileHash(file)
 		if err != nil {
 			b.Fatalf("Error computing file hash: %v", err)
 		}

--- a/pkg/filehash/hash_test.go
+++ b/pkg/filehash/hash_test.go
@@ -1,0 +1,51 @@
+package filehash_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/filehash"
+)
+
+func computeFileHashOld(file *os.File) (string, error) {
+	h := sha256.New()
+
+	_, err := io.Copy(h, file)
+	if err != nil {
+		return "", errfmt.WrapError(err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func TestCurrentHashCompatibility(t *testing.T) {
+	files := []string{
+		"/usr/bin/uname",
+		"/usr/bin/date",
+	}
+
+	for _, filePath := range files {
+
+		file, err := os.Open(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		h1, err := filehash.ComputeFileHash(file)
+		require.NoError(t, err)
+		_, err = file.Seek(0, 0)
+		require.NoError(t, err)
+		h2, err := computeFileHashOld(file)
+		require.NoError(t, err)
+		err = file.Close()
+		require.NoError(t, err)
+		assert.Equal(t, h1, h2)
+	}
+}

--- a/pkg/filehash/key.go
+++ b/pkg/filehash/key.go
@@ -1,0 +1,104 @@
+package filehash
+
+import (
+	"fmt"
+
+	"github.com/aquasecurity/tracee/pkg/config"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+)
+
+const hostDigest = "host"
+
+type Key struct {
+	filePath string
+	mountNS  int
+
+	device      uint32
+	inode       uint64
+	ctime       int64
+	imageDigest string
+}
+
+// NewKey creates a base key for usage with the file hash cache.
+// It requires a filepath and mountns for the key as base information.
+// Further information must be added through options.
+func NewKey(filepath string, mountNS int, opts ...func(*Key)) Key {
+	k := Key{filePath: filepath, mountNS: mountNS}
+	for _, o := range opts {
+		o(&k)
+	}
+	return k
+}
+
+// WithDevice adds a device to the key.
+func WithDevice(device uint32) func(*Key) {
+	return func(k *Key) {
+		k.device = device
+	}
+}
+
+// WithInode adds inode information to the key.
+func WithInode(ino uint64, ctime int64) func(*Key) {
+	return func(k *Key) {
+		k.inode = ino
+		k.ctime = ctime
+	}
+}
+
+// With digest associates the key to a specific container digest, or to host.
+func WithDigest(digest string) func(*Key) {
+	return func(k *Key) {
+		if digest == "" {
+			digest = hostDigest
+		}
+		k.imageDigest = digest
+	}
+}
+
+// Pathname returns the file's pathname associated to the key.
+func (k *Key) Pathname() string {
+	return k.filePath
+}
+
+// Pathname returns the file's mount namespace associated to the key.
+func (k *Key) MountNS() int {
+	return k.mountNS
+}
+
+// DeviceKey returns a string key for the file's device and inode.
+// Format is "device:ctime:inode".
+func (k *Key) DeviceKey() string {
+	return fmt.Sprintf("%d:%s", k.device, k.InodeKey())
+}
+
+// DigestKey returns a string key based on the file container origin(digest or host),
+// and it's inode key.
+// Format is "digest:ctime:inode".
+func (k *Key) DigestKey() string {
+	if k.imageDigest == "" {
+		return ""
+	}
+
+	return fmt.Sprintf("%s:%s", k.imageDigest, k.InodeKey())
+}
+
+// InodeKey returns a string key based on the file inode
+// Format is "ctime:inode"
+func (k *Key) InodeKey() string {
+	return fmt.Sprintf("%d:%d", k.ctime, k.inode)
+}
+
+// get key with relation to CalcHashesOption
+// Note: this may still return empty according to values supplied to the key
+func getKeyByExecHashMode(k *Key, mode config.CalcHashesOption) (string, error) {
+	switch mode {
+	case config.CalcHashesInode:
+		return k.InodeKey(), nil
+	case config.CalcHashesDevInode:
+		return k.DeviceKey(), nil
+	case config.CalcHashesDigestInode:
+		return k.DigestKey(), nil // can be empty if container digest is not available
+	}
+
+	return "", errfmt.Errorf("unknown calc hash option type")
+}


### PR DESCRIPTION
### 1. Explain what the PR does

c2ebbb290 **feat(exechash): optimize hash by reusing buffer**
9f9e5a44d **feat(ebpf): expand exec-hash output option**
eb17fc6fc **feat(ebpf): optimize computeFileHash**
db51e0b0e **fix(ebpf): fix getFileHash()**
c469486e5 **fix(bucketscache): GetBucket was not thread safe**
041bcff5e **chore(bucketscache): add benchmark**

### 2. Explain how to test it

Added tests to confirm parity with previous hash functionality.
Can be manually tested by using:
`tracee -o option:exec-hash={inode|dev-inode|digest-inode}`
where you may choose which hash option you want, with varying degrees of accuracy and performance.

Close #3734
Close #3745
