### PR TITLE
feat(signatures): expose signatures helpers as Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/aquasecurity/libbpfgo v0.6.0-libbpf-1.3.0.20240111220235-90dbffffbdab
 	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20240111220235-90dbffffbdab
 	github.com/aquasecurity/tracee/api v0.0.0-20240118133111-07e087b036d4
-	github.com/aquasecurity/tracee/types v0.0.0-20231231104405-a33891f29d17
+	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-00010101000000-000000000000
+	github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/golang/protobuf v1.5.3
@@ -180,3 +181,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.68 // indirect
 )
+
+replace github.com/aquasecurity/tracee/signatures/helpers => ./signatures/helpers

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/aquasecurity/tracee/api v0.0.0-20231222010915-0f73aad36da9 h1:1y+/rhV
 github.com/aquasecurity/tracee/api v0.0.0-20231222010915-0f73aad36da9/go.mod h1:QJG2PABXucOsFVO85tQsKxV4c1GUhcjww/Kw+Wv7Y/c=
 github.com/aquasecurity/tracee/api v0.0.0-20240118133111-07e087b036d4 h1:Orj0N5kWVxWhZmzvapjurB1RyX4O+5s2abi8mIcQjgQ=
 github.com/aquasecurity/tracee/api v0.0.0-20240118133111-07e087b036d4/go.mod h1:o2YYIwIkn/nQM/JltGx1Lw6l9ojaEmYJPVGsZ+RYKcA=
-github.com/aquasecurity/tracee/types v0.0.0-20231231104405-a33891f29d17 h1:tgcl7BuyBLDng+47KKhyOB9gdsq3V9dKoapNyRDchwg=
-github.com/aquasecurity/tracee/types v0.0.0-20231231104405-a33891f29d17/go.mod h1:kHvgUMXGq5QEqSLPgu4RwGSJEoCuMQJnEkGk8OAcSUc=
+github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d h1:6CQjy5G6Cj/VKm8RP1uZnBZxDgfyGo15HfWFnYrkGro=
+github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d/go.mod h1:J0f9nzJWrFmFgMoK0s4Yirfh82vfKMatXytd1YdfU2I=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -1,0 +1,5 @@
+module github.com/aquasecurity/tracee/signatures/helpers
+
+go 1.21
+
+require github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d


### PR DESCRIPTION
### 1. Explain what the PR does

To allow users the option to use the up-to-date helpers for Go signatures, the helpers were exported to be an external Go module.

f9a60e590 **feat(signatures): expose signatures helpers as Go module**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
