### PR TITLE
Add `ArgVal` signature helper

### DIFF
--- a/signatures/helpers/arguments_helpers.go
+++ b/signatures/helpers/arguments_helpers.go
@@ -7,6 +7,25 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
+func ArgVal[T any](args []trace.Argument, argName string) (T, error) {
+	for _, arg := range args {
+		if arg.Name == argName {
+			val, ok := arg.Value.(T)
+			if !ok {
+				zeroVal := *new(T)
+				return zeroVal, fmt.Errorf(
+					"argument %s is not of type %T, is of type %T",
+					argName,
+					zeroVal,
+					arg.Value,
+				)
+			}
+			return val, nil
+		}
+	}
+	return *new(T), fmt.Errorf("argument %s not found", argName)
+}
+
 // GetArgOps represents options for arguments getters
 type GetArgOps struct {
 	DefaultArgs bool // Receive default args value (value equals 'nil'). If set to false, will return error if arg not initialized.


### PR DESCRIPTION
### 1. Explain what the PR does

Add `ArgVal` signature helper to extract a generic type from event arguments.

This function is simply copied from `pkg/events/parse/params.go` so it is now available for signatures.

### 3. Other comments

This PR is needed for https://github.com/aquasecurity/tracee/pull/3953
