### PR TITLE
Make policies config versioned

### DIFF
--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -373,6 +373,24 @@ typedef struct elf_files_map elf_files_map_t;
 //
 
 #define MAX_FILTER_VERSION 64 // max amount of filter versions to track
+struct policies_config_map {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, policies_config_t);
+} policies_config_map SEC(".maps");
+
+typedef struct policies_config_map policies_config_map_t;
+
+// map of policies config maps
+struct policies_config_version {
+    __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+    __uint(max_entries, MAX_FILTER_VERSION);
+    __type(key, u16);
+    __array(values, policies_config_map_t);
+} policies_config_version SEC(".maps");
+
+typedef struct policies_config_version policies_config_version_t;
 
 // filter events by UID prototype, for specific UIDs either by == or !=
 struct uid_filter {

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -546,7 +546,11 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 
     // Update the process tree map (filter related) if the parent has an entry.
 
-    if (p.config->proc_tree_filter_enabled_scopes) {
+    policies_config_t *policies_cfg = get_policies_config(&p);
+    if (unlikely(policies_cfg == NULL))
+        return 0;
+
+    if (policies_cfg->proc_tree_filter_enabled_scopes) {
         u16 version = p.event->context.policies_version;
         // Give the compiler a hint about the map type, otherwise libbpf will complain
         // about missing type information. i.e.: "can't determine value size for type".

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -287,12 +287,7 @@ typedef struct equality {
     u64 equality_set_in_scopes;
 } eq_t;
 
-typedef struct config_entry {
-    u32 tracee_pid;
-    u32 options;
-    u32 cgroup_v1_hid;
-    u16 policies_version;
-    u16 padding; // free for further use
+typedef struct policies_config {
     // enabled scopes bitmask per filter
     u64 uid_filter_enabled_scopes;
     u64 pid_filter_enabled_scopes;
@@ -327,6 +322,15 @@ typedef struct config_entry {
     u64 uid_min;
     u64 pid_max;
     u64 pid_min;
+} policies_config_t;
+
+typedef struct config_entry {
+    u32 tracee_pid;
+    u32 options;
+    u32 cgroup_v1_hid;
+    u16 padding; // free for further use
+    u16 policies_version;
+    policies_config_t policies_config;
 } config_entry_t;
 
 typedef struct event_config {

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -1,0 +1,42 @@
+package ebpf
+
+import (
+	"unsafe"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/policy"
+)
+
+const (
+	ConfigMap = "config_map"
+)
+
+// Config mirrors the C struct config_entry (config_entry_t).
+//
+// Order of fields is important, as it is used as a value for
+// the ConfigMap BPF map.
+type Config struct {
+	TraceePid       uint32
+	Options         uint32
+	CgroupV1Hid     uint32
+	_               uint16 // padding free for further use
+	PoliciesVersion uint16
+	PoliciesConfig  policy.PoliciesConfig
+}
+
+// UpdateBPF updates the ConfigMap BPF map with the current config.
+func (c *Config) UpdateBPF(bpfModule *bpf.Module) error {
+	bpfConfigMap, err := bpfModule.GetMap(ConfigMap)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+
+	cZero := uint32(0)
+	if err = bpfConfigMap.Update(unsafe.Pointer(&cZero), unsafe.Pointer(c)); err != nil {
+		return errfmt.WrapError(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Close: #3805 

Part of #3239.

### 1. Explain what the PR does

172f53367122d979cd2e41334ed69b475bd52c5e **chore: make policies config versioned**

```
This extracts the policy-related fields from config_entry_t into a new,
separate struct (policies_config_t), which continues to be stored in the
config_entry_t struct, as well as in the versioned policies_config_map.

This is required to enable access to the appropriate policies_config_t
based on the policy version.
```


### 2. Explain how to test it


### 3. Other comments

