### PR TITLE
Add timestamp docker tag for dev image

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -129,6 +129,12 @@ jobs:
             aquasec/tracee:x86_64-dev \
             aquasec/tracee:aarch64-dev
           docker manifest push aquasec/tracee:dev
+
+          timestamp=$(date +%Y%m%d-%H%M%S%Z)
+          docker manifest create aquasec/tracee:dev-$timestamp \
+            aquasec/tracee:x86_64-dev \
+            aquasec/tracee:aarch64-dev
+          docker manifest push aquasec/tracee:dev-$timestamp
         shell: bash
       # Disabled to avoid generating too many sigstore cosign signatures
       # - name: Sign Docker image


### PR DESCRIPTION
There is no way to currently use an architecture agnostic dev image for a specific build. This enables that use case.