### PR TITLE
fix(ebpf): use debug error level instead of error

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1592,15 +1592,14 @@ func (t *Tracee) triggerMemDump(event trace.Event) []error {
 	// We want to use the policies of relevant to the triggering event
 	policies, err := policy.Snapshots().Get(event.PoliciesVersion)
 	if err != nil {
-		logger.Errorw("Error getting policies for print_mem_dump event", "error", err)
-		// For fallback, try to use latest polcies
+		logger.Debugw("Error getting policies for print_mem_dump event", "error", err)
+		// For fallback, try to use latest policies
 		policies, err = policy.Snapshots().GetLast()
 		if err != nil {
-			logger.Errorw("Error getting last snapshots policies for print_mem_dump event", "error", err)
-			// Last resort is to use the policies from the config
-			policies = t.config.Policies
+			return []error{err}
 		}
 	}
+
 	for it := policies.CreateAllIterator(); it.HasNext(); {
 		p := it.Next()
 		// This might break in the future if PrintMemDump will become a dependency of another event.


### PR DESCRIPTION
### 1. Explain what the PR does

d621c3644 **fix(ebpf): use log debug level instead of error...**

```
... for internal requirements.

Considering that if GetLast() failed t.config.Policies is nil, this also
removes the use of t.config.Policies. Furthermore, the goal is to
concetrate all Policies access in the PolicyManager.
```

### 2. Explain how to test it

### 3. Other comments

