### PR TITLE
feat(proctree): control procfs query by config

### DIFF
--- a/docs/docs/advanced/data-sources/builtin/process-tree.md
+++ b/docs/docs/advanced/data-sources/builtin/process-tree.md
@@ -16,6 +16,13 @@ The underlying structure is populated using the core `sched_process_fork`, `sche
 
 The number of processes retained in the tree hinges on cache size. We have two separate caches at play: one for processes and another for threads. Both default to a size of 32K, supporting tracking for up to 32,768 processes and the same number of threads. It's worth noting that these are LRU caches: once full, they'll evict the least recently accessed entries to accommodate fresh ones.
 
+The process tree query the procfs upon initialization and during runtime to fill missing data:
+* During initialization, it runs over all procfs to fill all existing processes and threads
+* During runtime, it queries specific processes in the case of missing information caused by missing events. 
+
+> [!CAUTION]
+> The procfs query might increase the feature toll on CPU and memory. The runtime query might have a snowball effect on lost events, as it will reduce the system resources in the processes of filling missing information.
+
 ## Command Line Option
 
 ```bash
@@ -26,8 +33,9 @@ Example:
       events       | process tree is built from events.
       signals      | process tree is built from signals.
       both         | process tree is built from both events and signals.
-  --proctree process-cache=8192  | will cache up to 8192 processes in the tree (LRU cache).
-  --proctree thread-cache=4096   | will cache up to 4096 threads in the tree (LRU cache).
+  --proctree process-cache=8192   | will cache up to 8192 processes in the tree (LRU cache).
+  --proctree thread-cache=4096    | will cache up to 4096 threads in the tree (LRU cache).
+  --proctree disable-procfs-query | Will disable procfs quering during runtime
 
 Use comma OR use the flag multiple times to choose multiple options:
   --proctree source=A,process-cache=B,thread-cache=C

--- a/pkg/cmd/flags/proctree.go
+++ b/pkg/cmd/flags/proctree.go
@@ -18,8 +18,9 @@ Example:
       events       | process tree is built from events.
       signals      | process tree is built from signals.
       both         | process tree is built from both events and signals.
-  --proctree process-cache=8192  | will cache up to 8192 processes in the tree (LRU cache).
-  --proctree thread-cache=4096   | will cache up to 4096 threads in the tree (LRU cache).
+  --proctree process-cache=8192   | will cache up to 8192 processes in the tree (LRU cache).
+  --proctree thread-cache=4096    | will cache up to 4096 threads in the tree (LRU cache).
+  --proctree disable-procfs-query | Will disable procfs queries during runtime
 
 Use comma OR use the flag multiple times to choose multiple options:
   --proctree source=A,process-cache=B,thread-cache=C
@@ -31,9 +32,11 @@ func PrepareProcTree(cacheSlice []string) (proctree.ProcTreeConfig, error) {
 	var err error
 
 	config := proctree.ProcTreeConfig{
-		Source:           proctree.SourceNone, // disabled by default
-		ProcessCacheSize: proctree.DefaultProcessCacheSize,
-		ThreadCacheSize:  proctree.DefaultThreadCacheSize,
+		Source:               proctree.SourceNone, // disabled by default
+		ProcessCacheSize:     proctree.DefaultProcessCacheSize,
+		ThreadCacheSize:      proctree.DefaultThreadCacheSize,
+		ProcfsInitialization: true,
+		ProcfsQuerying:       true,
 	}
 
 	cacheSet := false
@@ -88,6 +91,10 @@ func PrepareProcTree(cacheSlice []string) (proctree.ProcTreeConfig, error) {
 					config.ThreadCacheSize = size
 				}
 				cacheSet = true
+				continue
+			}
+			if strings.HasPrefix(value, "disable-procfs-query") {
+				config.ProcfsQuerying = false
 				continue
 			}
 			err = fmt.Errorf("unrecognized proctree option format: %v", value)

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -63,7 +63,9 @@ func (pt *ProcessTree) FeedFromFork(feed ForkFeed) error {
 			},
 			utils.NsSinceBootTimeToTime(feed.TimeStamp),
 		)
-		pt.FeedFromProcFSAsync(int(feed.ParentPid)) // try to enrich ppid and name from procfs
+		if pt.procfsQuery {
+			pt.FeedFromProcFSAsync(int(feed.ParentPid)) // try to enrich ppid and name from procfs
+		}
 	}
 
 	parent, found := pt.GetProcessByHash(feed.ParentHash) // always a real process
@@ -99,7 +101,9 @@ func (pt *ProcessTree) FeedFromFork(feed ForkFeed) error {
 			},
 			utils.NsSinceBootTimeToTime(feed.TimeStamp),
 		)
-		pt.FeedFromProcFSAsync(int(feed.LeaderPid)) // try to enrich name from procfs if needed
+		if pt.procfsQuery {
+			pt.FeedFromProcFSAsync(int(feed.LeaderPid)) // try to enrich name from procfs if needed
+		}
 	}
 
 	leader, found := pt.GetProcessByHash(feed.LeaderHash)


### PR DESCRIPTION
### 1. Explain what the PR does

Allow the procfs scanning and querying to be configured by the user. For now Tracee only enable to disable the procfs querying upon lost events. This should help to improve performance on high-load systems.

Fix #3988

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
