### PR TITLE
Run x86_64 & aarch64 builds in parallel

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -57,7 +57,6 @@ jobs:
       #   shell: bash
   release-snapshot-aarch64:
     name: Release Snapshot (aarch64)
-    needs: [ release-snapshot-x86_64 ]
     runs-on: 
       - graas_ami-03217ce7c37572c4d_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}
       - EXECUTION_TYPE=LONG


### PR DESCRIPTION
I don't think the aarch64 build depends on the x86_64 build after a cursory look. This should reduce build time by over and hour and let me have new builds at 11PM instead of 1AM in my timezone 😁 