### PR TITLE
feat(ebpf): optimize sendmsg/recvmsg kprobes

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5373,12 +5373,6 @@ int BPF_KPROBE(trace_security_sk_clone)
 
 statfunc u32 update_net_inodemap(struct socket *sock, event_data_t *event)
 {
-    if (!is_family_supported(sock))
-        return 0;
-
-    if (!is_socket_supported(sock))
-        return 0;
-
     struct file *sock_file = BPF_CORE_READ(sock, file);
     if (!sock_file)
         return 0;
@@ -5399,14 +5393,20 @@ statfunc u32 update_net_inodemap(struct socket *sock, event_data_t *event)
 SEC("kprobe/security_socket_recvmsg")
 int BPF_KPROBE(trace_security_socket_recvmsg)
 {
+    struct socket *sock = (void *) PT_REGS_PARM1(ctx);
+    if (sock == NULL)
+        return 0;
+    if (!is_family_supported(sock))
+        return 0;
+    if (!is_socket_supported(sock))
+        return 0;
+
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
         return 0;
 
     if (!should_trace(&p))
         return 0;
-
-    struct socket *sock = (void *) PT_REGS_PARM1(ctx);
 
     return update_net_inodemap(sock, p.event);
 }
@@ -5414,14 +5414,20 @@ int BPF_KPROBE(trace_security_socket_recvmsg)
 SEC("kprobe/security_socket_sendmsg")
 int BPF_KPROBE(trace_security_socket_sendmsg)
 {
+    struct socket *sock = (void *) PT_REGS_PARM1(ctx);
+    if (sock == NULL)
+        return 0;
+    if (!is_family_supported(sock))
+        return 0;
+    if (!is_socket_supported(sock))
+        return 0;
+
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
         return 0;
 
     if (!should_trace(&p))
         return 0;
-
-    struct socket *sock = (void *) PT_REGS_PARM1(ctx);
 
     return update_net_inodemap(sock, p.event);
 }


### PR DESCRIPTION
### 1. Explain what the PR does

9f90b1d70 **feat(ebpf): optimize sendmsg/recvmsg kprobes**

```
Move the socket validation section in these eBPF programs from the map
updating functions to the initial stage of the eBPF program.   
This is better because it is much quicker to validate the socket, than
initally checking `should_trace` and doing `init_program_data`.
It is also consistent with another networking kprobe of the packet logic
`trace_sock_alloc_file`.
    
Old version benchmark:
PROGRAM: security_socket_recvmsg (runtime: 569255060 ns, amount: 90974 times, average: 6257 ns)
PROGRAM: security_socket_sendmsg (runtime: 603516073 ns, amount: 109182 times, average: 5527 ns)
    
New version benchmark:
PROGRAM: security_socket_recvmsg (runtime: 613052965 ns, amount: 134066 times, average: 4572 ns)
PROGRAM: security_socket_sendmsg (runtime: 652289846 ns, amount: 161178 times, average: 4047 ns)
```

### 2. Explain how to test it

Validate e2e network tests, they should work the same.
