### PR TITLE
fix(proctree): fix clock type differences

### DIFF
--- a/pkg/ebpf/c/common/common.h
+++ b/pkg/ebpf/c/common/common.h
@@ -1,15 +1,17 @@
+#pragma once
+
 #ifndef __COMMON_COMMON_H__
-#define __COMMON_COMMON_H__
+    #define __COMMON_COMMON_H__
 
-#include <vmlinux.h>
+    #include <vmlinux.h>
 
-#include <bpf/bpf_core_read.h>
+    #include <bpf/bpf_core_read.h>
 
-#include <maps.h>
+    #include <maps.h>
 
 // PROTOTYPES
 
-#define statfunc static __always_inline
+    #define statfunc static __always_inline
 
 // FUNCTIONS & MACROS
 
@@ -28,31 +30,31 @@ statfunc const char *get_device_name(struct device *dev)
 //     ordering
 //
 
-#if defined(__clang__) && __clang_major__ > 13
+    #if defined(__clang__) && __clang_major__ > 13
 
-    #define has_prefix(p, s, n)                                                                    \
-        ({                                                                                         \
-            int rc = 0;                                                                            \
-            char *pre = p, *str = s;                                                               \
-            _Pragma("unroll") for (int z = 0; z < n; pre++, str++, z++)                            \
-            {                                                                                      \
-                if (!*pre) {                                                                       \
-                    rc = 1;                                                                        \
-                    break;                                                                         \
-                } else if (*pre != *str) {                                                         \
-                    rc = 0;                                                                        \
-                    break;                                                                         \
+        #define has_prefix(p, s, n)                                                                \
+            ({                                                                                     \
+                int rc = 0;                                                                        \
+                char *pre = p, *str = s;                                                           \
+                _Pragma("unroll") for (int z = 0; z < n; pre++, str++, z++)                        \
+                {                                                                                  \
+                    if (!*pre) {                                                                   \
+                        rc = 1;                                                                    \
+                        break;                                                                     \
+                    } else if (*pre != *str) {                                                     \
+                        rc = 0;                                                                    \
+                        break;                                                                     \
+                    }                                                                              \
                 }                                                                                  \
-            }                                                                                      \
-            rc;                                                                                    \
-        })
+                rc;                                                                                \
+            })
 
-#else
+    #else
 
 static __inline int has_prefix(char *prefix, char *str, int n)
 {
     int i;
-    #pragma unroll
+        #pragma unroll
     for (i = 0; i < n; prefix++, str++, i++) {
         if (!*prefix)
             return 1;
@@ -65,23 +67,30 @@ static __inline int has_prefix(char *prefix, char *str, int n)
     return 0;
 }
 
+    #endif
+
+    // helper macros for branch prediction
+    #ifndef likely
+        #define likely(x) __builtin_expect((x), 1)
+    #endif
+    #ifndef unlikely
+        #define unlikely(x) __builtin_expect((x), 0)
+    #endif
+
+    // helpers for iterating over a list_head struct
+    #define list_entry_ebpf(ptr, type, member) container_of(ptr, type, member)
+
+    #define list_next_entry_ebpf(pos, member)                                                      \
+        list_entry_ebpf(BPF_CORE_READ(pos, member.next), typeof(*(pos)), member)
+
+    #define list_first_entry_ebpf(ptr, type, member)                                               \
+        list_entry_ebpf(BPF_CORE_READ(ptr, next), type, member)
+
 #endif
 
-// helper macros for branch prediction
-#ifndef likely
-    #define likely(x) __builtin_expect((x), 1)
-#endif
-#ifndef unlikely
-    #define unlikely(x) __builtin_expect((x), 0)
-#endif
-
-// helpers for iterating over a list_head struct
-#define list_entry_ebpf(ptr, type, member) container_of(ptr, type, member)
-
-#define list_next_entry_ebpf(pos, member)                                                          \
-    list_entry_ebpf(BPF_CORE_READ(pos, member.next), typeof(*(pos)), member)
-
-#define list_first_entry_ebpf(ptr, type, member)                                                   \
-    list_entry_ebpf(BPF_CORE_READ(ptr, next), type, member)
-
-#endif
+statfunc u64 get_current_time_in_ns(void)
+{
+    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns))
+        return bpf_ktime_get_boot_ns();
+    return bpf_ktime_get_ns();
+}

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -6,6 +6,7 @@
 #include <common/logging.h>
 #include <common/task.h>
 #include <common/cgroups.h>
