### PR TITLE
fix: remove invalid "format" event from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,6 @@ nav:
                             - Dropped Executable: docs/events/builtin/signatures/dropped_executable.md
                             - Dynamic Code Loading: docs/events/builtin/signatures/dynamic_code_loading.md
                             - Fileless Execution: docs/events/builtin/signatures/fileless_execution.md
-                            - Format: docs/events/builtin/signatures/format.md
                             - Hidden File Created: docs/events/builtin/signatures/hidden_file_created.md
                             - Illegitimate Shell: docs/events/builtin/signatures/illegitimate_shell.md
                             - K8S API Connection: docs/events/builtin/signatures/kubernetes_api_connection.md


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Cherry-picked from main

Fix #4012

The documentation sports a "Format" security event: https://aquasecurity.github.io/tracee/latest/docs/events/builtin/signatures/format/ This is some error with how the documentation got created by AI.

Remove this "event" from docs.

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
