### PR TITLE
Optimize init program

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -3,6 +3,7 @@
 
 #include <vmlinux.h>
 
+#include <common/context.h>
 #include <common/hash.h>
 #include <common/network.h>
 
@@ -447,6 +448,10 @@ statfunc int events_perf_submit(program_data_t *p, u32 id, long ret)
 {
     p->event->context.eventid = id;
     p->event->context.retval = ret;
+
+    init_task_context(&p->event->context.task, p->event->task, p->config->options);
+    // keep task_info updated
+    bpf_probe_read_kernel(&p->task_info->context, sizeof(task_context_t), &p->event->context.task);
 
     // Get Stack trace
     if (p->config->options & OPT_CAPTURE_STACK_TRACES) {

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -9,7 +9,7 @@
 
 // PROTOTYPES
 
-statfunc int init_context(void *, event_context_t *, struct task_struct *, u32);
+statfunc int init_task_context(task_context_t *, struct task_struct *, u32);
 statfunc void init_proc_info_scratch(u32, scratch_t *);
 statfunc proc_info_t *init_proc_info(u32, u32);
 statfunc void init_task_info_scratch(u32, scratch_t *);
@@ -21,74 +21,43 @@ statfunc void reset_event_args(program_data_t *);
 
 // FUNCTIONS
 
-statfunc int
-init_context(void *ctx, event_context_t *context, struct task_struct *task, u32 options)
+statfunc int init_task_context(task_context_t *tsk_ctx, struct task_struct *task, u32 options)
 {
-    long ret = 0;
-    u64 id = bpf_get_current_pid_tgid();
-
     // NOTE: parent is always a real process, not a potential thread group leader
     struct task_struct *leader = get_leader_task(task);
     struct task_struct *up_parent = get_leader_task(get_parent_task(leader));
 
     // Task Info on Host
-    context->task.host_tid = id;
-    context->task.host_pid = id >> 32;
-    context->task.host_ppid = get_task_pid(up_parent); // always a real process (not a lwp)
+    tsk_ctx->host_ppid = get_task_pid(up_parent); // always a real process (not a lwp)
     // Namespaces Info
-    context->task.tid = get_task_ns_pid(task);
-    context->task.pid = get_task_ns_tgid(task);
+    tsk_ctx->tid = get_task_ns_pid(task);
+    tsk_ctx->pid = get_task_ns_tgid(task);
 
     u32 task_pidns_id = get_task_pid_ns_id(task);
     u32 up_parent_pidns_id = get_task_pid_ns_id(up_parent);
 
     if (task_pidns_id == up_parent_pidns_id)
-        context->task.ppid = get_task_ns_pid(up_parent); // e.g: pid 1 will have nsppid 0
+        tsk_ctx->ppid = get_task_ns_pid(up_parent); // e.g: pid 1 will have nsppid 0
 
-    context->task.pid_id = task_pidns_id;
-    context->task.mnt_id = get_task_mnt_ns_id(task);
+    tsk_ctx->pid_id = task_pidns_id;
+    tsk_ctx->mnt_id = get_task_mnt_ns_id(task);
     // User Info
-    context->task.uid = bpf_get_current_uid_gid();
+    tsk_ctx->uid = bpf_get_current_uid_gid();
     // Times
-    context->task.start_time = get_task_start_time(task);
-    context->task.leader_start_time = get_task_start_time(leader);
-    context->task.parent_start_time = get_task_start_time(up_parent);
-
-    context->task.flags = 0;
+    tsk_ctx->start_time = get_task_start_time(task);
+    tsk_ctx->leader_start_time = get_task_start_time(leader);
+    tsk_ctx->parent_start_time = get_task_start_time(up_parent);
 
     if (is_compat(task))
-        context->task.flags |= IS_COMPAT_FLAG;
+        tsk_ctx->flags |= IS_COMPAT_FLAG;
 
     // Program name
-    __builtin_memset(context->task.comm, 0, sizeof(context->task.comm));
-    ret = bpf_get_current_comm(&context->task.comm, sizeof(context->task.comm));
-    if (unlikely(ret < 0)) {
-        tracee_log(ctx, BPF_LOG_LVL_ERROR, BPF_LOG_ID_GET_CURRENT_COMM, ret);
-        return -1;
-    }
+    bpf_get_current_comm(&tsk_ctx->comm, sizeof(tsk_ctx->comm));
 
     // UTS Name
     char *uts_name = get_task_uts_name(task);
-    if (uts_name) {
-        __builtin_memset(context->task.uts_name, 0, sizeof(context->task.uts_name));
-        bpf_probe_read_str(&context->task.uts_name, TASK_COMM_LEN, uts_name);
-    }
-
-    // Cgroup ID
-    if (options & OPT_CGROUP_V1) {
-        context->task.cgroup_id = get_cgroup_v1_subsys0_id(task);
-    } else {
-        context->task.cgroup_id = bpf_get_current_cgroup_id();
-    }
-
-    // Context timestamp
-    context->ts = bpf_ktime_get_ns();
-    // Clean Stack Trace ID
-    context->stack_id = 0;
-    // Processor ID
-    context->processor_id = (u16) bpf_get_smp_processor_id();
-    // Syscall ID
-    context->syscall = get_task_syscall_id(task);
+    if (uts_name)
+        bpf_probe_read_kernel_str(&tsk_ctx->uts_name, TASK_COMM_LEN, uts_name);
 
     return 0;
 }
@@ -112,10 +81,7 @@ statfunc proc_info_t *init_proc_info(u32 pid, u32 scratch_idx)
 
 statfunc void init_task_info_scratch(u32 tid, scratch_t *scratch)
 {
-    scratch->task_info.syscall_traced = false;
-    scratch->task_info.policies_version = 0;
-    scratch->task_info.recompute_scope = true;
-    scratch->task_info.container_state = CONTAINER_UNKNOWN;
+    __builtin_memset(&scratch->task_info, 0, sizeof(task_info_t));
     bpf_map_update_elem(&task_info_map, &tid, &scratch->task_info, BPF_NOEXIST);
 }
 
@@ -130,21 +96,12 @@ statfunc task_info_t *init_task_info(u32 tid, u32 scratch_idx)
     return bpf_map_lookup_elem(&task_info_map, &tid);
 }
 
-statfunc bool context_changed(task_context_t *old, task_context_t *new)
-{
-    return (old->cgroup_id != new->cgroup_id) || old->uid != new->uid ||
-           old->mnt_id != new->mnt_id || old->pid_id != new->pid_id ||
-           *(u64 *) old->comm != *(u64 *) new->comm ||
-           *(u64 *) &old->comm[8] != *(u64 *) &new->comm[8] ||
-           *(u64 *) old->uts_name != *(u64 *) new->uts_name ||
-           *(u64 *) &old->uts_name[8] != *(u64 *) &new->uts_name[8];
-}
-
 // clang-format off
 statfunc int init_program_data(program_data_t *p, void *ctx)
 {
-    long ret = 0;
     int zero = 0;
+
+    p->ctx = ctx;
 
     // allow caller to specify a stack/map based event_data_t pointer
     if (p->event == NULL) {
@@ -157,19 +114,20 @@ statfunc int init_program_data(program_data_t *p, void *ctx)
     if (unlikely(p->config == NULL))
         return 0;
 
-    p->event->task = (struct task_struct *) bpf_get_current_task();
-    ret = init_context(ctx, &p->event->context, p->event->task, p->config->options);
-    if (unlikely(ret < 0)) {
-        // disable logging as a workaround for instruction limit verifier error on kernel 4.19
-        // tracee_log(ctx, BPF_LOG_LVL_ERROR, BPF_LOG_ID_INIT_CONTEXT, ret);
-        return 0;
-    }
-
-    p->ctx = ctx;
     p->event->args_buf.offset = 0;
     p->event->args_buf.argnum = 0;
+    p->event->task = (struct task_struct *) bpf_get_current_task();
 
-    bool container_lookup_required = true;
+    __builtin_memset(&p->event->context.task, 0, sizeof(p->event->context.task));
+
+    // get the minimal context required at this stage
+    // any other context will be initialized only if event is submitted
+    u64 id = bpf_get_current_pid_tgid();
+    p->event->context.task.host_tid = id;
+    p->event->context.task.host_pid = id >> 32;
+    p->event->context.ts = bpf_ktime_get_ns();
+    p->event->context.processor_id = (u16) bpf_get_smp_processor_id();
+    p->event->context.syscall = get_task_syscall_id(p->event->task);
 
     u32 host_pid = p->event->context.task.host_pid;
     p->proc_info = bpf_map_lookup_elem(&proc_info_map, &host_pid);
@@ -186,29 +144,9 @@ statfunc int init_program_data(program_data_t *p, void *ctx)
         if (unlikely(p->task_info == NULL))
             return 0;
 
-        // just initialized task info: recompute_scope is already set to true
-        goto out;
+        init_task_context(&p->task_info->context, p->event->task, p->config->options);
     }
 
-    // in some places we don't call should_trace() (e.g. sys_exit) which also initializes
-    // matched_policies. Use previously found scopes then to initialize it.
-    p->event->context.matched_policies = p->task_info->matched_scopes;
-
-    // check if we need to recompute scope due to context change
-    if (context_changed(&p->task_info->context, &p->event->context.task))
-        p->task_info->recompute_scope = true;
-
-    u8 container_state = p->task_info->container_state;
-
-    // if task is already part of a container: no need to check if state changed
-    switch (container_state) {
-        case CONTAINER_STARTED:
-        case CONTAINER_EXISTED:
-            p->event->context.task.flags |= CONTAINER_STARTED_FLAG;
-            container_lookup_required = false;
-    }
-
-out:
     if (unlikely(p->event->context.policies_version != p->config->policies_version)) {
         // copy policies_config to event data
         long ret = bpf_probe_read_kernel(
@@ -218,27 +156,26 @@ out:
 
         p->event->context.policies_version = p->config->policies_version;
     }
-    if (p->task_info->policies_version != p->event->context.policies_version) {
-        p->task_info->policies_version = p->event->context.policies_version;
-        p->task_info->recompute_scope = true;
+
+    if (p->config->options & OPT_CGROUP_V1) {
+        p->event->context.task.cgroup_id = get_cgroup_v1_subsys0_id(p->event->task);
+    } else {
+        p->event->context.task.cgroup_id = bpf_get_current_cgroup_id();
     }
-
-    if (container_lookup_required) {
-        u32 cgroup_id_lsb = p->event->context.task.cgroup_id;
-        u8 *state = bpf_map_lookup_elem(&containers_map, &cgroup_id_lsb);
-
-        if (state != NULL) {
-            p->task_info->container_state = *state;
-            switch (*state) {
-                case CONTAINER_STARTED:
-                case CONTAINER_EXISTED:
-                    p->event->context.task.flags |= CONTAINER_STARTED_FLAG;
-            }
+    p->task_info->context.cgroup_id = p->event->context.task.cgroup_id;
+    u32 cgroup_id_lsb = p->event->context.task.cgroup_id;
+    u8 *state = bpf_map_lookup_elem(&containers_map, &cgroup_id_lsb);
+    if (state != NULL) {
+        p->task_info->container_state = *state;
+        switch (*state) {
+            case CONTAINER_STARTED:
+            case CONTAINER_EXISTED:
+                p->event->context.task.flags |= CONTAINER_STARTED_FLAG;
         }
     }
 
-    // update task_info with the new context
-    bpf_probe_read(&p->task_info->context, sizeof(task_context_t), &p->event->context.task);
+    // initialize matched_policies to all policies match
+    p->event->context.matched_policies = ~0ULL;
 
     return 1;
 }
@@ -267,9 +204,6 @@ statfunc int init_tailcall_program_data(program_data_t *p, void *ctx)
     if (unlikely(p->proc_info == NULL)) {
         return 0;
     }
-
-    p->event->args_buf.offset = 0;
-    p->event->args_buf.argnum = 0;
 
     return 1;
 }

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -263,6 +263,14 @@ statfunc int init_tailcall_program_data(program_data_t *p, void *ctx)
         return 0;
     }
 
+    p->proc_info = bpf_map_lookup_elem(&proc_info_map, &p->event->context.task.host_pid);
+    if (unlikely(p->proc_info == NULL)) {
+        return 0;
+    }
+
+    p->event->args_buf.offset = 0;
+    p->event->args_buf.argnum = 0;
+
     return 1;
 }
 

--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -252,7 +252,7 @@ statfunc void *get_path_str(struct path *path)
         return NULL;
 
     size_t buf_off = get_path_str_buf(path, string_p);
-    return &string_p->buf[buf_off];
+    return &string_p->buf[buf_off & ((MAX_PERCPU_BUFSIZE >> 1) - 1)];
 }
 
 statfunc file_id_t get_file_id(struct file *file)
@@ -279,7 +279,7 @@ statfunc void *get_path_str_cached(struct file *file)
 
         size_t buf_off = get_path_str_buf(__builtin_preserve_access_index(&file->f_path), string_p);
         if (likely(sizeof(string_p->buf) > buf_off + sizeof(path_buf_t))) {
-            path = (path_buf_t *) (&string_p->buf[0] + buf_off);
+            path = (path_buf_t *) (&string_p->buf[buf_off & ((MAX_PERCPU_BUFSIZE >> 1) - 1)]);
             bpf_map_update_elem(&io_file_path_cache_map, &file_id, path, BPF_ANY);
         } else {
             return NULL;

--- a/pkg/ebpf/c/common/probes.h
+++ b/pkg/ebpf/c/common/probes.h
@@ -13,13 +13,6 @@
 #define TRACE_ENT_FUNC(name, id)                                                                   \
     int trace_##name(struct pt_regs *ctx)                                                          \
     {                                                                                              \
-        program_data_t p = {};                                                                     \
-        if (!init_program_data(&p, ctx))                                                           \
-            return 0;                                                                              \
-                                                                                                   \
-        if (!should_trace(&p))                                                                     \
-            return 0;                                                                              \
-                                                                                                   \
         args_t args = {};                                                                          \
         args.args[0] = PT_REGS_PARM1(ctx);                                                         \
         args.args[1] = PT_REGS_PARM2(ctx);                                                         \
@@ -41,6 +34,9 @@
                                                                                                    \
         program_data_t p = {};                                                                     \
         if (!init_program_data(&p, ctx))                                                           \
+            return 0;                                                                              \
+                                                                                                   \
+        if (!should_trace(&p))                                                                     \
             return 0;                                                                              \
                                                                                                    \
         if (!should_submit(id, p.event))                                                           \

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -49,7 +49,7 @@ typedef struct containers_map containers_map_t;
 // persist args between function entry and return
 struct args_map {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __uint(max_entries, 1024);
+    __uint(max_entries, 10240);
     __type(key, u64);
     __type(value, args_t);
 } args_map SEC(".maps");

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3283,13 +3283,6 @@ statfunc int do_vfs_write_magic_enter(struct pt_regs *ctx)
         return 0;
     }
 
-    program_data_t p = {};
-    if (!init_program_data(&p, ctx))
-        return 0;
-
-    if (!should_trace(&p))
-        return 0;
-
     args_t args = {};
     args.args[0] = PT_REGS_PARM1(ctx);
     args.args[1] = PT_REGS_PARM2(ctx);
@@ -3312,6 +3305,9 @@ statfunc int do_vfs_write_magic_return(struct pt_regs *ctx, bool is_buf)
 
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
+        return 0;
+
+    if (!should_trace(&p))
         return 0;
 
     if (!should_submit(MAGIC_WRITE, p.event))

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -210,11 +210,8 @@ enum container_state_e
 typedef struct task_info {
     task_context_t context;
     syscall_data_t syscall_data;
-    bool syscall_traced;  // indicates that syscall_data is valid
-    bool recompute_scope; // recompute matched_scopes (new task/context changed/policy changed)
-    u16 policies_version; // version of policies used to match this task
-    u64 matched_scopes;   // cached bitmap of scopes this task matched
-    u8 container_state;   // the state of the container the task resides in
+    bool syscall_traced; // indicates that syscall_data is valid
+    u8 container_state;  // the state of the container the task resides in
 } task_info_t;
 
 typedef struct file_id {

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11907,6 +11907,10 @@ var CoreEvents = map[ID]Definition{
 		name:    "socket_dup",
 		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.SyscallEnter__Internal, required: true},
+				{handle: probes.SyscallExit__Internal, required: true},
+			},
 			tailCalls: []TailCall{
 				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
 				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},


### PR DESCRIPTION
### 1. Explain what the PR does

    perf: use lazy program data initialization
    
    We currently initialize all task context related fields on the beginning
    of our BPF programs. Reading all the relevant fields takes some CPU
    cycles although these fields are not always used. In many cases, for
    example when filters are applied, the event is not sent to userspace and
    is just dropped without any side effects.
    
    Reading only the essential fields and leaving all other fields
    initialization to the submit stage will avoid wasting these cycles, and
    will also allow us to perform some of the event enrichment in userspace
    instead (not part of this PR).
    
    To do this change, we have to remove the matched_policies which were
    cached in task_info since we can't check if "context changed" anymore.
    Considering that the average user will only use one or two scope filters
    (e.g. container id or binary name), computing the scope on every run is
    not a big overhead - running BPF statistics with and without the
    change verified this is indeed the case, and with the change the
    performance is even slightly better.
    
    Although this change does not introduce a visible performance gain for
    most of the events, it is clear for some other specific event that it
    does. For example, the hidden_inode event which attach a program to the
    filldir64 function has a 50% performance gain.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
