### PR TITLE
feat: remove default usage of parse-arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -180,3 +180,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.68 // indirect
 )
+
+replace github.com/aquasecurity/tracee/signatures/helpers => ./signatures/helpers

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4 h1:rQ94U12Xlz2tncE8Rxnw3vpp/9
 github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4/go.mod h1:iI7QCIZ3kXG0MR+FHsDZck6cYs1y1HyZP3sMObBg0sk=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20240313150344-0080df4914d9 h1:BMnpLW1ouA1xjEIQUVx6g/orqgVkTixdfRIJk+vYlFE=
 github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20240313150344-0080df4914d9/go.mod h1:JIFvPdLaEVJ6cS2lt52lcyUia9LkpxtTVijOaYesi5Q=
-github.com/aquasecurity/tracee/api v0.0.0-20240219122500-ea2c242dcd60 h1:8f4SC/qwZaOQGxnbtsYUwD15AN5MfYl77Et/fHDpx2k=
-github.com/aquasecurity/tracee/api v0.0.0-20240219122500-ea2c242dcd60/go.mod h1:o2YYIwIkn/nQM/JltGx1Lw6l9ojaEmYJPVGsZ+RYKcA=
 github.com/aquasecurity/tracee/api v0.0.0-20240426195556-d4b717cdf189 h1:Kg+A5eAUWAhY0US5lgxZdZ/ZRa9xqwB7jcB2pMnVyF0=
 github.com/aquasecurity/tracee/api v0.0.0-20240426195556-d4b717cdf189/go.mod h1:jXLAr/iFkfaNTuNcdbx2blngdMD/qaAfxQe9rCL9jwk=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240122160245-67dec940088c h1:Gms5lUHPIq+OpI5HjcZ+l0NZHhSwBd/47nyUZY89c+M=

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -318,9 +318,6 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	runner.Printer = p
 	runner.InstallPath = traceeInstallPath
 
-	// parse arguments must be enabled if the rule engine is part of the pipeline
-	runner.TraceeConfig.Output.ParseArguments = true
-
 	runner.TraceeConfig.EngineConfig = engine.Config{
 		Enabled:          true,
 		SigNameToEventID: sigNameToEventId,

--- a/pkg/signatures/benchmark/signature/golang/code_injection.go
+++ b/pkg/signatures/benchmark/signature/golang/code_injection.go
@@ -65,11 +65,11 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	}
 	switch ee.EventName {
 	case "open", "openat":
-		flags, err := helpers.GetTraceeArgumentByName(ee, "flags", helpers.GetArgOps{DefaultArgs: false})
+		flags, err := helpers.GetTraceeIntArgumentByName(ee, "flags")
 		if err != nil {
 			return fmt.Errorf("%v %#v", err, ee)
 		}
-		if helpers.IsFileWrite(flags.Value.(string)) {
+		if helpers.IsFileWrite(flags) {
 			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname", helpers.GetArgOps{DefaultArgs: false})
 			if err != nil {
 				return err

--- a/pkg/signatures/regosig/aio.go
+++ b/pkg/signatures/regosig/aio.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/open-policy-agent/opa/rego"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -194,6 +195,12 @@ func (a *aio) OnEvent(event protocol.Event) error {
 	if !ok {
 		return fmt.Errorf("failed to cast event's payload")
 	}
+
+	err := events.ParseArgs(&ee)
+	if err != nil {
+		return fmt.Errorf("rego aio: failed to parse event data: %v", err)
+	}
+
 	input := rego.EvalInput(ee)
 
 	ctx := context.TODO()

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,12 +13,12 @@ import (
 
 type AntiDebuggingPtraceme struct {
 	cb            detect.SignatureHandler
-	ptraceTraceMe string
+	ptraceTraceMe int
 }
 
 func (sig *AntiDebuggingPtraceme) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptraceTraceMe = "PTRACE_TRACEME"
+	sig.ptraceTraceMe = int(libbpfgo.PTRACE_TRACEME.Value())
 	return nil
 }
 
@@ -52,7 +54,7 @@ func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/anti_debugging_ptraceme_test.go
+++ b/signatures/golang/anti_debugging_ptraceme_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_TRACEME"),
+							Value: interface{}(int64(helpers.PTRACE_TRACEME.Value())),
 						},
 					},
 				},
@@ -44,7 +46,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_TRACEME"),
+								Value: interface{}(int64(helpers.PTRACE_TRACEME.Value())),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +78,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: interface{}(int64(helpers.PTRACE_PEEKTEXT.Value())),
 						},
 					},
 				},

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -57,7 +57,7 @@ func (sig *AslrInspection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/aslr_inspection_test.go
+++ b/signatures/golang/aslr_inspection_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestAslrInspection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -94,7 +96,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},
@@ -111,7 +113,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -59,7 +59,7 @@ func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) erro
 		}
 		basename := path.Base(pathname)
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_notify_on_release_modification_test.go
+++ b/signatures/golang/cgroup_notify_on_release_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +37,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},
@@ -56,7 +58,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +96,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 					},
 				},
