### PR TITLE
Fix helm install option webhook

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -36,7 +36,8 @@ spec:
             - --config
             - /tracee/config.yaml
           {{- if .Values.webhook }}
-            - --output webhook:{{ .Values.webhook }}
+            - --output
+            - webhook:{{ .Values.webhook }}
           {{- end }}
           env:
             - name: LIBBPFGO_OSRELEASE_FILE

--- a/docs/contributing/setup-development-machine-with-vagrant.md
+++ b/docs/contributing/setup-development-machine-with-vagrant.md
@@ -226,7 +226,6 @@ detections to the standard output and send them over to Postee webhook on
 http://postee-svc:8082:
 
 ```console
-helm repo add aqua https://aquasecurity.github.io/helm-charts
 helm install tracee ./deploy/helm/tracee \
   --namespace tracee-system \
   --set hostPID=true \


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

37fd48037 **docs: helm add repo is not necessary from local installation**
58824a3c5 **fix: option webhook value on helm**


58824a3c5 **fix: option webhook value on helm**

```
If uses helm chart to install Tracee, the '--output' key need to be
separeted from value 'webhook' in order to work as excepted.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

Follow this [tutorial](https://aquasecurity.github.io/tracee/latest/contributing/setup-development-machine-with-vagrant/#deploy-tracee-with-postee-on-kubernetes), the issue raises during `helm install tracee` step.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
