### PR TITLE
chore(ci): labeler v5.0.0 is inconsistent

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,4 +12,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0


### PR DESCRIPTION

### 1. Explain what the PR does

6d5928686 **chore(ci): labeler v5.0.0 is inconsistent**

```
Despite the fact that the labeler v5.0.0 demands a different syntax
for the configuration file, it has inconsistent behavior:

https://github.com/actions/labeler/issues/712#issuecomment-2024563578

So, return to the most recent version that works as expected.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
