### PR TITLE
fix(ebpf): adjust inode struct to kernel v6.6

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -624,7 +624,7 @@ struct inode {
     umode_t i_mode;
     struct super_block *i_sb;
     long unsigned int i_ino;
-    struct timespec64 i_ctime;
+    struct timespec64 __i_ctime;
     loff_t i_size;
     struct file_operations *i_fop;
 };

--- a/pkg/ebpf/c/vmlinux_flavors.h
+++ b/pkg/ebpf/c/vmlinux_flavors.h
@@ -95,6 +95,11 @@ struct module___older_v64 {
     struct module_layout core_layout;
 };
 
+// kernel >= v6.6 inode i_ctime field change
+struct inode___older_v66 {
+    struct timespec64 i_ctime;
+};
+
 ///////////////////
 
 #pragma clang attribute pop


### PR DESCRIPTION
### 1. Explain what the PR does

18127c2b6 **fix(ebpf): adjust inode struct to kernel v6.6**

Fix #3768 
### 2. Explain how to test it

Tested on a coreos-fedora39 VM.