### PR TITLE
fix: triggeredBy should print event on table output

### DIFF
--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -326,10 +326,19 @@ func (p tableEventPrinter) Print(event trace.Event) {
 		}
 	}
 	for i, arg := range event.Args {
+		name := arg.Name
+		value := arg.Value
+
+		// triggeredBy from pkg/ebpf/finding.go breaks the table output,
+		// so we simplify it
+		if name == "triggeredBy" {
+			value = fmt.Sprintf("%s", value.(map[string]interface{})["name"])
+		}
+
 		if i == 0 {
-			fmt.Fprintf(p.out, "%s: %v", arg.Name, arg.Value)
+			fmt.Fprintf(p.out, "%s: %v", name, value)
 		} else {
-			fmt.Fprintf(p.out, ", %s: %v", arg.Name, arg.Value)
+			fmt.Fprintf(p.out, ", %s: %v", name, value)
 		}
 	}
 	fmt.Fprintln(p.out)


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/3790

```
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
14:36:15:580419  1000   strace           3450532 3450532 0                anti_debugging            triggeredBy: ptrace
```

instead of

```
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
14:38:21:840737  1000   strace           3452247 3452247 0                anti_debugging            triggeredBy: map[args:[{{request string} PTRACE_TRACEME} {{pid pid_t} 0} {{addr void*} 0x0} {{data void*} 0x0}] id:101 name:ptrace returnValue:0]

```