### PR TITLE
chore: remove gob printer

### DIFF
--- a/docs/docs/flags/output.1.md
+++ b/docs/docs/flags/output.1.md
@@ -26,8 +26,6 @@ Format options:
 
 - **json[:/path/to/file,...]**: Output events in JSON format. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
 
-- **gob[:/path/to/file,...]**: Output events in gob format. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
-
 - **gotemplate=/path/to/template[:/path/to/file,...]**: Output events formatted using a given Go template file. The default path to the file is stdout. Multiple file paths can be specified, separated by commas.
 
 - **none**: Ignore the stream of events output. This is usually used with the **\-\-capture** flag.
@@ -74,18 +72,6 @@ Other options:
 
   ```console
   --output gotemplate=/path/to/my.tmpl
-  ```
-
-- To output events in gob format to `/my/out`, use the following flag:
-
-  ```console
-  --output gob:/my/out
-  ```
-
-- To output events as JSON to stdout and as gob to `/my/out`, use the following flag:
-
-  ```console
-  --output json --output gob:/my/out
   ```
 
 - To output events as JSON to both `/my/out` and `/my/out2`, use the following flag:

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -87,10 +87,6 @@ output:
         files:
             - stdout
 
-    gob:
-        files:
-        - /path/to/gob1.out
-
     gotemplate:
         template: /path/to/my_template1.tmpl
         files:

