### PR TITLE
helm: remove old webhook config

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -35,10 +35,6 @@ spec:
           args:
             - --config
             - /tracee/config.yaml
-          {{- if .Values.webhook }}
-            - --output
-            - webhook:{{ .Values.webhook }}
-          {{- end }}
           env:
             - name: LIBBPFGO_OSRELEASE_FILE
               value: /etc/os-release-host

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -54,8 +54,6 @@ tolerations:
 
 affinity: {}
 
-webhook: ""
-
 # extraWebhookTemplates is a list of additional webhook templates that can be used by
 # the configFile or config.output.webhook fields
 # in the example below, the goTemplate content will be mounted as /tracee/templates/template1.tmpl


### PR DESCRIPTION
Remove old way of configuring webhook. One should now use the configfile -> https://github.com/aquasecurity/tracee/pull/3832