### PR TITLE
Writeable datasource types

### DIFF
--- a/pkg/cmd/flags/grpc.go
+++ b/pkg/cmd/flags/grpc.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"os"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -20,6 +21,14 @@ func PrepareGRPCServer(listenAddr string) (*grpc.Server, error) {
 
 	if len(addr[1]) == 0 {
 		return nil, errfmt.Errorf("grpc address cannot be empty")
+	}
+
+	// cleanup listen address if needed, for example if a panic happened
+	if _, err := os.Stat(addr[1]); err == nil {
+		err := os.Remove(addr[1])
+		if err != nil {
+			return nil, errfmt.Errorf("failed to cleanup gRPC listening address (%s): %v", addr[1], err)
+		}
 	}
 
 	return grpc.New(addr[0], addr[1])

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -25,7 +25,7 @@ const noSyscall int32 = -1
 // handleEvents is the main pipeline of tracee. It receives events from the perf buffer
 // and passes them through a series of stages, each stage is a goroutine that performs a
 // specific task on the event. The pipeline is started in a separate goroutine.
-func (t *Tracee) handleEvents(ctx context.Context) {
+func (t *Tracee) handleEvents(ctx context.Context, initialized chan<- struct{}) {
 	logger.Debugw("Starting handleEvents goroutine")
 	defer logger.Debugw("Stopped handleEvents goroutine")
 
@@ -78,6 +78,8 @@ func (t *Tracee) handleEvents(ctx context.Context) {
 
 	errc = t.sinkEvents(ctx, eventsChan)
 	errcList = append(errcList, errc)
+
+	initialized <- struct{}{}
 
 	// Pipeline started. Waiting for pipeline to complete
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1419,8 +1419,9 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 
 	t.eventsPerfMap.Poll(pollTimeout)
 
+	pipelineReady := make(chan struct{}, 1)
 	go t.processLostEvents() // termination signaled by closing t.done
-	go t.handleEvents(ctx)
+	go t.handleEvents(ctx, pipelineReady)
 
 	// Parallel perf buffer with file writes events
 
@@ -1443,6 +1444,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 
 	// Management
 
+	<-pipelineReady
 	t.running.Store(true) // set running state after writing pid file
 	t.ready(ctx)          // executes ready callback, non blocking
 	<-ctx.Done()          // block until ctx is cancelled elsewhere

--- a/types/detect/detect.go
+++ b/types/detect/detect.go
@@ -94,3 +94,20 @@ type DataSource interface {
 
 var ErrDataNotFound = errors.New("requested data was not found")
 var ErrKeyNotSupported = errors.New("queried key is not supported")
+var ErrFailedToUnmarshal = errors.New("given value could not be unmarshaled")
+
+type WriteableDataSource interface {
+	DataSource
+	// Write a value to a key in the data source. The value can not strictly match the schema defined
+	// in the data source, however the implementation must be able to unmarshal it successfully to some form
+	// where it can be eventually represented by the schema.
+	//
+	// The following errors should be returned for the appropriate cases:
+	//
+	// - ErrKeyNotSupported - When the key used does not match to a support key
+	// - ErrFailedToUnmarshal - When the value given could not be unmarshalled to an expected type
+	// - Otherwise errors may vary.
+	Write(key interface{}, value interface{}) error
+	// The types of values the data source supports writing.
+	Values() []string
+}


### PR DESCRIPTION
### 1. Explain what the PR does

Add types for PR #3725
Fix #3757 (opportunistically)

dfa6fe56a **feature(types): add WritableDatasource interface**
ef3bcd602 **feat(ebpf): synchronize ready callback to pipeline**
c831127db **fix(grpc): cleanup listen address**

### 2. Explain how to test it

For the bugfix: run tracee with `--grpc-listen-addr` set to something (tested with both unix and tcp) close tracee and run again. Note that tracee will not fail anymore.
