### PR TITLE
v0.21.0:chore(events): decrease SO loader error log level to debug

### DIFF
--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -144,8 +144,6 @@ func (symbsLoadedGen *symbolsLoadedEventGenerator) deriveArgs(
 		_, ok := symbsLoadedGen.returnedErrors[err.Error()]
 		if !ok {
 			symbsLoadedGen.returnedErrors[err.Error()] = true
-			logger.Warnw("symbols_loaded", "object loaded", loadingObjectInfo, "error", err.Error())
-		} else {
 			logger.Debugw("symbols_loaded", "object loaded", loadingObjectInfo, "error", err.Error())
 		}
 		return nil, nil


### PR DESCRIPTION
### 1. Explain what the PR does

Errors from the SO loader are pretty frequent because of race conditions.
As the user has nothing to do with it, the log level should be lowered from WARN.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
