### PR TITLE
Set exec-hash default option

### DIFF
--- a/docs/docs/flags/output.1.md
+++ b/docs/docs/flags/output.1.md
@@ -2,7 +2,7 @@
 title: TRACEE-OUTPUT
 section: 1
 header: Tracee Output Flag Manual
-date: 2023/10
+date: 2024/02
 ...
 
 ## NAME
@@ -11,7 +11,7 @@ tracee **\-\-output** - Control how and where output is printed
 
 ## SYNOPSIS
 
-tracee **\-\-output** <format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash={inode,dev-inode,digest-inode},parse-arguments,parse-arguments-fds,sort-events} ...
+tracee **\-\-output** <format[:file,...]\> | gotemplate=template[:file,...] | forward:url | webhook:url | option:{stack-addresses,exec-env,relative-time,exec-hash[={inode,dev-inode,digest-inode}],parse-arguments,parse-arguments-fds,sort-events} ...
 
 
 ## DESCRIPTION
@@ -49,8 +49,8 @@ Other options:
   - **relative-time**: Use relative timestamp instead of wall timestamp for events.
   - **exec-hash**: When tracing some file related events, show the file hash (sha256).
     - Affected events: *sched_process_exec*, *shared_object_loaded*
-    - **inode** option recalculates the file hash if the inode's creation time (ctime) differs, which can occur in different namespaces even for identical inode. This option is performant, but not recommended and should only be used if container enrichment can't be enabled for digest-inode, and if performance is preffered over correctness.
-    - **dev-inode** option generally offers better performance compared to the **inode** option, as it bypasses the need for recalculation by associating the creation time (ctime) with the device (dev) and inode pair. It's recommended if correctness is preffered over performance without container enrichment.
+    - **inode** option recalculates the file hash if the inode's creation time (ctime) differs, which can occur in different namespaces even for identical inode. This option is performant, but not recommended and should only be used if container enrichment can't be enabled for digest-inode, and if performance is preferred over correctness.
+    - **dev-inode** (default) option generally offers better performance compared to the **inode** option, as it bypasses the need for recalculation by associating the creation time (ctime) with the device (dev) and inode pair. It's recommended if correctness is preferred over performance without container enrichment.
     - **digest-inode**" option is the most efficient, as it keys the hash to a pair consisting of the container image digest and inode. This approach, however, necessitates container enrichment.
   - **parse-arguments**: Do not show raw machine-readable values for event arguments. Instead, parse them into human-readable strings.
   - **parse-arguments-fds**: Enable parse-arguments and enrich file descriptors (fds) with their file path translation. This can cause pipeline slowdowns.

--- a/docs/man/output.1
+++ b/docs/man/output.1
@@ -14,7 +14,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "TRACEE-OUTPUT" "1" "2023/10" "" "Tracee Output Flag Manual"
+.TH "TRACEE-OUTPUT" "1" "2024/02" "" "Tracee Output Flag Manual"
 .hy
 .SS NAME
 .PP
@@ -24,7 +24,7 @@ tracee \f[B]--output\f[R] - Control how and where output is printed
 tracee \f[B]--output\f[R] <format[:file,\&...]> |
 gotemplate=template[:file,\&...]
 | forward:url | webhook:url |
-option:{stack-addresses,exec-env,relative-time,exec-hash={inode,dev-inode,digest-inode},parse-arguments,parse-arguments-fds,sort-events}
+option:{stack-addresses,exec-env,relative-time,exec-hash[={inode,dev-inode,digest-inode}],parse-arguments,parse-arguments-fds,sort-events}
 \&...
 .SS DESCRIPTION
 .PP
@@ -95,15 +95,17 @@ Affected events: \f[I]sched_process_exec\f[R],
 .IP \[bu] 2
 \f[B]inode\f[R] option recalculates the file hash if the inode\[cq]s
 creation time (ctime) differs, which can occur in different namespaces
-even for identical inodes. This option is performant, but not recommended
-and should only be used if container enrichment can't be enabled for digest-inode,
-and if performance is preffered over correctness.
+even for identical inode.
+This option is performant, but not recommended and should only be used
+if container enrichment can\[cq]t be enabled for digest-inode, and if
+performance is preferred over correctness.
 .IP \[bu] 2
