### PR TITLE
Fix ksymbols mem consumption

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -121,6 +121,11 @@ type Tracee struct {
 	policyManager *policyManager
 	// The dependencies of events used by Tracee
 	eventsDependencies *dependencies.Manager
+
+	// Ksymbols needed to be kept alive in table.
+	// This does not mean they are required for tracee to function.
+	// TODO: remove this in favor of dependency manager nodes
+	requiredKsyms []string
 }
 
 func (t *Tracee) Stats() *metrics.Stats {
@@ -238,6 +243,7 @@ func New(cfg config.Config) (*Tracee, error) {
 			func(id events.ID) events.Dependencies {
 				return events.Core.GetDefinitionByID(id).GetDependencies()
 			}),
+		requiredKsyms: []string{},
 	}
 
 	t.eventsDependencies.SubscribeAdd(
@@ -378,26 +384,11 @@ func New(cfg config.Config) (*Tracee, error) {
 }
 
 // Init initialize tracee instance and it's various subsystems, potentially
-// performing external system operations to initialize them. NOTE: any
-// initialization logic, especially one that causes side effects, should go
-// here and not New().
+// performing external system operations to initialize them.
+// NOTE: any initialization logic, especially one that causes side effects
+// should go here and not New().
 func (t *Tracee) Init(ctx gocontext.Context) error {
 	var err error
-
-	// Init kernel symbols map
-
-	err = capabilities.GetInstance().Specific(
-		func() error {
-			t.kernelSymbols, err = environment.NewKernelSymbolTable()
-			return err
-		},
-		cap.SYSLOG,
-	)
-	if err != nil {
-		return errfmt.WrapError(err)
-	}
-
-	t.validateKallsymsDependencies() // disable events w/ missing ksyms dependencies
 
 	// Initialize buckets cache
 
@@ -470,6 +461,42 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	t.contPathResolver = containers.InitContainerPathResolver(&t.pidsInMntns)
 	t.contSymbolsLoader = sharedobjs.InitContainersSymbolsLoader(t.contPathResolver, 1024)
 
+	// Initialize eBPF probes
+
+	err = capabilities.GetInstance().EBPF(
+		func() error {
+			return t.initBPFProbes()
+		},
+	)
+	if err != nil {
+		t.Close()
+		return errfmt.WrapError(err)
+	}
+
+	// Init kernel symbols map
+
+	err = t.initKsymTableRequiredSyms()
+	if err != nil {
+		return err
+	}
+
+	err = capabilities.GetInstance().Specific(
+		func() error {
+			t.kernelSymbols, err = environment.NewKernelSymbolTable(
+				environment.WithRequiredSymbols(t.requiredKsyms),
+			)
+			// Cleanup memory in list
+			t.requiredKsyms = []string{}
+			return err
+		},
+		cap.SYSLOG,
+	)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+
+	t.validateKallsymsDependencies() // disable events w/ missing ksyms dependencies
+
 	// Initialize event derivation logic
 
 	err = t.initDerivationTable()
@@ -478,6 +505,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	}
 
 	// Initialize events parameter types map
+
 	t.eventsParamTypes = make(map[events.ID][]bufferdecoder.ArgType)
 	for _, eventDefinition := range events.Core.GetDefinitions() {
 		id := eventDefinition.GetID()
@@ -601,11 +629,11 @@ func (t *Tracee) initTailCall(tailCall events.TailCall) error {
 		if events.Core.GetDefinitionByID(events.ID(index)).IsSyscall() {
 			// Optimization: enable enter/exit probes only if at least one syscall is enabled.
 			once.Do(func() {
-				err := t.probes.Attach(probes.SyscallEnter__Internal)
+				err := t.probes.Attach(probes.SyscallEnter__Internal, t.kernelSymbols)
 				if err != nil {
 					logger.Errorw("error attaching to syscall enter", "error", err)
 				}
-				err = t.probes.Attach(probes.SyscallExit__Internal)
+				err = t.probes.Attach(probes.SyscallExit__Internal, t.kernelSymbols)
 				if err != nil {
 					logger.Errorw("error attaching to syscall enter", "error", err)
 				}
@@ -862,6 +890,104 @@ func (t *Tracee) newConfig(cfg *policy.PoliciesConfig, version uint16) *Config {
 	}
 }
 
+func (t *Tracee) initKsymTableRequiredSyms() error {
+	// Get all required symbols needed in the table
+	// 1. all event ksym dependencies
+	// 2. specific cases (hooked_seq_ops, hooked_symbols, print_mem_dump)
+	for id := range t.eventsState {
+		if !events.Core.IsDefined(id) {
+			return errfmt.Errorf("event %d is not defined", id)
+		}
+
+		depsNode, ok := t.eventsDependencies.GetEvent(id)
+		if !ok {
+			logger.Warnw("failed to extract required ksymbols from event", "event_id", id)
+			continue
+		}
+		// Add directly dependant symbols
+		deps := depsNode.GetDependencies()
+		ksyms := deps.GetKSymbols()
+		ksymNames := make([]string, 0, len(ksyms))
+		for _, sym := range ksyms {
+			ksymNames = append(ksymNames, sym.GetSymbolName())
+		}
+		t.requiredKsyms = append(t.requiredKsyms, ksymNames...)
+
+		// If kprobe/kretprobe, the event name itself is a required symbol
+		depsProbes := deps.GetProbes()
+		for _, probeDep := range depsProbes {
+			probe := t.probes.GetProbeByHandle(probeDep.GetHandle())
+			traceProbe, ok := probe.(*probes.TraceProbe)
+			if !ok {
+				continue
+			}
+			probeType := traceProbe.GetProbeType()
+			switch probeType {
+			case probes.KProbe, probes.KretProbe:
+				t.requiredKsyms = append(t.requiredKsyms, traceProbe.GetEventName())
+			}
+		}
+	}
+
+	// Specific cases
+	if _, ok := t.eventsState[events.HookedSeqOps]; ok {
+		for _, seqName := range derive.NetSeqOps {
+			t.requiredKsyms = append(t.requiredKsyms, seqName)
+		}
+	}
+	if _, ok := t.eventsState[events.HookedSyscall]; ok {
+		t.requiredKsyms = append(t.requiredKsyms, events.SyscallPrefix+"ni_syscall", "sys_ni_syscall")
+		for i, kernelRestrictionArr := range events.SyscallSymbolNames {
+			syscallName := t.getSyscallNameByKerVer(kernelRestrictionArr)
+			if syscallName == "" || strings.HasPrefix(syscallName, events.SyscallNotImplemented) {
+				logger.Debugw("hooked_syscall (symbol): skipping syscall", "index", i)
+				continue
+			}
+
+			t.requiredKsyms = append(t.requiredKsyms, events.SyscallPrefix+syscallName)
+		}
+	}
+	if _, ok := t.eventsState[events.PrintMemDump]; ok {
+		for it := t.config.Policies.CreateAllIterator(); it.HasNext(); {
+			p := it.Next()
+			// This might break in the future if PrintMemDump will become a dependency of another event.
+			_, isChosen := p.EventsToTrace[events.PrintMemDump]
+			if !isChosen {
+				continue
+			}
+			printMemDumpFilters := p.DataFilter.GetEventFilters(events.PrintMemDump)
+			if len(printMemDumpFilters) == 0 {
+				continue
+			}
+			symbolsFilter, ok := printMemDumpFilters["symbol_name"].(*filters.StringFilter)
+			if symbolsFilter == nil || !ok {
+				continue
+			}
+
+			for _, field := range symbolsFilter.Equal() {
+				symbolSlice := strings.Split(field, ":")
+				splittedLen := len(symbolSlice)
+				var name string
+				if splittedLen == 1 {
+					name = symbolSlice[0]
+				} else if splittedLen == 2 {
+					name = symbolSlice[1]
+				} else {
+					continue
+				}
+				t.requiredKsyms = append(
+					t.requiredKsyms,
+					// symbols
+					name,
+					"sys_"+name,
+					events.SyscallPrefix+name,
+				)
+			}
+		}
+	}
+	return nil
+}
+
 // getUnavKsymsPerEvtID returns event IDs and symbols that are unavailable to them.
 func (t *Tracee) getUnavKsymsPerEvtID() map[events.ID][]string {
 	unavSymsPerEvtID := map[events.ID][]string{}
@@ -1088,7 +1214,7 @@ func (t *Tracee) attachProbes() error {
 
 	// Attach probes to their respective eBPF programs or cancel events if a required probe is missing.
 	for probe, evtID := range probesToEvents {
-		err = t.probes.Attach(probe.GetHandle(), t.cgroups) // attach bpf program to probe
+		err = t.probes.Attach(probe.GetHandle(), t.cgroups, t.kernelSymbols) // attach bpf program to probe
 		if err != nil {
 			for _, evtID := range evtID {
 				evtName := events.Core.GetDefinitionByID(evtID).GetName()
@@ -1112,9 +1238,8 @@ func (t *Tracee) attachProbes() error {
 	return nil
 }
 
-func (t *Tracee) initBPF() error {
+func (t *Tracee) initBPFProbes() error {
 	var err error
-
 	// Execute code with higher privileges: ring1 (required)
 
 	newModuleArgs := bpf.NewModuleArgs{
@@ -1132,10 +1257,16 @@ func (t *Tracee) initBPF() error {
 
 	// Initialize probes
 
-	t.probes, err = probes.NewDefaultProbeGroup(t.bpfModule, t.netEnabled(), t.kernelSymbols)
+	t.probes, err = probes.NewDefaultProbeGroup(t.bpfModule, t.netEnabled())
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
+
+	return nil
+}
+
+func (t *Tracee) initBPF() error {
+	var err error
 
 	// Load the eBPF object into kernel
 

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -12197,6 +12197,11 @@ var CoreEvents = map[ID]Definition{
 				SyscallTableCheck,
 				DoInitModule,
 			},
+			capabilities: Capabilities{
+				base: []cap.Value{
+					cap.SYSLOG, // read /proc/kallsyms
+				},
+			},
 		},
 		sets: []string{},
 		params: []trace.ArgMeta{
@@ -12445,6 +12450,11 @@ var CoreEvents = map[ID]Definition{
 			probes: []Probe{
 				{handle: probes.DoInitModule, required: true},
 				{handle: probes.DoInitModuleRet, required: true},
+			},
+			capabilities: Capabilities{
+				base: []cap.Value{
+					cap.SYSLOG, // read /proc/kallsyms
+				},
 			},
 		},
 		sets: []string{},

--- a/pkg/utils/environment/kernel_symbols_test.go
+++ b/pkg/utils/environment/kernel_symbols_test.go
@@ -5,41 +5,172 @@ import (
 	"testing"
 )
 
-// TestParseLine tests the parseLine function.
-func TestParseLine(t *testing.T) {
+// TestParseLine tests the parseKallsymsLine function.
+func TestParseKallsymsLine(t *testing.T) {
 	testCases := []struct {
 		line     []string
 		expected *KernelSymbol
 	}{
 		{[]string{"00000000", "t", "my_symbol", "[my_owner]"}, &KernelSymbol{Name: "my_symbol", Type: "t", Address: 0, Owner: "my_owner"}},
-		// Add more test cases as needed.
+		{[]string{"00000001", "T", "another_symbol"}, &KernelSymbol{Name: "another_symbol", Type: "T", Address: 1, Owner: "system"}},
+		{[]string{"invalid_address", "T", "invalid_symbol"}, nil},
+		{[]string{"00000002", "T"}, nil},
 	}
 
 	for _, tc := range testCases {
-		result := parseLine(tc.line)
+		result := parseKallsymsLine(tc.line)
 		if !reflect.DeepEqual(result, tc.expected) {
-			t.Errorf("parseLine(%v) = %v; want %v", tc.line, result, tc.expected)
+			t.Errorf("parseKallsymsLine(%v) = %v; want %v", tc.line, result, tc.expected)
 		}
 	}
 }
 
-func TestRefresh(t *testing.T) {
+// TestNewKernelSymbolTable tests the NewKernelSymbolTable function.
+func TestNewKernelSymbolTable(t *testing.T) {
 	kst, err := NewKernelSymbolTable()
 	if err != nil {
 		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
 	}
 
-	// Test well-known symbols like _stext and _etext.
-	symbolsToTest := []string{"_stext", "_etext"}
+	if kst == nil {
+		t.Fatalf("NewKernelSymbolTable() returned nil")
+	}
 
+	// Check if the onlyRequired flag is set correctly
+	if kst.onlyRequired {
+		t.Errorf("onlyRequired flag should be false by default")
+	}
+
+	// Check if maps are initialized
+	if kst.symbols == nil || kst.addrs == nil || kst.symByName == nil || kst.symByAddr == nil {
+		t.Errorf("KernelSymbolTable maps are not initialized correctly")
+	}
+}
+
+// TestGetSymbolByName tests the GetSymbolByName function.
+func TestGetSymbolByName(t *testing.T) {
+	kst, err := NewKernelSymbolTable()
+	if err != nil {
+		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+	}
+
+	kst.symbols["test_symbol"] = []*KernelSymbol{
+		{Name: "test_symbol", Type: "t", Address: 0, Owner: "test_owner"},
+	}
+
+	symbols, err := kst.GetSymbolByName("test_symbol")
+	if err != nil {
+		t.Fatalf("GetSymbolByName() failed: %v", err)
+	}
+
+	if len(symbols) != 1 {
+		t.Errorf("Expected 1 symbol, got %d", len(symbols))
+	}
+
+	expectedSymbol := KernelSymbol{Name: "test_symbol", Type: "t", Address: 0, Owner: "test_owner"}
+	if !reflect.DeepEqual(symbols[0], expectedSymbol) {
+		t.Errorf("GetSymbolByName() = %v; want %v", symbols[0], expectedSymbol)
+	}
+}
+
+// TestGetSymbolByAddr tests the GetSymbolByAddr function.
+func TestGetSymbolByAddr(t *testing.T) {
+	kst, err := NewKernelSymbolTable()
+	if err != nil {
+		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+	}
+
+	kst.addrs[0x1234] = []*KernelSymbol{
+		{Name: "test_symbol", Type: "t", Address: 0x1234, Owner: "test_owner"},
+	}
+
+	symbols, err := kst.GetSymbolByAddr(0x1234)
+	if err != nil {
+		t.Fatalf("GetSymbolByAddr() failed: %v", err)
+	}
+
+	if len(symbols) != 1 {
+		t.Errorf("Expected 1 symbol, got %d", len(symbols))
+	}
+
+	expectedSymbol := KernelSymbol{Name: "test_symbol", Type: "t", Address: 0x1234, Owner: "test_owner"}
+	if !reflect.DeepEqual(symbols[0], expectedSymbol) {
+		t.Errorf("GetSymbolByAddr() = %v; want %v", symbols[0], expectedSymbol)
+	}
+}
+
+// TestRefresh tests the Refresh function.
+func TestRefresh(t *testing.T) {
+	// Creating a mock KernelSymbolTable with required symbols to test Refresh
+	kst, err := NewKernelSymbolTable(WithRequiredSymbols([]string{"_stext", "_etext"}))
+	if err != nil {
+		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+	}
+
+	// Simulate the presence of these symbols
+	kst.symbols["_stext"] = []*KernelSymbol{{Name: "_stext", Type: "T", Address: 0x1000, Owner: "system"}}
+	kst.symbols["_etext"] = []*KernelSymbol{{Name: "_etext", Type: "T", Address: 0x2000, Owner: "system"}}
+
+	// Call Refresh to update the symbol table
+	if err := kst.Refresh(); err != nil {
+		t.Fatalf("Refresh() failed: %v", err)
+	}
+
+	// Check if symbols were added correctly
+	symbolsToTest := []string{"_stext", "_etext"}
 	for _, symbol := range symbolsToTest {
 		if syms, err := kst.GetSymbolByName(symbol); err != nil || len(syms) == 0 {
 			t.Errorf("Expected to find symbol %s, but it was not found", symbol)
 		}
 	}
+}
 
-	// Text the text swegment contains function.
-	if _, err := kst.TextSegmentContains(0); err != nil {
-		t.Errorf("TextSegmentContains failed: %v", err)
+// TestTextSegmentContains tests the TextSegmentContains function.
+func TestTextSegmentContains(t *testing.T) {
+	// Creating a mock KernelSymbolTable with text segment addresses
+	kst, err := NewKernelSymbolTable()
+	if err != nil {
+		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+	}
+
+	kst.symByName[nameAndOwner{"_stext", "system"}] = []*KernelSymbol{{Name: "_stext", Type: "T", Address: 0x1000, Owner: "system"}}
+	kst.symByName[nameAndOwner{"_etext", "system"}] = []*KernelSymbol{{Name: "_etext", Type: "T", Address: 0x2000, Owner: "system"}}
+
+	tests := []struct {
+		addr     uint64
+		expected bool
+	}{
+		{0x1000, true},
+		{0x1500, true},
+		{0x2000, false},
+		{0x0999, false},
+	}
+
+	for _, tt := range tests {
+		result, err := kst.TextSegmentContains(tt.addr)
+		if err != nil {
+			t.Errorf("TextSegmentContains(%v) failed: %v", tt.addr, err)
+		}
+		if result != tt.expected {
+			t.Errorf("TextSegmentContains(%v) = %v; want %v", tt.addr, result, tt.expected)
+		}
+	}
+}
+
+// Helper function to test required symbols or addresses.
+func TestValidateOrAddRequired(t *testing.T) {
+	kst, err := NewKernelSymbolTable(WithRequiredSymbols([]string{"test_symbol"}))
+	if err != nil {
+		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+	}
+
+	kst.requiredSyms["test_symbol"] = struct{}{}
+
+	if err := kst.validateOrAddRequiredSym("test_symbol"); err != nil {
+		t.Errorf("validateOrAddRequiredSym() failed: %v", err)
+	}
+
+	if err := kst.validateOrAddRequiredAddr(0x1234); err != nil {
+		t.Errorf("validateOrAddRequiredAddr() failed: %v", err)
 	}
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

```
fix: add missing dependency for hooked_syscalls event
The hooked_syscalls event requires CAP_SYSLOG in order to
refresh its symbol table when reading /proc/kallsyms.
Add this missing dependency.
```

```
feat(ksymbols): restore lazy ksyms implementation
Use modified ksymbols implementation. The new implementation may take
a list of required symbols and addresses to track. If the list is given,
symbol scanning will only save those symbols or addresses which were
given in the list. If a new symbol is queried, then a rescan is needed.

Refactor tracee initialization to find all necessary symbols to track
ahead of runtime.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
