### PR TITLE
fix: create pid file under install-path

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -289,7 +289,8 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Decide BTF & BPF files to use (based in the kconfig, release & environment info)
 
-	err = initialize.BpfObject(&cfg, kernelConfig, osInfo, viper.GetString("install-path"), version)
+	traceeInstallPath := viper.GetString("install-path")
+	err = initialize.BpfObject(&cfg, kernelConfig, osInfo, traceeInstallPath, version)
 	if err != nil {
 		return runner, errfmt.Errorf("failed preparing BPF object: %v", err)
 	}
@@ -316,6 +317,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	runner.GRPCServer = grpcServer
 	runner.TraceeConfig = cfg
 	runner.Printer = p
+	runner.InstallPath = traceeInstallPath
 
 	// parse arguments must be enabled if the rule engine is part of the pipeline
 	runner.TraceeConfig.Output.ParseArguments = true

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -185,6 +185,7 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 	runner.HTTPServer = httpServer
 	runner.TraceeConfig = cfg
 	runner.Printer = broadcast
+	runner.InstallPath = traceeInstallPath
 
 	return runner, nil
 }

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -149,7 +149,7 @@ for TEST in $TESTS; do
     while true; do
         times=$((times + 1))
         sleep 1
-        if [[ -f $TRACEE_TMP_DIR/out/tracee.pid ]]; then
+        if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
             info
             info "UP AND RUNNING"
             info

--- a/tests/e2e-kernel-test.sh
+++ b/tests/e2e-kernel-test.sh
@@ -101,7 +101,7 @@ for TEST in $TESTS; do
     while true; do
         times=$(($times + 1))
         sleep 1
-        if [[ -f $TRACEE_TMP_DIR/out/tracee.pid ]]; then
+        if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
             info
             info "UP AND RUNNING"
             info

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -113,7 +113,7 @@ for TEST in $TESTS; do
     while true; do
         times=$(($times + 1))
         sleep 1
-        if [[ -f $TRACEE_TMP_DIR/out/tracee.pid ]]; then
+        if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
             info
             info "UP AND RUNNING"
             info


### PR DESCRIPTION
### 1. Explain what the PR does

5ca4667f4 **fix: create pid file under install-path**

Fix #3756

### 2. Explain how to test it

Run `tracee --install-path /tmp/blah/hehe`
Confirm with `ls /tmp/blah/hehe/tracee.pid` that tracee.pid will be under that path.
