### PR TITLE
fix(dependencies): allow multiple removes of same event

### DIFF
--- a/pkg/events/dependencies/manager_test.go
+++ b/pkg/events/dependencies/manager_test.go
@@ -76,24 +76,27 @@ func TestManager_AddEvent(t *testing.T) {
 						eventsAdditions = append(eventsAdditions, newEvtNode.GetID())
 					})
 
-				m.SelectEvent(testCase.eventToAdd)
+				// Check that multiple selects are not causing any issues
+				for i := 0; i < 3; i++ {
+					m.SelectEvent(testCase.eventToAdd)
 
-				for id, expDep := range testCase.deps {
-					evtNode, ok := m.GetEvent(id)
-					assert.True(t, ok)
-					dep := evtNode.GetDependencies()
-					assert.ElementsMatch(t, expDep.GetIDs(), dep.GetIDs())
-
-					// Test dependencies building
-					for _, dependency := range dep.GetIDs() {
-						dependencyNode, ok := m.GetEvent(dependency)
+					for id, expDep := range testCase.deps {
+						evtNode, ok := m.GetEvent(id)
 						assert.True(t, ok)
-						dependants := dependencyNode.GetDependants()
-						assert.Contains(t, dependants, id)
-					}
+						dep := evtNode.GetDependencies()
+						assert.ElementsMatch(t, expDep.GetIDs(), dep.GetIDs())
 
-					// Test addition watcher logic
-					assert.Contains(t, eventsAdditions, id)
+						// Test dependencies building
+						for _, dependency := range dep.GetIDs() {
+							dependencyNode, ok := m.GetEvent(dependency)
+							assert.True(t, ok)
+							dependants := dependencyNode.GetDependants()
+							assert.Contains(t, dependants, id)
+						}
+
+						// Test addition watcher logic
+						assert.Contains(t, eventsAdditions, id)
+					}
 				}
 			})
 	}
@@ -231,14 +234,17 @@ func TestManager_RemoveEvent(t *testing.T) {
 
 				m.SelectEvent(testCase.eventToAdd)
 
-				m.RemoveEvent(testCase.eventToAdd)
+				// Check that multiple removes are not causing any issues
+				for i := 0; i < 3; i++ {
+					m.RemoveEvent(testCase.eventToAdd)
 
-				for _, id := range testCase.expectedRemovedEvents {
-					_, ok := m.GetEvent(id)
-					assert.False(t, ok)
+					for _, id := range testCase.expectedRemovedEvents {
+						_, ok := m.GetEvent(id)
+						assert.False(t, ok)
 
-					// Test indirect addition watcher logic
-					assert.Contains(t, eventsRemoved, id)
+						// Test indirect addition watcher logic
+						assert.Contains(t, eventsRemoved, id)
+					}
 				}
 			})
 	}
@@ -376,14 +382,17 @@ func TestManager_UnselectEvent(t *testing.T) {
 
 				m.SelectEvent(testCase.eventToAdd)
 
-				m.UnselectEvent(testCase.eventToAdd)
+				// Check that multiple unselects are not causing any issues
+				for i := 0; i < 3; i++ {
+					m.UnselectEvent(testCase.eventToAdd)
 
-				for _, id := range testCase.expectedRemovedEvents {
-					_, ok := m.GetEvent(id)
-					assert.False(t, ok)
+					for _, id := range testCase.expectedRemovedEvents {
+						_, ok := m.GetEvent(id)
+						assert.False(t, ok)
 
-					// Test indirect addition watcher logic
-					assert.Contains(t, eventsRemoved, id)
+						// Test indirect addition watcher logic
+						assert.Contains(t, eventsRemoved, id)
+					}
 				}
 			})
 	}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Fix a bug of nil pointer reference when removing an event node from the dependencies after it was already removed.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
