### PR TITLE
GitHub actions chore

### DIFF
--- a/.github/workflows/debug-shell.yaml
+++ b/.github/workflows/debug-shell.yaml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -93,7 +93,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -107,7 +107,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -135,7 +135,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -191,7 +191,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -205,7 +205,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -219,7 +219,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -233,7 +233,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -247,7 +247,7 @@ jobs:
     timeout-minutes: 50400
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -260,7 +260,7 @@ jobs:
       ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"
@@ -273,7 +273,7 @@ jobs:
       ]
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Executing Debug Shell"

--- a/.github/workflows/mkdocs-dev.yaml
+++ b/.github/workflows/mkdocs-dev.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/mkdocs-latest.yaml
+++ b/.github/workflows/mkdocs-latest.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if flags flags man/markdown docs were changed
         id: changed-files
         uses: tj-actions/changed-files@v41.0.0
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
@@ -162,7 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies
@@ -336,7 +336,7 @@ jobs:
         GOROOT: "/usr/local/go"
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: "Prepare Image (Fix AMIs)"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -312,7 +312,7 @@ jobs:
                   output+="{\"job_name\": \"$job\", \"arch\": \"$arch\", \"ami\": \"$ami\", \"sufix\": \"$num\"}"
               done
             output+="]"
-            echo "::set-output name=matrix$num::$output"
+            echo "matrix$num=$output" >> $GITHUB_OUTPUT
             echo "matrix$num=$output"
           done
         shell: bash

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -63,7 +63,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -105,7 +105,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           submodules: true
@@ -63,7 +63,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           submodules: true
@@ -104,7 +104,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           submodules: true

--- a/.github/workflows/test-daily.yaml
+++ b/.github/workflows/test-daily.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install Dependencies


### PR DESCRIPTION
### 1. Explain what the PR does

e871343ee3a6d5d8b1e6a607c3155b9a558d66c0 chore(ci): remove deprecating set-output
    
    set-output is deprecated and will be removed in the future.
    
    More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

ef9514377bec843f89a544cf0005e309158885df chore(ci): bump checkout action to v4
    
    Due to the transition from Node 16 to Node 20, the checkout action
    needs to be updated to v4.
    
    More info: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

### 2. Explain how to test it


### 3. Other comments