@@ -117,7 +119,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -56,7 +56,7 @@ func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_release_agent_modification_test.go
+++ b/signatures/golang/cgroup_release_agent_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +37,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},
@@ -56,7 +58,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -141,7 +143,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_RDONLY)),
 						},
 					},
 				},
@@ -164,7 +166,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(helpers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -58,7 +58,7 @@ func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/core_pattern_modification_test.go
+++ b/signatures/golang/core_pattern_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +37,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +58,7 @@ func TestCorePatternModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +96,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -117,7 +119,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -59,7 +59,7 @@ func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/default_loader_modification_test.go
+++ b/signatures/golang/default_loader_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +37,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +58,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -141,7 +143,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -164,7 +166,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -61,7 +61,7 @@ func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/docker_abuse_test.go
+++ b/signatures/golang/docker_abuse_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +32,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +54,7 @@ func TestDockerAbuse(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -140,7 +142,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -164,7 +166,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -11,12 +11,12 @@ import (
 
 type DynamicCodeLoading struct {
 	cb        detect.SignatureHandler
-	alertText string
+	alertType trace.MemProtAlert
 }
 
 func (sig *DynamicCodeLoading) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.alertText = "Protection changed from W to E!"
+	sig.alertType = trace.ProtAlertMprotectWXToX
 	return nil
 }
 
@@ -52,12 +52,13 @@ func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "mem_prot_alert":
-		alert, err := helpers.GetTraceeStringArgumentByName(eventObj, "alert")
+		alert, err := helpers.GetTraceeUintArgumentByName(eventObj, "alert")
 		if err != nil {
 			return err
 		}
+		memProtAlert := trace.MemProtAlert(alert)
 
-		if alert == sig.alertText {
+		if memProtAlert == sig.alertType {
 			metadata, err := sig.GetMetadata()
 			if err != nil {
 				return err

--- a/signatures/golang/dynamic_code_loading_test.go
+++ b/signatures/golang/dynamic_code_loading_test.go
@@ -29,7 +29,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed from W to E!"),
+							Value: uint32(trace.ProtAlertMprotectWXToX),
 						},
 					},
 				},
@@ -44,7 +44,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "alert",
 								},
-								Value: interface{}("Protection changed from W to E!"),
+								Value: uint32(trace.ProtAlertMprotectWXToX),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +76,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed to Executable!"),
+							Value: uint32(trace.ProtAlertMmapWX),
 						},
 					},
 				},

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -70,7 +70,7 @@ func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/k8s_service_account_token_test.go
+++ b/signatures/golang/k8s_service_account_token_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +32,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +54,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -91,7 +93,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -115,7 +117,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -139,7 +141,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/kernel_module_loading_test.go
+++ b/signatures/golang/kernel_module_loading_test.go
@@ -60,7 +60,7 @@ func TestKernelModuleLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "type",
 							},
-							Value: interface{}("kernel-module"),
+							Value: trace.KernelReadKernelModule,
 						},
 					},
 				},
@@ -75,7 +75,7 @@ func TestKernelModuleLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "type",
 								},
-								Value: interface{}("kernel-module"),
+								Value: trace.KernelReadKernelModule,
 							},
 						},
 					}.ToProtocol(),
@@ -107,7 +107,7 @@ func TestKernelModuleLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "type",
 							},
-							Value: interface{}("firmware"),
+							Value: trace.KernelReadFirmware,
 						},
 					},
 				},

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -65,7 +65,7 @@ func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) erro
 			}
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/kubernetes_certificate_theft_attempt_test.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +32,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +54,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -138,7 +140,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -162,7 +164,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -186,7 +188,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -85,7 +85,7 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ld_preload_test.go
+++ b/signatures/golang/ld_preload_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestLdPreload(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -194,7 +196,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -217,7 +219,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -58,7 +58,7 @@ func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_kcore_read_test.go
+++ b/signatures/golang/proc_kcore_read_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestProcKcoreRead(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -94,7 +96,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -117,7 +119,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -61,7 +61,7 @@ func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_access_test.go
+++ b/signatures/golang/proc_mem_access_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestProcMemAccess(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +90,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +113,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -61,7 +61,7 @@ func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_code_injection_test.go
+++ b/signatures/golang/proc_mem_code_injection_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +90,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +113,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,14 +13,14 @@ import (
 
 type PtraceCodeInjection struct {
 	cb             detect.SignatureHandler
-	ptracePokeText string
-	ptracePokeData string
+	ptracePokeText int
+	ptracePokeData int
 }
 
 func (sig *PtraceCodeInjection) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptracePokeText = "PTRACE_POKETEXT"
-	sig.ptracePokeData = "PTRACE_POKEDATA"
+	sig.ptracePokeText = int(libbpfgo.PTRACE_POKETEXT.Value())
+	sig.ptracePokeData = int(libbpfgo.PTRACE_POKEDATA.Value())
 	return nil
 }
 
@@ -54,7 +56,7 @@ func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ptrace_code_injection_test.go
+++ b/signatures/golang/ptrace_code_injection_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKETEXT"),
+							Value: int32(helpers.PTRACE_POKETEXT.Value()),
 						},
 					},
 				},
