### PR TITLE
fix: socket_dup never emitted

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -403,6 +403,9 @@ int syscall__execveat(void *ctx)
 
 statfunc int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd)
 {
+    if (!should_trace(p))
+        return 0;
+
     if (!should_submit(SOCKET_DUP, p->event))
         return 0;
 

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11906,6 +11906,10 @@ var CoreEvents = map[ID]Definition{
 		name:    "socket_dup",
 		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.SyscallEnter__Internal, required: true},
+				{handle: probes.SyscallExit__Internal, required: true},
+			},
 			tailCalls: []TailCall{
 				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
 				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

socket_dup event is never emitted.
The reason for that is matched_policies always equals 0 for this event since we don't call should_trace() in the bpf program that sends the event, but we do call should_submit(), which then returns with 0 since matched_policies equals 0 before this call.

Fix by calling should_trace() before calling should_submit()

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
