### PR TITLE
fix(proctree): limit tree memory usage and reduce it

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -1,6 +1,7 @@
 package changelog
 
 import (
+	"slices"
 	"time"
 
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -25,13 +26,15 @@ type item[T comparable] struct {
 type Changelog[T comparable] struct {
 	changes    []item[T]              // list of changes
 	timestamps map[time.Time]struct{} // set of timestamps (used to avoid duplicates)
+	maxSize    int                    // maximum amount of changes to keep track of
 }
 
 // NewChangelog creates a new changelog.
-func NewChangelog[T comparable]() *Changelog[T] {
+func NewChangelog[T comparable](maxSize int) *Changelog[T] {
 	return &Changelog[T]{
 		changes:    []item[T]{},
 		timestamps: map[time.Time]struct{}{},
+		maxSize:    maxSize,
 	}
 }
 
@@ -126,14 +129,20 @@ func (clv *Changelog[T]) setAt(value T, targetTime time.Time) {
 		value:     value,
 	}
 
-	// Insert the new entry in the changelog, keeping the list sorted by timestamp.
 	idx := clv.findIndex(entry.timestamp)
+	// If the changelog has reached its maximum size and the new change would be inserted as the oldest,
+	// there is no need to add the new change. We can simply return without making any modifications.
+	if len(clv.changes) >= clv.maxSize && idx == 0 {
+		return
+	}
+	// Insert the new entry in the changelog, keeping the list sorted by timestamp.
 	clv.changes = append(clv.changes, item[T]{})
 	copy(clv.changes[idx+1:], clv.changes[idx:])
 	clv.changes[idx] = entry
-
 	// Mark the timestamp as set.
 	clv.timestamps[targetTime] = struct{}{}
+
+	clv.enforceSizeBoundary()
 }
 
 // findIndex returns the index of the first item in the changelog that is after the given time.
@@ -150,6 +159,33 @@ func (clv *Changelog[T]) findIndex(target time.Time) int {
 	}
 
 	return left
+}
+
+// enforceSizeBoundary ensures that the size of the inner array doesn't exceed the limit.
+// It applies two methods to reduce the log size to the maximum allowed:
+// 1. Unite duplicate values that are trailing one another.
+// 2. Remove the oldest logs as they are likely less important.
+
+func (clv *Changelog[T]) enforceSizeBoundary() {
+	if len(clv.changes) > clv.maxSize {
+		// Get rid of oldest changes to keep max size boundary
+		boundaryDiff := len(clv.changes) - clv.maxSize
+
+		// First try to unite states
+		clv.changes = slices.CompactFunc(clv.changes, func(i item[T], i2 item[T]) bool {
+			if i.value == i2.value && boundaryDiff > 0 {
+				delete(clv.timestamps, i2.timestamp)
+				boundaryDiff--
+				return true
+			}
+			return false
+		})
+
+		clv.changes = clv.changes[len(clv.changes)-clv.maxSize:]
+		for i := 0; i < boundaryDiff; i++ {
+			delete(clv.timestamps, clv.changes[i].timestamp)
+		}
+	}
 }
 
 // returnZero returns the zero value of the type T.

--- a/pkg/proctree/fileinfo.go
+++ b/pkg/proctree/fileinfo.go
@@ -66,9 +66,19 @@ func (fi *FileInfo) SetFeedAt(feed FileInfoFeed, targetTime time.Time) {
 	fi.setFeedAt(feed, targetTime)
 }
 
+// Paths theoretically has no limit, but we do need to set a limit for the sake of
+// managing memory more responsibly.
+const MaxPathLen = 1024
+
 func (fi *FileInfo) setFeedAt(feed FileInfoFeed, targetTime time.Time) {
 	if feed.Path != "" {
-		fi.path.Set(feed.Path, targetTime)
+		filePath := feed.Path
+		if len(filePath) > MaxPathLen {
+			// Take only the end of the path, as the specific file name and location are the most
+			// important parts.
+			filePath = filePath[len(filePath)-MaxPathLen:]
+		}
+		fi.path.Set(filePath, targetTime)
 	}
 	if feed.Dev >= 0 {
 		fi.dev.Set(feed.Dev, targetTime)

--- a/pkg/proctree/fileinfo.go
+++ b/pkg/proctree/fileinfo.go
@@ -32,20 +32,20 @@ type FileInfo struct {
 }
 
 // NewFileInfo creates a new file.
-func NewFileInfo() *FileInfo {
+func NewFileInfo(maxLogSize int) *FileInfo {
 	return &FileInfo{
-		path:      ch.NewChangelog[string](),
-		dev:       ch.NewChangelog[int](),
-		ctime:     ch.NewChangelog[int](),
-		inode:     ch.NewChangelog[int](),
-		inodeMode: ch.NewChangelog[int](),
+		path:      ch.NewChangelog[string](maxLogSize),
+		dev:       ch.NewChangelog[int](maxLogSize),
+		ctime:     ch.NewChangelog[int](maxLogSize),
+		inode:     ch.NewChangelog[int](maxLogSize),
+		inodeMode: ch.NewChangelog[int](maxLogSize),
 		mutex:     &sync.RWMutex{},
 	}
 }
 
 // NewFileInfoFeed creates a new file with values from the given feed.
-func NewFileInfoFeed(feed FileInfoFeed) *FileInfo {
-	new := NewFileInfo()
+func NewFileInfoFeed(maxLogSize int, feed FileInfoFeed) *FileInfo {
+	new := NewFileInfo(maxLogSize)
 	new.SetFeed(feed)
 	return new
 }

--- a/pkg/proctree/process.go
+++ b/pkg/proctree/process.go
@@ -28,9 +28,9 @@ func NewProcess(hash uint32) *Process {
 		processHash: hash,
 		parentHash:  0,
 		info:        NewTaskInfo(),
-		executable:  NewFileInfo(),
-		interpreter: NewFileInfo(),
-		interp:      NewFileInfo(),
+		executable:  NewFileInfo(5), // Binary's history is much more important to save
+		interpreter: NewFileInfo(2),
+		interp:      NewFileInfo(2),
 		children:    make(map[uint32]struct{}),
 		threads:     make(map[uint32]struct{}),
 		mutex:       &sync.RWMutex{},

--- a/pkg/proctree/process.go
+++ b/pkg/proctree/process.go
@@ -29,8 +29,9 @@ func NewProcess(hash uint32) *Process {
 		parentHash:  0,
 		info:        NewTaskInfo(),
 		executable:  NewFileInfo(5), // Binary's history is much more important to save
-		interpreter: NewFileInfo(2),
-		interp:      NewFileInfo(2),
+		// TODO: Decide whether remove the interpreter and interp from the tree or add them back
+		interpreter: NewFileInfo(0),
+		interp:      NewFileInfo(0),
 		children:    make(map[uint32]struct{}),
 		threads:     make(map[uint32]struct{}),
 		mutex:       &sync.RWMutex{},

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -236,23 +236,10 @@ func (pt *ProcessTree) FeedFromExec(feed ExecFeed) error {
 		utils.NsSinceBootTimeToTime(feed.TimeStamp),
 	)
 
-	process.GetInterpreter().SetFeedAt(
-		FileInfoFeed{
-			Path:      feed.InterpreterPath,
-			Dev:       int(feed.InterpreterDev),
-			Ctime:     int(feed.InterpreterCtime),
-			Inode:     int(feed.InterpreterInode),
-			InodeMode: -1, // no inode mode for interpreter
-		},
-		utils.NsSinceBootTimeToTime(feed.TimeStamp),
-	)
-
-	process.GetInterp().SetFeedAt(
-		FileInfoFeed{
-			Path: feed.Interp,
-		},
-		utils.NsSinceBootTimeToTime(feed.TimeStamp),
-	)
+	// The interpreter and interp info are taking a lot of memory.
+	// As their usage is still unclear in the process tree, it was decided
+	// to not save their information until it was clear how they would be used.
+	// TODO: Decide whether remove the interpreter and interp from the tree or add them back.
 
 	return nil
 }

--- a/pkg/proctree/taskinfo.go
+++ b/pkg/proctree/taskinfo.go
@@ -46,11 +46,13 @@ type TaskInfo struct {
 // NewTaskInfo creates a new task.
 func NewTaskInfo() *TaskInfo {
 	return &TaskInfo{
-		name:   ch.NewChangelog[string](),
-		pPid:   ch.NewChangelog[int](),
-		nsPPid: ch.NewChangelog[int](),
-		uid:    ch.NewChangelog[int](),
-		gid:    ch.NewChangelog[int](),
+		name: ch.NewChangelog[string](5),
+		// All the folloowing values changes are currently not monitored by the process tree.
+		// Hence, for now, they will only contain one value in the changelog
+		pPid:   ch.NewChangelog[int](1),
+		nsPPid: ch.NewChangelog[int](1),
+		uid:    ch.NewChangelog[int](1),
+		gid:    ch.NewChangelog[int](1),
 		mutex:  &sync.RWMutex{},
 	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

This PR add limitation on the changelog objects sizes, and reduces drastically the memory usage of the tree by not saving the interpreter and interp information in the tree.
This should reduce the chance for memory leakage.
By rough calculation, before the PR the process tree would take around 150MB of memory on average.
After this change, it should be reduced by at least 60MB on average.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
