### PR TITLE
perf: Optmize event parameter decoding in pipeline

### DIFF
--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -89,26 +89,25 @@ func (decoder *EbpfDecoder) DecodeContext(eCtx *EventContext) error {
 // DecodeArguments decodes the remaining buffer's argument values, according to the given event definition.
 // It should be called last, and after decoding the argnum with DecodeUint8.
 //
-// Argument array passed should be initialized with the size of len(eventDefinition.Params).
-func (decoder *EbpfDecoder) DecodeArguments(args []trace.Argument, argnum int, evtDef events.Definition, eventId events.ID) error {
+// Argument array passed should be initialized with the size of len(evtParams).
+func (decoder *EbpfDecoder) DecodeArguments(args []trace.Argument, argnum int, evtParams []trace.ArgMeta, evtName string, eventId events.ID) error {
 	for i := 0; i < argnum; i++ {
 		idx, arg, err := readArgFromBuff(
 			eventId,
 			decoder,
-			evtDef.GetParams(),
+			evtParams,
 		)
 		if err != nil {
-			logger.Errorw("error reading argument from buffer", "error", errfmt.Errorf("failed to read argument %d of event %s: %v", i, evtDef.GetName(), err))
+			logger.Errorw("error reading argument from buffer", "error", errfmt.Errorf("failed to read argument %d of event %s: %v", i, evtName, err))
 			continue
 		}
 		if args[idx].Value != nil {
-			logger.Warnw("argument overridden from buffer", "error", errfmt.Errorf("read more than one instance of argument %s of event %s. Saved value: %v. New value: %v", arg.Name, evtDef.GetName(), args[idx].Value, arg.Value))
+			logger.Warnw("argument overridden from buffer", "error", errfmt.Errorf("read more than one instance of argument %s of event %s. Saved value: %v. New value: %v", arg.Name, evtName, args[idx].Value, arg.Value))
 		}
 		args[idx] = arg
 	}
-	evtParams := evtDef.GetParams()
 	// Fill missing arguments metadata
-	for i := 0; i < len(evtDef.GetParams()); i++ {
+	for i := 0; i < len(evtParams); i++ {
 		if args[i].Value == nil {
 			args[i].ArgMeta = evtParams[i]
 		}

--- a/pkg/ebpf/controlplane/signal.go
+++ b/pkg/ebpf/controlplane/signal.go
@@ -30,8 +30,10 @@ func (sig *signal) Unmarshal(buffer []byte) error {
 		return errfmt.Errorf("failed to get event %d configuration", sig.id)
 	}
 	eventDefinition := events.Core.GetDefinitionByID(sig.id)
-	sig.args = make([]trace.Argument, len(eventDefinition.GetParams()))
-	err = ebpfDecoder.DecodeArguments(sig.args, int(argnum), eventDefinition, sig.id)
+	evtParams := eventDefinition.GetParams()
+	evtName := eventDefinition.GetName()
+	sig.args = make([]trace.Argument, len(evtParams))
+	err = ebpfDecoder.DecodeArguments(sig.args, int(argnum), evtParams, evtName, sig.id)
 	if err != nil {
 		return errfmt.Errorf("failed to decode signal arguments: %v", err)
 	}

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -180,8 +180,10 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 				continue
 			}
 			eventDefinition := events.Core.GetDefinitionByID(eventId)
-			args := make([]trace.Argument, len(eventDefinition.GetParams()))
-			err := ebpfMsgDecoder.DecodeArguments(args, int(argnum), eventDefinition, eventId)
+			evtParams := eventDefinition.GetParams()
+			evtName := eventDefinition.GetName()
+			args := make([]trace.Argument, len(evtParams))
+			err := ebpfMsgDecoder.DecodeArguments(args, int(argnum), evtParams, evtName, eventId)
 			if err != nil {
 				t.handleError(err)
 				continue
@@ -244,7 +246,7 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 			evt.Container = containerData
 			evt.Kubernetes = kubernetesData
 			evt.EventID = int(eCtx.EventID)
-			evt.EventName = eventDefinition.GetName()
+			evt.EventName = evtName
 			evt.PoliciesVersion = eCtx.PoliciesVersion
 			evt.MatchedPoliciesKernel = eCtx.MatchedPolicies
 			evt.MatchedPoliciesUser = 0


### PR DESCRIPTION
### 1. Explain what the PR does

Refactor the event decoding stage in the Tracee pipeline to fetch event parameters and related data (e.g., event name) from the event definition only once. Previously, the `GetParams` function was called multiple times within `DecodeArguments`, leading to unnecessary overhead.

This optimization improves the efficiency of event processing, particularly for events with a large number of parameters or frequent occurrences.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
