### PR TITLE
capture: fixes and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -757,7 +757,7 @@ $(OUTPUT_DIR)/syscaller: \
 test-integration: \
 	.checkver_$(CMD_GO) \
 	$(OUTPUT_DIR)/syscaller \
-	tracee-ebpf
+	tracee
 #
 	@$(GO_ENV_EBPF) \
 	$(CMD_GO) test \

--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -427,7 +427,7 @@ statfunc void fill_vfs_file_bin_args_io_data(io_data_t io_data, bin_args_t *bin_
         bin_args->iov_len = io_data.len;
         bin_args->iov_idx = 0;
         struct iovec io_vec;
-        bpf_probe_read_kernel(&io_vec, sizeof(struct iovec), &bin_args->vec[0]);
+        bpf_probe_read_user(&io_vec, sizeof(struct iovec), &bin_args->vec[0]);
         bin_args->ptr = io_vec.iov_base;
         bin_args->full_size = io_vec.iov_len;
     }

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2933,8 +2933,7 @@ statfunc u32 send_bin_helper(void *ctx, void *prog_array, int tail_call)
         // Save binary chunk and file position of write
         bpf_probe_read_kernel(
             (void **) &(file_buf_p->buf[F_POS_OFF]), sizeof(off_t), &bin_args->start_off);
-        bpf_probe_read_kernel(
-            (void **) &(file_buf_p->buf[F_CHUNK_OFF]), F_CHUNK_SIZE, bin_args->ptr);
+        bpf_probe_read_user((void **) &(file_buf_p->buf[F_CHUNK_OFF]), F_CHUNK_SIZE, bin_args->ptr);
         bin_args->ptr += F_CHUNK_SIZE;
         bin_args->start_off += F_CHUNK_SIZE;
 
@@ -2954,7 +2953,7 @@ statfunc u32 send_bin_helper(void *ctx, void *prog_array, int tail_call)
     if (chunk_size) {
         // Save last chunk
         chunk_size = chunk_size & ((MAX_PERCPU_BUFSIZE >> 1) - 1);
-        bpf_probe_read_kernel((void **) &(file_buf_p->buf[F_CHUNK_OFF]), chunk_size, bin_args->ptr);
+        bpf_probe_read_user((void **) &(file_buf_p->buf[F_CHUNK_OFF]), chunk_size, bin_args->ptr);
         bpf_probe_read_kernel(
             (void **) &(file_buf_p->buf[F_SZ_OFF]), sizeof(unsigned int), &chunk_size);
         bpf_probe_read_kernel(

--- a/tests/e2e-inst-signatures/e2e-vfs_writev.go
+++ b/tests/e2e-inst-signatures/e2e-vfs_writev.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aquasecurity/tracee/signatures/helpers"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type e2eVfsWritev struct {
+	cb detect.SignatureHandler
+}
+
+func (sig *e2eVfsWritev) Init(ctx detect.SignatureContext) error {
+	sig.cb = ctx.Callback
+	return nil
+}
+
+func (sig *e2eVfsWritev) GetMetadata() (detect.SignatureMetadata, error) {
+	return detect.SignatureMetadata{
+		ID:          "VFS_WRITEV",
+		EventName:   "VFS_WRITEV",
+		Version:     "0.1.0",
+		Name:        "Vfs Writev Test",
+		Description: "Instrumentation events E2E Tests: Vfs Writev",
+		Tags:        []string{"e2e", "instrumentation"},
+	}, nil
+}
+
+func (sig *e2eVfsWritev) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
+	return []detect.SignatureEventSelector{
+		{Source: "tracee", Name: "vfs_writev"},
+	}, nil
+}
+
+func (sig *e2eVfsWritev) OnEvent(event protocol.Event) error {
+	eventObj, ok := event.Payload.(trace.Event)
+	if !ok {
+		return fmt.Errorf("failed to cast event's payload")
+	}
+
+	switch eventObj.EventName {
+	case "vfs_writev":
+		filePath, err := helpers.GetTraceeStringArgumentByName(eventObj, "pathname")
+		if err != nil {
+			return err
+		}
+
+		// check expected values from test for detection
+
+		if !strings.HasSuffix(filePath, "/vfs_writev.txt") {
+			return nil
+		}
+
+		m, _ := sig.GetMetadata()
+
+		sig.cb(&detect.Finding{
+			SigMetadata: m,
+			Event:       event,
+			Data:        map[string]interface{}{},
+		})
+	}
+
+	return nil
+}
+
+func (sig *e2eVfsWritev) OnSignal(s detect.Signal) error {
+	return nil
+}
+
+func (sig *e2eVfsWritev) Close() {}

