### PR TITLE
Improve bpf policies config access

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -542,9 +542,7 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 
     // Update the process tree map (filter related) if the parent has an entry.
 
-    policies_config_t *policies_cfg = get_policies_config(&p);
-    if (unlikely(policies_cfg == NULL))
-        return 0;
+    policies_config_t *policies_cfg = &p.event->policies_config;
 
     if (policies_cfg->proc_tree_filter_enabled_scopes) {
         u16 version = p.event->context.policies_version;
@@ -1025,7 +1023,6 @@ int uprobe_lkm_seeker_submitter(struct pt_regs *ctx)
 
     // Uprobes are not triggered by syscalls, so we need to override the false value.
     p.event->context.syscall = NO_SYSCALL;
-    p.event->context.policies_version = p.config->policies_version;
     p.event->context.matched_policies = ULLONG_MAX;
 
     u32 trigger_pid = bpf_get_current_pid_tgid() >> 32;
@@ -1058,7 +1055,6 @@ int uprobe_lkm_seeker(struct pt_regs *ctx)
 
     // Uprobes are not triggered by syscalls, so we need to override the false value.
     p.event->context.syscall = NO_SYSCALL;
-    p.event->context.policies_version = p.config->policies_version;
     p.event->context.matched_policies = ULLONG_MAX;
 
     // uprobe was triggered from other tracee instance
@@ -1577,7 +1573,6 @@ int uprobe_syscall_table_check(struct pt_regs *ctx)
 
     // Uprobes are not triggered by syscalls, so we need to override the false value.
     p.event->context.syscall = NO_SYSCALL;
-    p.event->context.policies_version = p.config->policies_version;
     p.event->context.matched_policies = ULLONG_MAX;
 
     syscall_table_check(&p);
@@ -1614,7 +1609,6 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
 
     // Uprobes are not triggered by syscalls, so we need to override the false value.
     p.event->context.syscall = NO_SYSCALL;
-    p.event->context.policies_version = p.config->policies_version;
     p.event->context.matched_policies = ULLONG_MAX;
 
     // uprobe was triggered from other tracee instance
@@ -1696,7 +1690,6 @@ int uprobe_mem_dump_trigger(struct pt_regs *ctx)
 
     // Uprobes are not triggered by syscalls, so we need to override the false value.
     p.event->context.syscall = NO_SYSCALL;
-    p.event->context.policies_version = p.config->policies_version;
     p.event->context.matched_policies = ULLONG_MAX;
 
     // uprobe was triggered from other tracee instance

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -211,6 +211,7 @@ typedef struct task_info {
     syscall_data_t syscall_data;
     bool syscall_traced;  // indicates that syscall_data is valid
     bool recompute_scope; // recompute matched_scopes (new task/context changed/policy changed)
+    u16 policies_version; // version of policies used to match this task
     u64 matched_scopes;   // cached bitmap of scopes this task matched
     u8 container_state;   // the state of the container the task resides in
 } task_info_t;
@@ -363,6 +364,7 @@ typedef struct event_data {
     args_buffer_t args_buf;
     struct task_struct *task;
     u64 param_types;
+    policies_config_t policies_config;
 } event_data_t;
 
 // A control plane signal - sent to indicate some critical event which should be processed


### PR DESCRIPTION
### 1. Explain what the PR does

f1b2d39e **chore: reduce bpf map lookups for policies config**

```
Instead of always retrieving the policies config map version in the
outer and inner maps, create a holder in the event_data and update it
only when config entry version changes.
```

### 2. Explain how to test it


### 3. Other comments

