### PR TITLE
helm: config go template only if passed

### DIFF
--- a/deploy/helm/tracee/templates/tracee-config.yaml
+++ b/deploy/helm/tracee/templates/tracee-config.yaml
@@ -46,7 +46,9 @@ data:
                 host: {{ .host | default "localhost" }}
                 port: {{ .port | default "8080" }}
                 timeout: {{ .timeout | default "3s" }}
+                {{- if .goTemplate }}
                 gotemplate: {{ .goTemplate }}
+                {{- end }}
                 content-type: {{ .contentType | default "application/json" }}
         {{- end }}
     {{- if .Values.config.blobPerfBufferSize }}


### PR DESCRIPTION
if we pass an empty go template it breaks the config file, as it doesn't have a default we only configure it if we pass a template