+#include <common/common.h>
 
 // PROTOTYPES
 
@@ -137,7 +138,7 @@ statfunc int init_program_data(program_data_t *p, void *ctx, u32 event_id)
     p->event->context.task.host_tid = id;
     p->event->context.task.host_pid = id >> 32;
     p->event->context.eventid = event_id;
-    p->event->context.ts = bpf_ktime_get_ns();
+    p->event->context.ts = get_current_time_in_ns();
     p->event->context.processor_id = (u16) bpf_get_smp_processor_id();
     p->event->context.syscall = get_task_syscall_id(p->event->task);
 

--- a/pkg/ebpf/c/common/logging.h
+++ b/pkg/ebpf/c/common/logging.h
@@ -31,7 +31,7 @@ statfunc void do_tracee_log(
 
     bpf_log_count_t counter_buf = {};
     counter_buf.count = 1;
-    counter_buf.ts = bpf_ktime_get_ns(); // store the current ts
+    counter_buf.ts = get_current_time_in_ns(); // store the current ts
     u64 ts_prev = 0;
 
     bpf_log_count_t *counter = bpf_map_lookup_elem(&logs_count, &log_output->log);

--- a/pkg/ebpf/c/common/task.h
+++ b/pkg/ebpf/c/common/task.h
@@ -151,6 +151,15 @@ statfunc u32 get_task_ppid(struct task_struct *task)
 
 statfunc u64 get_task_start_time(struct task_struct *task)
 {
+    // Only use the boot time member if we can use boot time for current time
+    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns)) {
+        // real_start_time was renamed to start_boottime in kernel 5.5, so most likely
+        // it will be available as the bpf_ktime_get_boot_ns is available since kernel 5.8.
+        // The only case it won't be available is if it was backported to an older kernel.
+        if (bpf_core_field_exists(struct task_struct, start_boottime))
+            return BPF_CORE_READ(task, start_boottime);
+        return BPF_CORE_READ(task, real_start_time);
+    }
     return BPF_CORE_READ(task, start_time);
 }
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -266,6 +266,8 @@ struct task_struct {
     struct pid *thread_pid;
     struct list_head thread_group;
     u64 start_time;
+    u64 start_boottime;
+    u64 real_start_time;
     const struct cred *real_cred;
     char comm[16];
     struct files_struct *files;
@@ -675,6 +677,7 @@ enum bpf_func_id
     BPF_FUNC_probe_write_user = 36,
     BPF_FUNC_override_return = 58,
     BPF_FUNC_sk_storage_get = 107,
+    BPF_FUNC_ktime_get_boot_ns = 125,
     BPF_FUNC_copy_from_user = 148,
     BPF_FUNC_for_each_map_elem = 164,
 };

--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -109,13 +109,7 @@ func (t *Tracee) handleFileCaptures(ctx context.Context) {
 					continue
 				}
 				// note: size of buffer will determine maximum extracted file size! (as writes from kernel are immediate)
