### PR TITLE
fix(proctree): fix clock type differences

### DIFF
--- a/pkg/ebpf/c/common/common.h
+++ b/pkg/ebpf/c/common/common.h
@@ -84,4 +84,11 @@ static __inline int has_prefix(char *prefix, char *str, int n)
 #define list_first_entry_ebpf(ptr, type, member)                                                   \
     list_entry_ebpf(BPF_CORE_READ(ptr, next), type, member)
 
-#endif
+statfunc u64 get_current_time_in_ns(void)
+{
+    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns))
+        return bpf_ktime_get_boot_ns();
+    return bpf_ktime_get_ns();
+}
+
+#endif // __COMMON_COMMON_H__

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -6,6 +6,7 @@
 #include <common/logging.h>
 #include <common/task.h>
 #include <common/cgroups.h>
+#include <common/common.h>
 
 // PROTOTYPES
 
@@ -137,7 +138,7 @@ statfunc int init_program_data(program_data_t *p, void *ctx, u32 event_id)
     p->event->context.task.host_tid = id;
     p->event->context.task.host_pid = id >> 32;
     p->event->context.eventid = event_id;
-    p->event->context.ts = bpf_ktime_get_ns();
+    p->event->context.ts = get_current_time_in_ns();
     p->event->context.processor_id = (u16) bpf_get_smp_processor_id();
     p->event->context.syscall = get_task_syscall_id(p->event->task);
 

--- a/pkg/ebpf/c/common/logging.h
+++ b/pkg/ebpf/c/common/logging.h
@@ -31,7 +31,7 @@ statfunc void do_tracee_log(
 
     bpf_log_count_t counter_buf = {};
     counter_buf.count = 1;
-    counter_buf.ts = bpf_ktime_get_ns(); // store the current ts
+    counter_buf.ts = get_current_time_in_ns(); // store the current ts
     u64 ts_prev = 0;
 
     bpf_log_count_t *counter = bpf_map_lookup_elem(&logs_count, &log_output->log);

--- a/pkg/ebpf/c/common/task.h
+++ b/pkg/ebpf/c/common/task.h
@@ -151,6 +151,15 @@ statfunc u32 get_task_ppid(struct task_struct *task)
 
 statfunc u64 get_task_start_time(struct task_struct *task)
 {
+    // Only use the boot time member if we can use boot time for current time
+    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_ktime_get_boot_ns)) {
+        // real_start_time was renamed to start_boottime in kernel 5.5, so most likely
+        // it will be available as the bpf_ktime_get_boot_ns is available since kernel 5.8.
+        // The only case it won't be available is if it was backported to an older kernel.
+        if (bpf_core_field_exists(struct task_struct, start_boottime))
+            return BPF_CORE_READ(task, start_boottime);
+        return BPF_CORE_READ(task, real_start_time);
+    }
     return BPF_CORE_READ(task, start_time);
 }
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -266,6 +266,8 @@ struct task_struct {
     struct pid *thread_pid;
     struct list_head thread_group;
     u64 start_time;
+    u64 start_boottime;
+    u64 real_start_time;
     const struct cred *real_cred;
     char comm[16];
     struct files_struct *files;
@@ -675,6 +677,7 @@ enum bpf_func_id
     BPF_FUNC_probe_write_user = 36,
     BPF_FUNC_override_return = 58,
     BPF_FUNC_sk_storage_get = 107,
+    BPF_FUNC_ktime_get_boot_ns = 125,
     BPF_FUNC_copy_from_user = 148,
     BPF_FUNC_for_each_map_elem = 164,
 };

--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -109,13 +109,7 @@ func (t *Tracee) handleFileCaptures(ctx context.Context) {
 					continue
 				}
 				// note: size of buffer will determine maximum extracted file size! (as writes from kernel are immediate)
-				if t.config.Output.RelativeTime {
-					// To get the monotonic time since tracee was started, we have to subtract the start time from the timestamp.
-					mprotectMeta.Ts -= t.startTime
-				} else {
-					// To get the current ("wall") time, we add the boot time into it.
-					mprotectMeta.Ts += t.bootTime
-				}
+				mprotectMeta.Ts = uint64(t.timeNormalizer.NormalizeTime(int(mprotectMeta.Ts)))
 				filename = fmt.Sprintf("bin.pid-%d.ts-%d", mprotectMeta.Pid, mprotectMeta.Ts)
 			} else if meta.BinType == bufferdecoder.SendKernelModule {
 				err = metaBuffDecoder.DecodeKernelModuleMeta(&kernelModuleMeta)

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/proctree"
+	traceetime "github.com/aquasecurity/tracee/pkg/time"
 )
 
 // TODO: With the introduction of signal events, the control plane can now have a generic argument
