### PR TITLE
chore: remove clang march flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ $(OUTPUT_DIR)/tracee.bpf.o: \
 		-I ./3rdparty/include \
 		-target bpf \
 		-O2 -g \
-		-march=bpf -mcpu=$(BPF_VCPU) \
+		-mcpu=$(BPF_VCPU) \
 		-c $(TRACEE_EBPF_OBJ_SRC) \
 		-o $@
 


### PR DESCRIPTION
### 1. Explain what the PR does

f771010c65d3f3df0a3807bdc3fd8c52aaa7e929 chore: remove clang march flag
    
    clang versions ~16 and above do not support the march flag.
    
    - 16.0.6:
    
      clang: warning: argument unused during compilation: '-march=bpf' [-Wunused-command-line-argument]
    
    - 17.0.2:
    
      clang: error: unsupported option '-march=' for target 'bpf'


### 2. Explain how to test it


### 3. Other comments

