### PR TITLE
0.21.0/fix(changelog): size enforcement corrupted cache 

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -181,9 +181,13 @@ func (clv *Changelog[T]) enforceSizeBoundary() {
 			return false
 		})
 
-		clv.changes = clv.changes[len(clv.changes)-clv.maxSize:]
-		for i := 0; i < boundaryDiff; i++ {
-			delete(clv.timestamps, clv.changes[i].timestamp)
+		if boundaryDiff == 0 {
+			return
+		}
+		removedChanges := clv.changes[:boundaryDiff]
+		clv.changes = clv.changes[boundaryDiff:]
+		for _, removedChange := range removedChanges {
+			delete(clv.timestamps, removedChange.timestamp)
 		}
 	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

Fix bug with changelog max size enforcement that caused the remove of wrong entries from the timestamps cache, corrupting it.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
