### PR TITLE
feat: allow webhook configuration via helm values

### DIFF
--- a/deploy/helm/tracee/templates/tracee-config.yaml
+++ b/deploy/helm/tracee/templates/tracee-config.yaml
@@ -30,8 +30,8 @@ data:
         level: {{ .Values.config.log.level }}
     output:
         {{ .Values.config.output.format }}:
-          files:
-            - stdout
+            files:
+                - stdout
         options:
             parse-arguments: {{ .Values.config.output.options.parseArguments }}
             stack-addresses: {{ .Values.config.output.options.stackAddresses }}
@@ -39,6 +39,16 @@ data:
             relative-time: {{ .Values.config.output.options.relativeTime }}
             exec-hash: {{ .Values.config.output.options.execHash }}
             sort-events: {{ .Values.config.output.options.sortEvents }}
+        {{- with .Values.config.output.webhook }}
+        webhook:
+            - {{ .name | default "webhook1" }}:
+                protocol: {{ .protocol | default "http" }}
+                host: {{ .host | default "localhost" }}
+                port: {{ .port | default "8080" }}
+                timeout: {{ .timeout | default "3s" }}
+                gotemplate: {{ .goTemplate }}
+                content-type: {{ .contentType | default "application/json" }}
+        {{- end }}
     {{- if .Values.config.blobPerfBufferSize }}
     blob-perf-buffer-size: {{ .Values.config.blobPerfBufferSize}}
     {{- end }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -82,6 +82,16 @@ config:
       relativeTime: true
       execHash: dev-inode
       sortEvents: false
+    # uncomment config.output.webhook to enable a single webhook
+    # to configure multiple webhooks, use the traceeConfig field
+    # webhook:
+    #   name: "webhook1"
+    #   contentType: "application/json"
+    #   goTemplate: ""
+    #   host: ""
+    #   port: "8080"
+    #   protocol: http
+    #   timeout: 3s
 
 defaultPolicy: true
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

903fb1188 **chore: bump chart version to 0.19.1**
32a892a26 **feat: allow webhook configuration via helm values**

the webhook section of the tracee config map can not be configured anymore since the refactoring in version 0.19.0 of the Helm chart. This PR allows to configure the webhook. Choice has been made to map the webhook keys (instead of just dumping the values as is in the config map), similarly to what already exists for other portions of this configmap's values file content.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

```
helm template tracee ./deploy/helm/tracee --show-only templates/tracee-config.yaml
```

output doesn't include the webhook configuration (no reg).

```
cat > ci.yaml <<EOF
config:
  output:
    webhook:
      - name: "named-webhook"
        protocol: http
        host: localhost
        port: 8080
        timeout: 3s
        goTemplate: /tracee/templates/simple.tmpl
        contentType: application/json
      - goTemplate: /tracee/templates/simple.tmpl
EOF
helm template tracee ./deploy/helm/tracee --show-only templates/tracee-config.yaml -f ci.yaml
```

output contains this webhook configuration:
```
    output:
        json:
            files:
                - stdout
        options:
            parse-arguments: true
            stack-addresses: false
            exec-env: false
            relative-time: true
            exec-hash: dev-inode
            sort-events: false
        webhook:
            - named-webhook:
                protocol: http
                host: localhost
                port: 8080
                timeout: 3s
                gotemplate: /tracee/templates/simple.tmpl
                content-type: application/json
            - webhook1:
                protocol: http
                host: localhost
                port: 8080
                timeout: 3s
                gotemplate: /tracee/templates/simple.tmpl
                content-type: application/json
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
webhook content example in config samples: https://github.com/aquasecurity/tracee/blob/main/examples/config/global_config.yaml
