### PR TITLE
Invert Policies inner maps key pair

### DIFF
--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -123,7 +123,7 @@ func (r Runner) Run(ctx context.Context) error {
 func GetContainerMode(cfg config.Config) config.ContainerMode {
 	containerMode := config.ContainerModeDisabled
 
-	for p := range cfg.Policies.Map() {
+	for _, p := range cfg.Policies.Map() {
 		if p.ContainerFilterEnabled() {
 			// Container Enrichment is enabled by default ...
 			containerMode = config.ContainerModeEnriched

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,7 @@ type Config struct {
 // Validate does static validation of the configuration
 func (c Config) Validate() error {
 	// Policies
-	for p := range c.Policies.Map() {
+	for _, p := range c.Policies.Map() {
 		if p == nil {
 			return errfmt.Errorf("policy is nil")
 		}

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -302,7 +302,7 @@ func (t *Tracee) matchPolicies(event *trace.Event) uint64 {
 		return bitmap
 	}
 
-	for p := range policies.FilterableInUserlandMap() { // range through each userland filterable policy
+	for _, p := range policies.FilterableInUserlandMap() { // range through each userland filterable policy
 		// Policy ID is the bit offset in the bitmap.
 		bitOffset := uint(p.ID)
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -264,7 +264,7 @@ func New(cfg config.Config) (*Tracee, error) {
 
 	// TODO: extract this to a function to be called from here and from
 	// policies changes.
-	for p := range t.config.Policies.Map() {
+	for _, p := range t.config.Policies.Map() {
 		for e := range p.EventsToTrace {
 			var submit, emit uint64
 			if _, ok := t.eventsState[e]; ok {
@@ -1596,7 +1596,7 @@ func (t *Tracee) triggerMemDump(event trace.Event) []error {
 	errs := []error{}
 
 	// TODO: consider to iterate over given policies when policies are changed
-	for p := range t.config.Policies.Map() {
+	for _, p := range t.config.Policies.Map() {
 		printMemDumpFilters := p.ArgFilter.GetEventFilters(events.PrintMemDump)
 		if len(printMemDumpFilters) == 0 {
 			errs = append(errs, errfmt.Errorf("policy %d: no address or symbols were provided to print_mem_dump event. "+

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -29,7 +29,7 @@ func SymbolsCollision(soLoader sharedobjs.DynamicSymbolsLoader, policies *policy
 	symbolsCollisionFilters := map[string]filters.Filter{}
 
 	// pick white and black lists from the filters (TODO: change this)
-	for policies := range policies.Map() {
+	for _, policies := range policies.Map() {
 		f := policies.ArgFilter.GetEventFilters(events.SymbolsCollision)
 		maps.Copy(symbolsCollisionFilters, f)
 	}

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -23,7 +23,7 @@ func SymbolsLoaded(
 ) DeriveFunction {
 	symbolsLoadedFilters := map[string]filters.Filter{}
 
-	for p := range policies.Map() {
+	for _, p := range policies.Map() {
 		f := p.ArgFilter.GetEventFilters(events.SymbolsLoaded)
 		maps.Copy(symbolsLoadedFilters, f)
 	}

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -77,7 +77,7 @@ type filtersEqualities struct {
 // updating the provided filtersEqualities struct
 // TODO: refactor this method deduplicating code
 func (ps *Policies) computeFilterEqualities(fEqs *filtersEqualities, cts *containers.Containers) error {
-	for p := range ps.Map() {
+	for _, p := range ps.Map() {
 		policyID := uint(p.ID)
 
 		// UIDFilters equalities
@@ -832,7 +832,7 @@ func (pc *PoliciesConfig) UpdateBPF(bpfConfigMap *bpf.BPFMapLow) error {
 func (ps *Policies) computePoliciesConfig() *PoliciesConfig {
 	cfg := &PoliciesConfig{}
 
-	for p := range ps.Map() {
+	for _, p := range ps.Map() {
 		offset := p.ID
 
 		// filter enabled policies bitmap

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -23,7 +23,3 @@ func PoliciesMaxExceededError() error {
 func PoliciesOutOfRangeError(idx int) error {
 	return fmt.Errorf("policies index [%d] out-of-range [0-%d]", idx, MaxPolicies-1)
 }
-
-func PolicyAlreadyExists(policy *Policy, id int) error {
-	return fmt.Errorf("policy [%+v] already set with different id [%d]", policy, id)
-}

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -140,11 +140,6 @@ func (ps *Policies) set(id int, p *Policy) error {
 	if !isIDInRange(id) {
 		return PoliciesOutOfRangeError(id)
 	}
-	if _, found := ps.filterEnabledPoliciesMap[p]; found {
-		if p.ID != id {
-			return PolicyAlreadyExists(p, id)
-		}
-	}
 
 	p.ID = id
 	ps.policiesArray[id] = p

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -27,7 +27,7 @@ func TestPoliciesClone(t *testing.T) {
 
 	copy := policies.Clone().(*Policies)
 
-	if !arePoliciesEqual(policies, copy) {
+	if !reflect.DeepEqual(policies, copy) {
 		t.Errorf("Clone did not produce an identical copy")
 	}
 
@@ -38,55 +38,7 @@ func TestPoliciesClone(t *testing.T) {
 	err = copy.Add(p3)
 	require.NoError(t, err)
 
-	if arePoliciesEqual(policies, copy) {
+	if reflect.DeepEqual(policies, copy) {
 		t.Errorf("Changes to copied policy affected the original")
 	}
-}
-
-// arePoliciesEqual is a helper function for TestPoliciesClone
-// since reflect.DeepEqual does not dereference pointers which are keys in maps.
-// TODO: remove this when Policies is refactored to not use pointers as keys in maps
-func arePoliciesEqual(p1, p2 *Policies) bool {
-	// check non-pointer fields
-	if !areNonPointerFieldsEqual(p1, p2) {
-		return false
-	}
-
-	// then compare the maps with pointers as keys
-	return areMapsEqual(p1.filterEnabledPoliciesMap, p2.filterEnabledPoliciesMap) &&
-		areMapsEqual(p1.filterUserlandPoliciesMap, p2.filterUserlandPoliciesMap)
-}
-
-func areMapsEqual(map1, map2 map[*Policy]int) bool {
-	if len(map1) != len(map2) {
-		return false
-	}
-
-	for k1, v1 := range map1 {
-		found := false
-		for k2, v2 := range map2 {
-			if reflect.DeepEqual(k1, k2) && v1 == v2 {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	return true
-}
-
-func areNonPointerFieldsEqual(p1, p2 *Policies) bool {
-	return p1.version == p2.version &&
-		reflect.DeepEqual(p1.bpfInnerMaps, p2.bpfInnerMaps) &&
-		reflect.DeepEqual(p1.policiesArray, p2.policiesArray) &&
-		p1.uidFilterMin == p2.uidFilterMin &&
-		p1.uidFilterMax == p2.uidFilterMax &&
-		p1.pidFilterMin == p2.pidFilterMin &&
-		p1.pidFilterMax == p2.pidFilterMax &&
-		p1.uidFilterableInUserland == p2.uidFilterableInUserland &&
-		p1.pidFilterableInUserland == p2.pidFilterableInUserland &&
-		p1.containerFiltersEnabled == p2.containerFiltersEnabled
 }

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1838,7 +1838,7 @@ func newPolicies(polsFilesID []policyFileWithID) *policy.Policies {
 	}
 
 	policiesWithIDSet := policy.NewPolicies()
-	for pol := range policies.Map() {
+	for _, pol := range policies.Map() {
 		pol.ID = polsFilesID[pol.ID].id - 1
 		policiesWithIDSet.Set(pol)
 	}


### PR DESCRIPTION
### 1. Explain what the PR does

9d2a1c59b **chore(policy): remove PolicyAlreadyExists**

```
Remove wrong logic from set method to check if a policy already exists.

If it exists, the method should always overwrite the policy.

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

bace1d126 **chore(policy): change Policies inner maps key pair**

```
Invert the key pair of the Policies inner maps to make it easier to
do reflection (tests).

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it


### 3. Other comments

