### PR TITLE
fix(capture): restore absolute time in pcap frames

### DIFF
--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -15,9 +15,9 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
-func (t *Tracee) processFileCaptures(ctx context.Context) {
-	logger.Debugw("Starting processFileCaptures go routine")
-	defer logger.Debugw("Stopped processFileCaptures go routine")
+func (t *Tracee) handleFileCaptures(ctx context.Context) {
+	logger.Debugw("Starting handleFileCaptures go routine")
+	defer logger.Debugw("Stopped handleFileCaptures go routine")
 
 	const (
 		// stat_S_IFMT uint32 = 0170000 // bit mask for the file type bit field

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -58,12 +58,10 @@ func (t *Tracee) processNetCapEvents(ctx context.Context, in <-chan *trace.Event
 		for {
 			select {
 			case event := <-in:
-				// Go through event processors if needed
-				errs := t.processEvent(event)
-				if len(errs) > 0 {
-					for _, err := range errs {
-						t.handleError(err)
-					}
+				// TODO: Support captures pipeline in t.processEvent
+				err := t.normalizeEventCtxTimes(event)
+				if err != nil {
+					t.handleError(err)
 					t.eventsPool.Put(event)
 					continue
 				}

--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -23,7 +23,7 @@ func init() {
 
 // processEvent processes an event by passing it through all registered event processors.
 func (t *Tracee) processEvent(event *trace.Event) []error {
-	errs := []error{}
+	var errs []error
 
 	processors := t.eventProcessor[events.ID(event.EventID)]         // this event processors
 	processors = append(processors, t.eventProcessor[events.All]...) // all events processors

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1407,14 +1407,14 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 
 	if t.config.BlobPerfBufferSize > 0 {
 		t.fileWrPerfMap.Poll(pollTimeout)
-		go t.processFileCaptures(ctx)
+		go t.handleFileCaptures(ctx)
 	}
 
 	// Network capture perf buffer (similar to regular pipeline)
 
 	if pcaps.PcapsEnabled(t.config.Capture.Net) {
 		t.netCapPerfMap.Poll(pollTimeout)
-		go t.processNetCaptureEvents(ctx)
+		go t.handleNetCaptureEvents(ctx)
 	}
 
 	// Logging perf buffer


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

1763cd440 **fix(capture): restore absolute time in pcap frames**

Use the normal process events step in the pipeline for the network capture buffer pipeline as well.
This fixes the issue that the conversion of the monotonic time to absolute time moved from the decode step to the process step, leaving the network capture events timestamp monotonic.

Fix #3799

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
