### PR TITLE
chore: make Cloner generic

### DIFF
--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -26,7 +26,7 @@ import (
 
 func SymbolsCollision(soLoader sharedobjs.DynamicSymbolsLoader, policies *policy.Policies,
 ) DeriveFunction {
-	symbolsCollisionFilters := map[string]filters.Filter{}
+	symbolsCollisionFilters := map[string]filters.Filter[*filters.StringFilter]{}
 
 	// pick white and black lists from the filters (TODO: change this)
 	for it := policies.CreateAllIterator(); it.HasNext(); {

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -21,7 +21,7 @@ func SymbolsLoaded(
 	soLoader sharedobjs.DynamicSymbolsLoader,
 	policies *policy.Policies,
 ) DeriveFunction {
-	symbolsLoadedFilters := map[string]filters.Filter{}
+	symbolsLoadedFilters := map[string]filters.Filter[*filters.StringFilter]{}
 
 	for it := policies.CreateAllIterator(); it.HasNext(); {
 		p := it.Next()

--- a/pkg/filters/args_test.go
+++ b/pkg/filters/args_test.go
@@ -19,7 +19,7 @@ func TestArgsFilterClone(t *testing.T) {
 	err := filter.Parse("read.args.fd", "=argval", events.Core.NamesToIDs())
 	require.NoError(t, err)
 
-	copy := filter.Clone().(*ArgFilter)
+	copy := filter.Clone()
 
 	opt1 := cmp.AllowUnexported(
 		ArgFilter{},

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -22,6 +22,9 @@ type BinaryFilter struct {
 	enabled  bool
 }
 
+// Compile-time check to ensure that BinaryFilter implements the Cloner interface
+var _ utils.Cloner[*BinaryFilter] = &BinaryFilter{}
+
 func getHostMntNS() (uint32, error) {
 	var ns int
 	var err error
@@ -153,7 +156,7 @@ func (f *BinaryFilter) Equalities() BinaryFilterEqualities {
 	}
 }
 
-func (f *BinaryFilter) Clone() utils.Cloner {
+func (f *BinaryFilter) Clone() *BinaryFilter {
 	if f == nil {
 		return nil
 	}

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -13,6 +13,9 @@ type BoolFilter struct {
 	enabled      bool
 }
 
+// Compile-time check to ensure that BoolFilter implements the Cloner interface
+var _ utils.Cloner[*BoolFilter] = &BoolFilter{}
+
 func NewBoolFilter() *BoolFilter {
 	return &BoolFilter{}
 }
@@ -145,7 +148,7 @@ func (f *BoolFilter) FilterOut() bool {
 	return !f.Value()
 }
 
-func (f *BoolFilter) Clone() utils.Cloner {
+func (f *BoolFilter) Clone() *BoolFilter {
 	if f == nil {
 		return nil
 	}

--- a/pkg/filters/bool_test.go
+++ b/pkg/filters/bool_test.go
@@ -115,7 +115,7 @@ func TestBoolFilterClone(t *testing.T) {
 	err := filter.Parse("=false")
 	require.NoError(t, err)
 
-	copy := filter.Clone().(*BoolFilter)
+	copy := filter.Clone()
 
 	if !reflect.DeepEqual(filter, copy) {
 		t.Errorf("Clone did not produce an identical copy")

--- a/pkg/filters/context.go
+++ b/pkg/filters/context.go
@@ -14,6 +14,9 @@ type ContextFilter struct {
 	enabled bool
 }
 
+// Compile-time check to ensure that ContextFilter implements the Cloner interface
+var _ utils.Cloner[*ContextFilter] = &ContextFilter{}
+
 func NewContextFilter() *ContextFilter {
 	return &ContextFilter{
 		filters: make(map[events.ID]*eventCtxFilter),
@@ -138,6 +141,9 @@ type eventCtxFilter struct {
 	syscallFilter              *StringFilter
 }
 
+// Compile-time check to ensure that eventCtxFilter implements the Cloner interface
+var _ utils.Cloner[*eventCtxFilter] = &eventCtxFilter{}
+
 func (f *eventCtxFilter) Enable() {
 	f.enabled = true
 }
@@ -234,30 +240,30 @@ func (f *eventCtxFilter) Parse(field string, operatorAndValues string) error {
 	// eventname.context.container.id and so on...
 	case "containerId":
 		filter := f.containerIDFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	case "containerImage":
 		filter := f.containerImageFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	case "containerImageDigest":
 		filter := f.containerImageDigestFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	case "containerName":
 		filter := f.containerNameFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	// TODO: change this and below pod filters to the format
 	// eventname.context.kubernetes.podName and so on...
 	case "podName":
 		filter := f.podNameFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	case "podNamespace":
 		filter := f.podNSFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	case "podUid":
 		filter := f.podUIDFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*StringFilter](f, filter, operatorAndValues)
 	case "podSandbox":
 		filter := f.podSandboxFilter
-		return f.addContainer(filter, operatorAndValues)
+		return addContainer[*BoolFilter](f, filter, operatorAndValues)
 	case "syscall":
 		filter := f.syscallFilter
 		return filter.Parse(operatorAndValues)
@@ -265,7 +271,7 @@ func (f *eventCtxFilter) Parse(field string, operatorAndValues string) error {
 	return InvalidContextField(field)
 }
 
-func (f *eventCtxFilter) addContainer(filter Filter, operatorAndValues string) error {
+func addContainer[T any](f *eventCtxFilter, filter Filter[T], operatorAndValues string) error {
 	err := filter.Parse(operatorAndValues)
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -277,7 +283,7 @@ func (f *eventCtxFilter) addContainer(filter Filter, operatorAndValues string) e
 	return nil
 }
 
-func (f *eventCtxFilter) Clone() utils.Cloner {
+func (f *eventCtxFilter) Clone() *eventCtxFilter {
 	if f == nil {
 		return nil
 	}
@@ -285,35 +291,35 @@ func (f *eventCtxFilter) Clone() utils.Cloner {
 	n := &eventCtxFilter{}
 
 	n.enabled = f.enabled
-	n.timestampFilter = f.timestampFilter.Clone().(*IntFilter[int64])
-	n.processorIDFilter = f.processorIDFilter.Clone().(*IntFilter[int64])
-	n.pidFilter = f.pidFilter.Clone().(*IntFilter[int64])
-	n.tidFilter = f.tidFilter.Clone().(*IntFilter[int64])
-	n.ppidFilter = f.ppidFilter.Clone().(*IntFilter[int64])
-	n.hostPidFilter = f.hostPidFilter.Clone().(*IntFilter[int64])
-	n.hostTidFilter = f.hostTidFilter.Clone().(*IntFilter[int64])
-	n.hostPpidFilter = f.hostPpidFilter.Clone().(*IntFilter[int64])
-	n.uidFilter = f.uidFilter.Clone().(*IntFilter[int64])
-	n.mntNSFilter = f.mntNSFilter.Clone().(*IntFilter[int64])
-	n.pidNSFilter = f.pidNSFilter.Clone().(*IntFilter[int64])
-	n.processNameFilter = f.processNameFilter.Clone().(*StringFilter)
-	n.hostNameFilter = f.hostNameFilter.Clone().(*StringFilter)
-	n.cgroupIDFilter = f.cgroupIDFilter.Clone().(*UIntFilter[uint64])
-	n.containerFilter = f.containerFilter.Clone().(*BoolFilter)
-	n.containerIDFilter = f.containerIDFilter.Clone().(*StringFilter)
-	n.containerImageFilter = f.containerImageFilter.Clone().(*StringFilter)
-	n.containerImageDigestFilter = f.containerImageDigestFilter.Clone().(*StringFilter)
-	n.containerNameFilter = f.containerNameFilter.Clone().(*StringFilter)
-	n.podNameFilter = f.podNameFilter.Clone().(*StringFilter)
-	n.podNSFilter = f.podNSFilter.Clone().(*StringFilter)
-	n.podUIDFilter = f.podUIDFilter.Clone().(*StringFilter)
-	n.podSandboxFilter = f.podSandboxFilter.Clone().(*BoolFilter)
-	n.syscallFilter = f.syscallFilter.Clone().(*StringFilter)
+	n.timestampFilter = f.timestampFilter.Clone()
+	n.processorIDFilter = f.processorIDFilter.Clone()
+	n.pidFilter = f.pidFilter.Clone()
+	n.tidFilter = f.tidFilter.Clone()
+	n.ppidFilter = f.ppidFilter.Clone()
+	n.hostPidFilter = f.hostPidFilter.Clone()
+	n.hostTidFilter = f.hostTidFilter.Clone()
+	n.hostPpidFilter = f.hostPpidFilter.Clone()
+	n.uidFilter = f.uidFilter.Clone()
+	n.mntNSFilter = f.mntNSFilter.Clone()
+	n.pidNSFilter = f.pidNSFilter.Clone()
+	n.processNameFilter = f.processNameFilter.Clone()
+	n.hostNameFilter = f.hostNameFilter.Clone()
+	n.cgroupIDFilter = f.cgroupIDFilter.Clone()
+	n.containerFilter = f.containerFilter.Clone()
+	n.containerIDFilter = f.containerIDFilter.Clone()
+	n.containerImageFilter = f.containerImageFilter.Clone()
+	n.containerImageDigestFilter = f.containerImageDigestFilter.Clone()
+	n.containerNameFilter = f.containerNameFilter.Clone()
+	n.podNameFilter = f.podNameFilter.Clone()
+	n.podNSFilter = f.podNSFilter.Clone()
+	n.podUIDFilter = f.podUIDFilter.Clone()
+	n.podSandboxFilter = f.podSandboxFilter.Clone()
+	n.syscallFilter = f.syscallFilter.Clone()
 
 	return n
 }
 
-func (filter *ContextFilter) Clone() utils.Cloner {
+func (filter *ContextFilter) Clone() *ContextFilter {
 	if filter == nil {
 		return nil
 	}
@@ -321,7 +327,7 @@ func (filter *ContextFilter) Clone() utils.Cloner {
 	n := NewContextFilter()
 
 	for k, v := range filter.filters {
-		n.filters[k] = v.Clone().(*eventCtxFilter)
+		n.filters[k] = v.Clone()
 	}
 
 	n.enabled = filter.enabled

--- a/pkg/filters/context_test.go
+++ b/pkg/filters/context_test.go
@@ -14,7 +14,7 @@ func TestContextFilterClone(t *testing.T) {
 	err := filter.Parse("openat.context.processorId", "=0")
 	require.NoError(t, err)
 
-	copy := filter.Clone().(*ContextFilter)
+	copy := filter.Clone()
 
 	if !reflect.DeepEqual(filter, copy) {
 		t.Errorf("Clone did not produce an identical copy")

--- a/pkg/filters/filters.go
+++ b/pkg/filters/filters.go
@@ -1,7 +1,5 @@
 package filters
 
-import "github.com/aquasecurity/tracee/pkg/utils"
-
 type Operator uint
 
 const (
@@ -50,10 +48,10 @@ func stringToOperator(op string) Operator {
 }
 
 // This is a generic representation which cannot be implemented
-// With generics this may be a viable interface, with T replacing interface{}
+// With generics this may be a viable interface, with U replacing interface{}
 // Filters can be enabled or disabled - if a filter is enabled it will be skipped
-type Filter interface {
-	utils.Cloner
+type Filter[T any] interface {
+	Clone() T
 
 	Filter(val interface{}) bool
 	Parse(operatorAndValues string) error

--- a/pkg/filters/int.go
+++ b/pkg/filters/int.go
@@ -27,6 +27,9 @@ type IntFilter[T constraints.Signed] struct {
 	enabled  bool
 }
 
+// Compile-time check to ensure that IntFilter implements the Cloner interface
+var _ utils.Cloner[*IntFilter[int32]] = &IntFilter[int32]{}
+
 // TODO: Add int16 and int8 filters?
 
 func NewIntFilter() *IntFilter[int64] {
@@ -191,7 +194,7 @@ func (f *IntFilter[T]) Parse(operatorAndValues string) error {
 	return nil
 }
 
-func (f *IntFilter[T]) Clone() utils.Cloner {
+func (f *IntFilter[T]) Clone() *IntFilter[T] {
 	if f == nil {
 		return nil
 	}

--- a/pkg/filters/int_test.go
+++ b/pkg/filters/int_test.go
@@ -73,7 +73,7 @@ func TestIntFilterClone(t *testing.T) {
 	err := filter64.Parse("=50,8")
 	require.NoError(t, err)
 
-	copy64 := filter64.Clone().(*IntFilter[int64])
+	copy64 := filter64.Clone()
 
 	if !reflect.DeepEqual(filter64, copy64) {
 		t.Errorf("Clone did not produce an identical copy")
@@ -90,7 +90,7 @@ func TestIntFilterClone(t *testing.T) {
 	err = filter32.Parse("=50,8")
 	require.NoError(t, err)
 
-	copy32 := filter32.Clone().(*IntFilter[int32])
+	copy32 := filter32.Clone()
 
 	if !reflect.DeepEqual(filter32, copy32) {
 		t.Errorf("Clone did not produce an identical copy")

--- a/pkg/filters/processtree.go
+++ b/pkg/filters/processtree.go
@@ -16,6 +16,9 @@ type ProcessTreeFilter struct {
 	enabled  bool
 }
 
+// Compile-time check to ensure that ProcessTreeFilter implements the Cloner interface
+var _ utils.Cloner[*ProcessTreeFilter] = &ProcessTreeFilter{}
+
 func NewProcessTreeFilter() *ProcessTreeFilter {
 	return &ProcessTreeFilter{
 		equal:    map[uint32]struct{}{},
@@ -104,7 +107,7 @@ func (f *ProcessTreeFilter) Equalities() ProcessTreeFilterEqualities {
 	}
 }
 
-func (f *ProcessTreeFilter) Clone() utils.Cloner {
+func (f *ProcessTreeFilter) Clone() *ProcessTreeFilter {
 	if f == nil {
 		return nil
 	}

--- a/pkg/filters/retval.go
+++ b/pkg/filters/retval.go
@@ -13,6 +13,9 @@ type RetFilter struct {
 	enabled bool
 }
 
+// Compile-time check to ensure that RetFilter implements the Cloner interface
+var _ utils.Cloner[*RetFilter] = &RetFilter{}
+
 func NewRetFilter() *RetFilter {
 	return &RetFilter{
 		filters: map[events.ID]*IntFilter[int64]{},
@@ -85,7 +88,7 @@ func (filter *RetFilter) Parse(filterName string, operatorAndValues string, even
 	return nil
 }
 
-func (filter *RetFilter) Clone() utils.Cloner {
+func (filter *RetFilter) Clone() *RetFilter {
 	if filter == nil {
 		return nil
 	}
@@ -93,7 +96,7 @@ func (filter *RetFilter) Clone() utils.Cloner {
 	n := NewRetFilter()
 
 	for k, v := range filter.filters {
-		n.filters[k] = v.Clone().(*IntFilter[int64])
+		n.filters[k] = v.Clone()
 	}
 	n.enabled = filter.enabled
 

--- a/pkg/filters/sets/prefixset.go
+++ b/pkg/filters/sets/prefixset.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 
 	"golang.org/x/exp/maps"
+
+	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
 type PrefixSet struct {
@@ -13,6 +15,9 @@ type PrefixSet struct {
 	lengths   []int
 	minLen    int
 }
+
+// Compile-time check to ensure that PrefixSet implements the Cloner interface
+var _ utils.Cloner[*PrefixSet] = &PrefixSet{}
 
 func NewPrefixSet() PrefixSet {
 	return PrefixSet{

--- a/pkg/filters/sets/suffixset.go
+++ b/pkg/filters/sets/suffixset.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 
 	"golang.org/x/exp/maps"
+
+	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
 type SuffixSet struct {
@@ -13,6 +15,9 @@ type SuffixSet struct {
 	lengths   []int
 	minLen    int
 }
+
+// Compile-time check to ensure that SuffixSet implements the Cloner interface
+var _ utils.Cloner[*SuffixSet] = &SuffixSet{}
 
 func NewSuffixSet() SuffixSet {
 	return SuffixSet{

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -23,6 +23,9 @@ type StringFilter struct {
 	enabled      bool
 }
 
+// Compile-time check to ensure that StringFilter implements the Cloner interface
+var _ utils.Cloner[*StringFilter] = &StringFilter{}
+
 func NewStringFilter(valueHandler func(string) (string, error)) *StringFilter {
 	return &StringFilter{
 		valueHandler: valueHandler,
@@ -250,7 +253,7 @@ func (f *StringFilter) Equalities() StringFilterEqualities {
 	}
 }
 
-func (f *StringFilter) Clone() utils.Cloner {
+func (f *StringFilter) Clone() *StringFilter {
 	if f == nil {
 		return nil
 	}

--- a/pkg/filters/string_test.go
+++ b/pkg/filters/string_test.go
@@ -212,7 +212,7 @@ func TestStringFilterClone(t *testing.T) {
 	err = filter.Parse("!=abc")
 	assert.NoError(t, err)
 
-	copy := filter.Clone().(*StringFilter)
+	copy := filter.Clone()
 
 	opt1 := cmp.AllowUnexported(
 		StringFilter{},

--- a/pkg/filters/uint.go
+++ b/pkg/filters/uint.go
@@ -27,6 +27,9 @@ type UIntFilter[T constraints.Unsigned] struct {
 	enabled  bool
 }
 
+// Compile-time check to ensure that UIntFilter implements the Cloner interface
+var _ utils.Cloner[*UIntFilter[uint32]] = &UIntFilter[uint32]{}
+
 // TODO: Add uint16 and uint8 filters?
 
 func NewUIntFilter() *UIntFilter[uint64] {
@@ -235,7 +238,7 @@ func (f *UIntFilter[T]) Equalities() UIntFilterEqualities {
 	}
 }
 
-func (f *UIntFilter[T]) Clone() utils.Cloner {
+func (f *UIntFilter[T]) Clone() *UIntFilter[T] {
 	if f == nil {
 		return nil
 	}

--- a/pkg/filters/uint_test.go
+++ b/pkg/filters/uint_test.go
@@ -81,7 +81,7 @@ func TestUIntFilterClone(t *testing.T) {
 	err := filter64.Parse("=50,8")
 	require.NoError(t, err)
 
-	copy64 := filter64.Clone().(*UIntFilter[uint64])
+	copy64 := filter64.Clone()
 
 	if !reflect.DeepEqual(filter64, copy64) {
 		t.Errorf("Clone did not produce an identical copy")
@@ -97,7 +97,7 @@ func TestUIntFilterClone(t *testing.T) {
 	err = filter32.Parse("=50,8")
 	require.NoError(t, err)
 
-	copy32 := filter32.Clone().(*UIntFilter[uint32])
+	copy32 := filter32.Clone()
 
 	if !reflect.DeepEqual(filter32, copy32) {
 		t.Errorf("Clone did not produce an identical copy")

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -65,6 +65,9 @@ func NewPolicies() *Policies {
 	}
 }
 
+// Compile-time check to ensure that Policies implements the Cloner interface
+var _ utils.Cloner[*Policies] = &Policies{}
+
 func (ps *Policies) count() int {
 	return len(ps.policiesMapByID)
 }
@@ -282,7 +285,7 @@ func (ps *Policies) all() map[int]*Policy {
 // 4. and possibly other steps in which we iterate over the policies map
 
 // Clone returns a deep copy of Policies.
-func (ps *Policies) Clone() utils.Cloner {
+func (ps *Policies) Clone() *Policies {
 	if ps == nil {
 		return nil
 	}
@@ -296,7 +299,7 @@ func (ps *Policies) Clone() utils.Cloner {
 		if p == nil {
 			continue
 		}
-		if err := nPols.Add(p.Clone().(*Policy)); err != nil {
+		if err := nPols.Add(p.Clone()); err != nil {
 			logger.Errorw("Cloning policy %s: %v", p.Name, err)
 			return nil
 		}

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -27,7 +27,7 @@ func TestPoliciesClone(t *testing.T) {
 	err = policies.Add(p2)
 	require.NoError(t, err)
 
-	copy := policies.Clone().(*Policies)
+	copy := policies.Clone()
 
 	if !reflect.DeepEqual(policies, copy) {
 		t.Errorf("Clone did not produce an identical copy")

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -30,6 +30,9 @@ type Policy struct {
 	Follow            bool
 }
 
+// Compile-time check to ensure that Policy implements the Cloner interface
+var _ utils.Cloner[*Policy] = &Policy{}
+
 func NewPolicy() *Policy {
 	return &Policy{
 		ID:                0,
@@ -61,7 +64,7 @@ func (p *Policy) ContainerFilterEnabled() bool {
 		p.ContIDFilter.Enabled()
 }
 
-func (p *Policy) Clone() utils.Cloner {
+func (p *Policy) Clone() *Policy {
 	if p == nil {
 		return nil
 	}
@@ -71,21 +74,21 @@ func (p *Policy) Clone() utils.Cloner {
 	n.ID = p.ID
 	n.Name = p.Name
 	maps.Copy(n.EventsToTrace, p.EventsToTrace)
-	n.UIDFilter = p.UIDFilter.Clone().(*filters.UIntFilter[uint32])
-	n.PIDFilter = p.PIDFilter.Clone().(*filters.UIntFilter[uint32])
-	n.NewPidFilter = p.NewPidFilter.Clone().(*filters.BoolFilter)
-	n.MntNSFilter = p.MntNSFilter.Clone().(*filters.UIntFilter[uint64])
-	n.PidNSFilter = p.PidNSFilter.Clone().(*filters.UIntFilter[uint64])
-	n.UTSFilter = p.UTSFilter.Clone().(*filters.StringFilter)
-	n.CommFilter = p.CommFilter.Clone().(*filters.StringFilter)
-	n.ContFilter = p.ContFilter.Clone().(*filters.BoolFilter)
-	n.NewContFilter = p.NewContFilter.Clone().(*filters.BoolFilter)
-	n.ContIDFilter = p.ContIDFilter.Clone().(*filters.StringFilter)
-	n.RetFilter = p.RetFilter.Clone().(*filters.RetFilter)
-	n.ArgFilter = p.ArgFilter.Clone().(*filters.ArgFilter)
-	n.ContextFilter = p.ContextFilter.Clone().(*filters.ContextFilter)
-	n.ProcessTreeFilter = p.ProcessTreeFilter.Clone().(*filters.ProcessTreeFilter)
-	n.BinaryFilter = p.BinaryFilter.Clone().(*filters.BinaryFilter)
+	n.UIDFilter = p.UIDFilter.Clone()
+	n.PIDFilter = p.PIDFilter.Clone()
+	n.NewPidFilter = p.NewPidFilter.Clone()
+	n.MntNSFilter = p.MntNSFilter.Clone()
+	n.PidNSFilter = p.PidNSFilter.Clone()
+	n.UTSFilter = p.UTSFilter.Clone()
+	n.CommFilter = p.CommFilter.Clone()
+	n.ContFilter = p.ContFilter.Clone()
+	n.NewContFilter = p.NewContFilter.Clone()
+	n.ContIDFilter = p.ContIDFilter.Clone()
+	n.RetFilter = p.RetFilter.Clone()
+	n.ArgFilter = p.ArgFilter.Clone()
+	n.ContextFilter = p.ContextFilter.Clone()
+	n.ProcessTreeFilter = p.ProcessTreeFilter.Clone()
+	n.BinaryFilter = p.BinaryFilter.Clone()
 	n.Follow = p.Follow
 
 	return n

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -12,7 +12,7 @@ func TestPolicyClone(t *testing.T) {
 	err := policy.PIDFilter.Parse("=1")
 	require.NoError(t, err)
 
-	copy := policy.Clone().(*Policy)
+	copy := policy.Clone()
 
 	if !reflect.DeepEqual(policy, copy) {
 		t.Errorf("Clone did not produce an identical copy")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,9 +8,9 @@ import (
 	"github.com/aquasecurity/libbpfgo/helpers"
 )
 
-// Cloner is an interface for objects that can be cloned
-type Cloner interface {
-	Clone() Cloner
+// Cloner is a generic interface for objects that can clone themselves.
+type Cloner[T any] interface {
+	Clone() T
 }
 
 // Iterator is a generic interface for iterators.


### PR DESCRIPTION
### 1. Explain what the PR does

64ac6e62 **chore: make Cloner generic**

```
This simplifies the Cloner interface usage since it is not necessary to
assert the Clone return to the specific type.

This also includes compile-time checks to ensure that the Clone method
is implemented for all types that should be cloned.

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it

### 3. Other comments
