### PR TITLE
Added event containing full payload for all packets

### DIFF
--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -98,16 +98,17 @@ typedef struct nethdrs_t {
 
 typedef enum net_packet {
     CAP_NET_PACKET = 1 << 0,
+    SUB_NET_PACKET_RAW = 1 << 1,
     // Layer 3
-    SUB_NET_PACKET_IP = 1 << 1,
+    SUB_NET_PACKET_IP = 1 << 2,
     // Layer 4
-    SUB_NET_PACKET_TCP = 1 << 2,
-    SUB_NET_PACKET_UDP = 1 << 3,
-    SUB_NET_PACKET_ICMP = 1 << 4,
-    SUB_NET_PACKET_ICMPV6 = 1 << 5,
+    SUB_NET_PACKET_TCP = 1 << 3,
+    SUB_NET_PACKET_UDP = 1 << 4,
+    SUB_NET_PACKET_ICMP = 1 << 5,
+    SUB_NET_PACKET_ICMPV6 = 1 << 6,
     // Layer 7
-    SUB_NET_PACKET_DNS = 1 << 6,
-    SUB_NET_PACKET_HTTP = 1 << 7,
+    SUB_NET_PACKET_DNS = 1 << 7,
+    SUB_NET_PACKET_HTTP = 1 << 8,
 } net_packet_t;
 
 typedef struct net_event_contextmd {

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5238,6 +5238,8 @@ statfunc enum event_id_e net_packet_to_net_event(net_packet_t packet_type)
         case CAP_NET_PACKET:
             return NET_CAPTURE_BASE;
         // Packets
+        case SUB_NET_PACKET_RAW:
+            return NET_PACKET_RAW;
         case SUB_NET_PACKET_IP:
             return NET_PACKET_IP;
         case SUB_NET_PACKET_TCP:
@@ -6201,7 +6203,10 @@ CGROUP_SKB_HANDLE_FUNCTION(proto)
     if (!dest)
         return 1; // satisfy verifier for clang-12 generated binaries
 
-    // fastpath: submit the IP base event
+    // fastpath: submit the raw packet and IP base events
+
+    if (should_submit_net_event(neteventctx, SUB_NET_PACKET_RAW))
+        cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_RAW, FULL);
 
     if (should_submit_net_event(neteventctx, SUB_NET_PACKET_IP))
         cgroup_skb_submit_event(ctx, neteventctx, NET_PACKET_IP, HEADERS);

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -42,6 +42,7 @@ enum event_id_e
 {
     // Net events IDs
     NET_PACKET_BASE = 700,
+    NET_PACKET_RAW,
     NET_PACKET_IP,
     NET_PACKET_TCP,
     NET_PACKET_UDP,

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -25,6 +25,7 @@ type ID int32
 // Common events (used by all architectures).
 const (
 	NetPacketBase ID = iota + 700
+	NetPacketRaw
 	NetPacketIPBase
 	NetPacketTCPBase
 	NetPacketUDPBase
@@ -13235,6 +13236,21 @@ var CoreEvents = map[ID]Definition{
 		},
 		sets:   []string{"network_events"},
 		params: []trace.ArgMeta{},
+	},
+	NetPacketRaw: {
+		id:      NetPacketRaw,
+		id32Bit: Sys32Undefined,
+		name:    "net_packet_raw",
+		version: NewVersion(1, 0, 0),
+		dependencies: Dependencies{
+			ids: []ID{
+				NetPacketBase,
+			},
+		},
+		sets: []string{"packets"},
+		params: []trace.ArgMeta{
+			{Type: "bytes", Name: "data"},
+		},
 	},
 	NetPacketIPBase: {
 		id:       NetPacketIPBase,


### PR DESCRIPTION
### 1. Explain what the PR does

Add event containing the full payload of all network packets.

Closes #4121 

### 2. Explain how to test it

Run with the `net_packet_raw` event enabled.