### PR TITLE
fix(network): fix http request/response events

### DIFF
--- a/pkg/events/derive/net_packet.go
+++ b/pkg/events/derive/net_packet.go
@@ -394,7 +394,7 @@ func NetPacketHTTPRequest() DeriveFunction {
 				return nil, err
 			}
 			if getPacketHTTPDirection(&event) != protoHTTPRequest {
-				return nil, errfmt.Errorf("unspecified HTTP packet direction")
+				return nil, nil
 			}
 			protoHTTP, err := getProtoHTTPFromRequestPacket(packet)
 			if err != nil {
@@ -439,7 +439,7 @@ func NetPacketHTTPResponse() DeriveFunction {
 				return nil, err
 			}
 			if getPacketHTTPDirection(&event) != protoHTTPResponse {
-				return nil, errfmt.Errorf("unspecified HTTP packet direction")
+				return nil, nil
 			}
 			protoHTTP, err := getProtoHTTPFromResponsePacket(packet)
 			if err != nil {


### PR DESCRIPTION
The recent refactoring in the network derivation functions made HTTP request and HTTP response events to start failing due to wrong error being reported.