### PR TITLE
chore: add run-tracee.sh script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,12 @@ To learn more about Tracee, check out the [documentation](https://aquasecurity.g
 To quickly try Tracee use one of the following snippets. For a more complete installation guide, check out the [Installation section][installation].  
 Tracee should run on most common Linux distributions and kernels. For compatibility information see the [Prerequisites][prereqs] page.  Mac users, please read [this FAQ][macfaq].
 
+### Using script to run Tracee Docker image
+
+```shell
+bash <(wget -qO- http://tinyurl.com/tracee-docker)
+```
+
 ### Using Docker
 
 ```shell

--- a/run-tracee.sh
+++ b/run-tracee.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# run tracee in a container with or without additional arguments
+
+docker run --name tracee -it --rm \
+  --pid=host --cgroupns=host --privileged \
+  -v /etc/os-release:/etc/os-release-host:ro \
+  -v /var/run:/var/run:ro \
+  aquasec/tracee:latest "$@"


### PR DESCRIPTION
### 1. Explain what the PR does

This script is used to run tracee easily. It is a wrapper around the docker run command.

### 2. Explain how to test it

### 3. Other comments