--- a/docs/docs/outputs/output-formats.md
+++ b/docs/docs/outputs/output-formats.md
@@ -125,14 +125,3 @@ output:
     #         - /path/to/output1.out
     #         - /path/to/output2.out
 ```
-
-### GOB
-
-This outputs events in gob format. The default path to file is stdout.
-
-```
-output:
-    gob:
-        files:
-            - /path/to/gob1.out
-```

--- a/docs/man/output.1
+++ b/docs/man/output.1
@@ -46,10 +46,6 @@ Multiple file paths can be specified, separated by commas.
 The default path to the file is stdout.
 Multiple file paths can be specified, separated by commas.
 .IP \[bu] 2
-\f[B]gob[:/path/to/file,\&...]\f[R]: Output events in gob format.
-The default path to the file is stdout.
-Multiple file paths can be specified, separated by commas.
-.IP \[bu] 2
 \f[B]gotemplate=/path/to/template[:/path/to/file,\&...]\f[R]: Output
 events formatted using a given Go template file.
 The default path to the file is stdout.
@@ -153,28 +149,6 @@ following flag:
 .nf
 \f[C]
 --output gotemplate=/path/to/my.tmpl
-\f[R]
-.fi
-.RE
-.IP \[bu] 2
-To output events in gob format to \f[V]/my/out\f[R], use the following
-flag:
-.RS 2
-.IP
-.nf
-\f[C]
---output gob:/my/out
-\f[R]
-.fi
-.RE
-.IP \[bu] 2
-To output events as JSON to stdout and as gob to \f[V]/my/out\f[R], use
-the following flag:
-.RS 2
-.IP
-.nf
-\f[C]
---output json --output gob:/my/out
 \f[R]
 .fi
 .RE

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -79,10 +79,6 @@ output:
     #     files:
     #         - stdout
 
-    # gob:
-    #     files:
-    #     - /path/to/gob1.out
-
     # gotemplate:
     #     template: /path/to/my_template1.tmpl
     #     files:

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -377,7 +377,6 @@ type OutputConfig struct {
 	Table        OutputFormatConfig             `mapstructure:"table"`
 	TableVerbose OutputFormatConfig             `mapstructure:"table-verbose"`
 	JSON         OutputFormatConfig             `mapstructure:"json"`
-	Gob          OutputFormatConfig             `mapstructure:"gob"`
 	GoTemplate   OutputGoTemplateConfig         `mapstructure:"gotemplate"`
 	Forwards     map[string]OutputForwardConfig `mapstructure:"forward"`
 	Webhooks     map[string]OutputWebhookConfig `mapstructure:"webhook"`
@@ -417,7 +416,6 @@ func (c *OutputConfig) flags() []string {
 		"table":         c.Table.Files,
 		"table-verbose": c.TableVerbose.Files,
 		"json":          c.JSON.Files,
-		"gob":           c.Gob.Files,
 	}
 	for format, files := range formatFilesMap {
 		for _, file := range files {

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -327,7 +327,6 @@ output:
     json:
         files:
             - /path/to/json1.out
-    gob: # this won't be present since it does not have any files
     gotemplate:
         template: template1
         files:
@@ -376,7 +375,6 @@ output:
 				"table:file1",
 				"table-verbose:stdout",
 				"json:/path/to/json1.out",
-				// gob is not present since it does not have any files
 				"gotemplate=template1:file3,file4",
 				"forward:tcp://user:pass@127.0.0.1:24224?tag=tracee1",
 				"forward:udp://user:pass@127.0.0.1:24225?tag=tracee2",

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -45,7 +45,7 @@ func PrepareOutput(outputSlice []string, newBinary bool) (PrepareOutputResult, e
 				return outConfig, errors.New("none output does not support path. Use '--output help' for more info")
 			}
 			printerMap["stdout"] = "ignore"
-		case "table", "table-verbose", "json", "gob":
+		case "table", "table-verbose", "json":
 			err := parseFormat(outputParts, printerMap, newBinary)
 			if err != nil {
 				return outConfig, err

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -116,37 +116,6 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
-			testName:    "gob to stdout",
-			outputSlice: []string{"gob"},
-			expectedOutput: PrepareOutputResult{
-				PrinterConfigs: []config.PrinterConfig{
-					{Kind: "gob", OutPath: "stdout"},
-				},
-				TraceeConfig: &config.OutputConfig{},
-			},
-		},
-		{
-			testName:    "gob to stdout",
-			outputSlice: []string{"gob"},
-			expectedOutput: PrepareOutputResult{
-				PrinterConfigs: []config.PrinterConfig{
-					{Kind: "gob", OutPath: "stdout"},
-				},
-				TraceeConfig: &config.OutputConfig{},
-			},
-		},
-		{
-			testName:    "gob to /tmp/gob1,/tmp/gob2",
-			outputSlice: []string{"gob:/tmp/gob1,/tmp/gob2"},
-			expectedOutput: PrepareOutputResult{
-				PrinterConfigs: []config.PrinterConfig{
-					{Kind: "gob", OutPath: "/tmp/gob1"},
-					{Kind: "gob", OutPath: "/tmp/gob2"},
-				},
-				TraceeConfig: &config.OutputConfig{},
-			},
-		},
-		{
 			testName:    "table-verbose to stdout",
 			outputSlice: []string{"table-verbose"},
 			expectedOutput: PrepareOutputResult{
@@ -182,7 +151,6 @@ func TestPrepareOutput(t *testing.T) {
 			outputSlice: []string{
 				"table",
 				"json:/tmp/json,/tmp/json2",
-				"gob:/tmp/gob1",
 				"gotemplate=template.tmpl:/tmp/gotemplate1",
 			},
 			expectedOutput: PrepareOutputResult{
@@ -190,7 +158,6 @@ func TestPrepareOutput(t *testing.T) {
 					{Kind: "table", OutPath: "stdout"},
 					{Kind: "json", OutPath: "/tmp/json"},
 					{Kind: "json", OutPath: "/tmp/json2"},
-					{Kind: "gob", OutPath: "/tmp/gob1"},
 					{Kind: "gotemplate=template.tmpl", OutPath: "/tmp/gotemplate1"},
 				},
 				TraceeConfig: &config.OutputConfig{

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -14,7 +14,6 @@ Possible options:
 [format:]table                                     output events in table format (default)
 [format:]table-verbose                             output events in table format with extra fields per event
 [format:]json                                      output events in json format
-[format:]gob                                       output events in gob format
 [format:]gotemplate=/path/to/template              output events formatted using a given gotemplate file
 out-file:/path/to/file                             write the output to a specified file. create/trim the file if exists (default: stdout)
 none                                               ignore stream of events output, usually used with --capture
@@ -114,9 +113,8 @@ func validateFormat(printerKind string) error {
 	if printerKind != "table" &&
 		printerKind != "table-verbose" &&
 		printerKind != "json" &&
-		printerKind != "gob" &&
 		!strings.HasPrefix(printerKind, "gotemplate=") {
-		return errfmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", printerKind)
+		return errfmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info", printerKind)
 	}
 
 	return nil

--- a/pkg/cmd/flags/tracee_ebpf_output_test.go
+++ b/pkg/cmd/flags/tracee_ebpf_output_test.go
@@ -22,7 +22,7 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 			testName:    "invalid output option",
 			outputSlice: []string{"foo"},
 			// it's not the preparer job to validate input. in this case foo is considered an implicit output format.
-			expectedError: errors.New("unrecognized output format: foo. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info"),
+			expectedError: errors.New("unrecognized output format: foo. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info"),
 		},
 		{
 			testName:      "invalid output option",
@@ -37,7 +37,7 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 		{
 			testName:      "empty val",
 			outputSlice:   []string{"out-file"},
-			expectedError: errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info"),
+			expectedError: errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info"),
 		},
 		{
 			testName:    "default format",

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -2,7 +2,6 @@ package printer
 
 import (
 	"bytes"
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -64,10 +63,6 @@ func New(cfg config.PrinterConfig) (EventPrinter, error) {
 		}
 	case kind == "json":
 		res = &jsonEventPrinter{
-			out: cfg.OutFile,
-		}
-	case kind == "gob":
-		res = &gobEventPrinter{
 			out: cfg.OutFile,
 		}
 	case kind == "forward":
@@ -410,71 +405,6 @@ func (p jsonEventPrinter) Print(event trace.Event) {
 func (p jsonEventPrinter) Epilogue(stats metrics.Stats) {}
 
 func (p jsonEventPrinter) Close() {
-}
-
-// gobEventPrinter is printing events using golang's builtin Gob serializer
-type gobEventPrinter struct {
-	out    io.WriteCloser
-	outEnc *gob.Encoder
-}
-
-func (p *gobEventPrinter) Init() error {
-	p.outEnc = gob.NewEncoder(p.out)
-
-	// Event Types
-
-	gob.Register(trace.Event{})
-	gob.Register(trace.SlimCred{})
-	gob.Register(make(map[string]string))
-	gob.Register(trace.PktMeta{})
-	gob.Register([]trace.HookedSymbolData{})
-	gob.Register(map[string]trace.HookedSymbolData{})
-	gob.Register([]trace.DnsQueryData{})
-	gob.Register([]trace.DnsResponseData{})
-
-	// Network Protocol Event Types
-
-	// IPv4
-	gob.Register(trace.ProtoIPv4{})
-	// IPv6
-	gob.Register(trace.ProtoIPv6{})
-	// TCP
-	gob.Register(trace.ProtoTCP{})
-	// UDP
-	gob.Register(trace.ProtoUDP{})
-	// ICMP
-	gob.Register(trace.ProtoICMP{})
-	// ICMPv6
-	gob.Register(trace.ProtoICMPv6{})
-	// DNS
-	gob.Register(trace.ProtoDNS{})
-	gob.Register(trace.ProtoDNSQuestion{})
-	gob.Register(trace.ProtoDNSResourceRecord{})
-	gob.Register(trace.ProtoDNSSOA{})
-	gob.Register(trace.ProtoDNSSRV{})
-	gob.Register(trace.ProtoDNSMX{})
-	gob.Register(trace.ProtoDNSURI{})
-	gob.Register(trace.ProtoDNSOPT{})
-	// HTTP
-	gob.Register(trace.ProtoHTTP{})
-	gob.Register(trace.ProtoHTTPRequest{})
-	gob.Register(trace.ProtoHTTPResponse{})
-
-	return nil
-}
-
-func (p *gobEventPrinter) Preamble() {}
-
-func (p *gobEventPrinter) Print(event trace.Event) {
-	err := p.outEnc.Encode(event)
-	if err != nil {
-		logger.Errorw("Error encoding event to gob", "error", err)
-	}
-}
-
-func (p *gobEventPrinter) Epilogue(stats metrics.Stats) {}
-
-func (p gobEventPrinter) Close() {
 }
 
 // ignoreEventPrinter ignores events

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -24,13 +24,13 @@ func TestTraceeEbpfPrepareOutputPrinterConfig(t *testing.T) {
 			testName:        "invalid format",
 			outputSlice:     []string{"notaformat"},
 			expectedPrinter: config.PrinterConfig{},
-			expectedError:   fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", "notaformat"),
+			expectedError:   fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info", "notaformat"),
 		},
 		{
 			testName:        "invalid format with format prefix",
 			outputSlice:     []string{"format:notaformat2"},
 			expectedPrinter: config.PrinterConfig{},
-			expectedError:   fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', 'gob' or 'gotemplate='. Use '--output help' for more info", "notaformat2"),
+			expectedError:   fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info", "notaformat2"),
 		},
 		{
 			testName:    "default",


### PR DESCRIPTION
Remove the gob printer. This is a legacy printer which was used by `tracee-rules` and `tracee-ebpf`, which are no longer supported and will be soon removed from the repo. 