### PR TITLE
fix(performance.yaml): benchmark output location

### DIFF
--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -66,14 +66,14 @@ jobs:
         # 4. Move back to the base repository path
         run: |
           aws eks update-kubeconfig --region $AWS_REGION --name $PERF_CLUSTER
-          make bench-network
+          make bench-network IMAGE=$PR_REPO:$GITHUB_SHA OUTPUT=bench_output.json
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@1846227a307d8c0149b960b986d46f8f4c95db0c #v1.20.1
         with:
           # What benchmark tool the output.txt came from
           tool: 'customSmallerIsBetter'
           # Where the output from the benchmark tool is stored
-          output-file-path: ./performance/benchmark/network/bench_output.json
+          output-file-path: bench_output.json
           # Workflow will fail when an alert happens
           fail-on-alert: false
           # Tag user when alerted

--- a/Makefile
+++ b/Makefile
@@ -999,4 +999,4 @@ k8s-generate: ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyOb
 # benchmarks
 .PHONY: bench-network
 bench-network:
-	./performance/benchmark/network/bench.sh
+	./performance/benchmark/network/bench.sh $(IMAGE) $(OUTPUT) $(TIME)

--- a/performance/benchmark/network/bench.sh
+++ b/performance/benchmark/network/bench.sh
@@ -19,11 +19,11 @@ CleanupOnError() {
     exit 1
 }
 
-# constants
+# arguments
 
 TRACEE_IMAGE=${1:-"docker.io/aquasec/tracee:0.20.0"}
-BENCH_TIME=${2:-900}
-RESULT_ID=${3:-"default"}
+BENCH_OUTPUT=${2:-"bench_output.json"}
+BENCH_TIME=${3:-900}
 BENCHMARK_NAME="tracee_network_benchmark"
 
 


### PR DESCRIPTION
Benchmark output was previously uncoordinated between yaml and script. Commit adds an output location parameter to the script and corresponding make arguments, which are then used in the yaml.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
