### PR TITLE
Fix ksymbols mem consumption

### DIFF
--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -148,4 +148,5 @@ const (
 	ExecuteAtFinishedARM
 	ExecuteFinishedCompatARM
 	ExecuteAtFinishedCompatARM
+	NoProbe = 10000
 )

--- a/pkg/ebpf/probes/trace.go
+++ b/pkg/ebpf/probes/trace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/utils/environment"
 )
 
 // NOTE: thread-safety guaranteed by the ProbeGroup big lock.
@@ -22,7 +23,22 @@ const (
 	KretProbe            // github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-kp
 	Tracepoint           // github.com/iovisor/bcc/blob/master/docs/reference_guide.md#3-tracep
 	RawTracepoint        // github.com/iovisor/bcc/blob/master/docs/reference_guide.md#7-raw-tracep
+	InvalidProbeType
 )
+
+func (t ProbeType) String() string {
+	switch t {
+	case KProbe:
+		return "kprobe"
+	case KretProbe:
+		return "kretprobe"
+	case Tracepoint:
+		return "tracepoint"
+	case RawTracepoint:
+		return "raw_tracepoint"
+	}
+	return ""
+}
 
 // When attaching a traceProbe, by handle, to its eBPF program:
 //
@@ -77,6 +93,19 @@ func (p *TraceProbe) attach(module *bpf.Module, args ...interface{}) error {
 		return errfmt.WrapError(err)
 	}
 
