### PR TITLE
fix: security_socket_connect wrong fd

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2612,9 +2612,8 @@ int BPF_KPROBE(trace_security_socket_connect)
     void *args_buf = &p.event->args_buf;
     void *to = (void *) &sys->args.args[0];
 
-#if defined(bpf_target_x86) // only i386 binaries uses socketcall
-    to = (void *) sys->args.args[1];
-#endif
+    if (is_x86_compat(p.event->task)) // only i386 binaries uses socketcall
+        to = (void *) sys->args.args[1];
 
     // Save the socket fd, depending on the syscall.
     switch (sys->id) {


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The security_scoket_connect event sent the wrong fd number. This was due to using a wrong way to check if the binary is a 32bit binary.

Fix: #3950 

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
