### PR TITLE
chore: refactor equality computation

### DIFF
--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/pkg/utils/proc"
 )
 
@@ -47,205 +46,6 @@ const (
 
 	ProcInfoMap = "proc_info_map"
 )
-
-// equality mirrors the C struct equality (eq_t).
-// Check it for more info.
-type equality struct {
-	equalInPolicies       uint64
-	equalitySetInPolicies uint64
-}
-
-const (
-	// 8 bytes for equalInPolicies and 8 bytes for equalitySetInPolicies
-	equalityValueSize = 16
-)
-
-// filtersEqualities stores the equalities for each filter in the policies
-type filtersEqualities struct {
-	uidEqualities      map[uint64]equality
-	pidEqualities      map[uint64]equality
-	mntNSEqualities    map[uint64]equality
-	pidNSEqualities    map[uint64]equality
-	cgroupIdEqualities map[uint64]equality
-	utsEqualities      map[string]equality
-	commEqualities     map[string]equality
-	procTreeEqualities map[uint64]equality
-	binaryEqualities   map[filters.NSBinary]equality
-}
-
-// computeFilterEqualities computes the equalities for each filter in the policies
-// updating the provided filtersEqualities struct
-// TODO: refactor this method deduplicating code
-func (ps *Policies) computeFilterEqualities(fEqs *filtersEqualities, cts *containers.Containers) error {
-	for _, p := range ps.allFromMap() {
-		policyID := uint(p.ID)
-
-		// UIDFilters equalities
-		uidEqualities := p.UIDFilter.Equalities()
-		for uid := range uidEqualities.NotEqual {
-			eq := fEqs.uidEqualities[uid]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.uidEqualities[uid] = eq
-		}
-		for uid := range uidEqualities.Equal {
-			eq := fEqs.uidEqualities[uid]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.uidEqualities[uid] = eq
-		}
-
-		// PIDFilters equalities
-		pidEqualities := p.PIDFilter.Equalities()
-		for pid := range pidEqualities.NotEqual {
-			eq := fEqs.pidEqualities[pid]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidEqualities[pid] = eq
-		}
-		for pid := range pidEqualities.Equal {
-			eq := fEqs.pidEqualities[pid]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidEqualities[pid] = eq
-		}
-
-		// MntNSFilters equalities
-		mntNSEqualities := p.MntNSFilter.Equalities()
-		for mntNS := range mntNSEqualities.NotEqual {
-			eq := fEqs.mntNSEqualities[mntNS]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.mntNSEqualities[mntNS] = eq
-		}
-		for mntNS := range mntNSEqualities.Equal {
-			eq := fEqs.mntNSEqualities[mntNS]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.mntNSEqualities[mntNS] = eq
-		}
-
-		// PidNSFilters equalities
-		pidNSEqualities := p.PidNSFilter.Equalities()
-		for pidNS := range pidNSEqualities.NotEqual {
-			eq := fEqs.pidNSEqualities[pidNS]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidNSEqualities[pidNS] = eq
-		}
-		for pidNS := range pidNSEqualities.Equal {
-			eq := fEqs.pidNSEqualities[pidNS]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.pidNSEqualities[pidNS] = eq
-		}
-
-		// ContIDFilters equalities
-		contIDEqualities := p.ContIDFilter.Equalities()
-		for contID := range contIDEqualities.NotEqual {
-			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
-			if err != nil {
-				return err
-			}
-
-			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
-		}
-		for contID := range contIDEqualities.Equal {
-			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
-			if err != nil {
-				return err
-			}
-
-			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
-		}
-
-		// UTSFilters equalities
-		utsEqualities := p.UTSFilter.Equalities()
-		for uts := range utsEqualities.NotEqual {
-			eq := fEqs.utsEqualities[uts]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.utsEqualities[uts] = eq
-		}
-		for uts := range utsEqualities.Equal {
-			eq := fEqs.utsEqualities[uts]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.utsEqualities[uts] = eq
-		}
-
-		// CommFilters equalities
-		commEqualities := p.CommFilter.Equalities()
-		for comm := range commEqualities.NotEqual {
-			eq := fEqs.commEqualities[comm]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.commEqualities[comm] = eq
-		}
-		for comm := range commEqualities.Equal {
-			eq := fEqs.commEqualities[comm]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.commEqualities[comm] = eq
-		}
-
-		// ProcessTreeFilters equalities
-		procTreeEqualities := p.ProcessTreeFilter.Equalities()
-		for pid := range procTreeEqualities.NotEqual {
-			eq := fEqs.procTreeEqualities[uint64(pid)]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.procTreeEqualities[uint64(pid)] = eq
-		}
-		for pid := range procTreeEqualities.Equal {
-			eq := fEqs.procTreeEqualities[uint64(pid)]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.procTreeEqualities[uint64(pid)] = eq
-		}
-
-		// BinaryFilters equalities
-		binaryEqualities := p.BinaryFilter.Equalities()
-		for binaryNS := range binaryEqualities.NotEqual {
-			eq := fEqs.binaryEqualities[binaryNS]
-			// NotEqual == 0, so clear n bitmap bit
-			utils.ClearBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.binaryEqualities[binaryNS] = eq
-		}
-		for binaryNS := range binaryEqualities.Equal {
-			eq := fEqs.binaryEqualities[binaryNS]
-			// Equal == 1, so set n bitmap bit
-			utils.SetBit(&eq.equalInPolicies, policyID)
-			utils.SetBit(&eq.equalitySetInPolicies, policyID)
-			fEqs.binaryEqualities[binaryNS] = eq
-		}
-	}
-
-	return nil
-}
 
 // createNewInnerMap creates a new map for the given map name and version.
 func createNewInnerMap(m *bpf.Module, mapName string, mapVersion uint16) (*bpf.BPFMapLow, error) {
@@ -467,7 +267,7 @@ func (ps *Policies) updateStringFilterBPF(strEqualities map[string]equality, inn
 }
 
 // updateProcTreeFilterBPF updates the BPF maps for the given process tree equalities.
-func (ps *Policies) updateProcTreeFilterBPF(procTreeEqualities map[uint64]equality, innerMapName string) error {
+func (ps *Policies) updateProcTreeFilterBPF(procTreeEqualities map[uint32]equality, innerMapName string) error {
 	// ProcessTree equality
 	// 1. process_tree_filter  u32, eq_t
 
@@ -494,7 +294,7 @@ func (ps *Policies) updateProcTreeFilterBPF(procTreeEqualities map[uint64]equali
 
 	// First, update BPF for provided pids equalities
 	for pid, eq := range procTreeEqualities {
-		if err := updateBPF(uint32(pid), eq); err != nil {
+		if err := updateBPF(pid, eq); err != nil {
 			return err
 		}
 	}
@@ -541,7 +341,7 @@ func (ps *Policies) updateProcTreeFilterBPF(procTreeEqualities map[uint64]equali
 			}
 
 			// if the parent pid is in the provided pids, update BPF with its child pid
-			if eq, ok := procTreeEqualities[uint64(ppid)]; ok {
+			if eq, ok := procTreeEqualities[uint32(ppid)]; ok {
 				_ = updateBPF(uint32(pid), eq)
 				return
 			}
@@ -673,7 +473,6 @@ func (ps *Policies) UpdateBPF(
 		cgroupIdEqualities: make(map[uint64]equality),
 		utsEqualities:      make(map[string]equality),
 		commEqualities:     make(map[string]equality),
-		procTreeEqualities: make(map[uint64]equality),
 		binaryEqualities:   make(map[filters.NSBinary]equality),
 	}
 
@@ -714,8 +513,12 @@ func (ps *Policies) UpdateBPF(
 	}
 
 	if updateProcTree {
+		// ProcessTreeFilter equalities
+		procTreeEqualities := make(map[uint32]equality)
+		ps.computeProcTreeEqualities(procTreeEqualities)
+
 		// Update ProcessTree equalities filter map
-		if err := ps.updateProcTreeFilterBPF(fEqs.procTreeEqualities, ProcessTreeFilterMap); err != nil {
+		if err := ps.updateProcTreeFilterBPF(procTreeEqualities, ProcessTreeFilterMap); err != nil {
 			return nil, errfmt.WrapError(err)
 		}
 	}

--- a/pkg/policy/equality.go
+++ b/pkg/policy/equality.go
@@ -1,0 +1,172 @@
+package policy
+
+import (
+	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/filters"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// equality mirrors the C struct equality (eq_t).
+// Check it for more info.
+type equality struct {
+	equalInPolicies       uint64
+	equalitySetInPolicies uint64
+}
+
+const (
+	// 8 bytes for equalInPolicies and 8 bytes for equalitySetInPolicies
+	equalityValueSize = 16
+)
+
+// filtersEqualities stores the equalities for each filter in the policies
+type filtersEqualities struct {
+	uidEqualities      map[uint64]equality
+	pidEqualities      map[uint64]equality
+	mntNSEqualities    map[uint64]equality
+	pidNSEqualities    map[uint64]equality
+	cgroupIdEqualities map[uint64]equality
+	utsEqualities      map[string]equality
+	commEqualities     map[string]equality
+	binaryEqualities   map[filters.NSBinary]equality
+}
+
+// equalityType represents the type of equality.
+type equalityType int
+
+const (
+	notEqual equalityType = iota
+	equal
+)
+
+// equalUpdater updates the equality with the given policyID.
+type equalityUpdater func(eq *equality, policyID uint)
+
+// notEqualUpdate updates the equality as not equal with the given policyID.
+func notEqualUpdate(eq *equality, policyID uint) {
+	// NotEqual == 0, so clear n bitmap bit
+	utils.ClearBit(&eq.equalInPolicies, policyID)
+	utils.SetBit(&eq.equalitySetInPolicies, policyID)
+}
+
+// equalUpdate updates the equality as equal with the given policyID.
+func equalUpdate(eq *equality, policyID uint) {
+	// Equal == 1, so set n bitmap bit
+	utils.SetBit(&eq.equalInPolicies, policyID)
+	utils.SetBit(&eq.equalitySetInPolicies, policyID)
+}
+
+// updateEqualities updates the equalities map with the given filter equalities
+// for the given equality type and policy ID.
+func updateEqualities[T comparable](
+	equalitiesMap map[T]equality,
+	filterEqualities map[T]struct{},
+	eqType equalityType,
+	policyID uint,
+) {
+	var update equalityUpdater
+
+	switch eqType {
+	case notEqual:
+		update = notEqualUpdate
+	case equal:
+		update = equalUpdate
+	default:
+		logger.Errorw("Invalid equality type", "type", eqType)
+		return
+	}
+
+	for k := range filterEqualities {
+		eq, ok := equalitiesMap[k]
+		if !ok {
+			eq = equality{} // initialize if not exists
+		}
+		update(&eq, policyID) // update the equality
+		equalitiesMap[k] = eq // update the map
+	}
+}
+
+// computeFilterEqualities computes the equalities for each filter type in the policies
+// updating the provided filtersEqualities struct.
+func (ps *Policies) computeFilterEqualities(
+	fEqs *filtersEqualities,
+	cts *containers.Containers,
+) error {
+	for _, p := range ps.allFromMap() {
+		policyID := uint(p.ID)
+
+		// NOTE: Equal has precedence over NotEqual, so NotEqual must be updated first
+
+		// UIDFilters
+		uidEqualities := p.UIDFilter.Equalities()
+		updateEqualities(fEqs.uidEqualities, uidEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.uidEqualities, uidEqualities.Equal, equal, policyID)
+
+		// PIDFilters
+		pidEqualities := p.PIDFilter.Equalities()
+		updateEqualities(fEqs.pidEqualities, pidEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.pidEqualities, pidEqualities.Equal, equal, policyID)
+
+		// MntNSFilters
+		mntNSEqualities := p.MntNSFilter.Equalities()
+		updateEqualities(fEqs.mntNSEqualities, mntNSEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.mntNSEqualities, mntNSEqualities.Equal, equal, policyID)
+
+		// PidNSFilters
+		pidNSEqualities := p.PidNSFilter.Equalities()
+		updateEqualities(fEqs.pidNSEqualities, pidNSEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.pidNSEqualities, pidNSEqualities.Equal, equal, policyID)
+
+		// ContIDFilters
+		contIDEqualities := p.ContIDFilter.Equalities()
+		for contID := range contIDEqualities.NotEqual {
+			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
+			if err != nil {
+				return err
+			}
+
+			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
+			notEqualUpdate(&eq, policyID)
+			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
+		}
+		for contID := range contIDEqualities.Equal {
+			cgroupIDs, err := cts.FindContainerCgroupID32LSB(contID)
+			if err != nil {
+				return err
+			}
+
+			eq := fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])]
+			equalUpdate(&eq, policyID)
+			fEqs.cgroupIdEqualities[uint64(cgroupIDs[0])] = eq
+		}
+
+		// UTSFilters
+		utsEqualities := p.UTSFilter.Equalities()
+		updateEqualities(fEqs.utsEqualities, utsEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.utsEqualities, utsEqualities.Equal, equal, policyID)
+
+		// CommFilters
+		commEqualities := p.CommFilter.Equalities()
+		updateEqualities(fEqs.commEqualities, commEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.commEqualities, commEqualities.Equal, equal, policyID)
+
+		// BinaryFilters
+		binaryEqualities := p.BinaryFilter.Equalities()
+		updateEqualities(fEqs.binaryEqualities, binaryEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(fEqs.binaryEqualities, binaryEqualities.Equal, equal, policyID)
+	}
+
+	return nil
+}
+
+// computeProcTreeEqualities computes the equalities for the process tree filter
+// in the policies updating the provided eqs map.
+func (ps *Policies) computeProcTreeEqualities(eqs map[uint32]equality) {
+	for _, p := range ps.allFromMap() {
+		policyID := uint(p.ID)
+
+		procTreeEqualities := p.ProcessTreeFilter.Equalities()
+		updateEqualities(eqs, procTreeEqualities.NotEqual, notEqual, policyID)
+		updateEqualities(eqs, procTreeEqualities.Equal, equal, policyID)
+	}
+}


### PR DESCRIPTION
### 1. Explain what the PR does

405b8bedf **chore: refactor equality computation**

```
This moves the equality logic to equality.go, and uses Generics to
deduplicate the code.

This also changes procTreeEqualities map key to uint32, the right type
for the key.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
