### PR TITLE
fix(ebpf): check if engineOutput is closed

### DIFF
--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -108,6 +108,9 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 		for {
 			select {
 			case finding := <-engineOutput:
+				if finding == nil {
+					return // channel is closed
+				}
 				if finding.Event.Payload == nil {
 					continue // might happen during initialization (ctrl+c seg faults)
 				}


### PR DESCRIPTION
Close: #3993

### 1. Explain what the PR does

873599b17 **fix(ebpf): check if engineOutput is closed**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
