### PR TITLE
fix: update vagrant file to download kubectl

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -72,6 +72,7 @@ Vagrant.configure("2") do |config|
     VAGRANT_HOME="/home/vagrant"
     GO_VERSION="1.21.6"
     OPA_VERSION="v0.63.0"
+    KUBECTL_VERSION="v1.29"
 
     # silence 'dpkg-preconfigure: unable to re-open stdin: No such file or directory'
     export DEBIAN_FRONTEND=noninteractive
@@ -127,9 +128,11 @@ Vagrant.configure("2") do |config|
     # kubectl
     #
 
-    apt-get install --yes apt-transport-https ca-certificates curl
-    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
+    apt-get install -y apt-transport-https ca-certificates curl
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBECTL_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBECTL_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
+    chmod 644 /etc/apt/sources.list.d/kubernetes.list
     apt-get update
     apt-get install --yes kubectl
     echo 'source <(kubectl completion bash)' >> $VAGRANT_HOME/.profile


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

The current commands to download kubectl are outdated. Seems that the repository is not available anymore.
Update to kubectl v1.29.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
