### PR TITLE
Fix Policies Cloning

### DIFF
--- a/pkg/filters/bool_test.go
+++ b/pkg/filters/bool_test.go
@@ -1,9 +1,9 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,14 +117,18 @@ func TestBoolFilterClone(t *testing.T) {
 
 	copy := filter.Clone()
 
-	if !reflect.DeepEqual(filter, copy) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		BoolFilter{},
+	)
+	if !cmp.Equal(filter, copy, opt1) {
+		diff := cmp.Diff(filter, copy, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	err = copy.Parse("=true")
 	require.NoError(t, err)
-	if reflect.DeepEqual(filter, copy) {
+	if cmp.Equal(filter, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/context_test.go
+++ b/pkg/filters/context_test.go
@@ -1,10 +1,12 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/filters/sets"
 )
 
 func TestContextFilterClone(t *testing.T) {
@@ -16,14 +18,25 @@ func TestContextFilterClone(t *testing.T) {
 
 	copy := filter.Clone()
 
-	if !reflect.DeepEqual(filter, copy) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		ContextFilter{},
+		eventCtxFilter{},
+		IntFilter[int64]{},
+		UIntFilter[uint64]{},
+		BoolFilter{},
+		StringFilter{},
+		sets.PrefixSet{},
+		sets.SuffixSet{},
+	)
+	if !cmp.Equal(filter, copy, opt1) {
+		diff := cmp.Diff(filter, copy, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	err = copy.Parse("openat.context.pid", "=1")
 	require.NoError(t, err)
-	if reflect.DeepEqual(filter, copy) {
+	if cmp.Equal(filter, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/int_test.go
+++ b/pkg/filters/int_test.go
@@ -1,9 +1,9 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,14 +75,18 @@ func TestIntFilterClone(t *testing.T) {
 
 	copy64 := filter64.Clone()
 
-	if !reflect.DeepEqual(filter64, copy64) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		IntFilter[int64]{},
+	)
+	if !cmp.Equal(filter64, copy64, opt1) {
+		diff := cmp.Diff(filter64, copy64, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	err = copy64.Parse("=51")
 	require.NoError(t, err)
-	if reflect.DeepEqual(filter64, copy64) {
+	if cmp.Equal(filter64, copy64, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 
@@ -92,14 +96,18 @@ func TestIntFilterClone(t *testing.T) {
 
 	copy32 := filter32.Clone()
 
-	if !reflect.DeepEqual(filter32, copy32) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 = cmp.AllowUnexported(
+		IntFilter[int32]{},
+	)
+	if !cmp.Equal(filter32, copy32, opt1) {
+		diff := cmp.Diff(filter32, copy32, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	err = copy32.Parse("=51")
 	require.NoError(t, err)
-	if reflect.DeepEqual(filter32, copy32) {
+	if cmp.Equal(filter32, copy32, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/processtree_test.go
+++ b/pkg/filters/processtree_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -151,14 +152,19 @@ func TestProcessTreeFilterClone(t *testing.T) {
 
 	copy := filter.Clone()
 
-	if !reflect.DeepEqual(copy, filter) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		ProcessTreeFilter{},
+	)
+
+	if !cmp.Equal(filter, copy, opt1) {
+		diff := cmp.Diff(filter, copy, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	err = filter.Parse("=2")
 	require.NoError(t, err)
-	if reflect.DeepEqual(copy, filter) {
+	if cmp.Equal(filter, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/sets/sets_test.go
+++ b/pkg/filters/sets/sets_test.go
@@ -1,9 +1,9 @@
 package sets
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,15 +71,19 @@ func TestPrefixSetClone(t *testing.T) {
 	set := NewPrefixSet()
 	set.Put("/tmp")
 
-	copy := set.Clone()
+	copy := *set.Clone()
 
-	if !reflect.DeepEqual(&set, copy) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		PrefixSet{},
+	)
+	if !cmp.Equal(set, copy, opt1) {
+		diff := cmp.Diff(set, copy, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	copy.Put("/home")
-	if reflect.DeepEqual(&set, copy) {
+	if cmp.Equal(set, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }
@@ -90,15 +94,19 @@ func TestSuffixSetClone(t *testing.T) {
 	set := NewSuffixSet()
 	set.Put(".git")
 
-	copy := set.Clone()
+	copy := *set.Clone()
 
-	if !reflect.DeepEqual(&set, copy) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		SuffixSet{},
+	)
+	if !cmp.Equal(set, copy, opt1) {
+		diff := cmp.Diff(set, copy, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	copy.Put(".ssh")
-	if reflect.DeepEqual(&set, copy) {
+	if cmp.Equal(set, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -10,8 +10,11 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
+// ValueHandler is a function that can be passed to StringFilter to handle values when they are parsed
+type ValueHandler func(string) (string, error)
+
 type StringFilter struct {
-	valueHandler func(string) (string, error)
+	valueHandler ValueHandler
 	equal        map[string]struct{}
 	notEqual     map[string]struct{}
 	prefixes     sets.PrefixSet
@@ -26,9 +29,9 @@ type StringFilter struct {
 // Compile-time check to ensure that StringFilter implements the Cloner interface
 var _ utils.Cloner[*StringFilter] = &StringFilter{}
 
-func NewStringFilter(valueHandler func(string) (string, error)) *StringFilter {
+func NewStringFilter(valHandler ValueHandler) *StringFilter {
 	return &StringFilter{
-		valueHandler: valueHandler,
+		valueHandler: valHandler,
 		equal:        map[string]struct{}{},
 		notEqual:     map[string]struct{}{},
 		prefixes:     sets.NewPrefixSet(),
@@ -262,7 +265,6 @@ func (f *StringFilter) Clone() *StringFilter {
 
 	maps.Copy(n.equal, f.equal)
 	maps.Copy(n.notEqual, f.notEqual)
-	f.prefixes.Clone()
 	n.prefixes = *f.prefixes.Clone()
 	n.suffixes = *f.suffixes.Clone()
 	maps.Copy(n.contains, f.contains)

--- a/pkg/filters/string_test.go
+++ b/pkg/filters/string_test.go
@@ -219,19 +219,23 @@ func TestStringFilterClone(t *testing.T) {
 		sets.PrefixSet{},
 		sets.SuffixSet{},
 	)
-	opt2 := cmp.FilterPath(func(p cmp.Path) bool {
-		// ignore the valueHandler function
-		// https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/reflect/deepequal.go;l=187
-		return p.Last().String() == ".valueHandler"
-	}, cmp.Ignore())
+	opt2 := cmp.FilterPath(
+		func(p cmp.Path) bool {
+			// ignore the function field
+			// https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/reflect/deepequal.go;l=187
+			return p.Last().Type().Kind() == reflect.Func
+		},
+		cmp.Ignore(),
+	)
 
 	if !cmp.Equal(filter, copy, opt1, opt2) {
-		t.Errorf("Clone did not produce an identical copy")
+		diff := cmp.Diff(filter, copy, opt1, opt2)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	copy.Parse("=xyz")
-	if reflect.DeepEqual(filter, copy) {
+	if cmp.Equal(filter, copy, opt1, opt2) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/uint_test.go
+++ b/pkg/filters/uint_test.go
@@ -1,9 +1,9 @@
 package filters
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -83,13 +83,17 @@ func TestUIntFilterClone(t *testing.T) {
 
 	copy64 := filter64.Clone()
 
-	if !reflect.DeepEqual(filter64, copy64) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		UIntFilter[uint64]{},
+	)
+	if !cmp.Equal(filter64, copy64, opt1) {
+		diff := cmp.Diff(filter64, copy64, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	copy64.Parse("=51")
-	if reflect.DeepEqual(filter64, copy64) {
+	if cmp.Equal(filter64, copy64, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 
@@ -99,14 +103,18 @@ func TestUIntFilterClone(t *testing.T) {
 
 	copy32 := filter32.Clone()
 
-	if !reflect.DeepEqual(filter32, copy32) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 = cmp.AllowUnexported(
+		UIntFilter[uint32]{},
+	)
+	if !cmp.Equal(filter32, copy32, opt1) {
+		diff := cmp.Diff(filter32, copy32, opt1)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
 	err = copy32.Parse("=51")
 	require.NoError(t, err)
-	if reflect.DeepEqual(filter32, copy32) {
+	if cmp.Equal(filter32, copy32, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -77,7 +77,7 @@ type filtersEqualities struct {
 // updating the provided filtersEqualities struct
 // TODO: refactor this method deduplicating code
 func (ps *Policies) computeFilterEqualities(fEqs *filtersEqualities, cts *containers.Containers) error {
-	for _, p := range ps.all() {
+	for _, p := range ps.allFromMap() {
 		policyID := uint(p.ID)
 
 		// UIDFilters equalities
@@ -832,7 +832,7 @@ func (pc *PoliciesConfig) UpdateBPF(bpfConfigMap *bpf.BPFMapLow) error {
 func (ps *Policies) computePoliciesConfig() *PoliciesConfig {
 	cfg := &PoliciesConfig{}
 
-	for _, p := range ps.all() {
+	for _, p := range ps.allFromMap() {
 		offset := p.ID
 
 		// filter enabled policies bitmap

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -128,7 +128,11 @@ func (ps *Policies) compute() {
 
 	userlandList := []*Policy{}
 	ps.filterableInUserland = 0
-	for _, p := range ps.policiesMapByID {
+	for _, p := range ps.policiesArray {
+		if p == nil {
+			continue
+		}
+
 		if p.ArgFilter.Enabled() ||
 			p.RetFilter.Enabled() ||
 			p.ContextFilter.Enabled() ||

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -299,13 +299,11 @@ func (ps *Policies) Clone() *Policies {
 		if p == nil {
 			continue
 		}
-		if err := nPols.Add(p.Clone()); err != nil {
+		if err := nPols.Set(p.Clone()); err != nil {
 			logger.Errorw("Cloning policy %s: %v", p.Name, err)
 			return nil
 		}
 	}
-
-	nPols.compute()
 
 	return nPols
 }

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -2,9 +2,16 @@ package policy
 
 import (
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/filters/sets"
 )
 
 func TestPoliciesClone(t *testing.T) {
@@ -22,6 +29,9 @@ func TestPoliciesClone(t *testing.T) {
 	err = p2.UIDFilter.Parse("=2")
 	require.NoError(t, err)
 
+	err = p2.ArgFilter.Parse("read.args.fd", "=argval", events.Core.NamesToIDs())
+	require.NoError(t, err)
+
 	err = policies.Add(p1)
 	require.NoError(t, err)
 	err = policies.Add(p2)
@@ -29,8 +39,34 @@ func TestPoliciesClone(t *testing.T) {
 
 	copy := policies.Clone()
 
-	if !reflect.DeepEqual(policies, copy) {
-		t.Errorf("Clone did not produce an identical copy")
+	opt1 := cmp.AllowUnexported(
+		Policies{},
+		sync.Mutex{},
+		sync.RWMutex{},
+		atomic.Int32{},
+		filters.StringFilter{},
+		filters.UIntFilter[uint32]{},
+		filters.UIntFilter[uint64]{},
+		filters.BoolFilter{},
+		filters.RetFilter{},
+		filters.ArgFilter{},
+		filters.ContextFilter{},
+		filters.ProcessTreeFilter{},
+		filters.BinaryFilter{},
+		sets.PrefixSet{},
+		sets.SuffixSet{},
+	)
+	opt2 := cmp.FilterPath(
+		func(p cmp.Path) bool {
+			// ignore the function field
+			// https://cs.opensource.google/go/go/+/refs/tags/go1.22.0:src/reflect/deepequal.go;l=187
+			return p.Last().Type().Kind() == reflect.Func
+		},
+		cmp.Ignore(),
+	)
+	if !cmp.Equal(policies, copy, opt1, opt2) {
+		diff := cmp.Diff(policies, copy, opt1, opt2)
+		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
 	// ensure that changes to the copy do not affect the original
@@ -41,7 +77,11 @@ func TestPoliciesClone(t *testing.T) {
 	err = copy.Add(p3)
 	require.NoError(t, err)
 
-	if reflect.DeepEqual(policies, copy) {
-		t.Errorf("Changes to copied policy affected the original")
+	p1, err = copy.LookupByName("p1")
+	require.NoError(t, err)
+	p1.Name = "p1-modified"
+
+	if cmp.Equal(policies, copy, opt1, opt2) {
+		t.Errorf("Changes to copied policy affected the original: %+v", policies)
 	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

6185bdcda **chore: improve Clone tests by using google/go-cmp**
227367504 **chore(filters): add ValueHandler function type**
02e4a1238 **chore(policy): add inner methods for iteration**
392535aea **fix(policy): iterate array to preserve order**
239087aca **fix(policy): Policies Clone method**


227367504 **chore(filters): add ValueHandler function type**

```
It is a function type that can be used to handle the value of a filter
when it is parsed.

This also removes a dead code.
```

02e4a1238 **chore(policy): add inner methods for iteration**

```
Depending o the use case, the iteration of the policies can be done
by allFromArray() or allFromMap().
```

392535aea **fix(policy): iterate array to preserve order**

```
To fill userlandPolicies, we need to iterate over the array of policies
to preserve the order, since the map iteration order is not guaranteed.
```

239087aca **fix(policy): Policies Clone method**

```
Use Set instead of Add to preserve the order of the policies.

This also removes the unnecessary call to compute() method as it is
already called by the Set inners.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
