### PR TITLE
fix: e2e-net-tests should use unified binary

### DIFF
--- a/pkg/events/derive/net_packet.go
+++ b/pkg/events/derive/net_packet.go
@@ -371,7 +371,7 @@ func NetPacketHTTP() DeriveFunction {
 				dstIP,
 				srcPort,
 				dstPort,
-				&trace.PacketMetadata{
+				trace.PacketMetadata{
 					Direction: getPacketDirection(&event),
 				},
 				*proto,

--- a/tests/e2e-kernel-test.sh
+++ b/tests/e2e-kernel-test.sh
@@ -62,7 +62,7 @@ set -e
 make -j$(nproc) all
 set +e
 if [[ ! -x ./dist/tracee ]]; then
-    error_exit "could not find tracee executables"
+    error_exit "could not find tracee executable"
 fi
 
 # if any test has failed
@@ -82,8 +82,8 @@ for TEST in $TESTS; do
         --cache cache-type=mem \
         --cache mem-cache-size=512 \
         --output json \
-        --scope container=new 2>&1 |
-        tee $SCRIPT_TMP_DIR/build-$$ 2>&1 &
+        --scope container=new 2>&1 \
+        | tee "$SCRIPT_TMP_DIR/build-$$" &
 
     # wait tracee to be started (30 sec most)
     times=0

--- a/tests/e2e-net-signatures/e2e-dns.go
+++ b/tests/e2e-net-signatures/e2e-dns.go
@@ -36,6 +36,7 @@ func (sig *e2eDNS) Init(ctx detect.SignatureContext) error {
 func (sig *e2eDNS) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "DNS",
+		EventName:   "DNS",
 		Version:     "0.1.0",
 		Name:        "Network DNS Test",
 		Description: "Network E2E Tests: DNS",

--- a/tests/e2e-net-signatures/e2e-http.go
+++ b/tests/e2e-net-signatures/e2e-http.go
@@ -29,6 +29,7 @@ func (sig *e2eHTTP) Init(ctx detect.SignatureContext) error {
 func (sig *e2eHTTP) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "HTTP",
+		EventName:   "HTTP",
 		Version:     "0.1.0",
 		Name:        "Network HTTP Test",
 		Description: "Network E2E Tests: HTTP",

--- a/tests/e2e-net-signatures/e2e-icmp.go
+++ b/tests/e2e-net-signatures/e2e-icmp.go
@@ -21,6 +21,7 @@ func (sig *e2eICMP) Init(ctx detect.SignatureContext) error {
 func (sig *e2eICMP) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "ICMP",
+		EventName:   "ICMP",
 		Version:     "0.1.0",
 		Name:        "Network ICMP Test",
 		Description: "Network E2E Tests: ICMP",

--- a/tests/e2e-net-signatures/e2e-icmpv6.go
+++ b/tests/e2e-net-signatures/e2e-icmpv6.go
@@ -21,6 +21,7 @@ func (sig *e2eICMPv6) Init(ctx detect.SignatureContext) error {
 func (sig *e2eICMPv6) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "ICMPv6",
+		EventName:   "ICMPv6",
 		Version:     "0.1.0",
 		Name:        "Network ICMPv6 Test",
 		Description: "Network E2E Tests: ICMPv6",

--- a/tests/e2e-net-signatures/e2e-ipv4.go
+++ b/tests/e2e-net-signatures/e2e-ipv4.go
@@ -21,6 +21,7 @@ func (sig *e2eIPv4) Init(ctx detect.SignatureContext) error {
 func (sig *e2eIPv4) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "IPv4",
+		EventName:   "IPv4",
 		Version:     "0.1.0",
 		Name:        "Network IPv4 Test",
 		Description: "Network E2E Tests: IPv4",

--- a/tests/e2e-net-signatures/e2e-ipv6.go
+++ b/tests/e2e-net-signatures/e2e-ipv6.go
@@ -21,6 +21,7 @@ func (sig *e2eIPv6) Init(ctx detect.SignatureContext) error {
 func (sig *e2eIPv6) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "IPv6",
+		EventName:   "IPv6",
 		Version:     "0.1.0",
 		Name:        "Network IPv6 Test",
 		Description: "Network E2E Tests: IPv6",

--- a/tests/e2e-net-signatures/e2e-tcp.go
+++ b/tests/e2e-net-signatures/e2e-tcp.go
@@ -21,6 +21,7 @@ func (sig *e2eTCP) Init(ctx detect.SignatureContext) error {
 func (sig *e2eTCP) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "TCP",
+		EventName:   "TCP",
 		Version:     "0.1.0",
 		Name:        "Network TCP Test",
 		Description: "Network E2E Tests: TCP",

--- a/tests/e2e-net-signatures/e2e-udp.go
+++ b/tests/e2e-net-signatures/e2e-udp.go
@@ -21,6 +21,7 @@ func (sig *e2eUDP) Init(ctx detect.SignatureContext) error {
 func (sig *e2eUDP) GetMetadata() (detect.SignatureMetadata, error) {
 	return detect.SignatureMetadata{
 		ID:          "UDP",
+		EventName:   "UDP",
 		Version:     "0.1.0",
 		Name:        "Network UDP Test",
 		Description: "Network E2E Tests: UDP",

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -72,7 +72,7 @@ make -j$(nproc) all
 make e2e-net-signatures
 set +e
 if [[ ! -x ./dist/tracee ]]; then
-    error_exit "could not find tracee executables"
+    error_exit "could not find tracee executable"
 fi
 
 # if any test has failed
@@ -93,8 +93,8 @@ for TEST in $TESTS; do
         --cache mem-cache-size=512 \
         --output json \
         --scope comm=ping,nc,nslookup,isc-net-0000,isc-worker0000,curl \
-        --signatures-dir ./dist/e2e-net-signatures/ 2>&1 |
-        tee $SCRIPT_TMP_DIR/build-$$ 2>&1 &
+        --signatures-dir ./dist/e2e-net-signatures/ 2>&1 \
+        | tee "$SCRIPT_TMP_DIR/build-$$" &
 
     # wait tracee to be started (30 sec most)
     times=0


### PR DESCRIPTION
Fixing e2e tests to use the `tracee` binary instead of `tracee-rules` and `tracee-ebpf`.