### PR TITLE
Packet capture context

### DIFF
--- a/pkg/pcaps/interface.go
+++ b/pkg/pcaps/interface.go
@@ -1,0 +1,121 @@
+package pcaps
+
+import (
+	"encoding/json"
+	"math"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/google/gopacket/layers"
+	"github.com/google/gopacket/pcapgo"
+)
+
+// This struct represents the context of a packet capture.
+// Packet captures can be per process, command, container or a single capture,
+// which affects the context info relevant to it.
+// The context contains information that is supposed to be constant for the
+// entire capture, although this may not always be the case.
+// For example, if a process changes its name, this won't be reflected in the
+// capture's context information.
+type PacketContext struct {
+	// Present for container, command and process captures
+	Container  *ContainerContext  `json:"container,omitempty"`
+	Kubernetes *KubernetesContext `json:"kubernetes,omitempty"`
+	HostName   string             `json:"hostName,omitempty"`
+
+	// Present for command and process captures
+	ProcessName string `json:"processName,omitempty"`
+
+	// Present for process captures
+	Process *ProcessContext `json:"process,omitempty"`
+}
+
+type ProcessContext struct {
+	ThreadStartTime     int    `json:"threadStartTime"`
+	ProcessID           int    `json:"processId"`
+	CgroupID            uint   `json:"cgroupId"`
+	ThreadID            int    `json:"threadId"`
+	ParentProcessID     int    `json:"parentProcessId"`
+	HostProcessID       int    `json:"hostProcessId"`
+	HostThreadID        int    `json:"hostThreadId"`
+	HostParentProcessID int    `json:"hostParentProcessId"`
+	UserID              int    `json:"userId"`
+	MountNS             int    `json:"mountNamespace"`
+	PIDNS               int    `json:"pidNamespace"`
+	Executable          string `json:"executable"`
+}
+
+type ContainerContext struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	ImageName   string `json:"image"`
+	ImageDigest string `json:"imageDigest"`
+}
+
+type KubernetesContext struct {
+	PodName      string `json:"podName"`
+	PodNamespace string `json:"podNamespace"`
+	PodUID       string `json:"podUID"`
+	PodSandbox   bool   `json:"podSandbox"`
+}
+
+func initPacketContext(event *trace.Event, t PcapType) PacketContext {
+	ctx := PacketContext{}
+
+	if t == Container || t == Command || t == Process {
+		ctx.Container = &ContainerContext{
+			ID:          event.Container.ID,
+			Name:        event.Container.Name,
+			ImageName:   event.Container.ImageName,
+			ImageDigest: event.Container.ImageDigest,
+		}
+		ctx.Kubernetes = &KubernetesContext{
+			PodName:      event.Kubernetes.PodName,
+			PodNamespace: event.Kubernetes.PodNamespace,
+			PodUID:       event.Kubernetes.PodUID,
+			PodSandbox:   event.Kubernetes.PodSandbox,
+		}
+		ctx.HostName = event.HostName
+	}
+
+	if t == Command || t == Process {
+		ctx.ProcessName = event.ProcessName
+	}
+
+	if t == Process {
+		ctx.Process = &ProcessContext{
+			ThreadStartTime:     event.ThreadStartTime,
+			ProcessID:           event.ProcessID,
+			CgroupID:            event.CgroupID,
+			ThreadID:            event.ThreadID,
+			ParentProcessID:     event.ParentProcessID,
+			HostProcessID:       event.HostProcessID,
+			HostThreadID:        event.HostThreadID,
+			HostParentProcessID: event.HostParentProcessID,
+			UserID:              event.UserID,
+			MountNS:             event.MountNS,
+			PIDNS:               event.PIDNS,
+			Executable:          event.Executable.Path,
+		}
+	}
+
+	return ctx
+}
+
+func GenerateInterface(event *trace.Event, t PcapType) (pcapgo.NgInterface, error) {
+	packetContext := initPacketContext(event, t)
+
+	descBytes, err := json.Marshal(packetContext)
+	if err != nil {
+		return pcapgo.NgInterface{}, errfmt.WrapError(err)
+	}
+	desc := string(descBytes)
+
+	return pcapgo.NgInterface{ // https://www.tcpdump.org/linktypes.html
+		Name:        "tracee",
+		Comment:     "tracee packet capture",
+		Description: desc,
+		LinkType:    layers.LinkTypeNull, // layer2 is 4 bytes (or 32bit)
+		SnapLength:  uint32(math.MaxUint32),
+	}, nil
+}

