### PR TITLE
Manage `EventStates` via Policies

### DIFF
--- a/pkg/cmd/cobra/helper.go
+++ b/pkg/cmd/cobra/helper.go
@@ -2,21 +2,22 @@ package cobra
 
 import (
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/config"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
 )
 
-func createPoliciesFromK8SPolicy(policies []k8s.PolicyInterface) (*policy.Policies, error) {
+func createPoliciesFromK8SPolicy(cfg config.PoliciesConfig, policies []k8s.PolicyInterface) (*policy.Policies, error) {
 	policyScopeMap, policyEventsMap, err := flags.PrepareFilterMapsFromPolicies(policies)
 	if err != nil {
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(cfg, policyScopeMap, policyEventsMap, true)
 }
 
-func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, error) {
+func createPoliciesFromPolicyFiles(cfg config.PoliciesConfig, policyFlags []string) (*policy.Policies, error) {
 	policyFiles, err := v1beta1.PoliciesFromPaths(policyFlags)
 	if err != nil {
 		return nil, err
@@ -27,10 +28,10 @@ func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, erro
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(cfg, policyScopeMap, policyEventsMap, true)
 }
 
-func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Policies, error) {
+func createPoliciesFromCLIFlags(cfg config.PoliciesConfig, scopeFlags, eventFlags []string) (*policy.Policies, error) {
 	policyScopeMap, err := flags.PrepareScopeMapFromFlags(scopeFlags)
 	if err != nil {
 		return nil, err
@@ -41,5 +42,5 @@ func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Polici
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(cfg, policyScopeMap, policyEventsMap, true)
 }

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
@@ -101,7 +102,12 @@ func PrepareFilterMapsFromPolicies(policies []k8s.PolicyInterface) (PolicyScopeM
 }
 
 // CreatePolicies creates a Policies object from the scope and events maps.
-func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMap, newBinary bool) (*policy.Policies, error) {
+func CreatePolicies(
+	cfg config.PoliciesConfig,
+	policyScopeMap PolicyScopeMap,
+	policyEventsMap PolicyEventMap,
+	newBinary bool,
+) (*policy.Policies, error) {
 	eventsNameToID := events.Core.NamesToIDs()
 	// remove internal events since they shouldn't be accessible by users
 	for event, id := range eventsNameToID {
@@ -110,7 +116,7 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 		}
 	}
 
-	policies := policy.NewPolicies()
+	policies := policy.NewPolicies(cfg)
 	for policyIdx, policyScopeFilters := range policyScopeMap {
 		p := policy.NewPolicy()
 		p.ID = policyIdx

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -22,8 +22,8 @@ func PrepareFilterMapsFromPolicies(policies []k8s.PolicyInterface) (PolicyScopeM
 		return nil, nil, errfmt.Errorf("no policies provided")
 	}
 
-	if len(policies) > policy.MaxPolicies {
-		return nil, nil, errfmt.Errorf("too many policies provided, there is a limit of %d policies", policy.MaxPolicies)
+	if len(policies) > policy.PolicyMax {
+		return nil, nil, errfmt.Errorf("too many policies provided, there is a limit of %d policies", policy.PolicyMax)
 	}
 
 	policyNames := make(map[string]bool)

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
@@ -2076,7 +2077,11 @@ func TestCreatePolicies(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			_, err = CreatePolicies(policyScopeMap, policyEventsMap, false)
+			policiesCfg := config.NewPoliciesConfig(config.Config{
+				Capture: &config.CaptureConfig{},
+			})
+
+			_, err = CreatePolicies(policiesCfg, policyScopeMap, policyEventsMap, false)
 			if tc.expectPolicyErr != nil {
 				assert.ErrorContains(t, err, tc.expectPolicyErr.Error())
 			} else {

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -120,23 +120,18 @@ func (r Runner) Run(ctx context.Context) error {
 	return err
 }
 
-func GetContainerMode(cfg config.Config) config.ContainerMode {
-	containerMode := config.ContainerModeDisabled
-
-	for p := range cfg.Policies.Map() {
-		if p.ContainerFilterEnabled() {
-			// Container Enrichment is enabled by default ...
-			containerMode = config.ContainerModeEnriched
-			if cfg.NoContainersEnrich {
-				// ... but might be disabled as a safeguard measure.
-				containerMode = config.ContainerModeEnabled
-			}
-
-			break
-		}
+func GetContainerMode(containerFilterEnabled, noContainersEnrich bool) config.ContainerMode {
+	if !containerFilterEnabled {
+		return config.ContainerModeDisabled
 	}
 
-	return containerMode
+	// If "no-containers" enrichment is set, return just enabled mode ...
+	if noContainersEnrich {
+		return config.ContainerModeEnabled
+	}
+
+	// ... otherwise return enriched mode as default.
+	return config.ContainerModeEnriched
 }
 
 const pidFileName = "tracee.pid"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,16 +8,13 @@ import (
 	"github.com/aquasecurity/tracee/pkg/containers/runtime"
 	"github.com/aquasecurity/tracee/pkg/dnscache"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
-	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
-	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/proctree"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
 )
 
 // Config is a struct containing user defined configuration of tracee
 type Config struct {
-	Policies           *policy.Policies
 	Capture            *CaptureConfig
 	Capabilities       *CapabilitiesConfig
 	Output             *OutputConfig
@@ -39,22 +36,6 @@ type Config struct {
 
 // Validate does static validation of the configuration
 func (c Config) Validate() error {
-	// Policies
-	for p := range c.Policies.Map() {
-		if p == nil {
-			return errfmt.Errorf("policy is nil")
-		}
-		if p.EventsToTrace == nil {
-			return errfmt.Errorf("policy [%d] has no events to trace", p.ID)
-		}
-
-		for e := range p.EventsToTrace {
-			if !events.Core.IsDefined(e) {
-				return errfmt.Errorf("invalid event [%d] to trace in policy [%d]", e, p.ID)
-			}
-		}
-	}
-
 	// Buffer sizes
 	if (c.PerfBufferSize & (c.PerfBufferSize - 1)) != 0 {
 		return errfmt.Errorf("invalid perf buffer size - must be a power of 2")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,3 +203,28 @@ type PrinterConfig struct {
 	ContainerMode ContainerMode
 	RelativeTS    bool
 }
+
+// PoliciesConfig holds the Tracee configuration required by the Policies computation.
+type PoliciesConfig struct {
+	DNSCacheConfig bool
+	ProcTreeSource proctree.SourceType
+	Capture        CaptureConfig
+}
+
+// NewPoliciesConfig returns a new PoliciesConfig based on the given Tracee configuration.
+func NewPoliciesConfig(cfg Config) PoliciesConfig {
+	return PoliciesConfig{
+		DNSCacheConfig: cfg.DNSCacheConfig.Enable,
+		ProcTreeSource: cfg.ProcTree.Source,
+		Capture: CaptureConfig{
+			OutputPath: cfg.Capture.OutputPath,
+			FileWrite:  cfg.Capture.FileWrite,
+			FileRead:   cfg.Capture.FileRead,
+			Module:     cfg.Capture.Module,
+			Exec:       cfg.Capture.Exec,
+			Mem:        cfg.Capture.Mem,
+			Bpf:        cfg.Capture.Bpf,
+			Net:        cfg.Capture.Net,
+		},
+	}
+}

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -262,9 +262,9 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 			// thus the need to continue with those within the pipeline.
 			if t.matchPolicies(evt) == 0 {
 				_, hasDerivation := t.eventDerivations[eventId]
-				_, hasSignature := t.eventSignatures[eventId]
+				ep := t.eventProperties[eventId]
 
-				if !hasDerivation && !hasSignature {
+				if !hasDerivation && !ep.RequiredBySignature() {
 					_ = t.stats.EventsFiltered.Increment()
 					t.eventsPool.Put(evt)
 					continue

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -465,7 +465,7 @@ func (t *Tracee) processEvents(ctx context.Context, in <-chan *trace.Event) (
 			}
 
 			// Get a bitmap with all policies containing container filters
-			policiesWithContainerFilter := policies.ContainerFilterEnabled()
+			policiesWithContainerFilter := policies.WithContainerFilterEnabled()
 
 			// Filter out events that don't have a container ID from all the policies that
 			// have container filters. This will guarantee that any of those policies

--- a/pkg/ebpf/hidden_kernel_module.go
+++ b/pkg/ebpf/hidden_kernel_module.go
@@ -4,7 +4,6 @@ import (
 	gocontext "context"
 	"time"
 
-	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/derive"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
@@ -32,10 +31,6 @@ const throttleSecs = 2 // Seconds
 func (t *Tracee) lkmSeekerRoutine(ctx gocontext.Context) {
 	logger.Debugw("Starting lkmSeekerRoutine goroutine")
 	defer logger.Debugw("Stopped lkmSeekerRoutine goroutine")
-
-	if t.eventsState[events.HiddenKernelModule].Emit == 0 {
-		return
-	}
 
 	modsMap, err := t.bpfModule.GetMap("modules_map")
 	if err != nil {

--- a/pkg/ebpf/hooked_syscall_table.go
+++ b/pkg/ebpf/hooked_syscall_table.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/capabilities"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/derive"
+	"github.com/aquasecurity/tracee/pkg/ksymbols"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
@@ -158,12 +159,17 @@ func (t *Tracee) getSyscallNameByKerVer(restrictions []events.KernelRestrictions
 
 // populateExpectedSyscallTableArray fills the expected values of the syscall table
 func (t *Tracee) populateExpectedSyscallTableArray(tableMap *bpf.BPFMap) error {
+	ksyms, err := ksymbols.GetInstance()
+	if err != nil {
+		return err
+	}
+
 	// Get address to the function that defines the not implemented sys call
-	niSyscallSymbol, err := t.kernelSymbols.GetSymbolByOwnerAndName("system", events.SyscallPrefix+"ni_syscall")
+	niSyscallSymbol, err := ksyms.GetSymbolByOwnerAndName("system", events.SyscallPrefix+"ni_syscall")
 	if err != nil {
 		e := err
 		// RHEL 8.x uses sys_ni_syscall instead of __arch_ni_syscall
-		niSyscallSymbol, err = t.kernelSymbols.GetSymbolByOwnerAndName("system", "sys_ni_syscall")
+		niSyscallSymbol, err = ksyms.GetSymbolByOwnerAndName("system", "sys_ni_syscall")
 		if err != nil {
 			logger.Debugw("hooked_syscall: syscall symbol not found", "name", "sys_ni_syscall")
 			return e
@@ -187,7 +193,7 @@ func (t *Tracee) populateExpectedSyscallTableArray(tableMap *bpf.BPFMap) error {
 			continue
 		}
 
-		kernelSymbol, err := t.kernelSymbols.GetSymbolByOwnerAndName("system", events.SyscallPrefix+syscallName)
+		kernelSymbol, err := ksyms.GetSymbolByOwnerAndName("system", events.SyscallPrefix+syscallName)
 		if err != nil {
 			logger.Errorw("hooked_syscall: syscall symbol not found", "id", index)
 			return err

--- a/pkg/ebpf/hooked_syscall_table.go
+++ b/pkg/ebpf/hooked_syscall_table.go
@@ -26,10 +26,6 @@ func (t *Tracee) hookedSyscallTableRoutine(ctx gocontext.Context) {
 	logger.Debugw("Starting hookedSyscallTable goroutine")
 	defer logger.Debugw("Stopped hookedSyscallTable goroutine")
 
-	if t.eventsState[events.HookedSyscall].Submit == 0 {
-		return
-	}
-
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		logger.Debugw("hooked syscall table: unsupported architecture")
 		return

--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/ksymbols"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -40,10 +41,15 @@ func (t *Tracee) UpdateKallsyms() error {
 		}
 	}
 
+	ksyms, err := ksymbols.GetInstance()
+	if err != nil {
+		return err
+	}
+
 	// For every ksymbol required by tracee ...
 	for _, required := range allReqSymbols {
 		// ... get the symbol address from the kallsyms file ...
-		symbol, err := t.kernelSymbols.GetSymbolByOwnerAndName(globalSymbolOwner, required)
+		symbol, err := ksyms.GetSymbolByOwnerAndName(globalSymbolOwner, required)
 		if err != nil {
 			logger.Debugw("failed to get symbol", "symbol", required, "error", err)
 			continue

--- a/pkg/ebpf/policy_manager_test.go
+++ b/pkg/ebpf/policy_manager_test.go
@@ -83,7 +83,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableRule(i, e)
 			}
@@ -93,7 +93,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableRule(i, e)
 			}
@@ -103,12 +103,12 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.MaxPolicies; i++ {
+	for i := 0; i < policy.PolicyMax; i++ {
 		for _, e := range eventsToEnable {
-			assert.True(t, policyManager.IsRuleEnabled(policy.AllPoliciesOn, e))
+			assert.True(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
 		}
 		for _, e := range eventsToDisable {
-			assert.False(t, policyManager.IsRuleEnabled(policy.AllPoliciesOn, e))
+			assert.False(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
 		}
 	}
 }
@@ -182,7 +182,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableEvent(e)
 			}
@@ -192,7 +192,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableEvent(e)
 			}
@@ -202,7 +202,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.MaxPolicies; i++ {
+	for i := 0; i < policy.PolicyMax; i++ {
 		for _, e := range eventsToEnable {
 			assert.True(t, policyManager.IsEventEnabled(e))
 		}

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/dnscache"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/proctree"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -29,7 +30,17 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 
 	// Share event states (by reference)
 	t.config.EngineConfig.ShouldDispatchEvent = func(eventIdInt32 int32) bool {
-		_, ok := t.eventsState[events.ID(eventIdInt32)]
+		// Getting the last policies since here we haven't consumed the event yet to know the policies version.
+		// So it is not synced with the event processing (possible mismatch).
+		// However, this will be deprecated in the future. Check ShouldDispatchEvent comment in Config (engine.go).
+		policies, err := policy.Snapshots().GetLast()
+		if err != nil {
+			logger.Errorw("Failed to get policies", "error", err)
+			return false
+		}
+
+		_, ok := policies.EventsStates().GetOk(events.ID(eventIdInt32))
+
 		return ok
 	}
 
@@ -61,8 +72,15 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 
 		id := events.ID(event.EventID)
 
+		policies, err := policy.Snapshots().Get(event.PoliciesVersion)
+		if err != nil {
+			t.handleError(err)
+			return
+		}
+
 		// if the event is marked as submit, we pass it to the engine
-		if t.eventsState[id].Submit > 0 {
+		evtStates := policies.EventsStates().Get(id)
+		if evtStates.ShouldSubmit() {
 			err := t.parseArguments(event)
 			if err != nil {
 				t.handleError(err)
@@ -118,7 +136,13 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 					continue
 				}
 
-				if t.matchPolicies(event) == 0 {
+				policies, err := policy.Snapshots().Get(event.PoliciesVersion)
+				if err != nil {
+					t.handleError(err)
+					continue
+				}
+
+				if t.matchPolicies(policies, event) == 0 {
 					_ = t.stats.EventsFiltered.Increment()
 					continue
 				}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1737,7 +1737,7 @@ func (t *Tracee) triggerMemDumpCall(address uint64, length uint64, eventHandle u
 
 // SubscribeAll returns a stream subscribed to all policies
 func (t *Tracee) SubscribeAll() *streams.Stream {
-	return t.subscribe(policy.AllPoliciesOn)
+	return t.subscribe(policy.PolicyAll)
 }
 
 // Subscribe returns a stream subscribed to selected policies

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -173,8 +173,8 @@ func New(cfg config.Config) (*Tracee, error) {
 	// Update capabilities rings with all events dependencies
 
 	err = policies.UpdateCapabilitiesRings()
-		if err != nil {
-			return t, errfmt.WrapError(err)
+	if err != nil {
+		return t, errfmt.WrapError(err)
 	}
 
 	// Add/Drop capabilities to/from the Base ring (always effective)
@@ -424,20 +424,6 @@ type InitValues struct {
 	Kallsyms bool
 }
 
-func (t *Tracee) generateInitValues() (InitValues, error) {
-	initVals := InitValues{}
-	for evt := range t.eventsState {
-		if !events.Core.IsDefined(evt) {
-			return initVals, errfmt.Errorf("event %d is undefined", evt)
-		}
-		for range events.Core.GetDefinitionByID(evt).GetDependencies().GetKSymbols() {
-			initVals.Kallsyms = true // only if length > 0
-		}
-	}
-
-	return initVals, nil
-}
-
 // initTailCall initializes a given tailcall.
 func (t *Tracee) initTailCall(tailCall events.TailCall) error {
 	tailCallMapName := tailCall.GetMapName()
@@ -649,15 +635,6 @@ func (t *Tracee) initDerivationTable(ps *policy.Policies) error {
 	}
 
 	return nil
-}
-
-// RegisterEventDerivation registers an event derivation handler for tracee to use in the event pipeline
-func (t *Tracee) RegisterEventDerivation(deriveFrom events.ID, deriveTo events.ID, deriveCondition func() bool, deriveLogic derive.DeriveFunction) error {
-	if t.eventDerivations == nil {
-		return errfmt.Errorf("tracee not initialized yet")
-	}
-
-	return t.eventDerivations.Register(deriveFrom, deriveTo, deriveCondition, deriveLogic)
 }
 
 // options config should match defined values in ebpf code
@@ -1037,7 +1014,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	// HookedSeqOps event
 	// check if event is defined even if it's not enabled (emit/submit)
 	if _, ok := evtsStates.GetOk(events.HookedSeqOps); ok {
-	t.triggerSeqOpsIntegrityCheck(trace.Event{})
+		t.triggerSeqOpsIntegrityCheck(trace.Event{})
 	}
 
 	// HookedSyscall event
@@ -1049,14 +1026,14 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	// check if event is defined even if it's not enabled (emit/submit)
 	if _, ok := evtsStates.GetOk(events.PrintMemDump); ok {
 		errs := t.triggerMemDump(policies, trace.Event{})
-	for _, err := range errs {
-		logger.Warnw("Memory dump", "error", err)
+		for _, err := range errs {
+			logger.Warnw("Memory dump", "error", err)
 		}
 	}
 
 	// HiddenKernelModule event
 	if evtsStates.Get(events.HiddenKernelModule).ShouldEmit() {
-	go t.lkmSeekerRoutine(ctx)
+		go t.lkmSeekerRoutine(ctx)
 	}
 
 	// Start control plane

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -243,21 +243,9 @@ func New(cfg config.Config) (*Tracee, error) {
 
 	// Update capabilities rings with all events dependencies
 
-	// TODO: extract this to a function to be called from here and from
-	// policies changes.
-	for id := range t.eventsState {
-		if !events.Core.IsDefined(id) {
-			return t, errfmt.Errorf("event %d is not defined", id)
-		}
-		evtCaps := events.Core.GetDefinitionByID(id).GetDependencies().GetCapabilities()
-		err = caps.BaseRingAdd(evtCaps.GetBase()...)
+	err = policies.UpdateCapabilitiesRings()
 		if err != nil {
 			return t, errfmt.WrapError(err)
-		}
-		err = caps.BaseRingAdd(evtCaps.GetEBPF()...)
-		if err != nil {
-			return t, errfmt.WrapError(err)
-		}
 	}
 
 	// Add/Drop capabilities to/from the Base ring (always effective)

--- a/pkg/events/definition_group.go
+++ b/pkg/events/definition_group.go
@@ -8,13 +8,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
-// TODO: add states to the EventGroup struct (to keep states of events from that group)
-
-type EventState struct {
-	Submit uint64 // should be submitted to userspace (by policies bitmap)
-	Emit   uint64 // should be emitted to the user (by policies bitmap)
-}
-
 // ATTENTION: the definition group is instantiable (all the rest is immutable)
 
 type ByID []Definition
@@ -181,14 +174,14 @@ func (d *DefinitionGroup) IDs32ToIDs() map[ID]ID {
 }
 
 // GetTailCalls returns a list of tailcalls of all definitions in the group (for initialization).
-func (d *DefinitionGroup) GetTailCalls(state map[ID]EventState) []TailCall {
+func (d *DefinitionGroup) GetTailCalls(evtsShouldSubmit map[ID]struct{}) []TailCall {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
 	var tailCalls []TailCall
 
 	for evtDefID, evtDef := range d.definitions {
-		if state[evtDefID].Submit > 0 { // only traced events to provide their tailcalls
+		if _, ok := evtsShouldSubmit[evtDefID]; ok { // only traced events to provide their tailcalls
 			tailCalls = append(tailCalls, evtDef.GetDependencies().GetTailCalls()...)
 		}
 	}

--- a/pkg/events/dependencies.go
+++ b/pkg/events/dependencies.go
@@ -1,0 +1,22 @@
+package events
+
+// GetAllEventsDependencies returns a map of all the dependencies of a given event ID.
+// It gathers all the dependencies recursively.
+func GetAllEventsDependencies(givenEvtId ID) map[ID]struct{} {
+	allDeps := make(map[ID]struct{})
+
+	var gatherDeps func(evtId ID)
+	gatherDeps = func(evtId ID) {
+		eventDefinition := Core.GetDefinitionByID(evtId)
+		for _, depEventId := range eventDefinition.GetDependencies().GetIDs() {
+			if _, found := allDeps[depEventId]; !found {
+				allDeps[depEventId] = struct{}{}
+				gatherDeps(depEventId) // Recursively gather dependencies
+			}
+		}
+	}
+
+	gatherDeps(givenEvtId) // Start the recursion with the given event ID
+
+	return allDeps
+}

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/policy"
@@ -486,13 +487,18 @@ func TestSymbolsCollision(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			ps := policy.NewPolicies()
-			policy.Snapshots().Store(ps)
-			err := ps.Set(p)
+			policiesCfg := config.NewPoliciesConfig(
+				config.Config{
+					Capture: &config.CaptureConfig{},
+				},
+			)
+
+			policies := policy.NewPolicies(policiesCfg)
+			err := policies.Set(p)
 			require.NoError(t, err)
 
 			// Pick derive function from mocked tests
-			deriveFunc := SymbolsCollision(mockLoader, ps)
+			deriveFunc := SymbolsCollision(mockLoader, policies)
 
 			mockLoader.addSOSymbols(
 				testSOInstance{

--- a/pkg/events/properties.go
+++ b/pkg/events/properties.go
@@ -1,0 +1,15 @@
+package events
+
+import "sync/atomic"
+
+type Properties struct {
+	requiredBySignature atomic.Bool
+}
+
+func (p *Properties) RequiredBySignature() bool {
+	return p.requiredBySignature.Load()
+}
+
+func (p *Properties) SetRequiredBySignature(required bool) {
+	p.requiredBySignature.Store(required)
+}

--- a/pkg/ksymbols/ksymbols.go
+++ b/pkg/ksymbols/ksymbols.go
@@ -1,0 +1,47 @@
+package ksymbols
+
+import (
+	"fmt"
+	"sync"
+
+	"kernel.org/pub/linux/libs/security/libcap/cap"
+
+	"github.com/aquasecurity/libbpfgo/helpers"
+
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+)
+
+var (
+	instance *helpers.KernelSymbolTable
+	once     sync.Once
+)
+
+// GetInstance lazily initializes and returns the singleton instance of KernelSymbolTable.
+// It ensures that the instance is created only once, even in concurrent scenarios.
+// If initialization fails, it returns nil and the error encountered during initialization.
+func GetInstance() (*helpers.KernelSymbolTable, error) {
+	var instanceErr error
+
+	once.Do(func() {
+		var kst *helpers.KernelSymbolTable
+
+		err := capabilities.GetInstance().Specific(func() error {
+			var innerErr error
+			kst, innerErr = helpers.NewKernelSymbolTable()
+			if innerErr != nil {
+				return fmt.Errorf("failed to create new kernel symbol table: %w", innerErr)
+			}
+
+			return nil
+		}, cap.SYSLOG)
+		if err != nil {
+			instanceErr = fmt.Errorf("failed to initialize kernel symbols: %w", err)
+			return // early return from the Once.Do block
+		}
+
+		instance = kst
+	})
+
+	return instance, instanceErr
+}
+

--- a/pkg/ksymbols/ksymbols.go
+++ b/pkg/ksymbols/ksymbols.go
@@ -44,4 +44,3 @@ func GetInstance() (*helpers.KernelSymbolTable, error) {
 
 	return instance, instanceErr
 }
-

--- a/pkg/policy/caps.go
+++ b/pkg/policy/caps.go
@@ -1,0 +1,36 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/events"
+)
+
+// UpdateCapabilitiesRings updates the capabilities rings based on the policies events states.
+func (ps *Policies) UpdateCapabilitiesRings() error {
+	// NOTE: This only adds capabilities from events that are defined in the policies.
+	// TODO: On the Snapshot pruning, we should check which capabilities are not used
+	// for any snapshot and remove them from the capabilities rings.
+
+	caps := capabilities.GetInstance()
+
+	ps.rwmu.RLock()
+	defer ps.rwmu.RUnlock()
+
+	for id := range ps.eventsStates().getAll() {
+		if !events.Core.IsDefined(id) {
+			return errfmt.Errorf("event %d is not defined", id)
+		}
+		evtCaps := events.Core.GetDefinitionByID(id).GetDependencies().GetCapabilities()
+		err := caps.BaseRingAdd(evtCaps.GetBase()...)
+		if err != nil {
+			return errfmt.WrapError(err)
+		}
+		err = caps.BaseRingAdd(evtCaps.GetEBPF()...)
+		if err != nil {
+			return errfmt.WrapError(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -325,7 +325,7 @@ func (ps *Policies) createNewFilterMapsVersion(bpfModule *bpf.Module) error {
 		BinaryFilterMap:      BinaryFilterMapVersion,
 	}
 
-	polsVersion := ps.Version()
+	polsVersion := uint16(ps.version)
 	for innerMapName, outerMapName := range mapsNames {
 		// TODO: This only spawns new inner filter maps. Their termination must
 		// be tackled by the versioning mechanism.
@@ -360,7 +360,7 @@ func (ps *Policies) createNewEventsMapVersion(
 	bpfModule *bpf.Module,
 	eventsParams map[events.ID][]bufferdecoder.ArgType,
 ) error {
-	polsVersion := ps.Version()
+	polsVersion := uint16(ps.version)
 	innerMapName := "events_map"
 	outerMapName := "events_map_version"
 
@@ -758,7 +758,7 @@ func (ps *Policies) UpdateBPF(
 
 // createNewPoliciesConfigMap creates a new version of the policies config map
 func (ps *Policies) createNewPoliciesConfigMap(bpfModule *bpf.Module) error {
-	version := ps.Version()
+	version := uint16(ps.version)
 	newInnerMap, err := createNewInnerMap(bpfModule, PoliciesConfigMap, version)
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -915,10 +915,10 @@ func (ps *Policies) computePoliciesConfig() *PoliciesConfig {
 		cfg.EnabledScopes |= 1 << offset
 	}
 
-	cfg.UidMax = ps.UIDFilterMax()
-	cfg.UidMin = ps.UIDFilterMin()
-	cfg.PidMax = ps.PIDFilterMax()
-	cfg.PidMin = ps.PIDFilterMin()
+	cfg.UidMax = ps.uidFilterMax
+	cfg.UidMin = ps.uidFilterMin
+	cfg.PidMax = ps.pidFilterMax
+	cfg.PidMin = ps.pidFilterMin
 
 	return cfg
 }

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -17,11 +17,11 @@ func PolicyNotFoundByNameError(name string) error {
 }
 
 func PoliciesMaxExceededError() error {
-	return fmt.Errorf("policies maximum exceeded [%d]", MaxPolicies)
+	return fmt.Errorf("policies maximum exceeded [%d]", PolicyMax)
 }
 
 func PoliciesOutOfRangeError(idx int) error {
-	return fmt.Errorf("policies index [%d] out-of-range [0-%d]", idx, MaxPolicies-1)
+	return fmt.Errorf("policies index [%d] out-of-range [0-%d]", idx, PolicyMax-1)
 }
 
 func PolicyAlreadyExists(policy *Policy, id int) error {

--- a/pkg/policy/eventstates.go
+++ b/pkg/policy/eventstates.go
@@ -1,0 +1,217 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/events"
+)
+
+// EventStates defines an interface for accessing the states of a single event in a read-only manner.
+type EventStates interface {
+	// GetSubmit returns the submit state of the event.
+	GetSubmit() uint64
+
+	// GetEmit returns the emit state of the event.
+	GetEmit() uint64
+
+	// ShouldSubmit returns true if the event is marked to be submitted.
+	ShouldSubmit() bool
+
+	// ShouldEmit returns true if the event is marked to be emitted.
+	ShouldEmit() bool
+}
+
+// EventsStates defines an interface for accessing a collection of event states in a read-only manner.
+// It allows for querying individual events or collections of events.
+type EventsStates interface {
+	// Get returns the event states of the given event ID.
+	Get(events.ID) EventStates
+
+	// GetOk returns the event states of the given event ID and a boolean indicating if the event ID exists.
+	GetOk(events.ID) (EventStates, bool)
+
+	// GetAll returns a map of all event states.
+	GetAll() map[events.ID]EventStates
+
+	// GetAllSubmittable returns a map of all event IDs that are marked as submittable.
+	GetAllSubmittable() map[events.ID]struct{}
+
+	// GetAllEmittable returns a map of all event IDs that are marked as emittable.
+	GetAllEmittable() map[events.ID]struct{}
+
+	// GetAllCancelled returns a map of all event IDs that are marked as cancelled.
+	GetAllCancelled() map[events.ID]struct{}
+}
+
+// ATTENTION!
+// The eventStates and eventsStates are managed by the Policies struct, all of
+// which are made available through the read-only interfaces EventStates and
+// EventsStates. This arrangement ensures safe access to these types from
+// multiple goroutines without the necessity for additional locking mechanisms.
+
+//
+// eventStates
+//
+
+// eventStates describes the states of an event.
+type eventStates struct {
+	submit uint64 // should be submitted to userspace (by policies bitmap)
+	emit   uint64 // should be emitted to the user (by policies bitmap)
+}
+
+// eventStatesOption is a function that sets an option on an eventStates.
+type eventStatesOption func(*eventStates)
+
+// eventStatesWithSubmit sets the submit value.
+func eventStatesWithSubmit(submit uint64) eventStatesOption {
+	return func(es *eventStates) {
+		es.submit = submit
+	}
+}
+
+// eventStatesWithEmit sets the emit value.
+func eventStatesWithEmit(emit uint64) eventStatesOption {
+	return func(es *eventStates) {
+		es.emit = emit
+	}
+}
+
+// newEventStates creates a new eventStates with the given options.
+func newEventStates(options ...eventStatesOption) eventStates {
+	// default values
+	es := eventStates{
+		submit: 0,
+		emit:   0,
+	}
+
+	// apply options
+	for _, option := range options {
+		option(&es)
+	}
+
+	return es
+}
+
+// eventStates implements the EventStates interface.
+
+func (es eventStates) GetSubmit() uint64 {
+	return es.submit
+}
+
+func (es eventStates) GetEmit() uint64 {
+	return es.emit
+}
+
+func (es eventStates) ShouldSubmit() bool {
+	return es.submit > 0
+}
+
+func (es eventStates) ShouldEmit() bool {
+	return es.emit > 0
+}
+
+//
+// eventsStates
+//
+
+// eventsStates is a struct describing a collection of eventStates.
+type eventsStates struct {
+	states    map[events.ID]eventStates
+	cancelled map[events.ID]struct{}
+}
+
+// newEventsStates creates a new eventsStates.
+func newEventsStates() *eventsStates {
+	return &eventsStates{
+		states:    make(map[events.ID]eventStates),
+		cancelled: make(map[events.ID]struct{}),
+	}
+}
+
+// set sets the event's states.
+func (es *eventsStates) set(id events.ID, states EventStates) {
+	es.states[id] = states.(eventStates)
+}
+
+// cancelEvent cancels an event and updates the cancelled events list.
+func (es *eventsStates) cancelEvent(id events.ID) {
+	delete(es.states, id)
+	es.cancelled[id] = struct{}{}
+}
+
+// cancelEventAndAllDeps cancels an event and all its dependencies.
+func (es *eventsStates) cancelEventAndAllDeps(id events.ID) {
+	es.cancelEvent(id)
+
+	evtDef := events.Core.GetDefinitionByID(id)
+	for _, evtDepID := range evtDef.GetDependencies().GetIDs() {
+		es.cancelEventAndAllDeps(evtDepID)
+	}
+}
+
+// eventsStates implements the EventsStates interface.
+
+func (es *eventsStates) Get(id events.ID) EventStates {
+	return es.getAll()[id]
+}
+
+func (es *eventsStates) GetOk(id events.ID) (EventStates, bool) {
+	states, ok := es.getAll()[id]
+	return states, ok
+}
+
+// getAll returns all event states.
+func (es *eventsStates) getAll() map[events.ID]eventStates {
+	return es.states
+}
+
+func (es *eventsStates) GetAll() map[events.ID]EventStates {
+	all := make(map[events.ID]EventStates, len(es.getAll()))
+
+	for id, states := range es.getAll() {
+		all[id] = states
+	}
+
+	// return a copy to prevent modification of the original map
+	return all
+}
+
+func (es *eventsStates) GetAllSubmittable() map[events.ID]struct{} {
+	submittable := make(map[events.ID]struct{}, len(es.getAll()))
+
+	for id, states := range es.getAll() {
+		if states.ShouldSubmit() {
+			submittable[id] = struct{}{}
+		}
+	}
+
+	// return a copy to prevent modification of the original map
+	return submittable
+}
+
+func (es *eventsStates) GetAllEmittable() map[events.ID]struct{} {
+	emittable := make(map[events.ID]struct{}, len(es.getAll()))
+
+	for id, states := range es.getAll() {
+		if states.ShouldEmit() {
+			emittable[id] = struct{}{}
+		}
+	}
+
+	// return a copy to prevent modification of the original map
+	return emittable
+}
+
+// getAllCancelled returns all cancelled event IDs.
+func (es *eventsStates) getAllCancelled() map[events.ID]struct{} {
+	return es.cancelled
+}
+
+func (es *eventsStates) GetAllCancelled() map[events.ID]struct{} {
+	cancelled := make(map[events.ID]struct{}, len(es.getAllCancelled()))
+
+	for id := range es.getAllCancelled() {
+		cancelled[id] = struct{}{}
+	}
+
+	// return a copy to prevent modification of the original map
+	return cancelled
+}

--- a/pkg/policy/eventstates_compute.go
+++ b/pkg/policy/eventstates_compute.go
@@ -1,0 +1,150 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/pcaps"
+	"github.com/aquasecurity/tracee/pkg/proctree"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// computeEventsStates computes the events states based on the policies and its configuration.
+func (ps *Policies) computeEventsStates() {
+	evtsStates := newEventsStates()
+
+	// Initialize events states with mandatory events (TODO: review this need for sched exec)
+
+	evtsStates.set(events.SchedProcessFork, newEventStates())
+	evtsStates.set(events.SchedProcessExec, newEventStates())
+	evtsStates.set(events.SchedProcessExit, newEventStates())
+
+	// Control Plane Events
+
+	evtsStates.set(events.SignalCgroupMkdir, submitAllPolicies)
+	evtsStates.set(events.SignalCgroupRmdir, submitAllPolicies)
+
+	// Control Plane Process Tree Events
+
+	pipeEvts := func() {
+		evtsStates.set(events.SchedProcessFork, submitAllPolicies)
+		evtsStates.set(events.SchedProcessExec, submitAllPolicies)
+		evtsStates.set(events.SchedProcessExit, submitAllPolicies)
+	}
+	signalEvts := func() {
+		evtsStates.set(events.SignalSchedProcessFork, submitAllPolicies)
+		evtsStates.set(events.SignalSchedProcessExec, submitAllPolicies)
+		evtsStates.set(events.SignalSchedProcessExit, submitAllPolicies)
+	}
+
+	// DNS Cache events
+
+	if ps.config.DNSCacheConfig {
+		evtsStates.set(events.NetPacketDNS, submitAllPolicies)
+	}
+
+	switch ps.config.ProcTreeSource {
+	case proctree.SourceBoth:
+		pipeEvts()
+		signalEvts()
+	case proctree.SourceSignals:
+		signalEvts()
+	case proctree.SourceEvents:
+		pipeEvts()
+	}
+
+	// Pseudo events added by capture (if enabled by the user)
+
+	for eventID, eCfg := range ps.getCaptureEventsList().getAll() {
+		evtsStates.set(eventID, eCfg)
+	}
+
+	// Events chosen by the user
+
+	for p := range ps.filterEnabledPoliciesMap {
+		for e := range p.EventsToTrace {
+			var submit, emit uint64
+			if evtStates, ok := evtsStates.GetOk(e); ok {
+				submit = evtStates.GetSubmit()
+				emit = evtStates.GetEmit()
+			}
+			utils.SetBit(&submit, uint(p.ID))
+			utils.SetBit(&emit, uint(p.ID))
+			evtsStates.set(
+				e,
+				newEventStates(
+					eventStatesWithSubmit(submit),
+					eventStatesWithEmit(emit),
+				),
+			)
+		}
+	}
+
+	// Handle all essential events dependencies
+
+	for id, states := range evtsStates.getAll() {
+		handleEventsDependencies(evtsStates, id, states)
+	}
+
+	// Finally, replace the events states with the computed ones
+
+	ps.evtsStates = evtsStates
+}
+
+// handleEventsDependencies handles all events dependencies recursively.
+func handleEventsDependencies(
+	evtsStates *eventsStates,
+	givenEvtId events.ID,
+	givenEvtStates eventStates,
+) {
+	givenEventDefinition := events.Core.GetDefinitionByID(givenEvtId)
+
+	for _, depEventId := range givenEventDefinition.GetDependencies().GetIDs() {
+		depEventStates, ok := evtsStates.GetOk(depEventId)
+		if !ok {
+			depEventStates = eventStates{}
+			handleEventsDependencies(evtsStates, depEventId, givenEvtStates)
+		}
+
+		// Make sure dependencies are submitted if the given event is submitted.
+		depEvtSubmit := depEventStates.GetSubmit() | givenEvtStates.GetSubmit()
+		evtsStates.set(
+			depEventId,
+			newEventStates(
+				eventStatesWithSubmit(depEvtSubmit),
+				eventStatesWithEmit(depEventStates.GetEmit()),
+			),
+		)
+	}
+}
+
+// getCaptureEventsList sets events used to capture data.
+func (ps *Policies) getCaptureEventsList() *eventsStates {
+	captureEvents := newEventsStates()
+
+	// INFO: All capture events should be placed, at least for now, to all matched policies, or else
+	// the event won't be set to matched policy in eBPF and should_submit() won't submit the capture
+	// event to userland.
+
+	if ps.config.Capture.Exec {
+		captureEvents.set(events.CaptureExec, submitAllPolicies)
+	}
+	if ps.config.Capture.FileWrite.Capture {
+		captureEvents.set(events.CaptureFileWrite, submitAllPolicies)
+	}
+	if ps.config.Capture.FileRead.Capture {
+		captureEvents.set(events.CaptureFileRead, submitAllPolicies)
+	}
+	if ps.config.Capture.Module {
+		captureEvents.set(events.CaptureModule, submitAllPolicies)
+	}
+	if ps.config.Capture.Mem {
+		captureEvents.set(events.CaptureMem, submitAllPolicies)
+	}
+	if ps.config.Capture.Bpf {
+		captureEvents.set(events.CaptureBpf, submitAllPolicies)
+	}
+	if pcaps.PcapsEnabled(ps.config.Capture.Net) {
+		captureEvents.set(events.CaptureNetPacket, submitAllPolicies)
+	}
+
+	return captureEvents
+}

--- a/pkg/policy/ksymbols.go
+++ b/pkg/policy/ksymbols.go
@@ -1,0 +1,92 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/ksymbols"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+// ValidateKallsymsDependencies load all symbols required by events dependencies
+// from the kallsyms file to check for missing symbols. If some symbols are
+// missing, it will cancel their event with informative error message.
+func (ps *Policies) ValidateKallsymsDependencies() {
+	ps.rwmu.Lock()
+	defer ps.rwmu.Unlock()
+
+	depsToCancel := make(map[events.ID]string)
+
+	// Cancel events with unavailable symbols dependencies
+	for eventToCancel, missingDepSyms := range getUnavKsymsPerEvtID(ps.evtsStates) {
+		eventNameToCancel := events.Core.GetDefinitionByID(eventToCancel).GetName()
+		logger.Debugw(
+			"Event cancelled because of missing kernel symbol dependency",
+			"missing symbols", missingDepSyms, "event", eventNameToCancel,
+		)
+		ps.eventsStates().cancelEvent(eventToCancel)
+
+		// Find all events that depend on eventToCancel
+		for eventID := range ps.eventsStates().getAll() {
+			depsIDs := events.Core.GetDefinitionByID(eventID).GetDependencies().GetIDs()
+			for _, depID := range depsIDs {
+				if depID == eventToCancel {
+					depsToCancel[eventID] = eventNameToCancel
+				}
+			}
+		}
+
+		// Cancel all events that require eventToCancel
+		for eventID, depEventName := range depsToCancel {
+			logger.Debugw(
+				"Event cancelled because it depends on an previously cancelled event",
+				"event", events.Core.GetDefinitionByID(eventID).GetName(),
+				"dependency", depEventName,
+			)
+			ps.eventsStates().cancelEvent(eventID)
+		}
+	}
+}
+
+// getUnavKsymsPerEvtID returns event IDs and symbols that are unavailable to them.
+func getUnavKsymsPerEvtID(evtsStates *eventsStates) map[events.ID][]string {
+	unavSymsPerEvtID := map[events.ID][]string{}
+
+	for evtID := range evtsStates.getAll() {
+		unavailable := getUnavEvtKsymsDeps(evtID)
+		if len(unavailable) > 0 {
+			unavSymsPerEvtID[evtID] = unavailable
+		}
+	}
+
+	return unavSymsPerEvtID
+}
+
+// getUnavEvtKsymsDeps returns the unavailable symbols for an event.
+// TODO: move this to events package (dependencies.go).
+func getUnavEvtKsymsDeps(evtID events.ID) []string {
+	unavSyms := []string{}
+	ksyms, err := ksymbols.GetInstance()
+	if err != nil {
+		logger.Errorw("Failed to get kallsyms", "error", err)
+		return unavSyms
+	}
+
+	evtDefSymDeps := events.Core.GetDefinitionByID(evtID).GetDependencies().GetKSymbols()
+
+	for _, symDep := range evtDefSymDeps {
+		sym, err := ksyms.GetSymbolByName(symDep.GetSymbolName())
+		symName := symDep.GetSymbolName()
+		if err != nil {
+			// If the symbol is not found, it means it's unavailable.
+			unavSyms = append(unavSyms, symName)
+			continue
+		}
+		for _, s := range sym {
+			if s.Address == 0 {
+				// Same if the symbol is found but its address is 0.
+				unavSyms = append(unavSyms, symName)
+			}
+		}
+	}
+
+	return unavSyms
+}

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -24,10 +24,18 @@ var (
 	)
 )
 
+// TODO: create {Policy,Policies} interface to be the only way to interact with Policies
+// after its creation. It should be read-only and used by the PolicyManager API.
+// TODO: create {Policy,Policies}Builder interface to create new instances of {Policy,Policies}.
 // TODO: refactor filterEnabledPoliciesMap and filterUserlandPoliciesMap
 // maps to use int (Policy id) as key instead of *Policy.
 // TODO: create a new map with policy name as key to speed up LookupByName()
 type Policies struct {
+	// TODO: this type is not thread-safe and shouldn't be.
+	// The optimal solution would be to have a read-only interface to access this value,
+	// from a snapshot which pointer should be used exclusively for this purpose.
+	// Snapshot/PolicyManager should be improved to provide a cloned Policies instance for use in new versions.
+	// TODO: remove rwmu and atomic operations from this type based on the above.
 	rwmu sync.RWMutex
 
 	config                   config.PoliciesConfig
@@ -282,7 +290,7 @@ func (ps *Policies) set(id int, p *Policy) error {
 // SetVersion sets the version of Policies.
 func (ps *Policies) SetVersion(version uint16) {
 	ps.version = uint32(version)
-			}
+}
 
 // isIDInRange returns true if the given ID is in the range of policies.
 func isIDInRange(id int) bool {

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -90,26 +90,6 @@ func (ps *Policies) Count() int {
 	return len(ps.filterEnabledPoliciesMap)
 }
 
-func (ps *Policies) UIDFilterMin() uint64 {
-	return atomic.LoadUint64(&ps.uidFilterMin)
-}
-
-func (ps *Policies) UIDFilterMax() uint64 {
-	return atomic.LoadUint64(&ps.uidFilterMax)
-}
-
-func (ps *Policies) PIDFilterMin() uint64 {
-	return atomic.LoadUint64(&ps.pidFilterMin)
-}
-
-func (ps *Policies) PIDFilterMax() uint64 {
-	return atomic.LoadUint64(&ps.pidFilterMax)
-}
-
-func (ps *Policies) SetVersion(version uint16) {
-	atomic.StoreUint32(&ps.version, uint32(version))
-}
-
 func (ps *Policies) Version() uint16 {
 	return uint16(atomic.LoadUint32(&ps.version))
 }

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -37,6 +37,7 @@ type Policies struct {
 	filterEnabledPoliciesMap map[*Policy]int           // stores only enabled policies
 
 	// computed values
+	evtsStates                *eventsStates
 	filterUserlandPoliciesMap map[*Policy]int // stores a reduced map with only userland filterable policies
 	uidFilterMin              uint64
 	uidFilterMax              uint64
@@ -56,6 +57,7 @@ func NewPolicies(cfg config.PoliciesConfig) *Policies {
 		bpfInnerMaps:              map[string]*bpf.BPFMapLow{},
 		policiesArray:             [PolicyMax]*Policy{},
 		filterEnabledPoliciesMap:  map[*Policy]int{},
+		evtsStates:                newEventsStates(),
 		filterUserlandPoliciesMap: map[*Policy]int{},
 		uidFilterMin:              filters.MinNotSetUInt,
 		uidFilterMax:              filters.MaxNotSetUInt,
@@ -66,6 +68,19 @@ func NewPolicies(cfg config.PoliciesConfig) *Policies {
 		filterableInUserland:      PolicyNone,
 		containerFiltersEnabled:   PolicyNone,
 	}
+}
+
+// eventsStates returns the events states of Policies.
+func (ps *Policies) eventsStates() *eventsStates {
+	return ps.evtsStates
+}
+
+// EventsStates returns the events states of Policies.
+func (ps *Policies) EventsStates() EventsStates {
+	ps.rwmu.RLock()
+	defer ps.rwmu.RUnlock()
+
+	return ps.eventsStates()
 }
 
 func (ps *Policies) Count() int {

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -27,6 +27,7 @@ var AlwaysSubmit = events.EventState{
 type Policies struct {
 	rwmu sync.RWMutex
 
+	config                   config.PoliciesConfig
 	version                  uint32                    // updated on snapshot store
 	bpfInnerMaps             map[string]*bpf.BPFMapLow // BPF inner maps
 	policiesArray            [MaxPolicies]*Policy      // underlying filter policies array
@@ -44,9 +45,10 @@ type Policies struct {
 	containerFiltersEnabled   uint64 // bitmap of policies that have at least one container filter type enabled
 }
 
-func NewPolicies() *Policies {
+func NewPolicies(cfg config.PoliciesConfig) *Policies {
 	return &Policies{
 		rwmu:                      sync.RWMutex{},
+		config:                    cfg,
 		version:                   0,
 		bpfInnerMaps:              map[string]*bpf.BPFMapLow{},
 		policiesArray:             [MaxPolicies]*Policy{},
@@ -283,7 +285,7 @@ func (ps *Policies) Clone() utils.Cloner {
 		return nil
 	}
 
-	nPols := NewPolicies()
+	nPols := NewPolicies(ps.config)
 
 	// Deep copy of all policies
 	ps.rwmu.RLock()

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -114,10 +114,16 @@ func (ps *Policies) Version() uint16 {
 	return uint16(atomic.LoadUint32(&ps.version))
 }
 
-// ContainerFilterEnabled returns a bitmap of policies that have at least
-// one container filter type enabled.
-func (ps *Policies) ContainerFilterEnabled() uint64 {
+// WithContainerFilterEnabled returns a bitmap of policies representing the
+// container filter types enabled.
+func (ps *Policies) WithContainerFilterEnabled() uint64 {
 	return atomic.LoadUint64(&ps.containerFiltersEnabled)
+}
+
+// ContainerFilterEnabled returns true if at least one policy has a
+// container filter type enabled.
+func (ps *Policies) ContainerFilterEnabled() bool {
+	return ps.WithContainerFilterEnabled() > 0
 }
 
 // FilterableInUserland returns a bitmap of policies that must be filtered in userland

--- a/pkg/policy/policies_compute.go
+++ b/pkg/policy/policies_compute.go
@@ -1,0 +1,142 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// compute recalculates values, updates flags, fills the reduced userland map,
+// and sets the related bitmap that is used to prevent the iteration of the entire map.
+// It also computes the events states.
+//
+// It must be called at initialization and at every runtime policies changes.
+func (ps *Policies) compute() {
+	ps.calculateGlobalMinMax()
+	ps.updateContainerFilterEnabled()
+	ps.updateFilterableInUserland()
+	ps.computeEventsStates()
+}
+
+// calculateGlobalMinMax sets the global min and max, to be checked in kernel,
+// of the Minimum and Maximum enabled filters only if context filter types
+// (e.g. UIDFilter) from all policies have both Minimum and Maximum values set.
+//
+// Policies userland filter flags are also set (e.g. uidFilterableInUserland).
+//
+// The context filter types relevant for this function are just UIDFilter and
+// PIDFilter.
+func (ps *Policies) calculateGlobalMinMax() {
+	var (
+		uidMinFilterCount int
+		uidMaxFilterCount int
+		uidFilterCount    int
+		pidMinFilterCount int
+		pidMaxFilterCount int
+		pidFilterCount    int
+		policyCount       int
+
+		uidMinFilterableInUserland bool
+		uidMaxFilterableInUserland bool
+		pidMinFilterableInUserland bool
+		pidMaxFilterableInUserland bool
+	)
+
+	for p := range ps.Map() {
+		policyCount++
+
+		if p.UIDFilter.Enabled() {
+			uidFilterCount++
+
+			if p.UIDFilter.Minimum() != filters.MinNotSetUInt {
+				uidMinFilterCount++
+			}
+			if p.UIDFilter.Maximum() != filters.MaxNotSetUInt {
+				uidMaxFilterCount++
+			}
+		}
+		if p.PIDFilter.Enabled() {
+			pidFilterCount++
+
+			if p.PIDFilter.Minimum() != filters.MinNotSetUInt {
+				pidMinFilterCount++
+			}
+			if p.PIDFilter.Maximum() != filters.MaxNotSetUInt {
+				pidMaxFilterCount++
+			}
+		}
+	}
+
+	uidMinFilterableInUserland = policyCount > 1 && (uidMinFilterCount != uidFilterCount)
+	uidMaxFilterableInUserland = policyCount > 1 && (uidMaxFilterCount != uidFilterCount)
+	pidMinFilterableInUserland = policyCount > 1 && (pidMinFilterCount != pidFilterCount)
+	pidMaxFilterableInUserland = policyCount > 1 && (pidMaxFilterCount != pidFilterCount)
+
+	// reset global min max
+	ps.uidFilterMax = filters.MaxNotSetUInt
+	ps.uidFilterMin = filters.MinNotSetUInt
+	ps.pidFilterMax = filters.MaxNotSetUInt
+	ps.pidFilterMin = filters.MinNotSetUInt
+
+	ps.uidFilterableInUserland = uidMinFilterableInUserland || uidMaxFilterableInUserland
+	ps.pidFilterableInUserland = pidMinFilterableInUserland || pidMaxFilterableInUserland
+
+	if ps.uidFilterableInUserland && ps.pidFilterableInUserland {
+		// there's no need to iterate filter policies again since
+		// all uint events will be submitted from ebpf with no regards
+
+		return
+	}
+
+	// set a reduced range of uint values to be filtered in ebpf
+	for p := range ps.filterEnabledPoliciesMap {
+		if p.UIDFilter.Enabled() {
+			if !uidMinFilterableInUserland {
+				ps.uidFilterMin = utils.Min(ps.uidFilterMin, p.UIDFilter.Minimum())
+			}
+			if !uidMaxFilterableInUserland {
+				ps.uidFilterMax = utils.Max(ps.uidFilterMax, p.UIDFilter.Maximum())
+			}
+		}
+		if p.PIDFilter.Enabled() {
+			if !pidMinFilterableInUserland {
+				ps.pidFilterMin = utils.Min(ps.pidFilterMin, p.PIDFilter.Minimum())
+			}
+			if !pidMaxFilterableInUserland {
+				ps.pidFilterMax = utils.Max(ps.pidFilterMax, p.PIDFilter.Maximum())
+			}
+		}
+	}
+}
+
+// updateContainerFilterEnabled sets the containerFiltersEnabled bitmap.
+func (ps *Policies) updateContainerFilterEnabled() {
+	ps.containerFiltersEnabled = 0
+
+	for p := range ps.filterEnabledPoliciesMap {
+		if p.ContainerFilterEnabled() {
+			utils.SetBit(&ps.containerFiltersEnabled, uint(p.ID))
+		}
+	}
+}
+
+// updateFilterableInUserland sets the filterableInUserland bitmap and the
+// filterUserlandPoliciesMap.
+func (ps *Policies) updateFilterableInUserland() {
+	ps.filterableInUserland = 0
+
+	userlandMap := make(map[*Policy]int)
+	for p := range ps.filterEnabledPoliciesMap {
+		if p.ArgFilter.Enabled() ||
+			p.RetFilter.Enabled() ||
+			p.ContextFilter.Enabled() ||
+			(p.UIDFilter.Enabled() && ps.uidFilterableInUserland) ||
+			(p.PIDFilter.Enabled() && ps.pidFilterableInUserland) {
+			// add policy and set the related bit
+			userlandMap[p] = p.ID
+			utils.SetBit(&ps.filterableInUserland, uint(p.ID))
+		}
+	}
+
+	// replace the map
+	ps.filterUserlandPoliciesMap = userlandMap
+}

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -5,12 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/config"
 )
 
 func TestPoliciesClone(t *testing.T) {
 	t.Parallel()
 
-	policies := NewPolicies()
+	policiesCfg := config.NewPoliciesConfig(
+		config.Config{
+			Capture: &config.CaptureConfig{},
+		},
+	)
+
+	policies := NewPolicies(policiesCfg)
 
 	p1 := NewPolicy()
 	err := p1.PIDFilter.Parse("=1")

--- a/pkg/policy/probes.go
+++ b/pkg/policy/probes.go
@@ -1,0 +1,61 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/cgroup"
+	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+// AttachProbes attaches selected events probes to their respective eBPF progs
+func (ps *Policies) AttachProbes(probeGroup *probes.ProbeGroup, cgroups *cgroup.Cgroups) error {
+	var err error
+
+	// TODO: On Snapshot pruning, we should check which probes are not used for
+	// any snapshot and detach them.
+
+	// Get probe dependencies for a given event ID
+	getProbeDeps := func(id events.ID) []events.Probe {
+		return events.Core.GetDefinitionByID(id).GetDependencies().GetProbes()
+	}
+
+	ps.rwmu.Lock()
+	defer ps.rwmu.Unlock()
+
+	// Get the list of probes to attach for each event being traced.
+	probesToEvents := make(map[events.Probe][]events.ID)
+	for id := range ps.eventsStates().getAll() {
+		if !events.Core.IsDefined(id) {
+			continue
+		}
+		for _, probeDep := range getProbeDeps(id) {
+			probesToEvents[probeDep] = append(probesToEvents[probeDep], id)
+		}
+	}
+
+	// Attach probes to their respective eBPF programs or cancel events if a required probe is missing.
+	for probe, evtsIDs := range probesToEvents {
+		err = probeGroup.Attach(probe.GetHandle(), cgroups) // attach bpf program to probe
+		if err != nil {
+			for _, evtID := range evtsIDs {
+				evtName := events.Core.GetDefinitionByID(evtID).GetName()
+				if probe.IsRequired() {
+					logger.Warnw(
+						"Cancelling event and its dependencies because of missing probe",
+						"missing probe", probe.GetHandle(), "event", evtName,
+						"error", err,
+					)
+					ps.eventsStates().cancelEventAndAllDeps(evtID)
+				} else {
+					logger.Debugw(
+						"Failed to attach non-required probe for event",
+						"event", evtName,
+						"probe", probe.GetHandle(), "error", err,
+					)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/policy/snapshots.go
+++ b/pkg/policy/snapshots.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	maxSnapshots = MaxPolicies
+	maxSnapshots = PolicyMax
 )
 
 // snapshot is a snapshot of the Policies at a given version.

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -68,7 +68,13 @@ func (b *eventBuffer) getCopy() []trace.Event {
 }
 
 // load tracee into memory with args
-func startTracee(ctx context.Context, t *testing.T, cfg config.Config, output *config.OutputConfig, capture *config.CaptureConfig) (*tracee.Tracee, error) {
+func startTracee(
+	ctx context.Context,
+	t *testing.T,
+	cfg config.Config,
+	output *config.OutputConfig,
+	capture *config.CaptureConfig,
+) (*tracee.Tracee, error) {
 	initialize.SetLibbpfgoCallbacks()
 
 	kernelConfig, err := initialize.KernelConfig()


### PR DESCRIPTION
Close: #3849 

### 1. Explain what the PR does

d068d9b4a **chore: add TODOs**
56dcdc830 **chore: remove unused functions**
362969c9e **chore: refactor policies computation**
203ad455d **chore: minor renaming**
860924de7 **chore: move attachProbes to policy package**
600351a98 **chore: relocate validateKallsymsDependencies**
ffb652039 **chore: move UpdateCapabilitiesRings to policy pkg**
189712956 **chore: add EventState and EventsStates interfaces**
7f1405d9c **chore: introduces ksymbols.go with singleton**
f816b9215 **chore: rename consts**
4ffcd9da1 **chore: introduce events.Properties type**
f79fe97ba **chore: introduce config.PoliciesConfig**


d068d9b4a **chore: add TODOs**

```
As this is a transitionary effort, we need to keep track of what needs
to be done.
```

600351a98 **chore: relocate validateKallsymsDependencies**

```
Move it into policy package.
```

189712956 **chore: add EventState and EventsStates interfaces**

```
- Moves all EventState management into policy package, introducing
  policy.EventState and policy.EventStates interfaces.
- Changes DefinitionGroup.GetTailCalls() signature to deal only
  with subimittable events. This avoids circular import.
- Removes Config.Policies, forcing to get policies from Snapshot and
  inject it when required.
```

f816b9215 **chore: rename consts**

```
- Rename:
  MaxPolicies to PolicyMax
  AllPoliciesOn to PolicyAll
  AlwaysSubmit to submitAllPolicies

- Create PolicyNone const
```

4ffcd9da1 **chore: introduce events.Properties type**

```
Properties holds the static properties of an event wich are not
hardcoded in the event definition and have to be computed at runtime.

This also introduces a new file `dependencies.go` in the `events` package
with the helper:

`func GetAllEventsDependencies(givenEvtId ID) map[ID]struct{}`
```

f79fe97ba **chore: introduce config.PoliciesConfig**

```
PoliciesConfig is a new struct that holds the configuration used on
the Policies computation.

This also optimises cmd.GetContainerMode() and starts to decouple
Policies from the config.Config.
```

### 2. Explain how to test it

### 3. Other comments

This is a transitionary PR focused in bring the `EventState` and `EventStates` read-only interfaces - used by Policies internals. It also introduces `events.Properties` type as a holder for non hardcoded information about events.