### PR TITLE
fix: skip timestamp normalizing in derived events

### DIFF
--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -331,6 +331,12 @@ func (t *Tracee) processPrintMemDump(event *trace.Event) error {
 // normalizeEventCtxTimes normalizes the event context timings to be relative to tracee start time
 // or current time in nanoseconds.
 func (t *Tracee) normalizeEventCtxTimes(event *trace.Event) error {
+	eventId := events.ID(event.EventID)
+	if eventId > events.MaxCommonID && eventId < events.MaxUserSpace {
+		// derived events are normalized from their base event, skip the processing
+		return nil
+	}
+
 	//
 	// Currently, the timestamp received from the bpf code is of the monotonic clock.
 	//


### PR DESCRIPTION
### 1. Explain what the PR does

**a78e7c129e**: fix: skip timestamp normalizing in derived events

### 2. Explain how to test it

1. `tracee --events container_create`
2. `docker run --rm ubuntu`
3. Timestamp should make sense

### 3. Other comments
 
Fix #3828 
