### PR TITLE
Helm webhook custom templates

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -75,6 +75,12 @@ spec:
               readOnly: true
               mountPath: /tracee/config.yaml
               subPath: config.yaml
+            {{- range .Values.extraWebhookTemplates }}
+            - name: tracee-templates
+              readonly: true
+              mountPath: "/tracee/templates/{{ .name }}"
+              subPath: {{ .name }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -111,3 +117,8 @@ spec:
         - name: tracee-config
           configMap:
             name: tracee-config
+        {{- if .Values.extraWebhookTemplates }}
+        - name: "tracee-templates"
+          configMap:
+            name: tracee-templates
+        {{- end }}

--- a/deploy/helm/tracee/templates/tracee-config.yaml
+++ b/deploy/helm/tracee/templates/tracee-config.yaml
@@ -45,11 +45,13 @@ data:
                 protocol: {{ .protocol | default "http" }}
                 host: {{ .host | default "localhost" }}
                 port: {{ .port | default "8080" }}
-                timeout: {{ .timeout | default "3s" }}
-                {{- if .goTemplate }}
-                gotemplate: {{ .goTemplate }}
+                {{ if .timeout }}
+                timeout: {{ .timeout }}
                 {{- end }}
-                content-type: {{ .contentType | default "application/json" }}
+                gotemplate: {{ .goTemplate }}
+                {{- if .contentType }}
+                content-type: {{ .contentType }}
+                {{- end }}
         {{- end }}
     {{- if .Values.config.blobPerfBufferSize }}
     blob-perf-buffer-size: {{ .Values.config.blobPerfBufferSize}}

--- a/deploy/helm/tracee/templates/tracee-templates.yaml
+++ b/deploy/helm/tracee/templates/tracee-templates.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.extraWebhookTemplates }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tracee-templates
+  labels:
+    {{- include "tracee.labels" . | nindent 4 }}
+data:
+  {{- range .Values.extraWebhookTemplates }}
+  {{ .name }}: | {{ .goTemplate | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -56,6 +56,24 @@ affinity: {}
 
 webhook: ""
 
+# extraWebhookTemplates is a list of additional webhook templates that can be used by
+# the traceeConfig or config.output.webhook fields
+# in the example below, the goTemplate content will be mounted as /tracee/templates/template1.tmpl
+extraWebhookTemplates: []
+# - name: "template1.tmpl"
+#   goTemplate: |
+#   {
+#     "hostname": "{{ .HostName }}",
+#     "message": "Signature name: \"{{ .Metadata.Properties.signatureName }}\" description:\n{{ .Metadata.Description }}",
+#     "severity": "{{ .Metadata.Properties.Severity }}",
+#     "time": "{{ dateInZone "2006-01-02T15:04:05Z" (now) "UTC" }}",
+#     "tags": {
+#       "category": "{{ .Metadata.Properties.Category }}",
+#       "external_id": "{{ .Metadata.Properties.external_id }}",
+#       "signature_id": "{{ .Metadata.Properties.signatureId }}"
+#     }
+#   }
+
 traceeConfig: {}
 
 config:
@@ -87,7 +105,7 @@ config:
     # webhook:
     #   name: "webhook1"
     #   contentType: "application/json"
-    #   goTemplate: ""
+    #   goTemplate: "/tracee/templates/template1.tmpl"
     #   host: ""
     #   port: "8080"
     #   protocol: http


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

- feat: go templates for tracee webhooks (fixes #3886)
- fix: make only goTemplate mandatory in webhook config (temporary workaround for #3866)

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

```
➜ cat > test.yaml <<EOF
extraWebhookTemplates:
  - name: custom.tmpl
    goTemplate: |-
      {
        "event": "{{ .Event }}"
      }
config:
  output:
    webhook:
      name: local
      protocol: http
      host: localhost
      port: 8080
      goTemplate: /tracee/templates/custom.tmpl
EOF
➜ helm template tracee ./deploy/helm/tracee --show-only templates/tracee-templates.yaml -f test.yaml
---
# Source: tracee/templates/tracee-templates.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: tracee-templates
  labels:
    helm.sh/chart: tracee-0.20.0
    app.kubernetes.io/name: tracee
    app.kubernetes.io/instance: tracee
    app.kubernetes.io/version: "0.20.0"
    app.kubernetes.io/managed-by: Helm
data:
  custom.tmpl: |
    {
      "event": "{{ .Event }}"
    }
➜ helm template tracee ./deploy/helm/tracee --show-only templates/daemonset.yaml -f test.yaml | yq '.spec.template.spec.volumes[] | select(.name == "tracee-templates")'
name: "tracee-templates"
configMap:
  name: tracee-templates
➜ helm template tracee ./deploy/helm/tracee --show-only templates/daemonset.yaml -f test.yaml | yq '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "tracee-templates")'
name: tracee-templates
readonly: true
mountPath: "/tracee/templates/custom.tmpl"
subPath: custom.tmpl
```

Also tested no regressions when no extra templates are defined in the values file.

### 3. Other comments

Fix: #3886
Fix: #3866