### PR TITLE
fix: add missing nodeSelector and tolerations to tracee-operator

### DIFF
--- a/deploy/helm/tracee/templates/deploy.yaml
+++ b/deploy/helm/tracee/templates/deploy.yaml
@@ -16,6 +16,10 @@ spec:
       labels:
         app: {{ include "tracee-operator.fullname" . }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "tracee-operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/deploy/helm/tracee/templates/deploy.yaml
+++ b/deploy/helm/tracee/templates/deploy.yaml
@@ -39,4 +39,16 @@ spec:
           httpGet:
             path: /healthz
             port: {{ trimPrefix ":" .Values.operator.healthProbeBindAddress }}
+      {{- with .Values.operator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -101,3 +101,6 @@ operator:
   serviceAccount:
     name: "tracee-operator"
   healthProbeBindAddress: :8081
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

Allow options to schedule the tracee operator when deploying with the Helm chart

* fix: add missing nodeSelector and tolerations to tracee-operator deployment
* fix: add missing imagePullSecrets for tracee-operator

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

```
cat > test.yaml <<EOF
operator:
  nodeSelector:
    kubernetes.io/os: linux
  tolerations:
    - key: "workload"
      operator: "Equal"
      value: "security"
      effect: "NoSchedule"
EOF
helm template tracee ./deploy/helm/tracee --show-only templates/deploy.yaml
# shows no tolerations and no nodeSelect
helm template tracee ./deploy/helm/tracee --show-only templates/deploy.yaml -f test.yaml
# shows the specified nodeSelector and tolerations
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