+	var ksyms *environment.KernelSymbolTable
+
+	for _, arg := range args {
+		switch a := arg.(type) {
+		case *environment.KernelSymbolTable:
+			ksyms = a
+		}
+	}
+
+	if ksyms == nil {
+		return errfmt.Errorf("trace probes needs kernel symbols table argument")
+	}
+
 	// KProbe and KretProbe
 
 	switch p.probeType {
@@ -94,7 +123,7 @@ func (p *TraceProbe) attach(module *bpf.Module, args ...interface{}) error {
 		// kernels it won't fail when trying to attach to a symbol that has
 		// multiple addresses.
 		//
-		syms, err := kernelSymbolTable.GetSymbolByName(p.eventName)
+		syms, err := ksyms.GetSymbolByName(p.eventName)
 		if err != nil {
 			goto rollback
 		}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -121,6 +121,11 @@ type Tracee struct {
 	policyManager *policyManager
 	// The dependencies of events used by Tracee
 	eventsDependencies *dependencies.Manager
+
+	// Ksymbols needed to be kept alive in table.
+	// This doens't mean they are required for tracee to function.
+	// TOOD: remove this in favor of dependency manager nodes
+	requiredKsyms []string
 }
 
 func (t *Tracee) Stats() *metrics.Stats {
@@ -238,6 +243,7 @@ func New(cfg config.Config) (*Tracee, error) {
 			func(id events.ID) events.Dependencies {
 				return events.Core.GetDefinitionByID(id).GetDependencies()
 			}),
+		requiredKsyms: []string{},
 	}
 
 	t.eventsDependencies.SubscribeAdd(
@@ -378,26 +384,11 @@ func New(cfg config.Config) (*Tracee, error) {
 }
 
 // Init initialize tracee instance and it's various subsystems, potentially
-// performing external system operations to initialize them. NOTE: any
-// initialization logic, especially one that causes side effects, should go
-// here and not New().
+// performing external system operations to initialize them.
+// NOTE: any initialization logic, especially one that causes side effects
+// should go here and not New().
 func (t *Tracee) Init(ctx gocontext.Context) error {
 	var err error
-
-	// Init kernel symbols map
-
-	err = capabilities.GetInstance().Specific(
-		func() error {
-			t.kernelSymbols, err = environment.NewKernelSymbolTable()
-			return err
-		},
-		cap.SYSLOG,
-	)
-	if err != nil {
-		return errfmt.WrapError(err)
-	}
-
-	t.validateKallsymsDependencies() // disable events w/ missing ksyms dependencies
 
 	// Initialize buckets cache
 
@@ -486,6 +477,40 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 			t.eventsParamTypes[id] = append(t.eventsParamTypes[id], bufferdecoder.GetParamType(param.Type))
 		}
 	}
+
+	// Initialize eBPF probes
+	err = capabilities.GetInstance().EBPF(
+		func() error {
+			return t.initBPFProbes()
+		},
+	)
+	if err != nil {
+		t.Close()
+		return errfmt.WrapError(err)
+	}
+
+	// Init kernel symbols map
+	err = t.initKsymTableRequiredSyms()
+	if err != nil {
+		return err
+	}
+
+	err = capabilities.GetInstance().Specific(
+		func() error {
+			t.kernelSymbols, err = environment.NewKernelSymbolTable(
+				environment.WithRequiredSymbols(t.requiredKsyms),
+			)
+			// Cleanup memory in list
+			t.requiredKsyms = []string{}
+			return err
+		},
+		cap.SYSLOG,
+	)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+
+	t.validateKallsymsDependencies() // disable events w/ missing ksyms dependencies
 
 	// Initialize eBPF programs and maps
 
@@ -601,11 +626,11 @@ func (t *Tracee) initTailCall(tailCall events.TailCall) error {
 		if events.Core.GetDefinitionByID(events.ID(index)).IsSyscall() {
 			// Optimization: enable enter/exit probes only if at least one syscall is enabled.
 			once.Do(func() {
-				err := t.probes.Attach(probes.SyscallEnter__Internal)
+				err := t.probes.Attach(probes.SyscallEnter__Internal, t.kernelSymbols)
 				if err != nil {
 					logger.Errorw("error attaching to syscall enter", "error", err)
 				}
-				err = t.probes.Attach(probes.SyscallExit__Internal)
+				err = t.probes.Attach(probes.SyscallExit__Internal, t.kernelSymbols)
 				if err != nil {
 					logger.Errorw("error attaching to syscall enter", "error", err)
 				}
@@ -862,6 +887,104 @@ func (t *Tracee) newConfig(cfg *policy.PoliciesConfig, version uint16) *Config {
 	}
 }
 
+func (t *Tracee) initKsymTableRequiredSyms() error {
+	// Get all required symbols needed in the table
+	// 1. all event ksym dependencies
+	// 2. specific cases (hooked_seq_ops, hooked_symbols, print_mem_dump)
+	for id := range t.eventsState {
+		if !events.Core.IsDefined(id) {
+			return errfmt.Errorf("event %d is not defined", id)
+		}
+
+		depsNode, ok := t.eventsDependencies.GetEvent(id)
+		if !ok {
+			logger.Warnw("failed to extract required ksymbols from event", "event_id", id)
+			continue
+		}
+		// Add directly dependant symbols
+		deps := depsNode.GetDependencies()
+		ksyms := deps.GetKSymbols()
+		ksymNames := make([]string, len(ksyms))
+		for _, sym := range ksyms {
+			ksymNames = append(ksymNames, sym.GetSymbolName())
+		}
+		t.requiredKsyms = append(t.requiredKsyms, ksymNames...)
+
+		// If kprobe/kretprobe, the event name itself is a required symbol
+		depsProbes := deps.GetProbes()
+		for _, probeDep := range depsProbes {
+			probe := t.probes.GetProbeByHandle(probeDep.GetHandle())
+			traceProbe, ok := probe.(*probes.TraceProbe)
+			if !ok {
+				continue
+			}
+			probeType := traceProbe.GetProbeType()
+			switch probeType {
+			case probes.KProbe, probes.KretProbe:
+				t.requiredKsyms = append(t.requiredKsyms, traceProbe.GetEventName())
+			}
+		}
+	}
+
+	// Specific cases
+	if _, ok := t.eventsState[events.HookedSeqOps]; ok {
+		for _, seqName := range derive.NetSeqOps {
+			t.requiredKsyms = append(t.requiredKsyms, seqName)
+		}
+	}
+	if _, ok := t.eventsState[events.HookedSyscall]; ok {
+		t.requiredKsyms = append(t.requiredKsyms, events.SyscallPrefix+"ni_syscall", "sys_ni_syscall")
+		for i, kernelRestrictionArr := range events.SyscallSymbolNames {
+			syscallName := t.getSyscallNameByKerVer(kernelRestrictionArr)
+			if syscallName == "" {
+				logger.Debugw("hooked_syscall (symbol): skipping syscall", "index", i)
+				continue
+			}
+
+			t.requiredKsyms = append(t.requiredKsyms, events.SyscallPrefix+syscallName)
+		}
+	}
+	if _, ok := t.eventsState[events.PrintMemDump]; ok {
+		for it := t.config.Policies.CreateAllIterator(); it.HasNext(); {
+			p := it.Next()
+			// This might break in the future if PrintMemDump will become a dependency of another event.
+			_, isChosen := p.EventsToTrace[events.PrintMemDump]
+			if !isChosen {
+				continue
+			}
+			printMemDumpFilters := p.DataFilter.GetEventFilters(events.PrintMemDump)
+			if len(printMemDumpFilters) == 0 {
+				continue
+			}
+			symbolsFilter, ok := printMemDumpFilters["symbol_name"].(*filters.StringFilter)
+			if symbolsFilter == nil || !ok {
+				continue
+			}
+
+			for _, field := range symbolsFilter.Equal() {
+				symbolSlice := strings.Split(field, ":")
+				splittedLen := len(symbolSlice)
+				var name string
+				if splittedLen == 1 {
+					name = symbolSlice[0]
+				} else if splittedLen == 2 {
+					name = symbolSlice[1]
+				} else {
+					continue
+				}
+				t.requiredKsyms = append(
+					t.requiredKsyms,
+					name,
+					"sys_"+name,
+					"__x64_sys_"+name,
+					"__arm64_sys_"+name,
+				)
+			}
+		}
+	}
+	return nil
+}
+
 // getUnavKsymsPerEvtID returns event IDs and symbols that are unavailable to them.
 func (t *Tracee) getUnavKsymsPerEvtID() map[events.ID][]string {
 	unavSymsPerEvtID := map[events.ID][]string{}
@@ -1088,7 +1211,7 @@ func (t *Tracee) attachProbes() error {
 
 	// Attach probes to their respective eBPF programs or cancel events if a required probe is missing.
 	for probe, evtID := range probesToEvents {
-		err = t.probes.Attach(probe.GetHandle(), t.cgroups) // attach bpf program to probe
+		err = t.probes.Attach(probe.GetHandle(), t.cgroups, t.kernelSymbols) // attach bpf program to probe
 		if err != nil {
 			for _, evtID := range evtID {
 				evtName := events.Core.GetDefinitionByID(evtID).GetName()
@@ -1112,9 +1235,8 @@ func (t *Tracee) attachProbes() error {
 	return nil
 }
 
-func (t *Tracee) initBPF() error {
+func (t *Tracee) initBPFProbes() error {
 	var err error
-
 	// Execute code with higher privileges: ring1 (required)
 
 	newModuleArgs := bpf.NewModuleArgs{
@@ -1132,10 +1254,16 @@ func (t *Tracee) initBPF() error {
 
 	// Initialize probes
 
-	t.probes, err = probes.NewDefaultProbeGroup(t.bpfModule, t.netEnabled(), t.kernelSymbols)
+	t.probes, err = probes.NewDefaultProbeGroup(t.bpfModule, t.netEnabled())
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
+
+	return nil
+}
+
+func (t *Tracee) initBPF() error {
+	var err error
 
 	// Load the eBPF object into kernel
 

--- a/pkg/utils/environment/kernel_symbols.go
+++ b/pkg/utils/environment/kernel_symbols.go
@@ -31,13 +31,9 @@ func symNotFoundErr(v interface{}) error {
 // Interface implementation
 //
 
-type name struct {
-	name string
-}
+type name string
 
-type addr struct {
-	addr uint64
-}
+type addr uint64
 
 type nameAndOwner struct {
 	name  string
@@ -50,21 +46,47 @@ type addrAndOwner struct {
 }
 
 type KernelSymbolTable struct {
-	symbols      map[name][]*KernelSymbol
-	addrs        map[addr][]*KernelSymbol
-	symByName    map[nameAndOwner][]*KernelSymbol
-	symByAddr    map[addrAndOwner][]*KernelSymbol
-	textSegStart uint64
-	textSegEnd   uint64
-	updateLock   *sync.RWMutex
-	updateWg     *sync.WaitGroup
+	symbols       map[name][]*KernelSymbol
+	addrs         map[addr][]*KernelSymbol
+	requiredSyms  map[string]struct{}
+	requiredAddrs map[uint64]struct{}
+	onlyRequired  bool
+	symByName     map[nameAndOwner][]*KernelSymbol
+	symByAddr     map[addrAndOwner][]*KernelSymbol
+	updateLock    *sync.Mutex
+	updateWg      *sync.WaitGroup
 }
 
-func NewKernelSymbolTable() (*KernelSymbolTable, error) {
+func NewKernelSymbolTable(opts ...KSymbTableOption) (*KernelSymbolTable, error) {
 	k := KernelSymbolTable{
-		updateLock: &sync.RWMutex{},
+		updateLock: &sync.Mutex{},
 	}
+	for _, opt := range opts {
+		err := opt(&k)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	k.onlyRequired = k.requiredAddrs != nil || k.requiredSyms != nil
+
 	return &k, k.Refresh()
+}
+
+type KSymbTableOption func(k *KernelSymbolTable) error
+
+func WithRequiredSymbols(reqSyms []string) KSymbTableOption {
+	return func(k *KernelSymbolTable) error {
+		k.requiredSyms = sliceToValidationMap(reqSyms)
+		return nil
+	}
+}
+
+func WithRequiredAddresses(reqAddrs []uint64) KSymbTableOption {
+	return func(k *KernelSymbolTable) error {
+		k.requiredAddrs = sliceToValidationMap(reqAddrs)
+		return nil
+	}
 }
 
 //
@@ -73,18 +95,30 @@ func NewKernelSymbolTable() (*KernelSymbolTable, error) {
 
 // TextSegmentContains returns true if the given address is in the kernel text segment.
 func (k *KernelSymbolTable) TextSegmentContains(addr uint64) (bool, error) {
-	k.updateLock.RLock()
-	defer k.updateLock.RUnlock()
+	k.updateLock.Lock()
+	defer k.updateLock.Unlock()
 
-	return addr >= k.textSegStart && addr < k.textSegEnd, nil
+	segStart, segEnd, err := k.getTextSegmentAddresses()
+	if err != nil {
+		return false, err
+	}
+
+	return addr >= segStart && addr < segEnd, nil
 }
 
 // GetSymbolByName returns all the symbols with the given name.
+// NOTE: If table is in required only mode, method will add the new symbol
+// and rescan the file.
 func (k *KernelSymbolTable) GetSymbolByName(n string) ([]KernelSymbol, error) {
-	k.updateLock.RLock()
-	defer k.updateLock.RUnlock()
+	k.updateLock.Lock()
+	defer k.updateLock.Unlock()
 
-	symbols, exist := k.symbols[name{n}]
+	err := k.validateOrAddRequiredSym(name(n))
+	if err != nil {
+		return []KernelSymbol{}, nil
+	}
+
+	symbols, exist := k.symbols[name(n)]
 	if !exist {
 		return []KernelSymbol{}, symNotFoundErr(n)
 	}
@@ -93,11 +127,18 @@ func (k *KernelSymbolTable) GetSymbolByName(n string) ([]KernelSymbol, error) {
 }
 
 // GetSymbolByAddr returns all the symbols with the given address.
+// NOTE: If table is in required only mode, method will add the new symbol
+// and rescan the file.
 func (k *KernelSymbolTable) GetSymbolByAddr(a uint64) ([]KernelSymbol, error) {
-	k.updateLock.RLock()
-	defer k.updateLock.RUnlock()
+	k.updateLock.Lock()
+	defer k.updateLock.Unlock()
 
-	symbols, exist := k.addrs[addr{a}]
+	err := k.validateOrAddRequiredAddr(addr(a))
+	if err != nil {
+		return []KernelSymbol{}, err
+	}
+
+	symbols, exist := k.addrs[addr(a)]
 	if !exist {
 		return []KernelSymbol{}, symNotFoundErr(a)
 	}
@@ -107,8 +148,13 @@ func (k *KernelSymbolTable) GetSymbolByAddr(a uint64) ([]KernelSymbol, error) {
 
 // GetSymbolByOwnerAndName returns all the symbols with the given owner and name.
 func (k *KernelSymbolTable) GetSymbolByOwnerAndName(o, n string) ([]KernelSymbol, error) {
-	k.updateLock.RLock()
-	defer k.updateLock.RUnlock()
+	k.updateLock.Lock()
+	defer k.updateLock.Unlock()
+
+	err := k.validateOrAddRequiredSym(name(n))
+	if err != nil {
+		return []KernelSymbol{}, err
+	}
 
 	symbols, exist := k.symByName[nameAndOwner{n, o}]
 	if !exist {
@@ -120,8 +166,13 @@ func (k *KernelSymbolTable) GetSymbolByOwnerAndName(o, n string) ([]KernelSymbol
 
 // GetSymbolByOwnerAndAddr returns all the symbols with the given owner and address.
 func (k *KernelSymbolTable) GetSymbolByOwnerAndAddr(o string, a uint64) ([]KernelSymbol, error) {
-	k.updateLock.RLock()
-	defer k.updateLock.RUnlock()
+	k.updateLock.Lock()
+	defer k.updateLock.Unlock()
+
+	err := k.validateOrAddRequiredAddr(addr(a))
+	if err != nil {
+		return []KernelSymbol{}, err
+	}
 
 	symbols, exist := k.symByAddr[addrAndOwner{a, o}]
 	if !exist {
@@ -146,8 +197,11 @@ func (k *KernelSymbolTable) GetSymbolByOwnerAndAddr(o string, a uint64) ([]Kerne
 
 // Refresh refreshes the KernelSymbolTable, reading the symbols from /proc/kallsyms.
 func (k *KernelSymbolTable) Refresh() error {
-	k.updateLock.Lock()
-	defer k.updateLock.Unlock()
+	// Refresh may be called internally, after lock was already takne
+	needUnlock := k.updateLock.TryLock()
+	if needUnlock {
+		defer k.updateLock.Unlock()
+	}
 
 	// re-initialize the maps to include all new symbols.
 	k.symbols = make(map[name][]*KernelSymbol)
@@ -184,8 +238,7 @@ func (k *KernelSymbolTable) Refresh() error {
 	// Finally, wait for the map update goroutines to finish.
 	k.updateWg.Wait()
 
-	// Get the kernel text segment addresses.
-	return k.getTextSegmentAddresses()
+	return nil
 }
 
 //
@@ -193,16 +246,46 @@ func (k *KernelSymbolTable) Refresh() error {
 //
 
 // getTextSegmentAddresses gets the start and end addresses of the kernel text segment.
-func (k *KernelSymbolTable) getTextSegmentAddresses() error {
+func (k *KernelSymbolTable) getTextSegmentAddresses() (uint64, uint64, error) {
 	stext, exist1 := k.symByName[nameAndOwner{"_stext", "system"}]
 	etext, exist2 := k.symByName[nameAndOwner{"_etext", "system"}]
 
 	if !exist1 || !exist2 {
-		return fmt.Errorf("kernel text segment symbol(s) not found")
+		return 0, 0, fmt.Errorf("kernel text segment symbol(s) not found")
 	}
 
-	k.textSegStart = stext[0].Address
-	k.textSegEnd = etext[0].Address
+	textSegStart := stext[0].Address
+	textSegEnd := etext[0].Address
+
+	return textSegStart, textSegEnd, nil
+}
+
+// validateOrAddRequiredSym checks if the given symbol is in the required list.
+// If not, it adds it and rescans the kernel symbols.
+func (k *KernelSymbolTable) validateOrAddRequiredSym(sym name) error {
+	if k.onlyRequired && k.requiredSyms != nil {
+		sym := string(sym)
+		if _, ok := k.requiredSyms[sym]; !ok {
+			k.requiredSyms[sym] = struct{}{}
+			err := k.Refresh()
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateOrAddRequiredAddr checks if the given address is in the required list.
+// If not, it adds it and rescans the kernel symbols.
+func (k *KernelSymbolTable) validateOrAddRequiredAddr(addr addr) error {
+	if k.onlyRequired && k.requiredAddrs != nil {
+		addr := uint64(addr)
+		if _, ok := k.requiredAddrs[addr]; !ok {
+			k.requiredAddrs[addr] = struct{}{}
+			err := k.Refresh()
+			return err
+		}
+	}
 
 	return nil
 }
@@ -231,6 +314,13 @@ func (k *KernelSymbolTable) processLines(chans []chan *KernelSymbol) error {
 			continue
 		}
 		if sym := parseLine(fields); sym != nil {
+			if k.onlyRequired {
+				_, symRequired := k.requiredSyms[sym.Name]
+				_, addrRequired := k.requiredAddrs[sym.Address]
+				if !symRequired && !addrRequired {
+					continue
+				}
+			}
 			for _, ch := range chans {
 				ch <- sym
 			}
@@ -250,7 +340,7 @@ func (k *KernelSymbolTable) updateSymbolMap(symbolChan chan *KernelSymbol) {
 	defer k.updateWg.Done()
 
 	for sym := range symbolChan {
-		key := name{sym.Name}
+		key := name(sym.Name)
 		k.symbols[key] = append(k.symbols[key], sym)
 	}
 }
@@ -260,7 +350,7 @@ func (k *KernelSymbolTable) updateAddrsMap(addrChan chan *KernelSymbol) {
 	defer k.updateWg.Done()
 
 	for sym := range addrChan {
-		key := addr{sym.Address}
+		key := addr(sym.Address)
 		k.addrs[key] = append(k.addrs[key], sym)
 	}
 }
@@ -320,4 +410,12 @@ func copySliceOfPointersToSliceOfStructs(s []*KernelSymbol) []KernelSymbol {
 		ret = append(ret, *v)
 	}
 	return ret
+}
+
+func sliceToValidationMap[T comparable](items []T) map[T]struct{} {
+	res := make(map[T]struct{})
+	for _, item := range items {
+		res[item] = struct{}{}
+	}
+	return res
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

    ksymbols: reintroduce lazy symbol queries
    
    Add new required symbol and addresses lists to the KSymbolTable helper.
    When either list is given, the data structure will only save required
    symbols during scanning. This should reduce memory usage for users
    who can mostly guarentee that symbols are known ahead of time.
    
    Dynamic querying is still allowed in this mode, though it will incur
    a penalty as rescanning is required.

------------------------------------------------------------

    feat(ksymbols): restore lazy ksyms implementtion
    
    Use modified ksymbols implementation. The new implementation may take
    a list of required symbols and addresses to track. If the list is given,
    symbol scanning will only save those symbols or addresses which were
    given in the list. If a new symbol is queried, then a rescan is needed.
    
    Refactor tracee initialization to find all necessary symbols to track
    ahead of runtime.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
