### PR TITLE
fix(events): restore dependency in hooked_syscall

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -10401,6 +10401,7 @@ var CoreEvents = map[ID]Definition{
 		dependencies: Dependencies{
 			ids: []ID{
 				SyscallTableCheck,
+				DoInitModule,
 			},
 		},
 		sets: []string{},


### PR DESCRIPTION
### 1. Explain what the PR does

629883533:
```
fix(events): restore dependency in hooked_syscall
    
The event dependency for do_init_module in the hooked_syscall event was
removed in commit 43a3eac. As a result, installing a kernel module did
not immediately trigger a syscall table integrity check.
```

Fix #3783

### 2. Explain how to test it

See issue.
