### PR TITLE
Fix proc info lru

### DIFF
--- a/pkg/ebpf/c/common/filtering.h
+++ b/pkg/ebpf/c/common/filtering.h
@@ -210,17 +210,10 @@ statfunc u64 compute_scopes(program_data_t *p)
     task_context_t *context = &p->task_info->context;
 
     // Don't monitor self
-    if (p->config->tracee_pid == context->host_pid) {
+    if (p->config->tracee_pid == context->host_pid)
         return 0;
-    }
 
-    proc_info_t *proc_info = bpf_map_lookup_elem(&proc_info_map, &context->host_pid);
-    if (unlikely(proc_info == NULL)) {
-        // entry should exist in proc_map (init_program_data should have set it otherwise)
-        // disable logging as a workaround for instruction limit verifier error on kernel 4.19
-        // tracee_log(p->event->ctx, BPF_LOG_LVL_WARN, BPF_LOG_ID_MAP_LOOKUP_ELEM, 0);
-        return 0;
-    }
+    proc_info_t *proc_info = p->proc_info;
 
     policies_config_t *policies_cfg = get_policies_config(p);
     if (unlikely(policies_cfg == NULL)) {

--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -203,13 +203,6 @@ struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __uint(max_entries, 1);                 // simultaneous softirqs running per CPU (?)
     __type(key, u32);                       // per cpu index ... (always zero)
-    __type(value, scratch_t);               // ... linked to a scratch area
-} net_heap_scratch SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, 1);                 // simultaneous softirqs running per CPU (?)
-    __type(key, u32);                       // per cpu index ... (always zero)
     __type(value, event_data_t);            // ... linked to a scratch area
 } net_heap_event SEC(".maps");
 

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -69,7 +69,7 @@ typedef struct sys_32_to_64_map sys_32_to_64_map_t;
 // holds data for every process
 struct proc_info_map {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, 10240);
+    __uint(max_entries, 30720);
     __type(key, u32);
     __type(value, proc_info_t);
 } proc_info_map SEC(".maps");

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -331,7 +331,7 @@ typedef struct logs_count logs_count_t;
 // scratch space to avoid allocating stuff on the stack
 struct scratch_map {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, 1);
+    __uint(max_entries, 2);
     __type(key, u32);
     __type(value, scratch_t);
 } scratch_map SEC(".maps");

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -75,7 +75,7 @@ int sys_enter_init(struct bpf_raw_tracepoint_args *ctx)
     task_info_t *task_info = bpf_map_lookup_elem(&task_info_map, &tid);
     if (unlikely(task_info == NULL)) {
         u32 pid = pid_tgid >> 32;
-        task_info = init_task_info(tid, pid, NULL);
+        task_info = init_task_info(tid, pid, 0);
         if (unlikely(task_info == NULL)) {
             return 0;
         }
@@ -210,7 +210,7 @@ int sys_exit_init(struct bpf_raw_tracepoint_args *ctx)
     task_info_t *task_info = bpf_map_lookup_elem(&task_info_map, &tid);
     if (unlikely(task_info == NULL)) {
         u32 pid = pid_tgid >> 32;
-        task_info = init_task_info(tid, pid, NULL);
+        task_info = init_task_info(tid, pid, 0);
         if (unlikely(task_info == NULL)) {
             return 0;
         }
@@ -5785,14 +5785,8 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
     if (unlikely(e == NULL))
         return 0;
 
-    scratch_t *s = bpf_map_lookup_elem(&net_heap_scratch, &zero);
-    if (unlikely(s == NULL))
-        return 0;
-
-    program_data_t p = {
-        .event = e,
-        .scratch = s,
-    };
+    program_data_t p = {};
+    p.scratch_idx = 1;
     if (!init_program_data(&p, ctx))
         return 0;
 

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -438,6 +438,7 @@ typedef union scratch {
 typedef struct program_data {
     config_entry_t *config;
     task_info_t *task_info;
+    proc_info_t *proc_info;
     event_data_t *event;
     u32 scratch_idx;
     void *ctx;

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -439,7 +439,7 @@ typedef struct program_data {
     config_entry_t *config;
     task_info_t *task_info;
     event_data_t *event;
-    scratch_t *scratch;
+    u32 scratch_idx;
     void *ctx;
 } program_data_t;
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

    fix: always initialize proc_info map
    
    In environments with a high amount of CPUs the current proc_info map
    size of 10240 entries might not be enough, and gets filled quickly.
    In these cases we got an error of missing proc_info entry.
    
    A quick mitigation then will be to set a bigger map size.
    
    The root cause of this issue is that we assume that if task_info exists
    for some task in the task_info_map, then also the proc_info of the
    process to which the task belongs to also has an entry in the map,
    but that is not the case.
    
    To fix this issue, add proc_info lookup and initialization in
    init_program_data() function. In addition, init proc_info of the
    relevant pid in case it was not found in other places.
    
    Fix: #3914

### 2. Explain how to test it

To test, I changed proc_info_map size to 50, then reproduced the issue.
Then see that the issue is fixed with this change

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
