### PR TITLE
fix: make check-pr compliant with different shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -892,12 +892,16 @@ check-pr: \
 	@echo
 	@echo
 
-	@output=$$(git rev-list $(LOGFROM)..HEAD | while read commit; do \
-		if [[ "$$(git show --no-patch --format=%b $$commit)" ]]; then \
+	@output=$$($(CMD_GIT) rev-list $(LOGFROM)..HEAD | while read commit; do \
+		body="$$($(CMD_GIT) show --no-patch --format=%b $$commit | sed ':a;N;$$!ba;s/\n$$//')"; \
+		if [ -n "$$body" ]; then \
 			$(CMD_GIT) \
 				show -s $$commit \
 				--color=always \
-				--format='%C(auto,yellow)%h%Creset **%C(auto,red)%s%Creset**%n%n```%n%b%n```%n'; \
+				--format='%C(auto,yellow)%h%Creset **%C(auto,red)%s%Creset**%n'; \
+			echo '```'; \
+			echo "$$body"; \
+			echo '```'; \
 			echo; \
 		fi; \
 	done); \


### PR DESCRIPTION
Close: #3928

### 1. Explain what the PR does

ea5e6f445 **fix: make check-pr compliant with different shells**

```
It also now deals with trailing newlines in the commit bodies, printing
them following the same pattern.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