@@ -44,7 +46,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKETEXT"),
+								Value: int32(helpers.PTRACE_POKETEXT.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +78,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKEDATA"),
+							Value: int32(helpers.PTRACE_POKEDATA.Value()),
 						},
 					},
 				},
@@ -91,7 +93,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKEDATA"),
+								Value: int32(helpers.PTRACE_POKEDATA.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -123,7 +125,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: int32(helpers.PTRACE_PEEKTEXT.Value()),
 						},
 					},
 				},

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -65,7 +65,7 @@ func (sig *RcdModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/rcd_modification_test.go
+++ b/signatures/golang/rcd_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +90,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +111,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -288,7 +290,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -311,7 +313,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -57,7 +57,7 @@ func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sched_debug_recon_test.go
+++ b/signatures/golang/sched_debug_recon_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestSchedDebugRecon(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(helpers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +90,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +113,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -65,7 +65,7 @@ func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/scheduled_task_modification_test.go
+++ b/signatures/golang/scheduled_task_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +31,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +52,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +90,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +111,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -288,7 +290,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -311,7 +313,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -59,7 +59,7 @@ func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 	switch eventObj.EventName {
 	case "security_file_open":
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sudoers_modification_test.go
+++ b/signatures/golang/sudoers_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +37,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +58,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +96,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -115,7 +117,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -247,7 +249,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -270,7 +272,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -52,7 +52,7 @@ func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) err
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/system_request_key_config_modification_test.go
+++ b/signatures/golang/system_request_key_config_modification_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +37,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +58,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(helpers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +96,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(helpers.O_RDONLY),
 						},
 					},
 				},
@@ -117,7 +119,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(helpers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/test_helpers.go
+++ b/signatures/golang/test_helpers.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/aquasecurity/libbpfgo/helpers"
+)
+
+func buildFlagArgValue(flags ...helpers.SystemFunctionArgument) int32 {
+	var res int32
+	for _, flagVal := range flags {
+		res = res | int32(flagVal.Value())
+	}
+	return res
+}

--- a/signatures/helpers/arguments_helpers.go
+++ b/signatures/helpers/arguments_helpers.go
@@ -64,12 +64,44 @@ func GetTraceeIntArgumentByName(event trace.Event, argName string) (int, error) 
 	if err != nil {
 		return 0, err
 	}
-	argInt, ok := arg.Value.(int32)
+
+	argInt32, ok := arg.Value.(int32)
 	if ok {
-		return int(argInt), nil
+		return int(argInt32), nil
+	}
+	argInt64, ok := arg.Value.(int64)
+	if ok {
+		return int(argInt64), nil
+	}
+	argInt, ok := arg.Value.(int)
+	if ok {
+		return argInt, nil
 	}
 
-	return 0, fmt.Errorf("can't convert argument %v to int", argName)
+	return 0, fmt.Errorf("can't convert argument %v to int (argument is of type %T)", argName, arg.Value)
+}
+
+// GetTraceeUIntArgumentByName gets the argument matching the "argName" given from the event "argv" field, casted as int.
+func GetTraceeUintArgumentByName(event trace.Event, argName string) (uint, error) {
+	arg, err := GetTraceeArgumentByName(event, argName, GetArgOps{DefaultArgs: false})
+	if err != nil {
+		return 0, err
+	}
+
+	argUint32, ok := arg.Value.(uint32)
+	if ok {
+		return uint(argUint32), nil
+	}
+	argUint64, ok := arg.Value.(uint64)
+	if ok {
+		return uint(argUint64), nil
+	}
+	argUint, ok := arg.Value.(uint)
+	if ok {
+		return argUint, nil
+	}
+
+	return 0, fmt.Errorf("can't convert argument %v to int (argument is of type %T)", argName, arg.Value)
 }
 
 // GetTraceeSliceStringArgumentByName gets the argument matching the "argName" given from the event "argv" field, casted as []string.