@@ -28,6 +29,7 @@ type Controller struct {
 	cgroupManager  *containers.Containers
 	processTree    *proctree.ProcessTree
 	enrichDisabled bool
+	timeNormalizer traceetime.TimeNormalizer
 }
 
 // NewController creates a new controller.
@@ -36,6 +38,7 @@ func NewController(
 	cgroupManager *containers.Containers,
 	enrichDisabled bool,
 	procTree *proctree.ProcessTree,
+	timeNormalizer traceetime.TimeNormalizer,
 ) (*Controller, error) {
 	var err error
 
@@ -46,6 +49,7 @@ func NewController(
 		cgroupManager:  cgroupManager,
 		processTree:    procTree,
 		enrichDisabled: enrichDisabled,
+		timeNormalizer: timeNormalizer,
 	}
 
 	p.signalBuffer, err = bpfModule.InitPerfBuf("signals", p.signalChan, p.lostSignalChan, 1024)

--- a/pkg/ebpf/controlplane/processes.go
+++ b/pkg/ebpf/controlplane/processes.go
@@ -73,7 +73,7 @@ func (ctrl *Controller) procTreeForkProcessor(args []trace.Argument) error {
 
 	return ctrl.processTree.FeedFromFork(
 		proctree.ForkFeed{
-			TimeStamp:       timestamp,
+			TimeStamp:       uint64(ctrl.timeNormalizer.NormalizeTime(int(timestamp))),
 			ChildHash:       childHash,
 			ParentHash:      parentHash,
 			LeaderHash:      leaderHash,
@@ -81,17 +81,17 @@ func (ctrl *Controller) procTreeForkProcessor(args []trace.Argument) error {
 			ParentNsTid:     parentNsTid,
 			ParentPid:       parentPid,
 			ParentNsPid:     parentNsPid,
-			ParentStartTime: parentStartTime,
+			ParentStartTime: uint64(ctrl.timeNormalizer.NormalizeTime(int(parentStartTime))),
 			LeaderTid:       leaderTid,
 			LeaderNsTid:     leaderNsTid,
 			LeaderPid:       leaderPid,
 			LeaderNsPid:     leaderNsPid,
-			LeaderStartTime: leaderStartTime,
+			LeaderStartTime: uint64(ctrl.timeNormalizer.NormalizeTime(int(leaderStartTime))),
 			ChildTid:        childTid,
 			ChildNsTid:      childNsTid,
 			ChildPid:        childPid,
 			ChildNsPid:      childNsPid,
-			ChildStartTime:  childStartTime,
+			ChildStartTime:  uint64(ctrl.timeNormalizer.NormalizeTime(int(childStartTime))),
 		},
 	)
 }
@@ -154,7 +154,7 @@ func (ctrl *Controller) procTreeExecProcessor(args []trace.Argument) error {
 
 	return ctrl.processTree.FeedFromExec(
 		proctree.ExecFeed{
-			TimeStamp:         timestamp,
+			TimeStamp:         uint64(ctrl.timeNormalizer.NormalizeTime(int(timestamp))),
 			TaskHash:          taskHash,
 			ParentHash:        parentHash,
 			LeaderHash:        leaderHash,
@@ -208,7 +208,7 @@ func (ctrl *Controller) procTreeExitProcessor(args []trace.Argument) error {
 
 	return ctrl.processTree.FeedFromExit(
 		proctree.ExitFeed{
-			TimeStamp:  timestamp, // time of exit is already a timestamp
+			TimeStamp:  uint64(ctrl.timeNormalizer.NormalizeTime(int(timestamp))), // time of exit is already a timestamp
 			TaskHash:   taskHash,
 			ParentHash: parentHash,
 			LeaderHash: leaderHash,

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -727,7 +727,7 @@ func (t *Tracee) parseArguments(e *trace.Event) error {
 		}
 
 		if t.config.Output.ParseArgumentsFDs {
-			return events.ParseArgsFDs(e, uint64(t.getOrigEvtTimestamp(e)), t.FDArgPathMap)
+			return events.ParseArgsFDs(e, uint64(t.timeNormalizer.GetOriginalTime(e.Timestamp)), t.FDArgPathMap)
 		}
 	}
 

--- a/pkg/ebpf/processor_proctree.go
+++ b/pkg/ebpf/processor_proctree.go
@@ -2,11 +2,11 @@ package ebpf
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/proctree"
+	traceetime "github.com/aquasecurity/tracee/pkg/time"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -75,7 +75,7 @@ func (t *Tracee) procTreeForkProcessor(event *trace.Event) error {
 
 	return t.processTree.FeedFromFork(
 		proctree.ForkFeed{
-			TimeStamp:       childStartTime, // event timestamp is the same
+			TimeStamp:       uint64(t.timeNormalizer.NormalizeTime(int(childStartTime))), // event timestamp is the same
 			ChildHash:       childHash,
 			ParentHash:      parentHash,
 			LeaderHash:      leaderHash,
@@ -83,17 +83,17 @@ func (t *Tracee) procTreeForkProcessor(event *trace.Event) error {
 			ParentNsTid:     parentNsTid,
 			ParentPid:       parentPid,
 			ParentNsPid:     parentNsPid,
-			ParentStartTime: parentStartTime,
+			ParentStartTime: uint64(t.timeNormalizer.NormalizeTime(int(parentStartTime))),
 			LeaderTid:       leaderTid,
 			LeaderNsTid:     leaderNsTid,
 			LeaderPid:       leaderPid,
 			LeaderNsPid:     leaderNsPid,
-			LeaderStartTime: leaderStartTime,
+			LeaderStartTime: uint64(t.timeNormalizer.NormalizeTime(int(leaderStartTime))),
 			ChildTid:        childTid,
 			ChildNsTid:      childNsTid,
 			ChildPid:        childPid,
 			ChildNsPid:      childNsPid,
-			ChildStartTime:  childStartTime,
+			ChildStartTime:  uint64(t.timeNormalizer.NormalizeTime(int(childStartTime))),
 		},
 	)
 }
@@ -186,7 +186,7 @@ func (t *Tracee) procTreeExecProcessor(event *trace.Event) error {
 
 	return t.processTree.FeedFromExec(
 		proctree.ExecFeed{
-			TimeStamp:         timestamp,
+			TimeStamp:         uint64(t.timeNormalizer.NormalizeTime(int(timestamp))),
 			TaskHash:          taskHash,
 			ParentHash:        0, // regular pipeline does not have parent hash
 			LeaderHash:        0, // regular pipeline does not have leader hash
@@ -237,7 +237,7 @@ func (t *Tracee) procTreeExitProcessor(event *trace.Event) error {
 
 	return t.processTree.FeedFromExit(
 		proctree.ExitFeed{
-			TimeStamp:  timestamp, // time of exit is already a timestamp
+			TimeStamp:  uint64(t.timeNormalizer.NormalizeTime(int(timestamp))), // time of exit is already a timestamp
 			TaskHash:   taskHash,
 			ParentHash: 0, // regular pipeline does not have parent hash
 			LeaderHash: 0, // regular pipeline does not have leader hash
@@ -270,7 +270,7 @@ func (t *Tracee) procTreeAddBinInfo(event *trace.Event) error {
 	}
 
 	// Event timestamp is changed to relative (or not) at the end of all processors only.
-	eventTimestamp := time.Unix(0, int64(event.Timestamp)+int64(t.bootTime))
+	eventTimestamp := traceetime.NsSinceEpochToTime(uint64(t.timeNormalizer.NormalizeTime(event.Timestamp)))
 
 	executable := currentProcess.GetExecutable()
 

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -564,7 +564,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 			proctreeConfig.ProcfsInitialization = false
 			proctreeConfig.ProcfsQuerying = false
 		}
-		t.processTree, err = proctree.NewProcessTree(ctx, proctreeConfig)
+		t.processTree, err = proctree.NewProcessTree(ctx, proctreeConfig, t.timeNormalizer)
 		if err != nil {
 			return errfmt.WrapError(err)
 		}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1407,6 +1407,7 @@ func (t *Tracee) initBPF() error {
 		t.containers,
 		t.config.NoContainersEnrich,
 		t.processTree,
+		t.timeNormalizer,
 	)
 	if err != nil {
 		return errfmt.WrapError(err)

--- a/pkg/time/normalizetime.go
+++ b/pkg/time/normalizetime.go
@@ -1,0 +1,53 @@
+package time
+
+// TimeNormalizer normalizes the time to be relative to tracee start time or current time in nanoseconds.
+type TimeNormalizer interface {
+	NormalizeTime(timeNs int) int
+	GetOriginalTime(timeNs int) int
+}
+
+// CreateTimeNormalizerByConfig create a TimeNormalizer according to given configuration using
+// runtime functions.
+func CreateTimeNormalizerByConfig(relative bool, startTime uint64, bootTime uint64) TimeNormalizer {
+	if relative {
+		return NewRelativeTimeNormalizer(int(startTime))
+	}
+	return NewAbsoluteTimeNormalizer(int(bootTime))
+}
+
+// RelativeTimeNormalizer normalize the time to be relative to Tracee start time
+type RelativeTimeNormalizer struct {
+	startTime int
+}
+
+func NewRelativeTimeNormalizer(startTime int) *RelativeTimeNormalizer {
+	return &RelativeTimeNormalizer{
+		startTime: startTime,
+	}
+}
+
+func (rn *RelativeTimeNormalizer) NormalizeTime(timeNs int) int {
+	return timeNs - rn.startTime
+}
+
+func (rn *RelativeTimeNormalizer) GetOriginalTime(timeNs int) int {
+	return timeNs + rn.startTime
+}
+
+// AbsoluteTimeNormalizer normalize the time to be absolute time since epoch
+type AbsoluteTimeNormalizer struct {
+	bootTime int
+}
+
+func NewAbsoluteTimeNormalizer(bootTime int) *AbsoluteTimeNormalizer {
+	return &AbsoluteTimeNormalizer{
+		bootTime: bootTime,
+	}
+}
+func (rn *AbsoluteTimeNormalizer) NormalizeTime(timeNs int) int {
+	return timeNs + rn.bootTime
+}
+
+func (rn *AbsoluteTimeNormalizer) GetOriginalTime(timeNs int) int {
+	return timeNs - rn.bootTime
+}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

Tracee had an issue that all the times from the kernel were monotonic. However, many user-mode times like times in procfs are of boottime. As boottime is more accurate, change to use boottime if possible (mainly newer kernels).

If boottime is not available (old kernels), it's still possible to use the proctree option, but the proctree won't be built from procfs. Instead, it will be built from some events.

Fix https://github.com/aquasecurity/tracee/issues/4074

6be76aee5 **Enable time normalization for proctree**
9142b16ec **Enable time normalization for control plane**
0d4ea1022 **Check eBPF helper func symbol & Time normalization init**
aa68a61f5 **Time package**
51d562b5d **eBPF data plane - use boottime whenever possible**


6be76aee5 **Enable time normalization for proctree**

```
Co-authored-by: Alon Zivony <alon.zivony@aquasec.com>
```

9142b16ec **Enable time normalization for control plane**

```
Co-authored-by: Alon Zivony <alon.zivony@aquasec.com>
```

0d4ea1022 **Check eBPF helper func symbol & Time normalization init**

```
- Check if the eBPF helper function for getting boottime is available;
otherwise, use monotonic time. If boottime is available and proctree
is enabled: initialize proctree using procfs and querying.

- Initialize time normalization based on the option chosen by the user
(relative or absolute time).

Co-authored-by: Alon Zivony <alon.zivony@aquasec.com>
```

aa68a61f5 **Time package**

```
- Time normalization interface can be implemented by relative or
  absolute
time;
- Create package time under pkg/time/;
- Update utils function for time.

Co-authored-by: Alon Zivony <alon.zivony@aquasec.com>
```

51d562b5d **eBPF data plane - use boottime whenever possible**

```
- Replaced every instance of getting the current timestamp with the
function get_current_time_in_ns(). Internally, bpf_ktime_get_boot_ns()
(boottime) is used for newer kernels, while bpf_ktime_get_ns (monotonic)
is used for older kernels. Boottime is used whenever possible;

- Changed MAX_NUM_MODULES from 450 to 440.

Co-authored-by: Alon Zivony <alon.zivony@aquasec.com>
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

Need to enable proctree:
`sudo ./dist/tracee --events kill --proctree source=both`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

Credits to @AlonZivony, who did most of the work.