### PR TITLE
fix: network event context

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5920,6 +5920,10 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
 
     neteventctx.bytes = 0; // event arg size: no payload by default (changed inside skb prog)
 
+    // initialize task context before submit since it will not be available when
+    // submitting the network event.
+    init_task_context(&eventctx->task, p.event->task, p.config->options);
+
     // TODO: log collisions
     bpf_map_update_elem(cgrpctxmap, &indexer, &neteventctx, BPF_NOEXIST);
 

--- a/tests/e2e-net-signatures/e2e-dns.go
+++ b/tests/e2e-net-signatures/e2e-dns.go
@@ -57,6 +57,11 @@ func (sig *e2eDNS) OnEvent(event protocol.Event) error {
 	}
 
 	if eventObj.EventName == "net_packet_dns" {
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		dns, err := helpers.GetProtoDNSByName(eventObj, "proto_dns")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-http.go
+++ b/tests/e2e-net-signatures/e2e-http.go
@@ -54,6 +54,11 @@ func (sig *e2eHTTP) OnEvent(event protocol.Event) error {
 	}
 
 	if eventObj.EventName == "net_packet_http" {
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		http, err := helpers.GetProtoHTTPByName(eventObj, "proto_http")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-icmp.go
+++ b/tests/e2e-net-signatures/e2e-icmp.go
@@ -43,6 +43,11 @@ func (sig *e2eICMP) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "net_packet_icmp":
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-icmpv6.go
+++ b/tests/e2e-net-signatures/e2e-icmpv6.go
@@ -43,6 +43,11 @@ func (sig *e2eICMPv6) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "net_packet_icmpv6":
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-ipv4.go
+++ b/tests/e2e-net-signatures/e2e-ipv4.go
@@ -43,6 +43,11 @@ func (sig *e2eIPv4) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "net_packet_ipv4":
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-ipv6.go
+++ b/tests/e2e-net-signatures/e2e-ipv6.go
@@ -43,6 +43,11 @@ func (sig *e2eIPv6) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "net_packet_ipv6":
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-tcp.go
+++ b/tests/e2e-net-signatures/e2e-tcp.go
@@ -43,6 +43,11 @@ func (sig *e2eTCP) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "net_packet_tcp":
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err

--- a/tests/e2e-net-signatures/e2e-udp.go
+++ b/tests/e2e-net-signatures/e2e-udp.go
@@ -43,6 +43,11 @@ func (sig *e2eUDP) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "net_packet_udp":
+		// validate tast context
+		if eventObj.HostName == "" {
+			return nil
+		}
+
 		src, err := helpers.GetTraceeStringArgumentByName(eventObj, "src")
 		if err != nil {
 			return err


### PR DESCRIPTION
### 1. Explain what the PR does

714777811 **fix(ebpf): initialize network event task context**

```
Commit f806cb4b changed context initialization to occur in the submit
stage. However, network events do not have access to that context during
their submit stage (since they happen in a cgroup_skb program).

Therefore, add a call to init_task_context in the pre cgroup bpf program
(cgroup_bpf_run_filter_skb).
```

37716feb2 **tests(network): add task context validation**

```
Since network events have a different eBPF program architecture, they
can't initialize the task context the standard way.
Therefore, add a validation in the e2e tests so that task context
initialization doesn't break.
```

### 2. Explain how to test it

Added validation in existing e2e network tests.

Manually test by running `tracee --events net_packet_http` and then `curl yourfavoritesite.com`

### 3. Other comments

Fix #3949
