### PR TITLE
refactor: Improve API used by ebpf programs

### DIFF
--- a/pkg/ebpf/c/common/signal.h
+++ b/pkg/ebpf/c/common/signal.h
@@ -6,15 +6,17 @@
 #include <types.h>
 #include <common/common.h>
 
-statfunc controlplane_signal_t *init_controlplane_signal()
+statfunc controlplane_signal_t *init_controlplane_signal(u32 id)
 {
     int zero = 0;
     controlplane_signal_t *signal = bpf_map_lookup_elem(&signal_data_map, &zero);
     if (unlikely(signal == NULL))
         return NULL;
 
+    signal->event_id = id;
     signal->args_buf.argnum = 0;
     signal->args_buf.offset = 0;
+
     return signal;
 }
 

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -436,7 +436,7 @@ typedef struct pid_filter_version pid_filter_version_t;
 struct mnt_ns_filter {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 256);
-    __type(key, u64);
+    __type(key, u32);
     __type(value, eq_t);
 } mnt_ns_filter SEC(".maps");
 
@@ -456,7 +456,7 @@ typedef struct mnt_ns_filter_version mnt_ns_filter_version_t;
 struct pid_ns_filter {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 256);
-    __type(key, u64);
+    __type(key, u32);
     __type(value, eq_t);
 } pid_ns_filter SEC(".maps");
 

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -126,6 +126,7 @@ enum event_id_e
     MODULE_LOAD,
     MODULE_FREE,
     MAX_EVENT_ID,
+    NO_EVENT_SUBMIT,
 };
 
 enum signal_event_id_e
@@ -361,7 +362,7 @@ typedef struct event_data {
     event_context_t context;
     args_buffer_t args_buf;
     struct task_struct *task;
-    u64 param_types;
+    event_config_t config;
     policies_config_t policies_config;
 } event_data_t;
 

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -407,22 +407,13 @@ func (ps *Policies) updateUIntFilterBPF(uintEqualities map[uint64]equality, inne
 	// UInt equalities
 	// 1. uid_filter        u32, eq_t
 	// 2. pid_filter        u32, eq_t
-	// 3. mnt_ns_filter     u64, eq_t
-	// 4. pid_ns_filter     u64, eq_t
+	// 3. mnt_ns_filter     u32, eq_t
+	// 4. pid_ns_filter     u32, eq_t
 	// 5. cgroup_id_filter  u32, eq_t
 
 	for k, v := range uintEqualities {
 		u32Key := uint32(k)
-		u64Key := uint64(k)
-		var keyPointer unsafe.Pointer
-		switch innerMapName {
-		case UIDFilterMap, PIDFilterMap, CgroupIdFilterMap:
-			// key is uint32
-			keyPointer = unsafe.Pointer(&u32Key)
-		case MntNSFilterMap, PidNSFilterMap:
-			// key is uint64
-			keyPointer = unsafe.Pointer(&u64Key)
-		}
+		keyPointer := unsafe.Pointer(&u32Key)
 
 		eqVal := make([]byte, equalityValueSize)
 		valuePointer := unsafe.Pointer(&eqVal[0])


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

As preparation for migrating event scope filters into the kernel and matching filters by event id, we now save the event id in the program_data_t structure during initialization instead of when submitting the event to userspace.

By knowing the event id during program init, we can also retrieve the bitmap of the policies that requested this event, removing the need to call should_submit() within the program.

Next, should_trace() is renamed to evaluate_context_filters() to better represent its function and accommodate potential future argument filters. This function considers both event submit bits and matched context filters. Its return value is now boolean to hide the internal policy matching mechanism, ensuring future-proofing against changes in bitmap size or implementation.

For programs with logic for multiple events, we introduce event_is_selected() to determine if the event is selected by any policies. We also add reset_event() to reset matched_policies and argument buffer for a new event id, and reset_event_args_buf() for cases where the same event is submitted multiple times from the same program, addressing a bug where submitting multiple events may yield incorrect matched_policies bitmap.

Additionally, policies_matched() is added to return the result of matched_policies.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
