### PR TITLE
Move `AttachProbes` call out of initBPF

### DIFF
--- a/pkg/cmd/cobra/helper.go
+++ b/pkg/cmd/cobra/helper.go
@@ -2,21 +2,22 @@ package cobra
 
 import (
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
+	"github.com/aquasecurity/tracee/pkg/config"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
 )
 
-func createPoliciesFromK8SPolicy(policies []k8s.PolicyInterface) (*policy.Policies, error) {
+func createPoliciesFromK8SPolicy(cfg config.PoliciesConfig, policies []k8s.PolicyInterface) (*policy.Policies, error) {
 	policyScopeMap, policyEventsMap, err := flags.PrepareFilterMapsFromPolicies(policies)
 	if err != nil {
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(cfg, policyScopeMap, policyEventsMap, true)
 }
 
-func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, error) {
+func createPoliciesFromPolicyFiles(cfg config.PoliciesConfig, policyFlags []string) (*policy.Policies, error) {
 	policyFiles, err := v1beta1.PoliciesFromPaths(policyFlags)
 	if err != nil {
 		return nil, err
@@ -27,10 +28,10 @@ func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, erro
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(cfg, policyScopeMap, policyEventsMap, true)
 }
 
-func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Policies, error) {
+func createPoliciesFromCLIFlags(cfg config.PoliciesConfig, scopeFlags, eventFlags []string) (*policy.Policies, error) {
 	policyScopeMap, err := flags.PrepareScopeMapFromFlags(scopeFlags)
 	if err != nil {
 		return nil, err
@@ -41,5 +42,5 @@ func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Polici
 		return nil, err
 	}
 
-	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
+	return flags.CreatePolicies(cfg, policyScopeMap, policyEventsMap, true)
 }

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
@@ -21,8 +22,8 @@ func PrepareFilterMapsFromPolicies(policies []k8s.PolicyInterface) (PolicyScopeM
 		return nil, nil, errfmt.Errorf("no policies provided")
 	}
 
-	if len(policies) > policy.MaxPolicies {
-		return nil, nil, errfmt.Errorf("too many policies provided, there is a limit of %d policies", policy.MaxPolicies)
+	if len(policies) > policy.PolicyMax {
+		return nil, nil, errfmt.Errorf("too many policies provided, there is a limit of %d policies", policy.PolicyMax)
 	}
 
 	policyNames := make(map[string]bool)
@@ -101,7 +102,7 @@ func PrepareFilterMapsFromPolicies(policies []k8s.PolicyInterface) (PolicyScopeM
 }
 
 // CreatePolicies creates a Policies object from the scope and events maps.
-func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMap, newBinary bool) (*policy.Policies, error) {
+func CreatePolicies(cfg config.PoliciesConfig, policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMap, newBinary bool) (*policy.Policies, error) {
 	eventsNameToID := events.Core.NamesToIDs()
 	// remove internal events since they shouldn't be accessible by users
 	for event, id := range eventsNameToID {
@@ -110,7 +111,7 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 		}
 	}
 
-	policies := policy.NewPolicies()
+	policies := policy.NewPolicies(cfg)
 	for policyIdx, policyScopeFilters := range policyScopeMap {
 		p := policy.NewPolicy()
 		p.ID = policyIdx

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
@@ -2076,7 +2077,11 @@ func TestCreatePolicies(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			_, err = CreatePolicies(policyScopeMap, policyEventsMap, false)
+			policiesCfg := config.NewPoliciesConfig(config.Config{
+				Capture: &config.CaptureConfig{},
+			})
+
+			_, err = CreatePolicies(policiesCfg, policyScopeMap, policyEventsMap, false)
 			if tc.expectPolicyErr != nil {
 				assert.ErrorContains(t, err, tc.expectPolicyErr.Error())
 			} else {

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -120,23 +120,15 @@ func (r Runner) Run(ctx context.Context) error {
 	return err
 }
 
-func GetContainerMode(cfg config.Config) config.ContainerMode {
-	containerMode := config.ContainerModeDisabled
-
-	for p := range cfg.Policies.Map() {
-		if p.ContainerFilterEnabled() {
-			// Container Enrichment is enabled by default ...
-			containerMode = config.ContainerModeEnriched
-			if cfg.NoContainersEnrich {
-				// ... but might be disabled as a safeguard measure.
-				containerMode = config.ContainerModeEnabled
-			}
-
-			break
-		}
+func GetContainerMode(hasContainerFilterEnabled, noContainersEnrich bool) config.ContainerMode {
+	// Only enable container mode enricher if some container filter is enabled
+	// and the user did not explicitly disable its enricher.
+	if hasContainerFilterEnabled && !noContainersEnrich {
+		return config.ContainerModeEnriched
 	}
 
-	return containerMode
+	// Otherwise, return the disabled container mode.
+	return config.ContainerModeDisabled
 }
 
 const pidFileName = "tracee.pid"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,16 +8,13 @@ import (
 	"github.com/aquasecurity/tracee/pkg/containers/runtime"
 	"github.com/aquasecurity/tracee/pkg/dnscache"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
-	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
-	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/proctree"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
 )
 
 // Config is a struct containing user defined configuration of tracee
 type Config struct {
-	Policies           *policy.Policies
 	Capture            *CaptureConfig
 	Capabilities       *CapabilitiesConfig
 	Output             *OutputConfig
@@ -39,22 +36,6 @@ type Config struct {
 
 // Validate does static validation of the configuration
 func (c Config) Validate() error {
-	// Policies
-	for p := range c.Policies.Map() {
-		if p == nil {
-			return errfmt.Errorf("policy is nil")
-		}
-		if p.EventsToTrace == nil {
-			return errfmt.Errorf("policy [%d] has no events to trace", p.ID)
-		}
-
-		for e := range p.EventsToTrace {
-			if !events.Core.IsDefined(e) {
-				return errfmt.Errorf("invalid event [%d] to trace in policy [%d]", e, p.ID)
-			}
-		}
-	}
-
 	// Buffer sizes
 	if (c.PerfBufferSize & (c.PerfBufferSize - 1)) != 0 {
 		return errfmt.Errorf("invalid perf buffer size - must be a power of 2")
@@ -202,4 +183,32 @@ type PrinterConfig struct {
 	OutFile       io.WriteCloser
 	ContainerMode ContainerMode
 	RelativeTS    bool
+}
+
+// PoliciesConfig holds the Tracee configuration required by the Policies computation.
+type PoliciesConfig struct {
+	DNSCacheConfig   bool
+	ProcTreeSource   proctree.SourceType
+	CaptureExec      bool
+	CaptureFileWrite bool
+	CaptureFileRead  bool
+	CaptureModule    bool
+	CaptureMem       bool
+	CaptureBpf       bool
+	CaptureNet       PcapsConfig
+}
+
+// NewPoliciesConfig returns a new PoliciesConfig based on the given Tracee configuration.
+func NewPoliciesConfig(cfg Config) PoliciesConfig {
+	return PoliciesConfig{
+		DNSCacheConfig:   cfg.DNSCacheConfig.Enable,
+		ProcTreeSource:   cfg.ProcTree.Source,
+		CaptureExec:      cfg.Capture.Exec,
+		CaptureFileWrite: cfg.Capture.FileWrite.Capture,
+		CaptureFileRead:  cfg.Capture.FileRead.Capture,
+		CaptureModule:    cfg.Capture.Module,
+		CaptureMem:       cfg.Capture.Mem,
+		CaptureBpf:       cfg.Capture.Bpf,
+		CaptureNet:       cfg.Capture.Net,
+	}
 }

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -256,15 +256,23 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 			evt.ProcessEntityId = utils.HashTaskID(eCtx.HostPid, eCtx.LeaderStartTime)
 			evt.ParentEntityId = utils.HashTaskID(eCtx.HostPpid, eCtx.ParentStartTime)
 
+			policies, err := policy.Snapshots().Get(evt.PoliciesVersion)
+			if err != nil {
+				t.handleError(err)
+				t.eventsPool.Put(evt)
+				continue
+			}
+
 			// If there aren't any policies that need filtering in userland, tracee **may** skip
 			// this event, as long as there aren't any derivatives or signatures that depend on it.
 			// Some base events (derivative and signatures) might not have set related policy bit,
 			// thus the need to continue with those within the pipeline.
-			if t.matchPolicies(evt) == 0 {
+			if t.matchPolicies(policies, evt) == 0 {
+				// TODO: as isReqBySignature, eventDerivations must also be moved to policy package
 				_, hasDerivation := t.eventDerivations[eventId]
-				_, hasSignature := t.eventSignatures[eventId]
+				isReqBySignature := policies.EventsFlags().Get(events.ID(evt.EventID)).RequiredBySignature()
 
-				if !hasDerivation && !hasSignature {
+				if !hasDerivation && !isReqBySignature {
 					_ = t.stats.EventsFiltered.Increment()
 					t.eventsPool.Put(evt)
 					continue
@@ -286,15 +294,9 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 // not match the event after userland filters are applied. In those cases, the policy bit is cleared
 // (so the event is "filtered" for that policy). This may be called in different stages of the
 // pipeline (decode, derive, engine).
-func (t *Tracee) matchPolicies(event *trace.Event) uint64 {
+func (t *Tracee) matchPolicies(policies *policy.Policies, event *trace.Event) uint64 {
 	eventID := events.ID(event.EventID)
 	bitmap := event.MatchedPoliciesKernel
-
-	policies, err := policy.Snapshots().Get(event.PoliciesVersion)
-	if err != nil {
-		t.handleError(err)
-		return 0
-	}
 
 	// Short circuit if there are no policies in userland that need filtering.
 	if bitmap&policies.FilterableInUserland() == 0 {
@@ -464,7 +466,7 @@ func (t *Tracee) processEvents(ctx context.Context, in <-chan *trace.Event) (
 			}
 
 			// Get a bitmap with all policies containing container filters
-			policiesWithContainerFilter := policies.ContainerFilterEnabled()
+			policiesWithContainerFilter := policies.WithContainerFilterEnabled()
 
 			// Filter out events that don't have a container ID from all the policies that
 			// have container filters. This will guarantee that any of those policies
@@ -560,7 +562,13 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (
 					case events.PrintMemDump:
 					default:
 						// Derived events might need filtering as well
-						if t.matchPolicies(event) == 0 {
+						policies, err := policy.Snapshots().Get(event.PoliciesVersion)
+						if err != nil {
+							t.handleError(err)
+							continue
+						}
+
+						if t.matchPolicies(policies, event) == 0 {
 							_ = t.stats.EventsFiltered.Increment()
 							continue
 						}
@@ -602,17 +610,26 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 
 			// Only emit events requested by the user and matched by at least one policy.
 			id := events.ID(event.EventID)
-			event.MatchedPoliciesUser &= t.eventsState[id].Emit
-			if event.MatchedPoliciesUser == 0 {
-				t.eventsPool.Put(event)
-				continue
-			}
 
 			policies, err := policy.Snapshots().Get(event.PoliciesVersion)
 			if err != nil {
 				t.handleError(err)
 				continue
 			}
+
+			evtFlags, ok := policies.EventsFlags().GetOk(id)
+			if !ok {
+				t.handleError(errfmt.Errorf("failed to get event state for event %d", id))
+				t.eventsPool.Put(event)
+				continue
+			}
+
+			event.MatchedPoliciesUser &= evtFlags.GetEmit()
+			if event.MatchedPoliciesUser == 0 {
+				t.eventsPool.Put(event)
+				continue
+			}
+
 			// Populate the event with the names of the matched policies.
 			event.MatchedPolicies = policies.MatchedNames(event.MatchedPoliciesUser)
 

--- a/pkg/ebpf/hidden_kernel_module.go
+++ b/pkg/ebpf/hidden_kernel_module.go
@@ -4,7 +4,6 @@ import (
 	gocontext "context"
 	"time"
 
-	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/derive"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
@@ -32,10 +31,6 @@ const throttleSecs = 2 // Seconds
 func (t *Tracee) lkmSeekerRoutine(ctx gocontext.Context) {
 	logger.Debugw("Starting lkmSeekerRoutine goroutine")
 	defer logger.Debugw("Stopped lkmSeekerRoutine goroutine")
-
-	if t.eventsState[events.HiddenKernelModule].Emit == 0 {
-		return
-	}
 
 	modsMap, err := t.bpfModule.GetMap("modules_map")
 	if err != nil {

--- a/pkg/ebpf/hooked_syscall_table.go
+++ b/pkg/ebpf/hooked_syscall_table.go
@@ -25,10 +25,6 @@ func (t *Tracee) hookedSyscallTableRoutine(ctx gocontext.Context) {
 	logger.Debugw("Starting hookedSyscallTable goroutine")
 	defer logger.Debugw("Stopped hookedSyscallTable goroutine")
 
-	if t.eventsState[events.HookedSyscall].Submit == 0 {
-		return
-	}
-
 	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
 		logger.Debugw("hooked syscall table: unsupported architecture")
 		return

--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -15,7 +15,11 @@ import (
 var maxKsymNameLen = 64 // Most match the constant in the bpf code
 var globalSymbolOwner = "system"
 
-func (t *Tracee) UpdateKallsyms() error {
+// TODO: If it depends on events states, "ksymbols_map" could probably be versioned
+// and reside in the `policy` package.
+// Other change would be to make `UpdateKallsyms` receiving a list of symbols to load
+// instead of the events states.
+func (t *Tracee) UpdateKallsyms(evtsFlags events.EventsFlags) error {
 	// NOTE: Make sure to refresh the kernel symbols table before updating the eBPF map.
 
 	// Find the eBPF map.
@@ -29,12 +33,12 @@ func (t *Tracee) UpdateKallsyms() error {
 		return events.Core.GetDefinitionByID(id).GetDependencies().GetKSymbols()
 	}
 
-	// Get the symbols all events being traced require (t.eventsState already
+	// Get the symbols all events being traced require (evtsFlags already
 	// includes dependent events, no need to recurse again).
 
 	var allReqSymbols []string
 
-	for evtID := range t.eventsState {
+	for evtID := range evtsFlags.GetAll() {
 		for _, symDep := range evtDefSymDeps(evtID) {
 			allReqSymbols = append(allReqSymbols, symDep.GetSymbolName())
 		}

--- a/pkg/ebpf/policy_manager_test.go
+++ b/pkg/ebpf/policy_manager_test.go
@@ -83,7 +83,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableRule(i, e)
 			}
@@ -93,7 +93,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableRule(i, e)
 			}
@@ -103,12 +103,12 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.MaxPolicies; i++ {
+	for i := 0; i < policy.PolicyMax; i++ {
 		for _, e := range eventsToEnable {
-			assert.True(t, policyManager.IsRuleEnabled(policy.AllPoliciesOn, e))
+			assert.True(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
 		}
 		for _, e := range eventsToDisable {
-			assert.False(t, policyManager.IsRuleEnabled(policy.AllPoliciesOn, e))
+			assert.False(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
 		}
 	}
 }
@@ -182,7 +182,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableEvent(e)
 			}
@@ -192,7 +192,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.MaxPolicies; i++ {
+		for i := 0; i < policy.PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableEvent(e)
 			}
@@ -202,7 +202,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.MaxPolicies; i++ {
+	for i := 0; i < policy.PolicyMax; i++ {
 		for _, e := range eventsToEnable {
 			assert.True(t, policyManager.IsEventEnabled(e))
 		}

--- a/pkg/events/definition_group.go
+++ b/pkg/events/definition_group.go
@@ -8,13 +8,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
-// TODO: add states to the EventGroup struct (to keep states of events from that group)
-
-type EventState struct {
-	Submit uint64 // should be submitted to userspace (by policies bitmap)
-	Emit   uint64 // should be emitted to the user (by policies bitmap)
-}
-
 // ATTENTION: the definition group is instantiable (all the rest is immutable)
 
 type ByID []Definition
@@ -181,14 +174,14 @@ func (d *DefinitionGroup) IDs32ToIDs() map[ID]ID {
 }
 
 // GetTailCalls returns a list of tailcalls of all definitions in the group (for initialization).
-func (d *DefinitionGroup) GetTailCalls(state map[ID]EventState) []TailCall {
+func (d *DefinitionGroup) GetTailCalls(evtsFlags EventsFlags) []TailCall {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
 	var tailCalls []TailCall
 
 	for evtDefID, evtDef := range d.definitions {
-		if state[evtDefID].Submit > 0 { // only traced events to provide their tailcalls
+		if evtsFlags.Get(evtDefID).ShouldSubmit() { // only traced events to provide their tailcalls
 			tailCalls = append(tailCalls, evtDef.GetDependencies().GetTailCalls()...)
 		}
 	}

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/policy"
@@ -486,13 +487,18 @@ func TestSymbolsCollision(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			ps := policy.NewPolicies()
-			policy.Snapshots().Store(ps)
-			err := ps.Set(p)
+			policiesCfg := config.NewPoliciesConfig(
+				config.Config{
+					Capture: &config.CaptureConfig{},
+				},
+			)
+
+			policies := policy.NewPolicies(policiesCfg)
+			err := policies.Set(p)
 			require.NoError(t, err)
 
 			// Pick derive function from mocked tests
-			deriveFunc := SymbolsCollision(mockLoader, ps)
+			deriveFunc := SymbolsCollision(mockLoader, policies)
 
 			mockLoader.addSOSymbols(
 				testSOInstance{

--- a/pkg/events/eventflags.go
+++ b/pkg/events/eventflags.go
@@ -1,0 +1,35 @@
+package events
+
+// EventFlags defines an interface for accessing the flags of a single event in a read-only manner.
+type EventFlags interface {
+	// GetSubmit returns the submit flag of the event.
+	GetSubmit() uint64
+
+	// GetEmit returns the emit flag of the event.
+	GetEmit() uint64
+
+	// ShouldSubmit returns true if the event is marked to be submitted.
+	ShouldSubmit() bool
+
+	// ShouldEmit returns true if the event is marked to be emitted.
+	ShouldEmit() bool
+
+	// RequiredBySignature returns true if the event is required by a signature.
+	RequiredBySignature() bool
+}
+
+// EventsFlags defines an interface for accessing a collection of event flags in a read-only manner.
+// It allows for querying individual events or collections of events.
+type EventsFlags interface {
+	// Get returns the event flags of the given event ID.
+	Get(ID) EventFlags
+
+	// GetOk returns the event flags of the given event ID and a boolean indicating if the event ID exists.
+	GetOk(ID) (EventFlags, bool)
+
+	// GetAll returns a map of all event flags.
+	GetAll() map[ID]EventFlags
+
+	// GetAllCancelled returns a slice of all event IDs that are marked as cancelled.
+	GetAllCancelled() []ID
+}

--- a/pkg/policy/caps.go
+++ b/pkg/policy/caps.go
@@ -1,0 +1,36 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/capabilities"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/events"
+)
+
+// UpdateCapabilitiesRings updates the capabilities rings based on the policies events states.
+func (ps *Policies) UpdateCapabilitiesRings() error {
+	// NOTE: This only adds capabilities from events that are defined in the policies.
+	// TODO: On the Snapshot pruning, we should check which capabilities are not used
+	// for any snapshot and remove them from the capabilities rings.
+
+	caps := capabilities.GetInstance()
+
+	ps.rwmu.RLock()
+	defer ps.rwmu.RUnlock()
+
+	for id := range ps.eventsFlags().getAll() {
+		if !events.Core.IsDefined(id) {
+			return errfmt.Errorf("event %d is not defined", id)
+		}
+		evtCaps := events.Core.GetDefinitionByID(id).GetDependencies().GetCapabilities()
+		err := caps.BaseRingAdd(evtCaps.GetBase()...)
+		if err != nil {
+			return errfmt.WrapError(err)
+		}
+		err = caps.BaseRingAdd(evtCaps.GetEBPF()...)
+		if err != nil {
+			return errfmt.WrapError(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/pkg/utils/proc"
 )
 
@@ -83,209 +82,6 @@ var (
 		PoliciesConfigMap: PoliciesConfigVersion,
 	}
 )
-
-// equality mirrors the C struct equality (eq_t).
-// Check it for more info.
-type equality struct {
-	equalInPolicies       uint64
-	equalitySetInPolicies uint64
-}
-
-const (
-	// 8 bytes for equalInPolicies and 8 bytes for equalitySetInPolicies
-	equalityValueSize = 16
-)
-
-// filtersEqualities stores the equalities for each filter in the policies
-type filtersEqualities struct {
-	uidEqualities      map[uint64]equality
-	pidEqualities      map[uint64]equality
-	mntNSEqualities    map[uint64]equality
-	pidNSEqualities    map[uint64]equality
-	cgroupIdEqualities map[uint64]equality
-	utsEqualities      map[string]equality
-	commEqualities     map[string]equality
-	binaryEqualities   map[filters.NSBinary]equality
-}
-
-func (ps *Policies) computeProcTreeEqualities(eqs map[uint64]equality) {
-	for p := range ps.filterEnabledPoliciesMap {
-		policyID := uint(p.ID)
-
-		// ProcessTreeFilters equalities
-		procTreeEqualities := p.ProcessTreeFilter.Equalities()
-		for pid := range procTreeEqualities.NotEqual {
-			eq := eqs[uint64(pid)]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			eqs[uint64(pid)] = eq
-		}
-		for pid := range procTreeEqualities.Equal {
-			eq := eqs[uint64(pid)]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			eqs[uint64(pid)] = eq
-		}
-	}
-}
-
-// computeFilterEqualities computes the equalities for each filter in the policies
-// updating the provided filtersEqualities struct
-// TODO: refactor this method deduplicating code
-func (ps *Policies) computeFilterEqualities(fEqs *filtersEqualities, cts *containers.Containers) error {
-	for p := range ps.filterEnabledPoliciesMap {
-		policyID := uint(p.ID)
-
-		// UIDFilters equalities
-		uidEqualities := p.UIDFilter.Equalities()
-		for uid := range uidEqualities.NotEqual {
-			eq := fEqs.uidEqualities[uid]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.uidEqualities[uid] = eq
-		}
-		for uid := range uidEqualities.Equal {
-			eq := fEqs.uidEqualities[uid]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.uidEqualities[uid] = eq
-		}
-
-		// PIDFilters equalities
-		pidEqualities := p.PIDFilter.Equalities()
-		for pid := range pidEqualities.NotEqual {
-			eq := fEqs.pidEqualities[pid]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidEqualities[pid] = eq
-		}
-		for pid := range pidEqualities.Equal {
-			eq := fEqs.pidEqualities[pid]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidEqualities[pid] = eq
-		}
-
-		// MntNSFilters equalities
-		mntNSEqualities := p.MntNSFilter.Equalities()
-		for mntNS := range mntNSEqualities.NotEqual {
-			eq := fEqs.mntNSEqualities[mntNS]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.mntNSEqualities[mntNS] = eq
-		}
-		for mntNS := range mntNSEqualities.Equal {
-			eq := fEqs.mntNSEqualities[mntNS]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.mntNSEqualities[mntNS] = eq
-		}
-
-		// PidNSFilters equalities
-		pidNSEqualities := p.PidNSFilter.Equalities()
-		for pidNS := range pidNSEqualities.NotEqual {
-			eq := fEqs.pidNSEqualities[pidNS]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidNSEqualities[pidNS] = eq
-		}
-		for pidNS := range pidNSEqualities.Equal {
-			eq := fEqs.pidNSEqualities[pidNS]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidNSEqualities[pidNS] = eq
-		}
-
-		// ContIDFilters equalities
-		contIDEqualities := p.ContIDFilter.Equalities()
-		for contID := range contIDEqualities.NotEqual {
-			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
-			if err != nil {
-				return err
-			}
-
-			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
-		}
-		for contID := range contIDEqualities.Equal {
-			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
-			if err != nil {
-				return err
-			}
-
-			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
-		}
-
-		// UTSFilters equalities
-		utsEqualities := p.UTSFilter.Equalities()
-		for uts := range utsEqualities.NotEqual {
-			eq := fEqs.utsEqualities[uts]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.utsEqualities[uts] = eq
-		}
-		for uts := range utsEqualities.Equal {
-			eq := fEqs.utsEqualities[uts]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.utsEqualities[uts] = eq
-		}
-
-		// CommFilters equalities
-		commEqualities := p.CommFilter.Equalities()
-		for comm := range commEqualities.NotEqual {
-			eq := fEqs.commEqualities[comm]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.commEqualities[comm] = eq
-		}
-		for comm := range commEqualities.Equal {
-			eq := fEqs.commEqualities[comm]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.commEqualities[comm] = eq
-		}
-		// BinaryFilters equalities
-		binaryEqualities := p.BinaryFilter.Equalities()
-		for binaryNS := range binaryEqualities.NotEqual {
-			eq := fEqs.binaryEqualities[binaryNS]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.binaryEqualities[binaryNS] = eq
-		}
-		for binaryNS := range binaryEqualities.Equal {
-			eq := fEqs.binaryEqualities[binaryNS]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.binaryEqualities[binaryNS] = eq
-		}
-	}
-
-	return nil
-}
 
 // createNewInnerMap creates a new map for the given map name and version.
 func createNewInnerMap(m *bpf.Module, mapName string, mapVersion uint16) (*bpf.BPFMapLow, error) {
@@ -554,7 +350,7 @@ func (ps *Policies) populateStringFilterBPF(strEqualities map[string]equality, i
 }
 
 // populateProcTreeFilterBPF updates the BPF maps for the given process tree equalities.
-func (ps *Policies) populateProcTreeFilterBPF(procTreeEqualities map[uint64]equality, innerMapName string) error {
+func (ps *Policies) populateProcTreeFilterBPF(procTreeEqualities map[uint32]equality, innerMapName string) error {
 	// ProcessTree equality
 	// 1. process_tree_filter  u32, eq_t
 
@@ -581,7 +377,7 @@ func (ps *Policies) populateProcTreeFilterBPF(procTreeEqualities map[uint64]equa
 
 	// First, update BPF for provided pids equalities
 	for pid, eq := range procTreeEqualities {
-		if err := updateBPF(uint32(pid), eq); err != nil {
+		if err := updateBPF(pid, eq); err != nil {
 			return err
 		}
 	}
@@ -628,7 +424,7 @@ func (ps *Policies) populateProcTreeFilterBPF(procTreeEqualities map[uint64]equa
 			}
 
 			// if the parent pid is in the provided pids, update BPF with its child pid
-			if eq, ok := procTreeEqualities[uint64(ppid)]; ok {
+			if eq, ok := procTreeEqualities[uint32(ppid)]; ok {
 				_ = updateBPF(uint32(pid), eq)
 				return
 			}
@@ -745,7 +541,7 @@ func (ps *Policies) PopulateProcessTreeBPF() error {
 	defer ps.rwmu.Unlock()
 
 	// ProcessTreeFilters equalities
-	procTreeEqualities := make(map[uint64]equality)
+	procTreeEqualities := make(map[uint32]equality)
 	ps.computeProcTreeEqualities(procTreeEqualities)
 
 	// Update ProcessTree equalities filter map

--- a/pkg/policy/equality.go
+++ b/pkg/policy/equality.go
@@ -1,0 +1,172 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// equality mirrors the C struct equality (eq_t).
+// Check it for more info.
+type equality struct {
+	equalInPolicies       uint64
+	equalitySetInPolicies uint64
+}
+
+const (
+	// 8 bytes for equalInPolicies and 8 bytes for equalitySetInPolicies
+	equalityValueSize = 16
+)
+
+// filtersEqualities stores the equalities for each filter in the policies
+type filtersEqualities struct {
+	uidEqualities      map[uint64]equality
+	pidEqualities      map[uint64]equality
+	mntNSEqualities    map[uint64]equality
+	pidNSEqualities    map[uint64]equality
+	cgroupIdEqualities map[uint64]equality
+	utsEqualities      map[string]equality
+	commEqualities     map[string]equality
+	binaryEqualities   map[filters.NSBinary]equality
+}
+
+// equalityType represents the type of equality.
+type equalityType int
+
+const (
+	notEqual equalityType = iota
+	equal
+)
+
+// equalUpdater updates the equality with the given policyID.
+type equalityUpdater func(eq *equality, policyID uint)
+
+// notEqualUpdate updates the equality as not equal with the given policyID.
+func notEqualUpdate(eq *equality, policyID uint) {
+	// NotEqual == 0, so clear n bitmap bit
+	utils.ClearBit(&eq.equalInPolicies, policyID)
+	utils.SetBit(&eq.equalitySetInPolicies, policyID)
+}
+
+// equalUpdate updates the equality as equal with the given policyID.
+func equalUpdate(eq *equality, policyID uint) {
+	// Equal == 1, so set n bitmap bit
+	utils.SetBit(&eq.equalInPolicies, policyID)
+	utils.SetBit(&eq.equalitySetInPolicies, policyID)
+}
+
+// updateEqualities updates the equalities map with the given filter equalities
+// for the given equality type and policy ID.
+func updateEqualities[T comparable](
+	equalitiesMap map[T]equality,
+	filterEqualities map[T]struct{},
+	eqType equalityType,
+	policyID uint,
+) {
+	var update equalityUpdater
+
+	switch eqType {
+	case notEqual:
+		update = notEqualUpdate
+	case equal:
+		update = equalUpdate
+	default:
+		logger.Errorw("Invalid equality type", "type", eqType)
+		return
+	}
+
+	for k := range filterEqualities {
+		eq, ok := equalitiesMap[k]
+		if !ok {
+			eq = equality{} // initialize if not exists
+		}
+		update(&eq, policyID) // update the equality
+		equalitiesMap[k] = eq // update the map
+	}
+}
+
+// computeFilterEqualities computes the equalities for each filter type in the policies
+// updating the provided filtersEqualities struct.
+func (ps *Policies) computeFilterEqualities(
+	fEqs *filtersEqualities,
+	cts *containers.Containers,
+) error {
+	for p := range ps.filterEnabledPoliciesMap {
+		policyID := uint(p.ID)
+
+		// NOTE: Equal has precedence over NotEqual, so NotEqual must be updated first
+
+		// UIDFilters
+		uidEqualities := p.UIDFilter.Equalities()
+		updateEqualities(fEqs.uidEqualities, uidEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.uidEqualities, uidEqualities.Equal, equal, policyID)
+
+		// PIDFilters
+		pidEqualities := p.PIDFilter.Equalities()
+		updateEqualities(fEqs.pidEqualities, pidEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.pidEqualities, pidEqualities.Equal, equal, policyID)
+
+		// MntNSFilters
+		mntNSEqualities := p.MntNSFilter.Equalities()
+		updateEqualities(fEqs.mntNSEqualities, mntNSEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.mntNSEqualities, mntNSEqualities.Equal, equal, policyID)
+
+		// PidNSFilters
+		pidNSEqualities := p.PidNSFilter.Equalities()
+		updateEqualities(fEqs.pidNSEqualities, pidNSEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.pidNSEqualities, pidNSEqualities.Equal, equal, policyID)
+
+		// ContIDFilters
+		contIDEqualities := p.ContIDFilter.Equalities()
+		for contID := range contIDEqualities.NotEqual {
+			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
+			if err != nil {
+				return err
+			}
+
+			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
+			notEqualUpdate(&eq, policyID)
+			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
+		}
+		for contID := range contIDEqualities.Equal {
+			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
+			if err != nil {
+				return err
+			}
+
+			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
+			equalUpdate(&eq, policyID)
+			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
+		}
+
+		// UTSFilters
+		utsEqualities := p.UTSFilter.Equalities()
+		updateEqualities(fEqs.utsEqualities, utsEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.utsEqualities, utsEqualities.Equal, equal, policyID)
+
+		// CommFilters
+		commEqualities := p.CommFilter.Equalities()
+		updateEqualities(fEqs.commEqualities, commEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.commEqualities, commEqualities.Equal, equal, policyID)
+
+		// BinaryFilters
+		binaryEqualities := p.BinaryFilter.Equalities()
+		updateEqualities(fEqs.binaryEqualities, binaryEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.binaryEqualities, binaryEqualities.Equal, equal, policyID)
+	}
+
+	return nil
+}
+
+// computeProcTreeEqualities computes the equalities for the process tree filter
+// in the policies updating the provided eqs map.
+func (ps *Policies) computeProcTreeEqualities(eqs map[uint32]equality) {
+	for p := range ps.filterEnabledPoliciesMap {
+		policyID := uint(p.ID)
+
+		procTreeEqualities := p.ProcessTreeFilter.Equalities()
+		updateEqualities(eqs, procTreeEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(eqs, procTreeEqualities.Equal, equal, policyID)
+	}
+}

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -17,11 +17,11 @@ func PolicyNotFoundByNameError(name string) error {
 }
 
 func PoliciesMaxExceededError() error {
-	return fmt.Errorf("policies maximum exceeded [%d]", MaxPolicies)
+	return fmt.Errorf("policies maximum exceeded [%d]", PolicyMax)
 }
 
 func PoliciesOutOfRangeError(idx int) error {
-	return fmt.Errorf("policies index [%d] out-of-range [0-%d]", idx, MaxPolicies-1)
+	return fmt.Errorf("policies index [%d] out-of-range [0-%d]", idx, PolicyMax-1)
 }
 
 func PolicyAlreadyExists(policy *Policy, id int) error {

--- a/pkg/policy/eventflags.go
+++ b/pkg/policy/eventflags.go
@@ -1,0 +1,166 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/events"
+)
+
+// ATTENTION!
+// The eventFlags and eventsFlags are managed by the Policies struct,
+// all of which are made available through read-only interfaces. This
+// arrangement ensures safe access to these types from multiple goroutines
+// without the necessity for additional locking mechanisms.
+
+//
+// eventFlags
+//
+
+// eventFlags describes the flags of an event.
+type eventFlags struct {
+	submit         uint64 // should be submitted to userspace (by policies bitmap)
+	emit           uint64 // should be emitted to the user (by policies bitmap)
+	reqBySignature bool   // required by a signature
+}
+
+// eventFlagsOption is a function that sets an option on an eventFlags.
+type eventFlagsOption func(*eventFlags)
+
+// eventFlagsWithSubmit sets the submit value.
+func eventFlagsWithSubmit(submit uint64) eventFlagsOption {
+	return func(es *eventFlags) {
+		es.submit = submit
+	}
+}
+
+// eventFlagsWithEmit sets the emit value.
+func eventFlagsWithEmit(emit uint64) eventFlagsOption {
+	return func(es *eventFlags) {
+		es.emit = emit
+	}
+}
+
+// eventFlagsWithReqBySignature sets the reqBySignature value.
+func eventFlagsWithReqBySignature(required bool) eventFlagsOption {
+	return func(es *eventFlags) {
+		es.reqBySignature = required
+	}
+}
+
+// newEventFlags creates a new eventFlags with the given options.
+func newEventFlags(options ...eventFlagsOption) eventFlags {
+	// default values
+	es := eventFlags{
+		submit:         0,
+		emit:           0,
+		reqBySignature: false,
+	}
+
+	// apply options
+	for _, option := range options {
+		option(&es)
+	}
+
+	return es
+}
+
+// eventFlags implements the events.EventFlags interface.
+
+func (es eventFlags) GetSubmit() uint64 {
+	return es.submit
+}
+
+func (es eventFlags) GetEmit() uint64 {
+	return es.emit
+}
+
+func (es eventFlags) ShouldSubmit() bool {
+	return es.submit > 0
+}
+
+func (es eventFlags) ShouldEmit() bool {
+	return es.emit > 0
+}
+
+func (es eventFlags) RequiredBySignature() bool {
+	return es.reqBySignature
+}
+
+//
+// eventsFlags
+//
+
+// eventsFlags is a struct describing a collection of eventFlags.
+type eventsFlags struct {
+	flags     map[events.ID]eventFlags
+	cancelled map[events.ID]struct{}
+}
+
+// newEventsFlags creates a new eventsFlags.
+func newEventsFlags() *eventsFlags {
+	return &eventsFlags{
+		flags:     make(map[events.ID]eventFlags),
+		cancelled: make(map[events.ID]struct{}),
+	}
+}
+
+// set sets the event's flags.
+func (es *eventsFlags) set(id events.ID, flags events.EventFlags) {
+	es.flags[id] = flags.(eventFlags)
+}
+
+// cancelEvent cancels an event and updates the cancelled events list.
+func (es *eventsFlags) cancelEvent(id events.ID) {
+	delete(es.flags, id)
+	es.cancelled[id] = struct{}{}
+}
+
+// cancelEventAndAllDeps cancels an event and all its dependencies.
+func (es *eventsFlags) cancelEventAndAllDeps(id events.ID) {
+	es.cancelEvent(id)
+
+	evtDef := events.Core.GetDefinitionByID(id)
+	for _, evtDepID := range evtDef.GetDependencies().GetIDs() {
+		es.cancelEventAndAllDeps(evtDepID)
+	}
+}
+
+// eventsFlags implements the events.EventsFlags interface.
+
+func (es *eventsFlags) Get(id events.ID) events.EventFlags {
+	return es.flags[id]
+}
+
+func (es *eventsFlags) GetOk(id events.ID) (events.EventFlags, bool) {
+	flags, ok := es.flags[id]
+	return flags, ok
+}
+
+// getAll returns all event flags.
+func (es *eventsFlags) getAll() map[events.ID]eventFlags {
+	return es.flags
+}
+
+func (es *eventsFlags) GetAll() map[events.ID]events.EventFlags {
+	all := make(map[events.ID]events.EventFlags, len(es.getAll()))
+
+	for id, flags := range es.getAll() {
+		all[id] = flags
+	}
+
+	// return a copy to prevent modification of the original map
+	return all
+}
+
+// getAllCancelled returns all cancelled event IDs.
+func (es *eventsFlags) getAllCancelled() map[events.ID]struct{} {
+	return es.cancelled
+}
+
+func (es *eventsFlags) GetAllCancelled() []events.ID {
+	cancelled := make([]events.ID, 0, len(es.getAllCancelled()))
+
+	for id := range es.getAllCancelled() {
+		cancelled = append(cancelled, id)
+	}
+
+	return cancelled
+}

--- a/pkg/policy/eventflags_compute.go
+++ b/pkg/policy/eventflags_compute.go
@@ -1,0 +1,151 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/pcaps"
+	"github.com/aquasecurity/tracee/pkg/proctree"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// computeEventsFlags computes the events flags based on the policies and its configuration.
+func (ps *Policies) computeEventsFlags() {
+	evtsFlags := newEventsFlags()
+
+	// Initialize events flags with mandatory events (TODO: review this need for sched exec)
+
+	evtsFlags.set(events.SchedProcessFork, newEventFlags())
+	evtsFlags.set(events.SchedProcessExec, newEventFlags())
+	evtsFlags.set(events.SchedProcessExit, newEventFlags())
+
+	// Control Plane Events
+
+	evtsFlags.set(events.SignalCgroupMkdir, submitAllPolicies)
+	evtsFlags.set(events.SignalCgroupRmdir, submitAllPolicies)
+
+	// Control Plane Process Tree Events
+
+	pipeEvts := func() {
+		evtsFlags.set(events.SchedProcessFork, submitAllPolicies)
+		evtsFlags.set(events.SchedProcessExec, submitAllPolicies)
+		evtsFlags.set(events.SchedProcessExit, submitAllPolicies)
+	}
+	signalEvts := func() {
+		evtsFlags.set(events.SignalSchedProcessFork, submitAllPolicies)
+		evtsFlags.set(events.SignalSchedProcessExec, submitAllPolicies)
+		evtsFlags.set(events.SignalSchedProcessExit, submitAllPolicies)
+	}
+
+	// DNS Cache events
+
+	if ps.config.DNSCacheConfig {
+		evtsFlags.set(events.NetPacketDNS, submitAllPolicies)
+	}
+
+	switch ps.config.ProcTreeSource {
+	case proctree.SourceBoth:
+		pipeEvts()
+		signalEvts()
+	case proctree.SourceSignals:
+		signalEvts()
+	case proctree.SourceEvents:
+		pipeEvts()
+	}
+
+	// Pseudo events added by capture (if enabled by the user)
+
+	for eventID, eCfg := range ps.getCaptureEventsList().getAll() {
+		evtsFlags.set(eventID, eCfg)
+	}
+
+	// Events chosen by the user
+
+	for p := range ps.filterEnabledPoliciesMap {
+		for e := range p.EventsToTrace {
+			var submit, emit uint64
+			if evtFlags, ok := evtsFlags.GetOk(e); ok {
+				submit = evtFlags.GetSubmit()
+				emit = evtFlags.GetEmit()
+			}
+			utils.SetBit(&submit, uint(p.ID))
+			utils.SetBit(&emit, uint(p.ID))
+			evtsFlags.set(
+				e,
+				newEventFlags(
+					eventFlagsWithSubmit(submit),
+					eventFlagsWithEmit(emit),
+				),
+			)
+		}
+	}
+
+	// Handle all essential events dependencies
+
+	for id, flags := range evtsFlags.getAll() {
+		handleEventsDependencies(evtsFlags, id, flags)
+	}
+
+	// Finally, replace the events flags with the computed ones
+
+	ps.evtsFlags = evtsFlags
+}
+
+// handleEventsDependencies handles all events dependencies recursively.
+func handleEventsDependencies(
+	evtsFlags *eventsFlags,
+	givenEvtId events.ID,
+	givenEvtFlags eventFlags,
+) {
+	givenEventDefinition := events.Core.GetDefinitionByID(givenEvtId)
+
+	for _, depEventId := range givenEventDefinition.GetDependencies().GetIDs() {
+		depEventFlags, ok := evtsFlags.GetOk(depEventId)
+		if !ok {
+			depEventFlags = eventFlags{}
+			handleEventsDependencies(evtsFlags, depEventId, givenEvtFlags)
+		}
+
+		// Make sure dependencies are submitted if the given event is submitted.
+		depEvtSubmit := depEventFlags.GetSubmit() | givenEvtFlags.GetSubmit()
+		evtsFlags.set(
+			depEventId,
+			newEventFlags(
+				eventFlagsWithSubmit(depEvtSubmit),
+				eventFlagsWithEmit(depEventFlags.GetEmit()),
+				eventFlagsWithReqBySignature(givenEventDefinition.IsSignature()),
+			),
+		)
+	}
+}
+
+// getCaptureEventsList sets events used to capture data.
+func (ps *Policies) getCaptureEventsList() *eventsFlags {
+	captureEvents := newEventsFlags()
+
+	// INFO: All capture events should be placed, at least for now, to all matched policies, or else
+	// the event won't be set to matched policy in eBPF and should_submit() won't submit the capture
+	// event to userland.
+
+	if ps.config.CaptureExec {
+		captureEvents.set(events.CaptureExec, submitAllPolicies)
+	}
+	if ps.config.CaptureFileWrite {
+		captureEvents.set(events.CaptureFileWrite, submitAllPolicies)
+	}
+	if ps.config.CaptureFileRead {
+		captureEvents.set(events.CaptureFileRead, submitAllPolicies)
+	}
+	if ps.config.CaptureModule {
+		captureEvents.set(events.CaptureModule, submitAllPolicies)
+	}
+	if ps.config.CaptureMem {
+		captureEvents.set(events.CaptureMem, submitAllPolicies)
+	}
+	if ps.config.CaptureBpf {
+		captureEvents.set(events.CaptureBpf, submitAllPolicies)
+	}
+	if pcaps.PcapsEnabled(ps.config.CaptureNet) {
+		captureEvents.set(events.CaptureNetPacket, submitAllPolicies)
+	}
+
+	return captureEvents
+}

--- a/pkg/policy/ksymbols.go
+++ b/pkg/policy/ksymbols.go
@@ -1,0 +1,134 @@
+package policy
+
+import (
+	"sync"
+
+	"github.com/aquasecurity/libbpfgo/helpers"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+// TODO: This is a temporary solution to allow refactoring.
+// PolicyManager should be the best place, for now, to hold kernelSymTable.
+
+// ksyms is a singleton that holds the kernel symbols table
+// in the policy package.
+type ksyms struct {
+	rwmu           sync.RWMutex
+	kernelSymTable *helpers.KernelSymbolTable
+}
+
+func newKsyms() *ksyms {
+	return &ksyms{}
+}
+
+var (
+	kernelSymbolsInstance *ksyms
+	once                  sync.Once
+)
+
+func getKsymsInstance() *ksyms {
+	once.Do(func() {
+		kernelSymbolsInstance = newKsyms()
+	})
+
+	return kernelSymbolsInstance
+}
+
+// SetKsyms sets the kernel symbols to be used by policy package including
+// ValidateKallsymsDependencies.
+func SetKsyms(ks *helpers.KernelSymbolTable) {
+	ksi := getKsymsInstance()
+	ksi.rwmu.Lock()
+	defer ksi.rwmu.Unlock()
+
+	ksi.kernelSymTable = ks
+}
+
+func getKsyms() *helpers.KernelSymbolTable {
+	ksi := getKsymsInstance()
+	ksi.rwmu.RLock()
+	defer ksi.rwmu.RUnlock()
+
+	return ksi.kernelSymTable
+}
+
+// ValidateKallsymsDependencies load all symbols required by events dependencies
+// from the kallsyms file to check for missing symbols. If some symbols are
+// missing, it will cancel their event with informative error message.
+func (ps *Policies) ValidateKallsymsDependencies() {
+	ps.rwmu.Lock()
+	defer ps.rwmu.Unlock()
+
+	depsToCancel := make(map[events.ID]string)
+
+	// Cancel events with unavailable symbols dependencies
+	for eventToCancel, missingDepSyms := range getUnavKsymsPerEvtID(ps.evtsFlags) {
+		eventNameToCancel := events.Core.GetDefinitionByID(eventToCancel).GetName()
+		logger.Debugw(
+			"Event cancelled because of missing kernel symbol dependency",
+			"missing symbols", missingDepSyms, "event", eventNameToCancel,
+		)
+		ps.eventsFlags().cancelEvent(eventToCancel)
+
+		// Find all events that depend on eventToCancel
+		for eventID := range ps.eventsFlags().getAll() {
+			depsIDs := events.Core.GetDefinitionByID(eventID).GetDependencies().GetIDs()
+			for _, depID := range depsIDs {
+				if depID == eventToCancel {
+					depsToCancel[eventID] = eventNameToCancel
+				}
+			}
+		}
+
+		// Cancel all events that require eventToCancel
+		for eventID, depEventName := range depsToCancel {
+			logger.Debugw(
+				"Event cancelled because it depends on an previously cancelled event",
+				"event", events.Core.GetDefinitionByID(eventID).GetName(),
+				"dependency", depEventName,
+			)
+			ps.eventsFlags().cancelEvent(eventID)
+		}
+	}
+}
+
+// getUnavKsymsPerEvtID returns event IDs and symbols that are unavailable to them.
+func getUnavKsymsPerEvtID(evtsFlags *eventsFlags) map[events.ID][]string {
+	unavSymsPerEvtID := map[events.ID][]string{}
+
+	for evtID := range evtsFlags.getAll() {
+		unavailable := getUnavEvtKsymsDeps(evtID)
+		if len(unavailable) > 0 {
+			unavSymsPerEvtID[evtID] = unavailable
+		}
+	}
+
+	return unavSymsPerEvtID
+}
+
+// getUnavEvtKsymsDeps returns the unavailable symbols for an event.
+func getUnavEvtKsymsDeps(evtID events.ID) []string {
+	unavSyms := []string{}
+	ksyms := getKsyms()
+	evtDefSymDeps := events.Core.GetDefinitionByID(evtID).GetDependencies().GetKSymbols()
+
+	for _, symDep := range evtDefSymDeps {
+		sym, err := ksyms.GetSymbolByName(symDep.GetSymbolName())
+		symName := symDep.GetSymbolName()
+		if err != nil {
+			// If the symbol is not found, it means it's unavailable.
+			unavSyms = append(unavSyms, symName)
+			continue
+		}
+		for _, s := range sym {
+			if s.Address == 0 {
+				// Same if the symbol is found but its address is 0.
+				unavSyms = append(unavSyms, symName)
+			}
+		}
+	}
+
+	return unavSyms
+}

--- a/pkg/policy/policies_compute.go
+++ b/pkg/policy/policies_compute.go
@@ -41,7 +41,7 @@ func (ps *Policies) calculateGlobalMinMax() {
 		pidMaxFilterableInUserland bool
 	)
 
-	for p := range ps.Map() {
+	for p := range ps.filterEnabledPoliciesMap {
 		policyCount++
 
 		if p.UIDFilter.Enabled() {

--- a/pkg/policy/policies_compute.go
+++ b/pkg/policy/policies_compute.go
@@ -1,0 +1,142 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// compute recalculates values, updates flags, fills the reduced userland map,
+// and sets the related bitmap that is used to prevent the iteration of the entire map.
+// It also computes the events states.
+//
+// It must be called at initialization and at every runtime policies changes.
+func (ps *Policies) compute() {
+	ps.calculateGlobalMinMax()
+	ps.updateContainerFilterEnabled()
+	ps.updateFilterableInUserland()
+	ps.computeEventsFlags()
+}
+
+// calculateGlobalMinMax sets the global min and max, to be checked in kernel,
+// of the Minimum and Maximum enabled filters only if context filter types
+// (e.g. UIDFilter) from all policies have both Minimum and Maximum values set.
+//
+// Policies userland filter flags are also set (e.g. uidFilterableInUserland).
+//
+// The context filter types relevant for this function are just UIDFilter and
+// PIDFilter.
+func (ps *Policies) calculateGlobalMinMax() {
+	var (
+		uidMinFilterCount int
+		uidMaxFilterCount int
+		uidFilterCount    int
+		pidMinFilterCount int
+		pidMaxFilterCount int
+		pidFilterCount    int
+		policyCount       int
+
+		uidMinFilterableInUserland bool
+		uidMaxFilterableInUserland bool
+		pidMinFilterableInUserland bool
+		pidMaxFilterableInUserland bool
+	)
+
+	for p := range ps.Map() {
+		policyCount++
+
+		if p.UIDFilter.Enabled() {
+			uidFilterCount++
+
+			if p.UIDFilter.Minimum() != filters.MinNotSetUInt {
+				uidMinFilterCount++
+			}
+			if p.UIDFilter.Maximum() != filters.MaxNotSetUInt {
+				uidMaxFilterCount++
+			}
+		}
+		if p.PIDFilter.Enabled() {
+			pidFilterCount++
+
+			if p.PIDFilter.Minimum() != filters.MinNotSetUInt {
+				pidMinFilterCount++
+			}
+			if p.PIDFilter.Maximum() != filters.MaxNotSetUInt {
+				pidMaxFilterCount++
+			}
+		}
+	}
+
+	uidMinFilterableInUserland = policyCount > 1 && (uidMinFilterCount != uidFilterCount)
+	uidMaxFilterableInUserland = policyCount > 1 && (uidMaxFilterCount != uidFilterCount)
+	pidMinFilterableInUserland = policyCount > 1 && (pidMinFilterCount != pidFilterCount)
+	pidMaxFilterableInUserland = policyCount > 1 && (pidMaxFilterCount != pidFilterCount)
+
+	// reset global min max
+	ps.uidFilterMax = filters.MaxNotSetUInt
+	ps.uidFilterMin = filters.MinNotSetUInt
+	ps.pidFilterMax = filters.MaxNotSetUInt
+	ps.pidFilterMin = filters.MinNotSetUInt
+
+	ps.uidFilterableInUserland = uidMinFilterableInUserland || uidMaxFilterableInUserland
+	ps.pidFilterableInUserland = pidMinFilterableInUserland || pidMaxFilterableInUserland
+
+	if ps.uidFilterableInUserland && ps.pidFilterableInUserland {
+		// there's no need to iterate filter policies again since
+		// all uint events will be submitted from ebpf with no regards
+
+		return
+	}
+
+	// set a reduced range of uint values to be filtered in ebpf
+	for p := range ps.filterEnabledPoliciesMap {
+		if p.UIDFilter.Enabled() {
+			if !uidMinFilterableInUserland {
+				ps.uidFilterMin = utils.Min(ps.uidFilterMin, p.UIDFilter.Minimum())
+			}
+			if !uidMaxFilterableInUserland {
+				ps.uidFilterMax = utils.Max(ps.uidFilterMax, p.UIDFilter.Maximum())
+			}
+		}
+		if p.PIDFilter.Enabled() {
+			if !pidMinFilterableInUserland {
+				ps.pidFilterMin = utils.Min(ps.pidFilterMin, p.PIDFilter.Minimum())
+			}
+			if !pidMaxFilterableInUserland {
+				ps.pidFilterMax = utils.Max(ps.pidFilterMax, p.PIDFilter.Maximum())
+			}
+		}
+	}
+}
+
+// updateContainerFilterEnabled sets the containerFiltersEnabled bitmap.
+func (ps *Policies) updateContainerFilterEnabled() {
+	ps.containerFiltersEnabled = 0
+
+	for p := range ps.filterEnabledPoliciesMap {
+		if p.ContainerFilterEnabled() {
+			utils.SetBit(&ps.containerFiltersEnabled, uint(p.ID))
+		}
+	}
+}
+
+// updateFilterableInUserland sets the filterableInUserland bitmap and the
+// filterUserlandPoliciesMap.
+func (ps *Policies) updateFilterableInUserland() {
+	ps.filterableInUserland = 0
+
+	userlandMap := make(map[*Policy]int)
+	for p := range ps.filterEnabledPoliciesMap {
+		if p.ArgFilter.Enabled() ||
+			p.RetFilter.Enabled() ||
+			p.ContextFilter.Enabled() ||
+			(p.UIDFilter.Enabled() && ps.uidFilterableInUserland) ||
+			(p.PIDFilter.Enabled() && ps.pidFilterableInUserland) {
+			// add policy and set the related bit
+			userlandMap[p] = p.ID
+			utils.SetBit(&ps.filterableInUserland, uint(p.ID))
+		}
+	}
+
+	// replace the map
+	ps.filterUserlandPoliciesMap = userlandMap
+}

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -5,12 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/config"
 )
 
 func TestPoliciesClone(t *testing.T) {
 	t.Parallel()
 
-	policies := NewPolicies()
+	policiesCfg := config.NewPoliciesConfig(
+		config.Config{
+			Capture: &config.CaptureConfig{},
+		},
+	)
+
+	policies := NewPolicies(policiesCfg)
 
 	p1 := NewPolicy()
 	err := p1.PIDFilter.Parse("=1")

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -88,7 +88,7 @@ func areMapsEqual(map1, map2 map[*Policy]int) bool {
 
 func areNonPointerFieldsEqual(p1, p2 *Policies) bool {
 	return p1.version == p2.version &&
-		reflect.DeepEqual(p1.bpfInnerMaps, p2.bpfInnerMaps) &&
+		reflect.DeepEqual(p1.versionBPFMaps, p2.versionBPFMaps) &&
 		reflect.DeepEqual(p1.policiesArray, p2.policiesArray) &&
 		p1.uidFilterMin == p2.uidFilterMin &&
 		p1.uidFilterMax == p2.uidFilterMax &&

--- a/pkg/policy/probes.go
+++ b/pkg/policy/probes.go
@@ -1,0 +1,61 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/cgroup"
+	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
+)
+
+// AttachProbes attaches selected events probes to their respective eBPF progs
+func (ps *Policies) AttachProbes(probeGroup *probes.ProbeGroup, cgroups *cgroup.Cgroups) error {
+	var err error
+
+	// TODO: On Snapshot pruning, we should check which probes are not used for
+	// any snapshot and detach them.
+
+	// Get probe dependencies for a given event ID
+	getProbeDeps := func(id events.ID) []events.Probe {
+		return events.Core.GetDefinitionByID(id).GetDependencies().GetProbes()
+	}
+
+	ps.rwmu.Lock()
+	defer ps.rwmu.Unlock()
+
+	// Get the list of probes to attach for each event being traced.
+	probesToEvents := make(map[events.Probe][]events.ID)
+	for id := range ps.eventsFlags().getAll() {
+		if !events.Core.IsDefined(id) {
+			continue
+		}
+		for _, probeDep := range getProbeDeps(id) {
+			probesToEvents[probeDep] = append(probesToEvents[probeDep], id)
+		}
+	}
+
+	// Attach probes to their respective eBPF programs or cancel events if a required probe is missing.
+	for probe, evtsIDs := range probesToEvents {
+		err = probeGroup.Attach(probe.GetHandle(), cgroups) // attach bpf program to probe
+		if err != nil {
+			for _, evtID := range evtsIDs {
+				evtName := events.Core.GetDefinitionByID(evtID).GetName()
+				if probe.IsRequired() {
+					logger.Warnw(
+						"Cancelling event and its dependencies because of missing probe",
+						"missing probe", probe.GetHandle(), "event", evtName,
+						"error", err,
+					)
+					ps.eventsFlags().cancelEventAndAllDeps(evtID)
+				} else {
+					logger.Debugw(
+						"Failed to attach non-required probe for event",
+						"event", evtName,
+						"probe", probe.GetHandle(), "error", err,
+					)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/policy/snapshots.go
+++ b/pkg/policy/snapshots.go
@@ -78,7 +78,7 @@ func (s *snapshots) Store(ps *Policies) {
 		s.lastVersion++
 	}
 
-	ps.SetVersion(s.lastVersion)
+	ps.version = s.lastVersion
 
 	snap := &snapshot{
 		time:     time.Now(),

--- a/pkg/policy/snapshots.go
+++ b/pkg/policy/snapshots.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	maxSnapshots = MaxPolicies
+	maxSnapshots = PolicyMax
 )
 
 // snapshot is a snapshot of the Policies at a given version.

--- a/pkg/policy/snapshots_test.go
+++ b/pkg/policy/snapshots_test.go
@@ -23,7 +23,7 @@ func resetSnapshots() {
 func setPruneFunc() {
 	Snapshots().SetPruneFunc(func(ps *Policies) []error {
 		errs := []error{}
-		for _, bpfMap := range ps.bpfInnerMaps {
+		for _, bpfMap := range ps.versionBPFMaps {
 			err := syscall.Close(bpfMap.FileDescriptor())
 			if err != nil {
 				errs = append(errs, err)
@@ -96,7 +96,7 @@ func TestCircularBufferOverwrite(t *testing.T) {
 	// store one more snapshot to overwrite the first snapshot in the buffer
 	psOverwrite := &Policies{}
 	Snapshots().Store(psOverwrite)
-	assert.Equal(t, uint32(maxSnapshots+1), psOverwrite.version)
+	assert.Equal(t, uint16(maxSnapshots+1), psOverwrite.version)
 
 	// check if the oldest snapshot (version 1) has been overwritten
 	_, err = Snapshots().Get(1)


### PR DESCRIPTION
Close #3900

On top of #3848

### 1. Explain what the PR does

a8833424e **chore: refactor equality computation**
64ab539e1 **chore: extract probe attach to after main loop**


a8833424e **chore: refactor equality computation**

```
This moves the equality logic to equality.go, and uses Generics to
deduplicate the code.
```


64ab539e1 **chore: extract probe attach to after main loop**

```
Decouple initialization of Policies (eBPF) and sequential call to
AttachProbes() from main loop.

This also:

- Refactor creation/population and pruning of Policies related bpf maps.
- Enforces the use of inner objects when in a controlled (locked) state.
- Removes Policies.SetVersion().
```

### 2. Explain how to test it

### 3. Other comments

**_Consider for review only the commits above._**
