### PR TITLE
chore(ebpf): use core type size checks

### DIFF
--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -171,7 +171,7 @@ statfunc size_t get_path_str_buf(struct path *path, buf_t *out_buf)
     }
 
     struct path f_path;
-    bpf_probe_read_kernel(&f_path, sizeof(struct path), path);
+    bpf_probe_read_kernel(&f_path, bpf_core_type_size(struct path), path);
     char slash = '/';
     int zero = 0;
     struct dentry *dentry = f_path.dentry;

--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -170,12 +170,10 @@ statfunc size_t get_path_str_buf(struct path *path, buf_t *out_buf)
         return 0;
     }
 
-    struct path f_path;
-    bpf_probe_read_kernel(&f_path, bpf_core_type_size(struct path), path);
     char slash = '/';
     int zero = 0;
-    struct dentry *dentry = f_path.dentry;
-    struct vfsmount *vfsmnt = f_path.mnt;
+    struct dentry *dentry = BPF_CORE_READ(path, dentry);
+    struct vfsmount *vfsmnt = BPF_CORE_READ(path, mnt);
     struct mount *mnt_parent_p;
     struct mount *mnt_p = real_mount(vfsmnt);
     bpf_core_read(&mnt_parent_p, sizeof(struct mount *), &mnt_p->mnt_parent);

--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -360,7 +360,7 @@ statfunc volatile unsigned char get_sock_state(struct sock *sock)
 statfunc struct ipv6_pinfo *get_inet_pinet6(struct inet_sock *inet)
 {
     struct ipv6_pinfo *pinet6_own_impl;
-    bpf_core_read(&pinet6_own_impl, sizeof(pinet6_own_impl), &inet->pinet6);
+    bpf_core_read(&pinet6_own_impl, sizeof(struct ipv6_pinfo *), &inet->pinet6);
     return pinet6_own_impl;
 }
 
@@ -369,6 +369,7 @@ statfunc struct sockaddr_un get_unix_sock_addr(struct unix_sock *sock)
     struct unix_address *addr = BPF_CORE_READ(sock, addr);
     int len = BPF_CORE_READ(addr, len);
     struct sockaddr_un sockaddr = {};
+    // NOTE(nadav.str): stack allocated, so runtime core size check is avoided
     if (len <= sizeof(struct sockaddr_un)) {
         bpf_probe_read(&sockaddr, len, addr->name);
     }

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5849,11 +5849,11 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
     switch (family) {
         case PF_INET:
             eventctx->retval |= family_ipv4;
-            l3_size = get_type_size(struct iphdr);
+            l3_size = bpf_core_type_size(struct iphdr);
             break;
         case PF_INET6:
             eventctx->retval |= family_ipv6;
-            l3_size = get_type_size(struct ipv6hdr);
+            l3_size = bpf_core_type_size(struct ipv6hdr);
             break;
         default:
             return 1;
@@ -5880,7 +5880,7 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
                 return 1;
 
             if (nethdrs->iphdrs.iphdr.ihl > 5) { // re-read IP header if needed
-                l3_size -= get_type_size(struct iphdr);
+                l3_size -= bpf_core_type_size(struct iphdr);
                 l3_size += nethdrs->iphdrs.iphdr.ihl * 4;
                 bpf_core_read(nethdrs, l3_size, data_ptr);
             }
@@ -5978,11 +5978,11 @@ statfunc u32 cgroup_skb_generic(struct __sk_buff *ctx, void *cgrpctxmap)
     switch (family) {
         case PF_INET:
             dest = &nethdrs->iphdrs.iphdr;
-            size = get_type_size(struct iphdr);
+            size = bpf_core_type_size(struct iphdr);
             break;
         case PF_INET6:
             dest = &nethdrs->iphdrs.ipv6hdr;
-            size = get_type_size(struct ipv6hdr);
+            size = bpf_core_type_size(struct ipv6hdr);
             break;
         default:
             return 1; // verifier
@@ -6008,7 +6008,7 @@ statfunc u32 cgroup_skb_generic(struct __sk_buff *ctx, void *cgrpctxmap)
 
             ihl = nethdrs->iphdrs.iphdr.ihl;
             if (ihl > 5) { // re-read IPv4 header if needed
-                size -= get_type_size(struct iphdr);
+                size -= bpf_core_type_size(struct iphdr);
                 size += ihl * 4;
                 bpf_skb_load_bytes_relative(ctx, 0, dest, size, 1);
             }
@@ -6109,11 +6109,11 @@ CGROUP_SKB_HANDLE_FUNCTION(proto)
             switch (next_proto) {
                 case IPPROTO_TCP:
                     dest = &nethdrs->protohdrs.tcphdr;
-                    size = get_type_size(struct tcphdr);
+                    size = bpf_core_type_size(struct tcphdr);
                     break;
                 case IPPROTO_UDP:
                     dest = &nethdrs->protohdrs.udphdr;
-                    size = get_type_size(struct udphdr);
+                    size = bpf_core_type_size(struct udphdr);
                     break;
                 case IPPROTO_ICMP:
                     dest = &nethdrs->protohdrs.icmphdr;
@@ -6138,11 +6138,11 @@ CGROUP_SKB_HANDLE_FUNCTION(proto)
             switch (next_proto) {
                 case IPPROTO_TCP:
                     dest = &nethdrs->protohdrs.tcphdr;
-                    size = get_type_size(struct tcphdr);
+                    size = bpf_core_type_size(struct tcphdr);
                     break;
                 case IPPROTO_UDP:
                     dest = &nethdrs->protohdrs.udphdr;
-                    size = get_type_size(struct udphdr);
+                    size = bpf_core_type_size(struct udphdr);
                     break;
                 case IPPROTO_ICMPV6:
                     dest = &nethdrs->protohdrs.icmp6hdr;
@@ -6262,7 +6262,7 @@ CGROUP_SKB_HANDLE_FUNCTION(proto_tcp)
 
     if (nethdrs->protohdrs.tcphdr.doff > 5) { // offset flag set
         u32 doff = nethdrs->protohdrs.tcphdr.doff * (32 / 8);
-        neteventctx->md.header_size -= get_type_size(struct tcphdr);
+        neteventctx->md.header_size -= bpf_core_type_size(struct tcphdr);
         neteventctx->md.header_size += doff;
     }
 

--- a/pkg/ebpf/c/vmlinux_missing.h
+++ b/pkg/ebpf/c/vmlinux_missing.h
@@ -192,9 +192,8 @@ static inline struct inet_sock *inet_sk(const struct sock *sk)
 
 #define PIPE_BUF_FLAG_CAN_MERGE 0x10 /* can merge buffers */
 
-#define get_type_size(x) bpf_core_type_size(x)
 #define __get_node_addr(array, node_type, index)                                                   \
-    ((node_type *) ((void *) array + (index * get_type_size(node_type))))
+    ((node_type *) ((void *) array + (index * bpf_core_type_size(node_type))))
 #define get_node_addr(array, index) __get_node_addr(array, typeof(*array), index)
 
 // NOTE: new network code


### PR DESCRIPTION
### 1. Explain what the PR does

115610859 **chore(ebpf): replace sizeof with bpf type helpers**

```
When using sizeof on kernel structs, false results may happen due to the
sizeof builtin not being designed to take into account btf relocations.

Use the libbpf helpers bpf_core_type_size and bpf_core_field_size where
relevant.
```

cfd849e5c **chore(ebpf): remove get_type_size macro**

```
Use the builtin libbpf core helper instead, which
the macro was an alias of.
```

### 2. Explain how to test it



### 3. Other comments

Resolve #3774