-\f[B]dev-inode\f[R] option generally offers better performance compared
-to the \f[B]inode\f[R] option, as it bypasses the need for
+\f[B]dev-inode\f[R] (default) option generally offers better performance
+compared to the \f[B]inode\f[R] option, as it bypasses the need for
 recalculation by associating the creation time (ctime) with the device
-(dev) and inode pair. It's recommended if correctness is preffered over
-performance without container enrichment enabled.
+(dev) and inode pair.
+It\[cq]s recommended if correctness is preferred over performance
+without container enrichment.
 .IP \[bu] 2
 \f[B]digest-inode\f[R]\[rq] option is the most efficient, as it keys the
 hash to a pair consisting of the container image digest and inode.

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -111,10 +111,15 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 	case "sort-events":
 		cfg.EventsSorting = true
 	default:
-		if strings.HasPrefix(option, "exec-hash=") {
+		if strings.HasPrefix(option, "exec-hash") {
 			hashExecParts := strings.Split(option, "=")
-
-			if len(hashExecParts) == 2 {
+			if len(hashExecParts) == 1 {
+				if option != "exec-hash" {
+					goto invalidOption
+				}
+				// default
+				cfg.CalcHashes = config.CalcHashesDevInode
+			} else if len(hashExecParts) == 2 {
 				hashExecOpt := hashExecParts[1]
 				switch hashExecOpt {
 				case "none":
@@ -128,6 +133,8 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 				default:
 					goto invalidOption
 				}
+			} else {
+				goto invalidOption
 			}
 
 			return nil

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -325,6 +325,19 @@ func TestPrepareOutput(t *testing.T) {
 			},
 		},
 		{
+			testName:    "option exec-hash",
+			outputSlice: []string{"option:exec-hash"},
+			expectedOutput: PrepareOutputResult{
+				PrinterConfigs: []config.PrinterConfig{
+					{Kind: "table", OutPath: "stdout"},
+				},
+				TraceeConfig: &config.OutputConfig{
+					CalcHashes:     config.CalcHashesDevInode,
+					ParseArguments: true,
+				},
+			},
+		},
+		{
 			testName:    "option exec-hash=inode",
 			outputSlice: []string{"option:exec-hash=inode"},
 			expectedOutput: PrepareOutputResult{
@@ -341,6 +354,11 @@ func TestPrepareOutput(t *testing.T) {
 			testName:      "option exec-hash invalid",
 			outputSlice:   []string{"option:exec-hash=notvalid"},
 			expectedError: errors.New("invalid output option: exec-hash=notvalid, use '--output help' for more info"),
+		},
+		{
+			testName:      "option exec-hash invalid",
+			outputSlice:   []string{"option:exec-hasha"},
+			expectedError: errors.New("invalid output option: exec-hasha, use '--output help' for more info"),
 		},
 		{
 			testName:    "option parse-arguments",

--- a/pkg/filehash/cache.go
+++ b/pkg/filehash/cache.go
@@ -35,7 +35,7 @@ type Cache struct {
 //   - inode: recalculates the file hash if the inode's creation time (ctime) differs. The option is performant, but not necessarily correct.
 //   - dev-inode: generally offers better performance compared to the inode option, as it bypasses the need
 //     for recalculation by associating the creation time (ctime) with the device (dev) and inode pair. It's recommended if correctnes
-//     is preffered over performance without container enrichment.
+//     is preferred over performance without container enrichment.
 //   - digest-inode: is the most efficient, as it keys the hash to a pair consisting of the container image digest and inode.
 //     This approach, however, necessitates container enrichment.
 func NewCache(mode config.CalcHashesOption, resolver pathResolver) (*Cache, error) {


### PR DESCRIPTION
Close: #3817 

### 1. Explain what the PR does

354c152ff **fix: typo**
e481dbba9 **fix(flags): rollback exechash cli api**


e481dbba9 **fix(flags): rollback exechash cli api**

```
exechash can be set again as 'option:exec-hash' which will set it now as
'dev-inode' as default.
```

### 2. Explain how to test it


### 3. Other comments