-				if t.config.Output.RelativeTime {
-					// To get the monotonic time since tracee was started, we have to subtract the start time from the timestamp.
-					mprotectMeta.Ts -= t.startTime
-				} else {
-					// To get the current ("wall") time, we add the boot time into it.
-					mprotectMeta.Ts += t.bootTime
-				}
+				mprotectMeta.Ts = uint64(t.timeNormalizer.NormalizeTime(int(mprotectMeta.Ts)))
 				filename = fmt.Sprintf("bin.pid-%d.ts-%d", mprotectMeta.Pid, mprotectMeta.Ts)
 			} else if meta.BinType == bufferdecoder.SendKernelModule {
 				err = metaBuffDecoder.DecodeKernelModuleMeta(&kernelModuleMeta)

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/libbpfgo"
 
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/ebpf/reltime"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/proctree"
@@ -28,6 +29,7 @@ type Controller struct {
 	cgroupManager  *containers.Containers
 	processTree    *proctree.ProcessTree
 	enrichDisabled bool
+	timeNormalizer reltime.TimeNormalizer
 }
 
 // NewController creates a new controller.
@@ -36,6 +38,7 @@ func NewController(
 	cgroupManager *containers.Containers,
 	enrichDisabled bool,
 	procTree *proctree.ProcessTree,
+	timeNormalizer reltime.TimeNormalizer,
 ) (*Controller, error) {
 	var err error
 
@@ -46,6 +49,7 @@ func NewController(
 		cgroupManager:  cgroupManager,
 		processTree:    procTree,
 		enrichDisabled: enrichDisabled,
+		timeNormalizer: timeNormalizer,
 	}
 
 	p.signalBuffer, err = bpfModule.InitPerfBuf("signals", p.signalChan, p.lostSignalChan, 1024)

--- a/pkg/ebpf/controlplane/processes.go
+++ b/pkg/ebpf/controlplane/processes.go
@@ -73,7 +73,7 @@ func (ctrl *Controller) procTreeForkProcessor(args []trace.Argument) error {
 
 	return ctrl.processTree.FeedFromFork(
 		proctree.ForkFeed{
-			TimeStamp:       timestamp,
+			TimeStamp:       uint64(ctrl.timeNormalizer.NormalizeTime(int(timestamp))),
 			ChildHash:       childHash,
 			ParentHash:      parentHash,
 			LeaderHash:      leaderHash,
@@ -81,17 +81,17 @@ func (ctrl *Controller) procTreeForkProcessor(args []trace.Argument) error {
 			ParentNsTid:     parentNsTid,
 			ParentPid:       parentPid,
 			ParentNsPid:     parentNsPid,
-			ParentStartTime: parentStartTime,
+			ParentStartTime: uint64(ctrl.timeNormalizer.NormalizeTime(int(parentStartTime))),
 			LeaderTid:       leaderTid,
 			LeaderNsTid:     leaderNsTid,
 			LeaderPid:       leaderPid,
 			LeaderNsPid:     leaderNsPid,
-			LeaderStartTime: leaderStartTime,
+			LeaderStartTime: uint64(ctrl.timeNormalizer.NormalizeTime(int(leaderStartTime))),
 			ChildTid:        childTid,
 			ChildNsTid:      childNsTid,
 			ChildPid:        childPid,
 			ChildNsPid:      childNsPid,
-			ChildStartTime:  childStartTime,
+			ChildStartTime:  uint64(ctrl.timeNormalizer.NormalizeTime(int(childStartTime))),
 		},
 	)
 }
@@ -154,7 +154,7 @@ func (ctrl *Controller) procTreeExecProcessor(args []trace.Argument) error {
 
 	return ctrl.processTree.FeedFromExec(
 		proctree.ExecFeed{
-			TimeStamp:         timestamp,
+			TimeStamp:         uint64(ctrl.timeNormalizer.NormalizeTime(int(timestamp))),
 			TaskHash:          taskHash,
 			ParentHash:        parentHash,
 			LeaderHash:        leaderHash,
@@ -208,7 +208,7 @@ func (ctrl *Controller) procTreeExitProcessor(args []trace.Argument) error {
 
 	return ctrl.processTree.FeedFromExit(
 		proctree.ExitFeed{
-			TimeStamp:  timestamp, // time of exit is already a timestamp
+			TimeStamp:  uint64(ctrl.timeNormalizer.NormalizeTime(int(timestamp))), // time of exit is already a timestamp
 			TaskHash:   taskHash,
 			ParentHash: parentHash,
 			LeaderHash: leaderHash,

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -353,23 +353,8 @@ func (t *Tracee) normalizeEventCtxTimes(event *trace.Event) error {
 		// derived events are normalized from their base event, skip the processing
 		return nil
 	}
-
-	//
-	// Currently, the timestamp received from the bpf code is of the monotonic clock.
-	//
-	// TODO: The monotonic clock doesn't take into account system sleep time.
-	// Starting from kernel 5.7, we can get the timestamp relative to the system boot time
-	// instead which is preferable.
-
-	if t.config.Output.RelativeTime {
-		// monotonic time since tracee started: timestamp - tracee starttime
-		event.Timestamp = event.Timestamp - int(t.startTime)
-		event.ThreadStartTime = event.ThreadStartTime - int(t.startTime)
-	} else {
-		// current ("wall") time: add boot time to timestamp
-		event.Timestamp = event.Timestamp + int(t.bootTime)
-		event.ThreadStartTime = event.ThreadStartTime + int(t.bootTime)
-	}
+	event.Timestamp = t.timeNormalizer.NormalizeTime(event.Timestamp)
+	event.ThreadStartTime = t.timeNormalizer.NormalizeTime(event.ThreadStartTime)
 
 	return nil
 }
@@ -377,13 +362,7 @@ func (t *Tracee) normalizeEventCtxTimes(event *trace.Event) error {
 // getOrigEvtTimestamp returns the original timestamp of the event.
 // To be used only when the event timestamp was normalized via normalizeEventCtxTimes.
 func (t *Tracee) getOrigEvtTimestamp(event *trace.Event) int {
-	if t.config.Output.RelativeTime {
-		// if the time was normalized relative to tracee start time, add the start time back
-		return event.Timestamp + int(t.startTime)
-	}
-
-	// if the time was normalized to "wall" time, subtract the boot time
-	return event.Timestamp - int(t.bootTime)
+	return t.timeNormalizer.GetOriginalTime(event.Timestamp)
 }
 
 // processSchedProcessFork processes a sched_process_fork event by normalizing the start time.
@@ -402,13 +381,7 @@ func (t *Tracee) normalizeEventArgTime(event *trace.Event, argName string) error
 	if !ok {
 		return errfmt.Errorf("argument %s of event %s is not of type uint64", argName, event.EventName)
 	}
-	if t.config.Output.RelativeTime {
-		// monotonic time since tracee started: timestamp - tracee starttime
-		arg.Value = argTime - t.startTime
-	} else {
-		// current ("wall") time: add boot time to timestamp
-		arg.Value = argTime + t.bootTime
-	}
+	arg.Value = t.timeNormalizer.NormalizeTime(int(argTime))
 	return nil
 }
 

--- a/pkg/ebpf/reltime/time.go
+++ b/pkg/ebpf/reltime/time.go
@@ -1,0 +1,62 @@
+package reltime
+
+import (
+	"github.com/aquasecurity/tracee/pkg/config"
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// TimeNormalizer normalizes the time to be relative to tracee start time or current time in nanoseconds.
+type TimeNormalizer interface {
+	NormalizeTime(timeNs int) int
+	GetOriginalTime(timeNs int) int
+}
+
+// CreateTimeNormalizerByConfig create a TimeNormalizer according to given configuration using
+// runtime functions.
+func CreateTimeNormalizerByConfig(outConfig *config.OutputConfig, clockId int) TimeNormalizer {
+	if outConfig == nil {
+		return nil
+	}
+
+	if outConfig.RelativeTime {
+		return NewRelativeTimeNormalizer(int(utils.GetStartTimeNS(int32(clockId))))
+	}
+	return NewAbsoluteTimeNormalizer(int(utils.GetBootTimeNS(int32(clockId))))
+}
+
+// RelativeTimeNormalizer normalize the time to be relative to Tracee start time
+type RelativeTimeNormalizer struct {
+	startTime int
+}
+
+func NewRelativeTimeNormalizer(startTime int) *RelativeTimeNormalizer {
+	return &RelativeTimeNormalizer{
+		startTime: startTime,
+	}
+}
+
+func (rn *RelativeTimeNormalizer) NormalizeTime(timeNs int) int {
+	return timeNs - rn.startTime
+}
+
+func (rn *RelativeTimeNormalizer) GetOriginalTime(timeNs int) int {
+	return timeNs + rn.startTime
+}
+
+// AbsoluteTimeNormalizer normalize the time to be absolute time since epoch
+type AbsoluteTimeNormalizer struct {
+	bootTime int
+}
+
+func NewAbsoluteTimeNormalizer(bootTime int) *AbsoluteTimeNormalizer {
+	return &AbsoluteTimeNormalizer{
+		bootTime: bootTime,
+	}
+}
+func (rn *AbsoluteTimeNormalizer) NormalizeTime(timeNs int) int {
+	return timeNs + rn.bootTime
+}
+
+func (rn *AbsoluteTimeNormalizer) GetOriginalTime(timeNs int) int {
+	return timeNs - rn.bootTime
+}

--- a/pkg/proctree/proctree_procfs.go
+++ b/pkg/proctree/proctree_procfs.go
@@ -13,7 +13,8 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils/proc"
 )
 
-const debugMsgs = false // debug messages can be too verbose, so they are disabled by default
+const debugMsgs = false                    // debug messages can be too verbose, so they are disabled by default
+const ProcfsClockId = utils.CLOCK_BOOTTIME // Procfs uses jiffies, which are based on boottime
 
 const (
 	AllPIDs = 0
@@ -178,7 +179,7 @@ func dealWithProc(pt *ProcessTree, givenPid int) error {
 			Gid:         -1,     // do not change the parent gid
 			StartTimeNS: startTimeNs,
 		},
-		utils.NsSinceBootTimeToTime(uint64(start)), // try to be the first changelog entry
+		utils.NsSinceBootTimeToTime(ProcfsClockId, uint64(start)), // try to be the first changelog entry
 	)
 
 	// TODO: Update executable with information from /proc/<pid>/exe
@@ -247,7 +248,7 @@ func dealWithThread(pt *ProcessTree, givenPid int, givenTid int) error {
 			Gid:         -1,     // do not change the parent gid
 			StartTimeNS: startTimeNs,
 		},
-		utils.NsSinceBootTimeToTime(uint64(start)), // try to be the first changelog entry
+		utils.NsSinceBootTimeToTime(ProcfsClockId, uint64(start)), // try to be the first changelog entry
 	)
 
 	// thread group leader (leader tid is the same as the thread's pid, so we can find it)

--- a/pkg/proctree/taskinfo.go
+++ b/pkg/proctree/taskinfo.go
@@ -360,40 +360,33 @@ func (ti *TaskInfo) GetGidAt(targetTime time.Time) int {
 	return ti.gid.Get(targetTime)
 }
 
-// GetStartTimeNS returns the startTimeNS of the task.
+// GetStartTimeNS returns the start time of the task in nanoseconds since epoch
 func (ti *TaskInfo) GetStartTimeNS() uint64 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 	return ti.startTimeNS
 }
 
-// GetStartTime returns the "real" start time of the task.
+// GetStartTime returns the start time of the task.
 func (ti *TaskInfo) GetStartTime() time.Time {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
-	// Returns a real "time" to be used for the task.
-	duration := time.Duration(int64(ti.startTimeNS))
-	bootTime := utils.GetBootTime()
-	return bootTime.Add(duration)
+	return utils.NsSinceEpochToTime(ti.startTimeNS)
 }
 
-// GetExitTimeNS returns the exitTime of the task.
+// GetExitTimeNS returns the exitTime of the task in nanoseconds since epoch
 func (ti *TaskInfo) GetExitTimeNS() uint64 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 	return ti.exitTimeNS
 }
 
-// GetExitTime returns the "real" exit time of the task.
+// GetExitTime returns the exit time of the task.
 func (ti *TaskInfo) GetExitTime() time.Time {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
-
-	// Returns a real "time" to be used for the task.
-	duration := time.Duration(int64(ti.exitTimeNS))
-	bootTime := utils.GetBootTime()
-	return bootTime.Add(duration)
+	return utils.NsSinceEpochToTime(ti.exitTimeNS)
 }
 
 // IsAlive returns true if the task has exited.
@@ -409,13 +402,13 @@ func (ti *TaskInfo) IsAliveAt(targetTime time.Time) bool {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 	if ti.exitTimeNS != 0 {
-		if targetTime.After(utils.NsSinceBootTimeToTime(ti.exitTimeNS)) {
+		if targetTime.After(utils.NsSinceEpochToTime(ti.exitTimeNS)) {
 			return false
 		}
 	}
 	// If start time is not initialized it will count as 0 ns, meaning it will be before any
 	// query time given.
-	if targetTime.Before(utils.NsSinceBootTimeToTime(ti.startTimeNS)) {
+	if targetTime.Before(utils.NsSinceEpochToTime(ti.startTimeNS)) {
 		return false
 	}
 	return true


### PR DESCRIPTION
### 1. Explain what the PR does

Tracee had an issue that all the times from the kernel were monotonic. However, many user-mode times like times in procfs are of boottime. As boottime is more accurate, change to use boottime if possible (mainly newer kernels).

Fix #4074

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
