### PR TITLE
chore(policy): add policiesMapByName to Policies

### DIFF
--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -8,18 +8,22 @@ func PolicyNilError() error {
 	return fmt.Errorf("policy cannot be nil")
 }
 
-func PolicyNotFoundByIDError(idx int) error {
-	return fmt.Errorf("policy not found at index [%d]", idx)
-}
-
-func PolicyNotFoundByNameError(name string) error {
-	return fmt.Errorf("policy [%s] not found", name)
-}
-
 func PoliciesMaxExceededError() error {
 	return fmt.Errorf("policies maximum exceeded [%d]", MaxPolicies)
 }
 
 func PoliciesOutOfRangeError(idx int) error {
 	return fmt.Errorf("policies index [%d] out-of-range [0-%d]", idx, MaxPolicies-1)
+}
+
+func PolicyAlreadyExistsError(name string, idx int) error {
+	return fmt.Errorf("policy [%s] already exists at index [%d]", name, idx)
+}
+
+func PolicyNotFoundByIDError(idx int) error {
+	return fmt.Errorf("policy not found at index [%d]", idx)
+}
+
+func PolicyNotFoundByNameError(name string) error {
+	return fmt.Errorf("policy [%s] not found", name)
 }

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -13,10 +13,12 @@ func TestPoliciesClone(t *testing.T) {
 	policies := NewPolicies()
 
 	p1 := NewPolicy()
+	p1.Name = "p1"
 	err := p1.PIDFilter.Parse("=1")
 	require.NoError(t, err)
 
 	p2 := NewPolicy()
+	p2.Name = "p2"
 	err = p2.UIDFilter.Parse("=2")
 	require.NoError(t, err)
 
@@ -33,6 +35,7 @@ func TestPoliciesClone(t *testing.T) {
 
 	// ensure that changes to the copy do not affect the original
 	p3 := NewPolicy()
+	p3.Name = "p3"
 	err = p3.CommFilter.Parse("=comm")
 	require.NoError(t, err)
 	err = copy.Add(p3)


### PR DESCRIPTION

### 1. Explain what the PR does

043d0310d **chore(policy): add policiesMapByName to Policies**

```
- Introduce policiesMapByName to speed up LookupByName() and support
  Add(), Set() and Remove().
- Reintroduce PolicyAlreadyExistsError with different signature.
- Add() now checks against already existing policy name.
- Set() now only overwrites if name and ID of the given policy are
  identical.
- Add count() to be used internally.

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
