### PR TITLE
Add Iterator generic interface, debut it in Policies

### DIFF
--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -123,7 +123,8 @@ func (r Runner) Run(ctx context.Context) error {
 func GetContainerMode(cfg config.Config) config.ContainerMode {
 	containerMode := config.ContainerModeDisabled
 
-	for _, p := range cfg.Policies.Map() {
+	for it := cfg.Policies.CreateAllIterator(); it.HasNext(); {
+		p := it.Next()
 		if p.ContainerFilterEnabled() {
 			// Container Enrichment is enabled by default ...
 			containerMode = config.ContainerModeEnriched

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/containers/runtime"
 	"github.com/aquasecurity/tracee/pkg/dnscache"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
-	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/queue"
 	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/proctree"
@@ -39,22 +38,6 @@ type Config struct {
 
 // Validate does static validation of the configuration
 func (c Config) Validate() error {
-	// Policies
-	for _, p := range c.Policies.Map() {
-		if p == nil {
-			return errfmt.Errorf("policy is nil")
-		}
-		if p.EventsToTrace == nil {
-			return errfmt.Errorf("policy [%d] has no events to trace", p.ID)
-		}
-
-		for e := range p.EventsToTrace {
-			if !events.Core.IsDefined(e) {
-				return errfmt.Errorf("invalid event [%d] to trace in policy [%d]", e, p.ID)
-			}
-		}
-	}
-
 	// Buffer sizes
 	if (c.PerfBufferSize & (c.PerfBufferSize - 1)) != 0 {
 		return errfmt.Errorf("invalid perf buffer size - must be a power of 2")

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -302,7 +302,9 @@ func (t *Tracee) matchPolicies(event *trace.Event) uint64 {
 		return bitmap
 	}
 
-	for _, p := range policies.FilterableInUserlandMap() { // range through each userland filterable policy
+	// range through each userland filterable policy
+	for it := policies.CreateUserlandIterator(); it.HasNext(); {
+		p := it.Next()
 		// Policy ID is the bit offset in the bitmap.
 		bitOffset := uint(p.ID)
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -307,7 +307,8 @@ func New(cfg config.Config) (*Tracee, error) {
 
 	// TODO: extract this to a function to be called from here and from
 	// policies changes.
-	for _, p := range t.config.Policies.Map() {
+	for it := t.config.Policies.CreateAllIterator(); it.HasNext(); {
+		p := it.Next()
 		for e := range p.EventsToTrace {
 			var submit, emit uint64
 			if _, ok := t.eventsState[e]; ok {
@@ -1590,7 +1591,8 @@ func (t *Tracee) triggerMemDump(event trace.Event) []error {
 	errs := []error{}
 
 	// TODO: consider to iterate over given policies when policies are changed
-	for _, p := range t.config.Policies.Map() {
+	for it := t.config.Policies.CreateAllIterator(); it.HasNext(); {
+		p := it.Next()
 		printMemDumpFilters := p.ArgFilter.GetEventFilters(events.PrintMemDump)
 		if len(printMemDumpFilters) == 0 {
 			errs = append(errs, errfmt.Errorf("policy %d: no address or symbols were provided to print_mem_dump event. "+

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -29,8 +29,9 @@ func SymbolsCollision(soLoader sharedobjs.DynamicSymbolsLoader, policies *policy
 	symbolsCollisionFilters := map[string]filters.Filter{}
 
 	// pick white and black lists from the filters (TODO: change this)
-	for _, policies := range policies.Map() {
-		f := policies.ArgFilter.GetEventFilters(events.SymbolsCollision)
+	for it := policies.CreateAllIterator(); it.HasNext(); {
+		p := it.Next()
+		f := p.ArgFilter.GetEventFilters(events.SymbolsCollision)
 		maps.Copy(symbolsCollisionFilters, f)
 	}
 

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -23,7 +23,8 @@ func SymbolsLoaded(
 ) DeriveFunction {
 	symbolsLoadedFilters := map[string]filters.Filter{}
 
-	for _, p := range policies.Map() {
+	for it := policies.CreateAllIterator(); it.HasNext(); {
+		p := it.Next()
 		f := p.ArgFilter.GetEventFilters(events.SymbolsLoaded)
 		maps.Copy(symbolsLoadedFilters, f)
 	}

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -77,7 +77,7 @@ type filtersEqualities struct {
 // updating the provided filtersEqualities struct
 // TODO: refactor this method deduplicating code
 func (ps *Policies) computeFilterEqualities(fEqs *filtersEqualities, cts *containers.Containers) error {
-	for _, p := range ps.Map() {
+	for _, p := range ps.all() {
 		policyID := uint(p.ID)
 
 		// UIDFilters equalities
@@ -832,7 +832,7 @@ func (pc *PoliciesConfig) UpdateBPF(bpfConfigMap *bpf.BPFMapLow) error {
 func (ps *Policies) computePoliciesConfig() *PoliciesConfig {
 	cfg := &PoliciesConfig{}
 
-	for _, p := range ps.Map() {
+	for _, p := range ps.all() {
 		offset := p.ID
 
 		// filter enabled policies bitmap

--- a/pkg/policy/policies_iterator.go
+++ b/pkg/policy/policies_iterator.go
@@ -1,0 +1,24 @@
+package policy
+
+// PoliciesIterator is an iterator for Policies.
+type PoliciesIterator struct {
+	policies []*Policy
+	index    int
+}
+
+// HasNext returns true if there are more policies to iterate.
+func (i *PoliciesIterator) HasNext() bool {
+	return i.index < len(i.policies)
+}
+
+// Next returns the next policy in the iteration.
+func (i *PoliciesIterator) Next() *Policy {
+	if !i.HasNext() {
+		return nil
+	}
+
+	p := i.policies[i.index]
+	i.index++
+
+	return p
+}

--- a/pkg/policy/policies_iterator.go
+++ b/pkg/policy/policies_iterator.go
@@ -1,5 +1,7 @@
 package policy
 
+import "github.com/aquasecurity/tracee/pkg/utils"
+
 // PoliciesIterator is an iterator for Policies.
 type PoliciesIterator struct {
 	policies []*Policy
@@ -21,4 +23,14 @@ func (i *PoliciesIterator) Next() *Policy {
 	i.index++
 
 	return p
+}
+
+// CreateUserlandIterator returns a new iterator for a reduced list of policies
+// which must be filtered in userland (ArgFilter, RetFilter, ContextFilter,
+// UIDFilter and PIDFilter).
+func (ps *Policies) CreateUserlandIterator() utils.Iterator[*Policy] {
+	return &PoliciesIterator{
+		policies: ps.userlandPolicies,
+		index:    0,
+	}
 }

--- a/pkg/policy/policies_iterator.go
+++ b/pkg/policy/policies_iterator.go
@@ -34,3 +34,11 @@ func (ps *Policies) CreateUserlandIterator() utils.Iterator[*Policy] {
 		index:    0,
 	}
 }
+
+// CreateAllIterator returns a new iterator for all policies.
+func (ps *Policies) CreateAllIterator() utils.Iterator[*Policy] {
+	return &PoliciesIterator{
+		policies: ps.policiesList,
+		index:    0,
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -13,6 +13,15 @@ type Cloner interface {
 	Clone() Cloner
 }
 
+// Iterator is a generic interface for iterators.
+type Iterator[T any] interface {
+	// HasNext returns true if there are more elements to iterate.
+	HasNext() bool
+
+	// Next returns the next element in the iteration.
+	Next() T
+}
+
 func ParseSymbol(address uint64, table *helpers.KernelSymbolTable) helpers.KernelSymbol {
 	var hookingFunction helpers.KernelSymbol
 

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1838,7 +1838,8 @@ func newPolicies(polsFilesID []policyFileWithID) *policy.Policies {
 	}
 
 	policiesWithIDSet := policy.NewPolicies()
-	for _, pol := range policies.Map() {
+	for it := policies.CreateAllIterator(); it.HasNext(); {
+		pol := it.Next()
 		pol.ID = polsFilesID[pol.ID].id - 1
 		policiesWithIDSet.Set(pol)
 	}


### PR DESCRIPTION
### 1. Explain what the PR does
5dc0a1bbc **chore: add CreateAllIterator**
688c30403 **chore: add CreateUserlandIterator**
7de062cbd **chore: introduce PoliciesIterator**
faef01c64 **chore: introduce Iterator generic interface**


5dc0a1bbc **chore: add CreateAllIterator**

```
Use CreateAllIterator instead of directly accessing the policies map,
which is a private field.

This also removes a stale Policies validation from the Config struct
method.

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

688c30403 **chore: add CreateUserlandIterator**

```
Use CreateUserlandIterator instead of directly accessing userland
policies slice, which is a private field.

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

faef01c64 **chore: introduce Iterator generic interface**

```
The Iterator pattern can be used to traverse a collection of elements
without exposing its underlying representation.

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
