### PR TITLE
fix(ebpf): hidden_kernel_module fix max iterations

### DIFF
--- a/pkg/ebpf/c/tracee.h
+++ b/pkg/ebpf/c/tracee.h
@@ -35,8 +35,8 @@ statfunc int init_shown_modules();
 statfunc int is_hidden(u64);
 statfunc int find_modules_from_module_kset_list(program_data_t *);
 statfunc struct latch_tree_node *__lt_from_rb(struct rb_node *, int);
-statfunc int walk_mod_tree(program_data_t *p, struct rb_node *, int);
-statfunc int find_modules_from_mod_tree(program_data_t *);
+statfunc int walk_mod_tree(program_data_t *p, struct pt_regs *, struct rb_node *, int);
+statfunc int find_modules_from_mod_tree(program_data_t *, struct pt_regs *);
 statfunc int check_is_proc_modules_hooked(program_data_t *);
 
 // TODO: related to bpf tracing

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -677,6 +677,7 @@ enum bpf_func_id
     BPF_FUNC_sk_storage_get = 107,
     BPF_FUNC_copy_from_user = 148,
     BPF_FUNC_for_each_map_elem = 164,
+    BPF_FUNC_loop = 181,
 };
 
 #define MODULE_NAME_LEN (64 - sizeof(unsigned long))


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

A change was depicted on kernel 6.5 where mod_tree contains duplicate modules and thus MAX_NUM_MODULES is not enough to iterate on the tree, which yielded a warning.
The fix is to use bpf_loop helper, which is available on kernels 5.17 and above, and do more iterations.

"Replace me with `make check-pr` output"

### 2. Explain how to test it

./dist/tracee -e=hidden_kernel_module

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