--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -2,4 +2,9 @@ module github.com/aquasecurity/tracee/signatures/helpers
 
 go 1.21
 
-require github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d
+require (
+	github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20240313150344-0080df4914d9
+	github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d
+)
+
+require golang.org/x/sys v0.18.0 // indirect

--- a/signatures/helpers/go.sum
+++ b/signatures/helpers/go.sum
@@ -1,0 +1,14 @@
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20240313150344-0080df4914d9 h1:BMnpLW1ouA1xjEIQUVx6g/orqgVkTixdfRIJk+vYlFE=
+github.com/aquasecurity/libbpfgo/helpers v0.4.6-0.20240313150344-0080df4914d9/go.mod h1:JIFvPdLaEVJ6cS2lt52lcyUia9LkpxtTVijOaYesi5Q=
+github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d h1:6CQjy5G6Cj/VKm8RP1uZnBZxDgfyGo15HfWFnYrkGro=
+github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d/go.mod h1:J0f9nzJWrFmFgMoK0s4Yirfh82vfKMatXytd1YdfU2I=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -4,14 +4,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
 // IsFileWrite returns whether the passed file permissions string contains
 // o_wronly or o_rdwr
-func IsFileWrite(flags string) bool {
-	flagsLow := strings.ToLower(flags)
-	if strings.Contains(flagsLow, "o_wronly") || strings.Contains(flagsLow, "o_rdwr") {
+func IsFileWrite(flags int) bool {
+	accessMode := uint64(flags) & helpers.O_ACCMODE.Value()
+	if accessMode == helpers.O_WRONLY.Value() || accessMode == helpers.O_RDWR.Value() {
 		return true
 	}
 	return false
@@ -19,9 +21,10 @@ func IsFileWrite(flags string) bool {
 
 // IsFileRead returns whether the passed file permissions string contains
 // o_rdonly or o_rdwr
-func IsFileRead(flags string) bool {
-	flagsLow := strings.ToLower(flags)
-	if strings.Contains(flagsLow, "o_rdonly") || strings.Contains(flagsLow, "o_rdwr") {
+func IsFileRead(flags int) bool {
+	accessMode := uint64(flags) & helpers.O_ACCMODE.Value()
+
+	if accessMode == helpers.O_RDONLY.Value() || accessMode == helpers.O_RDWR.Value() {
 		return true
 	}
 	return false

--- a/tests/e2e-inst-signatures/e2e-bpf_attach.go
+++ b/tests/e2e-inst-signatures/e2e-bpf_attach.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	libbpfgo "github.com/aquasecurity/libbpfgo/helpers"
+
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -48,14 +50,14 @@ func (sig *e2eBpfAttach) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		attachType, err := helpers.GetTraceeStringArgumentByName(eventObj, "attach_type")
+		attachType, err := helpers.GetTraceeIntArgumentByName(eventObj, "attach_type")
 		if err != nil {
 			return err
 		}
 
 		// check expected values from test for detection
 
-		if symbolName != "security_file_open" || attachType != "kprobe" {
+		if symbolName != "security_file_open" || attachType != int(libbpfgo.BPFProgTypeKprobe) {
 			return nil
 		}
 


### PR DESCRIPTION
### 1. Explain what the PR does

The PR removes the default usage of parse-arguments. Data parsing will now be the default behavior only in the context of rego signatures. Go signatures have all been refactored to use raw data arguments. This should increase userspace pipeline performance in most use cases, and as such reduce the risk margin of event loss.

9c4cd8d5a **feat(rego): parse event arguments in sig**
bfd96e01b **feat(cmd): disable arg parsing by default**
a007d2d2c **feat(sigs): refactor to use nonparsed arguments**
6f0c1c9b0 **chore(go.mod): update sig helpers**
9c4cd8d5a **feat(rego): parse event arguments in sig**
```
Removing default argument parsing will break rego signatures, whose
implementation depends on parsed arguments. In order to keep the option
of readability in REGO signatures, events will be parsed by default in
the context of evaluating these kind of signatures.
This will also ensure that they will not be broken depending on the
selection of parse-arguments.
```
9d45a6522 **feat(helpers): robust int and uint arg helpers**
```
Add a new uint argument helpers, which extracts a data argument from an
event by name and returns it if it was one of the uint types.
Additionally, add further checks for int64 and int types in the already
existing int argument helper.
```

e14baa074 **feat(helpers): unparsed flag helpers**

```
flag helpers previously took a string argument to test against possible
flag configurations. New implementation takes the integer form and
makes the test with the bit flag directly.
```

### 2. Explain how to test it

### 3. Other comments
Resolve #2177
