### PR TITLE
Various cgroup and mounting fixes and optimizations

### DIFF
--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -185,7 +185,7 @@ func NewCgroup(ver CgroupVersion) (Cgroup, error) {
 // cgroupv1
 
 type CgroupV1 struct {
-	mounted    *mount.MountOnce
+	mounted    *mount.MountHostOnce
 	mountpoint string
 	hid        int
 }
@@ -201,7 +201,7 @@ func (c *CgroupV1) init() error {
 	}
 
 	// 1. mount cgroup (if needed)
-	c.mounted, err = mount.NewMountOnce(
+	c.mounted, err = mount.NewMountHostOnce(
 		CgroupV1FsType,
 		CgroupV1FsType,
 		CgroupDefaultController,
@@ -236,7 +236,7 @@ func (c *CgroupV1) GetVersion() CgroupVersion {
 // cgroupv2
 
 type CgroupV2 struct {
-	mounted    *mount.MountOnce
+	mounted    *mount.MountHostOnce
 	mountpoint string
 	hid        int
 }
@@ -252,7 +252,7 @@ func (c *CgroupV2) init() error {
 	}
 
 	// 1. mount cgroup (if needed)
-	c.mounted, err = mount.NewMountOnce(
+	c.mounted, err = mount.NewMountHostOnce(
 		CgroupV2FsType,
 		CgroupV2FsType,
 		"",          // cgroupv2 has no default controller

--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -84,8 +84,8 @@ func (clv *Changelog[T]) Get(targetTime time.Time) T {
 // GetAll returns all the values of the changelog.
 func (clv *Changelog[T]) GetAll() []T {
 	values := make([]T, len(clv.changes))
-	for i, entry := range clv.changes {
-		values[i] = entry.value
+	for i := range clv.changes {
+		values[i] = clv.changes[i].value
 	}
 	return values
 }

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -205,19 +205,19 @@ func (c *Containers) EnrichCgroupInfo(cgroupId uint64) (cruntime.ContainerMetada
 
 	// if there is no cgroup anymore for some reason, return early
 	if !ok {
-		return metadata, errfmt.Errorf("no cgroup to enrich")
+		return metadata, errfmt.Errorf("cgroup %d not found, won't enrich", cgroupId)
 	}
 
 	containerId := info.Container.ContainerId
 	runtime := info.Runtime
 
 	if containerId == "" {
-		return metadata, errfmt.Errorf("no containerId")
+		return metadata, errfmt.Errorf("cgroup %d: no containerId (path %s)", cgroupId, info.Path)
 	}
 
 	isMikubeOrKind := k8s.IsMinkube() || k8s.IsKind()
 	if info.Dead && !isMikubeOrKind {
-		return metadata, errfmt.Errorf("container already deleted")
+		return metadata, errfmt.Errorf("container %s already deleted in path %s", containerId, info.Path)
 	}
 
 	if info.Container.Image != "" {

--- a/pkg/ebpf/controlplane/cgroups.go
+++ b/pkg/ebpf/controlplane/cgroups.go
@@ -52,7 +52,9 @@ func (ctrl *Controller) processCgroupMkdir(args []trace.Argument) error {
 		go func() {
 			_, err := ctrl.cgroupManager.EnrichCgroupInfo(cgroupId)
 			if err != nil {
-				logger.Errorw("error triggering container enrich in control plane", "error", err)
+				logger.Errorw("error enriching container in control plane", "error", err, "cgroup_id", cgroupId)
+			} else {
+				logger.Debugw("enriched cgroup_id in control plane", "cgroup_id", cgroupId)
 			}
 		}()
 	}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1486,9 +1486,11 @@ func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
 
 	emit = t.eventsState[events.ExistingContainer].Emit
 	if emit > 0 {
-		for _, e := range events.ExistingContainersEvents(t.containers, t.config.NoContainersEnrich) {
-			setMatchedPolicies(&e, emit, t.config.Policies)
-			out <- &e
+		existingContainerEvents := events.ExistingContainersEvents(t.containers, t.config.NoContainersEnrich)
+		for i := range existingContainerEvents {
+			event := &(existingContainerEvents[i])
+			setMatchedPolicies(event, emit, t.config.Policies)
+			out <- event
 			_ = t.stats.EventCount.Increment()
 		}
 	}

--- a/pkg/events/derive/container_create.go
+++ b/pkg/events/derive/container_create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -26,6 +27,7 @@ func deriveContainerCreateArgs(cts *containers.Containers) func(event trace.Even
 			return nil, errfmt.WrapError(err)
 		}
 		if info := cts.GetCgroupInfo(cgroupId); info.ContainerRoot {
+			logger.Debugw("derive container_create from cgroup", "cgroup_id", cgroupId, "container_id", info.Container.ContainerId)
 			args := []interface{}{
 				info.Runtime.String(),
 				info.Container.ContainerId,
@@ -44,7 +46,7 @@ func deriveContainerCreateArgs(cts *containers.Containers) func(event trace.Even
 	}
 }
 
-// isCgroupEventInHid checks if cgroup event is relevant for deriving container event in it's hierarchy id.
+// isCgroupEventInHid checks if cgroup event is relevant for deriving container event in its hierarchy id.
 // in tracee we only care about containers inside the cpuset controller, as such other hierarchy ids will lead
 // to a failed query.
 func isCgroupEventInHid(event *trace.Event, cts *containers.Containers) (bool, error) {

--- a/pkg/events/usermode.go
+++ b/pkg/events/usermode.go
@@ -95,24 +95,28 @@ func ExistingContainersEvents(cts *containers.Containers, enrichDisabled bool) [
 	var events []trace.Event
 
 	def := Core.GetDefinitionByID(ExistingContainer)
-
-	for id, info := range cts.GetContainers() {
+	existingContainers := cts.GetContainers()
+	for id, info := range existingContainers {
+		cgroupId := uint64(id)
+		cRuntime := info.Runtime.String()
+		containerId := info.Container.ContainerId
+		ctime := info.Ctime.UnixNano()
 		container := runtime.ContainerMetadata{}
 		if !enrichDisabled {
-			container, _ = cts.EnrichCgroupInfo(uint64(id))
+			container, _ = cts.EnrichCgroupInfo(cgroupId)
 		}
 		params := def.GetParams()
 		args := []trace.Argument{
-			{ArgMeta: params[0], Value: info.Runtime.String()},
-			{ArgMeta: params[1], Value: info.Container.ContainerId},
-			{ArgMeta: params[2], Value: info.Ctime.UnixNano()},
+			{ArgMeta: params[0], Value: cRuntime},
+			{ArgMeta: params[1], Value: containerId},
+			{ArgMeta: params[2], Value: ctime},
 			{ArgMeta: params[3], Value: container.Image},
-			{ArgMeta: params[3], Value: container.ImageDigest},
-			{ArgMeta: params[4], Value: container.Name},
-			{ArgMeta: params[5], Value: container.Pod.Name},
-			{ArgMeta: params[6], Value: container.Pod.Namespace},
-			{ArgMeta: params[7], Value: container.Pod.UID},
-			{ArgMeta: params[8], Value: container.Pod.Sandbox},
+			{ArgMeta: params[4], Value: container.ImageDigest},
+			{ArgMeta: params[5], Value: container.Name},
+			{ArgMeta: params[6], Value: container.Pod.Name},
+			{ArgMeta: params[7], Value: container.Pod.Namespace},
+			{ArgMeta: params[8], Value: container.Pod.UID},
+			{ArgMeta: params[9], Value: container.Pod.Sandbox},
 		}
 		existingContainerEvent := trace.Event{
 			Timestamp:   int(time.Now().UnixNano()),


### PR DESCRIPTION
### 1. What the PR does

ae406df9c **optimize(enrich): skip non hid mkdir events**
9d97d239c **chore: improve logging in container related code**
96f0c9042 **fix: existing_container bad output**
04331580b **feat(mount): use mountinfo instead of /proc/mounts**
9d2206c4a **feat(cgroup): always switch to root cgroupns**

### 2. Explain how to test it

1. Deploy an EKS environment (v1.27+)
2. Deploy tracee with a rule for tracking container_create
3. Deploy a new pod
4. The two container_create events should be enriched (barring some race conditions)

### 3. Other comments

I've found that we have some race conditions right now where enrichment will finish but a container event will be sent before. This is another bug which should be tackled separately (either by fixing the condition itself, or changing how a container_create event is triggered).

Resolve #3826
Fix #3689
Fix #3824