--- a/tests/e2e-inst-signatures/export.go
+++ b/tests/e2e-inst-signatures/export.go
@@ -9,6 +9,7 @@ var ExportedSignatures = []detect.Signature{
 	// Instrumentation e2e signatures
 	&e2eProcessExecuteFailed{},
 	&e2eVfsWrite{},
+	&e2eVfsWritev{},
 	&e2eFileModification{},
 	&e2eSecurityInodeRename{},
 	&e2eContainersDataSource{},

--- a/tests/e2e-inst-signatures/scripts/vfs_writev.sh
+++ b/tests/e2e-inst-signatures/scripts/vfs_writev.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+exit_err() {
+    echo -n "ERROR: "
+    echo $@
+    exit 1
+}
+
+output_file="vfs_writev.txt"
+prog=writev
+dir=tests/e2e-inst-signatures/scripts/writev_tester
+gcc $dir/$prog.c -o $dir/$prog -lpthread || exit_err "could not compile $prog.c"
+
+./$dir/$prog > /dev/null
+
+rm -f $output_file
+rm -f $dir/$prog

--- a/tests/e2e-inst-signatures/scripts/writev_tester/writev.c
+++ b/tests/e2e-inst-signatures/scripts/writev_tester/writev.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <string.h>
+
+int main()
+{
+    // Open or create a file
+    int fd = open("vfs_writev.txt", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd == -1) {
+        perror("open");
+        exit(EXIT_FAILURE);
+    }
+
+    // Prepare the messages to write
+    char *message1 = "This is message 1.\n";
+    char *message2 = "This is message 2.\n";
+    char *message3 = "This is message 3.\n";
+
+    // Create iov structures for each message
+    struct iovec iov[3];
+    iov[0].iov_base = message1;
+    iov[0].iov_len = strlen(message1);
+    iov[1].iov_base = message2;
+    iov[1].iov_len = strlen(message2);
+    iov[2].iov_base = message3;
+    iov[2].iov_len = strlen(message3);
+
+    // Write to the file using writev syscall
+    ssize_t bytes_written = writev(fd, iov, 3);
+    if (bytes_written == -1) {
+        perror("writev");
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    printf("Total bytes written: %zd\n", bytes_written);
+
+    // Close the file
+    close(fd);
+
+    return 0;
+}

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -129,7 +129,7 @@ for TEST in $TESTS; do
         --output option:parse-arguments \
         --log file:$SCRIPT_TMP_DIR/tracee-log-$$ \
         --signatures-dir "$SIG_DIR" \
-        --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,fsnotify_tester,process_execute,tracee-ebpf \
+        --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,fsnotify_tester,process_execute,tracee-ebpf,writev \
         --dnscache enable \
         --grpc-listen-addr unix:/tmp/tracee.sock \
         --events "$TEST" &

--- a/tests/integration/capture_test.go
+++ b/tests/integration/capture_test.go
@@ -1,0 +1,318 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
+	"github.com/aquasecurity/tracee/tests/testutils"
+)
+
+func Test_TraceeCapture(t *testing.T) {
+	if !testutils.IsSudoCmdAvailableForThisUser() {
+		t.Skip("skipping: sudo command is not available for this user")
+	}
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	outputWriteFilter := fmt.Sprintf("write=%s/output*", homeDir)
+	outputReadFilter := fmt.Sprintf("read=%s/output*", homeDir)
+	pipeWriteFilter := fmt.Sprintf("write=%s/pipe*", homeDir)
+	pipeReadFilter := fmt.Sprintf("read=%s/pipe*", homeDir)
+
+	tt := []struct {
+		name        string
+		coolDown    time.Duration
+		directory   string
+		writeFilter string
+		readFilter  string
+		test        func(t *testing.T, captureDir string, workingDir string) error
+	}{
+		{
+			name:        "capture write/read",
+			coolDown:    0 * time.Second,
+			directory:   "/tmp/tracee/1",
+			writeFilter: outputWriteFilter,
+			readFilter:  outputReadFilter,
+			test:        readWriteCaptureTest,
+		},
+		{
+			name:        "capture write/readv",
+			coolDown:    2 * time.Second,
+			directory:   "/tmp/tracee/2",
+			writeFilter: outputWriteFilter,
+			readFilter:  outputReadFilter,
+			test:        readWritevCaptureTest,
+		},
+		{
+			name:        "capture pipe write/read",
+			coolDown:    2 * time.Second,
+			directory:   "/tmp/tracee/3",
+			writeFilter: pipeWriteFilter,
+			readFilter:  pipeReadFilter,
+			test:        readWritePipe,
+		},
+	}
+
+	// run tests cases
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			coolDown(t, tc.coolDown)
+			cmd := fmt.Sprintf("--events init_namespaces -c %s -c %s -c dir:%s", tc.readFilter, tc.writeFilter, tc.directory)
+			running := testutils.NewRunningTracee(context.Background(), cmd)
+
+			// start tracee
+			ready, runErr := running.Start(20 * time.Second)
+			require.NoError(t, runErr)
+
+			r := <-ready // block until tracee is ready (or not)
+			switch r {
+			case testutils.TraceeStarted:
+				t.Logf("  --- started tracee ---")
+			case testutils.TraceeFailed:
+				t.Fatal("tracee failed to start")
+			case testutils.TraceeTimedout:
+				t.Fatal("tracee timedout to start")
+			case testutils.TraceeAlreadyRunning:
+				t.Fatal("tracee is already running")
+			}
+
+			captureDir := tc.directory + "/out/host/"
+			err := tc.test(t, captureDir, homeDir)
+			if err != nil {
+				t.Errorf("test %s failed: %v", tc.name, err)
+				runErr = running.Stop() // stop tracee
+				require.NoError(t, runErr)
+				t.Fail()
+			}
+			runErr = running.Stop() // stop tracee
+			require.NoError(t, runErr)
+		})
+	}
+}
+
+func fileCaptureLocation(captureDir string, inode uint64, dev uint64, oper string) string {
+	return fmt.Sprintf("%s/%s.dev-%d.inode-%d", captureDir, oper, dev, inode)
+}
+
+func readWriteCaptureTest(t *testing.T, captureDir string, workingDir string) error {
+	outputFile := fmt.Sprintf("%s/output.txt", workingDir)
+	const input string = "Hello World\n"
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			t.Logf("Error closing file in read/write test: %v", err)
+		}
+		err = os.Remove(outputFile)
+		if err != nil {
+			t.Logf("Error closing file in read/write test: %v", err)
+		}
+	}()
+
+	fi, err := os.Stat(outputFile)
+	if err != nil {
+		return err
+	}
+
+	statInfo := fi.Sys().(*syscall.Stat_t)
+	inode := statInfo.Ino
+
+	// Write "Hello World" into the file
+	_, err = file.Write([]byte(input))
+	if err != nil {
+		return err
+	}
+
+	// Read from the file
+	res, err := os.ReadFile(outputFile)
+	if err != nil {
+		return err
+	}
+
+	return assertEntries(t, captureDir, input, string(res), inode)
+}
+
+func readWritevCaptureTest(t *testing.T, captureDir string, workingDir string) error {
+	outputFile := fmt.Sprintf("%s/output.txt", workingDir)
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			t.Logf("Error closing file in read/write test: %v", err)
+		}
+		err = os.Remove(outputFile)
+		if err != nil {
+			t.Logf("Error closing file in read/write test: %v", err)
+		}
+	}()
+
+	fi, err := os.Stat(outputFile)
+	if err != nil {
+		return err
+	}
+
+	statInfo := fi.Sys().(*syscall.Stat_t)
+	inode := statInfo.Ino
+
+	// Strings to write
+	str1 := "Hello World1\n"
+	str2 := "Hello World2\n"
+	str3 := "Hello World3\n"
+
+	// Prepare iovecs for writev syscall
+	iov := []syscall.Iovec{
+		{Base: &[]byte(str1)[0], Len: uint64(len(str1))},
+		{Base: &[]byte(str2)[0], Len: uint64(len(str2))},
+		{Base: &[]byte(str3)[0], Len: uint64(len(str3))},
+	}
+
+	// Write using writev syscall
+	_, _, errno := syscall.Syscall(syscall.SYS_WRITEV, uintptr(file.Fd()), uintptr(unsafe.Pointer(&iov[0])), uintptr(len(iov)))
+	if errno != 0 {
+		return errno
+	}
+
+	// Seek back to the beginning of the file
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+
+	// Prepare iovecs for readv syscall
+	buf1 := make([]byte, len(str1))
+	buf2 := make([]byte, len(str2))
+	buf3 := make([]byte, len(str3))
+
+	iovRead := []syscall.Iovec{
+		{Base: &buf1[0], Len: uint64(len(buf1))},
+		{Base: &buf2[0], Len: uint64(len(buf2))},
+		{Base: &buf3[0], Len: uint64(len(buf3))},
+	}
+
+	// Read using readv syscall
+	_, _, errno = syscall.Syscall(syscall.SYS_READV, uintptr(file.Fd()), uintptr(unsafe.Pointer(&iovRead[0])), uintptr(len(iovRead)))
+	if errno != 0 {
+		return errno
+	}
+
+	input := strings.Join([]string{str1, str2, str3}, "")
+	res := strings.Join([]string{string(buf1), string(buf2), string(buf3)}, "")
+
+	return assertEntries(t, captureDir, input, res, inode)
+}
+
+func readWritePipe(t *testing.T, captureDir string, workingDir string) error {
+	namedPipe := fmt.Sprintf("%s/pipe_test", workingDir)
+	err := syscall.Mkfifo(namedPipe, 0666)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := os.Remove(namedPipe)
+		if err != nil {
+			t.Logf("failed to remove named pipe: %v", err)
+		}
+	}()
+
+	const input = "Hello World!\n"
+
+	// Open named pipe
+	pipe, err := os.OpenFile(namedPipe, os.O_RDWR, os.ModeNamedPipe)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := pipe.Close()
+		if err != nil {
+			t.Logf("failed to close named pipe: %v", err)
+		}
+	}()
+
+	finfo, err := pipe.Stat()
+	require.NoError(t, err)
+	statInfo := finfo.Sys().(*syscall.Stat_t)
+	inode := statInfo.Ino
+
+	// Write "Hello World!" to the named pipe
+	_, err = pipe.WriteString(input)
+	if err != nil {
+		return err
+	}
+
+	// Read from the named pipe
+	buf := make([]byte, 100)
+	n, err := pipe.Read(buf)
+	if err != nil {
+		return err
+	}
+
+	res := string(buf[:n])
+
+	return assertEntries(t, captureDir, input, res, inode)
+}
+
+func assertEntries(t *testing.T, captureDir string, input string, readOut string, ino uint64) error {
+	// Ensure capture files are generated
+	coolDown(t, 5*time.Second)
+
+	entries, err := os.ReadDir(captureDir)
+	if err != nil {
+		return err
+	}
+
+	var (
+		readCaptureFile  []byte
+		writeCaptureFile []byte
+	)
+
+	found := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			return fmt.Errorf("unexpected directory %s in capture dir", e.Name())
+		}
+
+		entryName := e.Name()
+
+		if !strings.HasSuffix(entryName, fmt.Sprintf(".inode-%d", ino)) {
+			continue
+		}
+		if strings.HasPrefix(entryName, "read") {
+			readCaptureFile, err = os.ReadFile(captureDir + entryName)
+			if err != nil {
+				return err
+			}
+			found++
+		} else if strings.HasPrefix(entryName, "write") {
+			writeCaptureFile, err = os.ReadFile(captureDir + entryName)
+			if err != nil {
+				return err
+			}
+			found++
+		} else {
+			return fmt.Errorf("unexpected entry in capture dir: %s", entryName)
+		}
+	}
+	// Found 2 entries
+	assert.Equal(t, found, 2)
+
+	// Compare captured data to expected data
+	assert.Equal(t, input, string(writeCaptureFile))
+	assert.Equal(t, readOut, string(readCaptureFile))
+	return nil
+}

