### PR TITLE
fix: use thread safe wrapper for ksyms table

### DIFF
--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/utils/ksyms"
 )
 
 var maxKsymNameLen = 64 // Most match the constant in the bpf code
@@ -39,7 +40,7 @@ func SendKsymbolsToMap(bpfKsymsMap *libbpfgo.BPFMap, ksymbols map[string]*helper
 
 func (t *Tracee) NewKernelSymbols() error {
 	// reading kallsyms needs CAP_SYSLOG
-	kernelSymbols, err := helpers.NewLazyKernelSymbolsMap()
+	kernelSymbols, err := ksyms.NewSafeKsymbolTable()
 	if err != nil {
 		return errfmt.WrapError(err)
 	}

--- a/pkg/utils/ksyms/safe_ksym_table.go
+++ b/pkg/utils/ksyms/safe_ksym_table.go
@@ -1,0 +1,49 @@
+package ksyms
+
+import (
+	"sync"
+
+	"github.com/aquasecurity/libbpfgo/helpers"
+)
+
+type safeKsymbolTable struct {
+	helpers.KernelSymbolTable
+	l *sync.Mutex
+}
+
+// NewSafeKsymbolTable returns a safe wrapper for implementations of the KernelSymbolTable interface.
+// The wrapper is needed because provided implementations do not guarentee thread-safety.
+func NewSafeKsymbolTable() (*safeKsymbolTable, error) {
+	table, err := helpers.NewLazyKernelSymbolsMap()
+	if err != nil {
+		return nil, err
+	}
+
+	return &safeKsymbolTable{
+		table, new(sync.Mutex),
+	}, nil
+}
+
+func (t *safeKsymbolTable) TextSegmentContains(addr uint64) (bool, error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	return t.KernelSymbolTable.TextSegmentContains(addr)
+}
+
+func (t *safeKsymbolTable) GetSymbolByName(owner string, name string) (*helpers.KernelSymbol, error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	return t.KernelSymbolTable.GetSymbolByName(owner, name)
+}
+
+func (t *safeKsymbolTable) GetSymbolByAddr(addr uint64) (*helpers.KernelSymbol, error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	return t.KernelSymbolTable.GetSymbolByAddr(addr)
+}
+
+func (t *safeKsymbolTable) Refresh() error {
+	t.l.Lock()
+	defer t.l.Unlock()
+	return t.KernelSymbolTable.Refresh()
+}


### PR DESCRIPTION
### 1. Explain what the PR does

commit 2ad320e15435f1055ecff477e2fd28b42d2bf667
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Sun Dec 31 13:42:23 2023 +0000

    fix: use thread safe wrapper for ksyms table
    
    Original implementations in libbpfgo helpers aren't thread safe, they
    include golang maps which may are accessed without a thread safety
    mechanism.
    
    Provide a wrapper in the utils package which adds a mutex on top of
    calling the original methods.
```

Fix #3785 

### 2. Explain how to test it

No regressions in relevant e2es, should work the same as before.
