### PR TITLE
fix(ebpf): use kprobes for execute_finished

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5042,17 +5042,17 @@ int BPF_KPROBE(trace_security_bprm_creds_for_exec2)
     return execute_failed_tail2(ctx);
 }
 
-SEC("tracepoint/execute_finished")
-int execute_finished(struct sys_exit_tracepoint_args *args)
+SEC("kretprobe/execute_finished")
+int BPF_KPROBE(execute_finished)
 {
     program_data_t p = {};
-    if (!init_program_data(&p, args, EXECUTE_FINISHED))
+    if (!init_program_data(&p, ctx, EXECUTE_FINISHED))
         return -1;
 
     if (!evaluate_scope_filters(&p))
         return 0;
 
-    long exec_ret = args->ret;
+    long exec_ret = PT_REGS_RC(ctx);
     return events_perf_submit(&p, exec_ret);
 }
 

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -230,8 +230,14 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool, kSyms *helpers.Ke
 		SignalSchedProcessFork:     NewTraceProbe(RawTracepoint, "sched:sched_process_fork", "sched_process_fork_signal"),
 		SignalSchedProcessExec:     NewTraceProbe(RawTracepoint, "sched:sched_process_exec", "sched_process_exec_signal"),
 		SignalSchedProcessExit:     NewTraceProbe(RawTracepoint, "sched:sched_process_exit", "sched_process_exit_signal"),
-		ExecuteFinished:            NewTraceProbe(Tracepoint, "syscalls:sys_exit_execve", "execute_finished"),
-		ExecuteAtFinished:          NewTraceProbe(Tracepoint, "syscalls:sys_exit_execveat", "execute_finished"),
+		ExecuteFinishedX86:         NewTraceProbe(KretProbe, "__x64_sys_execve", "execute_finished"),
+		ExecuteAtFinishedX86:       NewTraceProbe(KretProbe, "__x64_sys_execveat", "execute_finished"),
+		ExecuteFinishedCompatX86:   NewTraceProbe(KretProbe, "__ia32_compat_sys_execve", "execute_finished"),
+		ExecuteAtFinishedCompatX86: NewTraceProbe(KretProbe, "__ia32_compat_sys_execveat", "execute_finished"),
+		ExecuteFinishedARM:         NewTraceProbe(KretProbe, "__arm64_sys_execve", "execute_finished"),
+		ExecuteAtFinishedARM:       NewTraceProbe(KretProbe, "__arm64_sys_execveat", "execute_finished"),
+		ExecuteFinishedCompatARM:   NewTraceProbe(KretProbe, "__arm64_compat_sys_execve", "execute_finished"),
+		ExecuteAtFinishedCompatARM: NewTraceProbe(KretProbe, "__arm64_compat_sys_execveat", "execute_finished"),
 	}
 
 	if !netEnabled {

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -139,6 +139,12 @@ const (
 	SignalSchedProcessFork
 	SignalSchedProcessExec
 	SignalSchedProcessExit
-	ExecuteFinished
-	ExecuteAtFinished
+	ExecuteFinishedX86
+	ExecuteAtFinishedX86
+	ExecuteFinishedCompatX86
+	ExecuteAtFinishedCompatX86
+	ExecuteFinishedARM
+	ExecuteAtFinishedARM
+	ExecuteFinishedCompatARM
+	ExecuteAtFinishedCompatARM
 )

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -12896,8 +12896,15 @@ var CoreEvents = map[ID]Definition{
 		internal: true,
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.ExecuteFinished, required: false},   // TODO: Change to required once fallback are supported
-				{handle: probes.ExecuteAtFinished, required: false}, // TODO: Change to required once fallback are supported
+				// TODO: Change all of these probes to tracepoints (requires debugfs)
+				{handle: probes.ExecuteFinishedX86, required: false},
+				{handle: probes.ExecuteAtFinishedX86, required: false},
+				{handle: probes.ExecuteFinishedCompatX86, required: false},
+				{handle: probes.ExecuteAtFinishedCompatX86, required: false},
+				{handle: probes.ExecuteFinishedARM, required: false},
+				{handle: probes.ExecuteAtFinishedARM, required: false},
+				{handle: probes.ExecuteFinishedCompatARM, required: false},
+				{handle: probes.ExecuteAtFinishedCompatARM, required: false},
 			},
 		},
 	},


### PR DESCRIPTION
### 1. Explain what the PR does

Recently, the process_execute_failed event implementation had been changed to use the new inner execute_finished event.
This event has used syscall tracepoints in its implementation.
However, tracepoints rely on debugfs, which was not a requirement of tracee until now.
To remove this requirement (at least for now), move to use architecture-specific kprobes instead.

This is a cherry pick of #4025 

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
