### PR TITLE
Fix existing containers tracking by selecting longest cgroup mount path

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -202,12 +202,14 @@ func SearchMountpoint(fstype string, search string) (string, error) {
 		}
 	}()
 
+	maxLen := 0
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.Split(scanner.Text(), " ")
 		mountpoint := line[1]
 		currFstype := line[2]
-		if fstype == currFstype && strings.Contains(mountpoint, search) {
+		if fstype == currFstype && strings.Contains(mountpoint, search) && len(mountpoint) > maxLen {
+			maxLen = len(mountpoint)
 			mp = mountpoint
 		}
 	}


### PR DESCRIPTION
Change the logic to pick the longest cgroup mount path in /proc/mounts. resolving issues with tracking existing containers in TAS Cloud-Foundry environments where mount paths are in reverse order.
This replaces the previous method of using the last record found, ensuring more accurate host mount detection.

Resolves #3824

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->


Modify the logic for selecting the mount path by considering the maximum length of the path, rather than its position in the list.

### How to test it

1. Deploy an Application: Run any application within a TAS (Tanzu Application Service) environment.
2. Install Tracee: Proceed to install Tracee in the same TAS environment.
3. Observe Application Tracking: After the installation of Tracee, observe the behavior related to existing application tracking. If they are tacked correctly.

Also may verify that existing containers are tracked correctly in other environments, e.g: K8S, OCP, etc.