--- a/pkg/pcaps/interface.go
+++ b/pkg/pcaps/interface.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
+var packetContextVersion = "1.0"
+
 // This struct represents the context of a packet capture.
 // Packet captures can be per process, command, container or a single capture,
 // which affects the context info relevant to it.
@@ -19,6 +21,8 @@ import (
 // For example, if a process changes its name, this won't be reflected in the
 // capture's context information.
 type PacketContext struct {
+	Version string `json:"version"`
+
 	// Present for container, command and process captures
 	Container  *ContainerContext  `json:"container,omitempty"`
 	Kubernetes *KubernetesContext `json:"kubernetes,omitempty"`
@@ -61,7 +65,7 @@ type KubernetesContext struct {
 }
 
 func initPacketContext(event *trace.Event, t PcapType) PacketContext {
-	ctx := PacketContext{}
+	ctx := PacketContext{Version: packetContextVersion}
 
 	if t == Container || t == Command || t == Process {
 		ctx.Container = &ContainerContext{

--- a/pkg/pcaps/interface.go
+++ b/pkg/pcaps/interface.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"math"
 
-	"github.com/aquasecurity/tracee/pkg/errfmt"
-	"github.com/aquasecurity/tracee/types/trace"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcapgo"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/types/trace"
 )
 
 // This struct represents the context of a packet capture.

--- a/pkg/pcaps/interface.go
+++ b/pkg/pcaps/interface.go
@@ -51,17 +51,17 @@ type ProcessContext struct {
 }
 
 type ContainerContext struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	ImageName   string `json:"image"`
-	ImageDigest string `json:"imageDigest"`
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	ImageName   string `json:"image,omitempty"`
+	ImageDigest string `json:"imageDigest,omitempty"`
 }
 
 type KubernetesContext struct {
-	PodName      string `json:"podName"`
-	PodNamespace string `json:"podNamespace"`
-	PodUID       string `json:"podUID"`
-	PodSandbox   bool   `json:"podSandbox"`
+	PodName      string `json:"podName,omitempty"`
+	PodNamespace string `json:"podNamespace,omitempty"`
+	PodUID       string `json:"podUID,omitempty"`
+	PodSandbox   bool   `json:"podSandbox,omitempty"`
 }
 
 func initPacketContext(event *trace.Event, t PcapType) PacketContext {


### PR DESCRIPTION
### 1. Explain what the PR does

This PR adds context information to pcap files generated by Tracee. Based on the type of pcap, an interface description that contains various pieces of context information in JSON format is added.

Example of an interface description for a process pcap:

```
{"container":{"id":"c373adfdc4ac4c3a330c4fda09ad9398bcfb99c381b97cb044c813a397547def","name":"gallant_nightingale","image":"busybox:latest","imageDigest":"busybox@sha256:5eef5ed34e1e1ff0a4ae850395cbf665c4de6b4b83a32a0bc7bcb998e24e7bbb"},"kubernetes":{"podName":"","podNamespace":"","podUID":"","podSandbox":false},"hostName":"c373adfdc4ac","processName":"ping","process":{"threadStartTime":1716378637481073915,"processId":1,"cgroupId":526,"threadId":1,"parentProcessId":0,"hostProcessId":191684,"hostThreadId":191684,"hostParentProcessId":191665,"userId":0,"mountNamespace":4026532371,"pidNamespace":4026532374,"executable":""}}
```

This closes #4050.

### 2. Explain how to test it

An integration test was added for the context information.

To manually read the interface description containing the context information, use the following python script with the pcap file as an argument:

```python
import sys
import pcapng

pcap_path = sys.argv[1]
with open(pcap_path, 'rb') as f:
    scanner = pcapng.FileScanner(f)
    for block in scanner:
        if isinstance(block, pcapng.blocks.InterfaceDescription):
            print(block.options['if_description'])
```