### PR TITLE
[v0.21.0] fix: select cgroup mountpoint with the smallest inode number

### DIFF
--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -214,6 +214,11 @@ func (c *CgroupV1) init() error {
 	// 2. discover where cgroup is mounted
 	c.mountpoint = c.mounted.GetMountpoint()
 
+	inode := c.mounted.GetMountpointInode()
+	if inode != 1 {
+		logger.Warnw("Cgroup mountpoint is not in the host cgroup namespace", "mountpoint", c.mountpoint, "inode", inode)
+	}
+
 	return nil
 }
 
@@ -264,6 +269,11 @@ func (c *CgroupV2) init() error {
 
 	// 2. discover where cgroup is mounted
 	c.mountpoint = c.mounted.GetMountpoint()
+
+	inode := c.mounted.GetMountpointInode()
+	if inode != 1 {
+		logger.Warnw("Cgroup mountpoint is not in the host cgroup namespace", "mountpoint", c.mountpoint, "inode", inode)
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

When running Tracee from within a container, multiple mount points of the cgroup filesystem may exist. In such cases, we need to ensure that we select the mountpoint from the host cgroup namespace. By checking for an inode equal to 1, we can identify the cgroupfs mountpoint belonging to the host cgroup namespace. This ensures that Tracee can discover preexisting containers using the host cgroup filesystem.

Additionally, a warning log is emitted if the cgroup mountpoint does not have an inode of 1, indicating that it might not be part of the host cgroup namespace.


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
