### PR TITLE
Revert "chore(k8s): prepare v0.21.0 release"

### DIFF
--- a/deploy/helm/tracee/Chart.yaml
+++ b/deploy/helm/tracee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tracee
 description: Linux Runtime Security and Forensics using eBPF
-home: https://aquasecurity.github.io/tracee/v0.21.0/
+home: https://aquasecurity.github.io/tracee/v0.20.0/
 sources:
   - https://github.com/aquasecurity/tracee
 
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.21.0"
+version: "0.20.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.21.0"
+appVersion: "0.20.0"

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: tracee
   labels:
-    helm.sh/chart: tracee-0.21.0
+    helm.sh/chart: tracee-0.20.0
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.21.0"
+    app.kubernetes.io/version: "0.20.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: tracee/templates/serviceaccount.yaml
@@ -17,10 +17,10 @@ kind: ServiceAccount
 metadata:
   name: tracee-operator
   labels:
-    helm.sh/chart: tracee-0.21.0
+    helm.sh/chart: tracee-0.20.0
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.21.0"
+    app.kubernetes.io/version: "0.20.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: tracee/templates/tracee-config.yaml
@@ -29,10 +29,10 @@ kind: ConfigMap
 metadata:
   name: tracee-config
   labels:
-    helm.sh/chart: tracee-0.21.0
+    helm.sh/chart: tracee-0.20.0
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.21.0"
+    app.kubernetes.io/version: "0.20.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |-
@@ -118,10 +118,10 @@ kind: DaemonSet
 metadata:
   name: tracee
   labels:
-    helm.sh/chart: tracee-0.21.0
+    helm.sh/chart: tracee-0.20.0
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.21.0"
+    app.kubernetes.io/version: "0.20.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -140,7 +140,7 @@ spec:
         {}
       containers:
         - name: tracee
-          image: "docker.io/aquasec/tracee:0.21.0"
+          image: "docker.io/aquasec/tracee:0.20.0"
           imagePullPolicy: IfNotPresent
           command:
             - /tracee/tracee
@@ -218,10 +218,10 @@ kind: Deployment
 metadata:
   name: tracee-operator
   labels:
-    helm.sh/chart: tracee-0.21.0
+    helm.sh/chart: tracee-0.20.0
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.21.0"
+    app.kubernetes.io/version: "0.20.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -238,7 +238,7 @@ spec:
         {}
       containers:
       - name: tracee-operator
-        image: "docker.io/aquasec/tracee:0.21.0"
+        image: "docker.io/aquasec/tracee:0.20.0"
         imagePullPolicy: IfNotPresent
         command:
           - /tracee/tracee-operator


### PR DESCRIPTION
Reverts aquasecurity/tracee#4007 due to https://github.com/aquasecurity/tracee/pull/4018#issuecomment-2106928157

### This PR must be the last one before releasing.