### PR TITLE
chore(ci): use dev tag for docker image building

### DIFF
--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -160,7 +160,7 @@ release: \
 	$(MAKE) -f builder/Makefile.tracee-make alpine-prepare
 	$(MAKE) -f builder/Makefile.tracee-make alpine-make ARG="clean"
 #
-	BTFHUB=1 $(MAKE) -f builder/Makefile.tracee-container build-tracee
+	BTFHUB=1 SNAPSHOT=$(SNAPSHOT) $(MAKE) -f builder/Makefile.tracee-container build-tracee
 #
 # build binaries (tracee, tracee-ebpf, tracee-rules, rules)
 #

--- a/builder/Makefile.tracee-container
+++ b/builder/Makefile.tracee-container
@@ -101,7 +101,14 @@ ifeq ($(BTFHUB),)
 BTFHUB=0
 endif
 
-TRACEE_CONT_NAME = tracee:latest
+SNAPSHOT ?= 0
+TAG ?= latest
+
+ifeq ($(SNAPSHOT),1)
+	TAG=dev
+endif
+
+TRACEE_CONT_NAME = tracee:$(TAG)
 TRACEE_CONT_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
 
 .PHONY: build-tracee


### PR DESCRIPTION
This is a continuation of https://github.com/aquasecurity/tracee/pull/4137.

### 1. Explain what the PR does

89dd6d0af **chore(ci): use dev tag for docker image building**

```
When SNAPSHOT=1, the local docker image will be tagged with dev tag to
differentiate it from the official release which is tagged with the
latest tag.
```

### 2. Explain how to test it

### 3. Other comments