--- a/tests/perftests/metrics_test.go
+++ b/tests/perftests/metrics_test.go
@@ -97,8 +97,6 @@ func checkIfPprofExist() error {
 
 // TestMetricsExist tests if the metrics endpoint returns all metrics.
 func TestMetricsandPprofExist(t *testing.T) {
-	t.Parallel()
-
 	if !testutils.IsSudoCmdAvailableForThisUser() {
 		t.Skip("skipping: sudo command is not available for this user")
 	}
@@ -107,7 +105,7 @@ func TestMetricsandPprofExist(t *testing.T) {
 	running := testutils.NewRunningTracee(context.Background(), cmd)
 
 	// start tracee
-	ready, runErr := running.Start()
+	ready, runErr := running.Start(testutils.TraceeDefaultStartupTimeout)
 	require.NoError(t, runErr)
 
 	t.Cleanup(func() {

--- a/tests/testutils/tracee.go
+++ b/tests/testutils/tracee.go
@@ -14,9 +14,9 @@ import (
 //
 
 const (
-	readinessPollTime    = 200 * time.Millisecond
-	httpRequestTimeout   = 1 * time.Second
-	traceeStartupTimeout = 5 * time.Second
+	readinessPollTime           = 200 * time.Millisecond
+	httpRequestTimeout          = 1 * time.Second
+	TraceeDefaultStartupTimeout = 5 * time.Second
 )
 
 var (
@@ -63,7 +63,7 @@ func NewRunningTracee(givenCtx context.Context, cmdLine string) *RunningTracee {
 }
 
 // Start starts the tracee process.
-func (r *RunningTracee) Start() (<-chan TraceeStatus, error) {
+func (r *RunningTracee) Start(timeout time.Duration) (<-chan TraceeStatus, error) {
 	var err error
 
 	imReady := func(s TraceeStatus) {
@@ -93,7 +93,7 @@ func (r *RunningTracee) Start() (<-chan TraceeStatus, error) {
 			imReady(TraceeStarted) // ready: running
 			break
 		}
-		if time.Since(now) > traceeStartupTimeout {
+		if time.Since(now) > timeout {
 			imReady(TraceeTimedout) // ready: timedout
 			break
 		}


### PR DESCRIPTION
### 1. Explain what the PR does

d92f13f43 **tests(integration): add capture tests**
8ad9959a4 **tests(inst): add vfs_writev test**
bb7cd569e **fix: restore io capture output**


bb7cd569e **fix: restore io capture output**

```
Commit 3ddf73d changed various probe_read calls to probe_read_kernel.
However, io capture relies on reading userspace buffers, as such the
pointers being read are userspace pointers. Therefore the relevant calls
in some of these changes, affecting IO capture, were changed to
probe_read_user.
```

### 2. Explain how to test it

1. With the new integration test
OR
1. Run tracee with `tracee -c read=/home/ubuntu/output* -c write=/home/ubuntu/output*`
2. `echo Hello > /home/ubuntu/output.txt`
3. `cat /home/ubuntu/output.txt`
4. Check `/tmp/tracee/out/host` for the relevant files and confirm their content (both should be `Hello`)

### 3. Other comments

Resolve #4013
