### PR TITLE
Wait for apt locks

### DIFF
--- a/tests/e2e-install-deps.sh
+++ b/tests/e2e-install-deps.sh
@@ -195,7 +195,7 @@ install_clang_from_github() {
         LLVM_URL=$LLVM_URL"clang+llvm-14.0.6-aarch64-linux-gnu.tar.xz"
     fi
 
-    LLVM_FILE=$(echo $(basename $LLVM_URL))
+    LLVM_FILE=$(basename $LLVM_URL)
     LLVM_DIR=$(echo $LLVM_FILE | sed 's:.tar.xz::g')
 
     # Download
@@ -219,7 +219,7 @@ install_golang_from_github() {
         GO_URL="https://go.dev/dl/go1.21.6.linux-arm64.tar.gz"
     fi
 
-    GO_FILE=$(echo $(basename $GO_URL))
+    GO_FILE=$(basename $GO_URL)
 
     # Download
     rm -f "/tmp/$GO_FILE"

--- a/tests/e2e-install-deps.sh
+++ b/tests/e2e-install-deps.sh
@@ -196,7 +196,7 @@ install_clang_from_github() {
     fi
 
     LLVM_FILE=$(basename $LLVM_URL)
-    LLVM_DIR=$(echo $LLVM_FILE | sed 's:.tar.xz::g')
+    LLVM_DIR="${LLVM_FILE%.tar.xz}"
 
     # Download
     rm -f "/tmp/$LLVM_FILE"

--- a/tests/e2e-install-deps.sh
+++ b/tests/e2e-install-deps.sh
@@ -205,8 +205,8 @@ install_clang_from_github() {
     # Install
     cd /usr/local
     rm -rf ./clang
-    tar xfJ /tmp/$LLVM_FILE
-    mv $LLVM_DIR ./clang
+    tar xfJ /tmp/"$LLVM_FILE"
+    mv "$LLVM_DIR" ./clang
     cd -
 
     link_llvm_usr_local_clang
@@ -228,7 +228,7 @@ install_golang_from_github() {
     # Install
     cd /usr/local
     rm -rf ./go
-    tar xfz /tmp/$GO_FILE
+    tar xfz /tmp/"$GO_FILE"
     cd -
 
     link_golang_usr_local_go

--- a/tests/e2e-install-deps.sh
+++ b/tests/e2e-install-deps.sh
@@ -271,6 +271,8 @@ remove_golang_os_packages() {
 
 KERNEL=$(uname -r)
 
+# shellcheck source=/dev/null
+# See SC1091
 . /etc/os-release
 
 if [[ $ID == "ubuntu" ]]; then


### PR DESCRIPTION
### 1. Explain what the PR does

d4a0dfa0a **fix(tests): address shellcheck SC1091**

```
Silence shellcheck SC1091 in e2e-install-deps.sh.
```

95ea66abd **fix(tests): address shellcheck SC2001**

```
- SC2001: See if you can use ${variable//search/replace} instead.

In this was used % (shortest match - suffix) since it's more appropriate
for the use case.
```

3700b4018 **fix(tests): address shellcheck SC2005**

```
- SC2005: Useless echo? Instead of 'cmd; echo $?' just use 'cmd'.
```

d06ef237f **fix(tests): address shellcheck SC2086**

```
- SC2086: Double quote to prevent globbing and word splitting.
```

a4475b83a **fix(tests): call wait_for_apt_locks before apt-get**

```
Reduce the window of opportunity for apt-get to fail due to locks by
calling wait_for_apt_locks before each apt-get command.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
