### PR TITLE
fix(derive): keep symbols_collision state between events

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -610,6 +610,7 @@ func (t *Tracee) initDerivationTable() error {
 	shouldSubmit := func(id events.ID) func() bool {
 		return func() bool { return t.eventsState[id].Submit > 0 }
 	}
+	symbolsCollisions := derive.SymbolsCollision(t.contSymbolsLoader, t.config.Policies)
 
 	t.eventDerivations = derive.Table{
 		events.CgroupMkdir: {
@@ -651,20 +652,14 @@ func (t *Tracee) initDerivationTable() error {
 				),
 			},
 			events.SymbolsCollision: {
-				Enabled: shouldSubmit(events.SymbolsCollision),
-				DeriveFunction: derive.SymbolsCollision(
-					t.contSymbolsLoader,
-					t.config.Policies,
-				),
+				Enabled:        shouldSubmit(events.SymbolsCollision),
+				DeriveFunction: symbolsCollisions,
 			},
 		},
 		events.SchedProcessExec: {
 			events.SymbolsCollision: {
-				Enabled: shouldSubmit(events.SymbolsCollision),
-				DeriveFunction: derive.SymbolsCollision(
-					t.contSymbolsLoader,
-					t.config.Policies,
-				),
+				Enabled:        shouldSubmit(events.SymbolsCollision),
+				DeriveFunction: symbolsCollisions,
 			},
 		},
 		events.SecuritySocketConnect: {


### PR DESCRIPTION
### 1. Explain what the PR does

`symbols_collisions` event use two events to operate. Fix the issue of initializing an object for each event, resulting broken event.
Fix #3882

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
