### PR TITLE
chore(ci): run x86_64 & aarch64 builds in parallel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,6 @@ jobs:
     name: Release (aarch64)
     env:
       GH_TOKEN: ${{ github.token }}
-    needs: [ release-x86_64 ]
     runs-on: [ "github-self-hosted_ami-03217ce7c37572c4d_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}" ]
     permissions:
       contents: write


### PR DESCRIPTION
### 1. Explain what the PR does

02a61c04 **chore(ci): run x86_64 & aarch64 builds in parallel**

```
See: #3962

Signed-off-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it


### 3. Other comments

