### PR TITLE
chore(derive/http): change log level when packets are malformed

### DIFF
--- a/pkg/events/derive/net_packet.go
+++ b/pkg/events/derive/net_packet.go
@@ -351,12 +351,14 @@ func NetPacketHTTP() DeriveFunction {
 			case protoHTTPRequest:
 				proto, err = getProtoHTTPFromRequestPacket(packet)
 				if err != nil {
-					return nil, err
+					logger.Warnw("attempted to derive net_packet_http event from malformed request packet, event will be skipped", "error", err)
+					return nil, nil
 				}
 			case protoHTTPResponse:
 				proto, err = getProtoHTTPFromResponsePacket(packet)
 				if err != nil {
-					return nil, err
+					logger.Warnw("attempted to derive net_packet_http event from malformed response packet, event will be skipped", "error", err)
+					return nil, nil
 				}
 			default:
 				return nil, errfmt.Errorf("unspecified HTTP packet direction")
@@ -398,7 +400,8 @@ func NetPacketHTTPRequest() DeriveFunction {
 			}
 			protoHTTP, err := getProtoHTTPFromRequestPacket(packet)
 			if err != nil {
-				return nil, err
+				logger.Warnw("attempted to derive net_packet_http_request event from malformed packet, event will be skipped", "error", err)
+				return nil, nil
 			}
 			if protoHTTP == nil {
 				return nil, nil // regular tcp/ip packet without HTTP payload
@@ -443,7 +446,8 @@ func NetPacketHTTPResponse() DeriveFunction {
 			}
 			protoHTTP, err := getProtoHTTPFromResponsePacket(packet)
 			if err != nil {
-				return nil, err
+				logger.Warnw("attempted to derive net_packet_http_response event from malformed packet, event will be skipped", "error", err)
+				return nil, nil // malformed packets shouldn't return an error
 			}
 			if protoHTTP == nil {
 				return nil, nil // regular tcp/ip packet without HTTP payload


### PR DESCRIPTION
### 1. Explain what the PR does

Deriving a net packet event for HTTP when given a malformed request/response would previously return an error. This error is useless for users as there always exists a chance for packet corruption when passing through the eBPF perf buffer. As such, log in WARN level instead.

### 2. Explain how to test it

Before `net_packet_helpers.go:632` add the following line:
<img width="608" alt="image" src="https://github.com/aquasecurity/tracee/assets/22661609/6f2536a6-2657-49d2-b11b-b9c3cf0a2b96">
Then compile and note the logs working.
`tracee --events net_packet_http_request`
`{"level":"warn","ts":1703593308.6970172,"msg":"attempted to derive net_packet_http_request event from malformed packet, event will be skipped","error":"invalid method \"G\\x00T\""}`
