### PR TITLE
chore: remove OPT_PROCESS_INFO

### DIFF
--- a/pkg/ebpf/c/common/consts.h
+++ b/pkg/ebpf/c/common/consts.h
@@ -36,11 +36,10 @@
 #define OPT_CAPTURE_STACK_TRACES  (1 << 3)
 #define OPT_CAPTURE_MODULES       (1 << 4)
 #define OPT_CGROUP_V1             (1 << 5)
-#define OPT_PROCESS_INFO          (1 << 6)
-#define OPT_TRANSLATE_FD_FILEPATH (1 << 7)
-#define OPT_CAPTURE_BPF           (1 << 8)
-#define OPT_CAPTURE_FILES_READ    (1 << 9)
-#define OPT_FORK_PROCTREE         (1 << 10)
+#define OPT_TRANSLATE_FD_FILEPATH (1 << 6)
+#define OPT_CAPTURE_BPF           (1 << 7)
+#define OPT_CAPTURE_FILES_READ    (1 << 8)
+#define OPT_FORK_PROCTREE         (1 << 9)
 
 #define STDIN  0
 #define STDOUT 1

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -590,7 +590,7 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
 
     // Submit the event
 
-    if (should_submit(SCHED_PROCESS_FORK, p.event) || p.config->options & OPT_PROCESS_INFO) {
+    if (should_submit(SCHED_PROCESS_FORK, p.event)) {
         // Parent information.
         u64 parent_start_time = get_task_start_time(parent);
         int parent_tid = get_task_host_pid(parent);
@@ -1248,8 +1248,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
 
     proc_info->follow_in_scopes = p.event->context.matched_policies; // follow task for matched scopes
 
-    if (!should_submit(SCHED_PROCESS_EXEC, p.event) &&
-        (p.config->options & OPT_PROCESS_INFO) != OPT_PROCESS_INFO)
+    if (!should_submit(SCHED_PROCESS_EXEC, p.event))
         return 0;
 
     // Note: From v5.9+, there are two interesting fields in bprm that could be added:
@@ -1373,7 +1372,7 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
 
     long exit_code = get_task_exit_code(p.event->task);
 
-    if (should_submit(SCHED_PROCESS_EXIT, p.event) || p.config->options & OPT_PROCESS_INFO) {
+    if (should_submit(SCHED_PROCESS_EXIT, p.event)) {
         save_to_submit_buf(&p.event->args_buf, (void *) &exit_code, sizeof(long), 0);
         save_to_submit_buf(&p.event->args_buf, (void *) &group_dead, sizeof(bool), 1);
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -796,7 +796,6 @@ const (
 	optStackAddresses
 	optCaptureModules
 	optCgroupV1
-	optProcessInfo
 	optTranslateFDFilePath
 	optCaptureBpf
 	optCaptureFileRead


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

OPT_PROCESS_INFO is not used anymore and can't be selected by the user. Remove old code that still uses it.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
