### PR TITLE
fix(ci): make release rule to have prerequisites

### DIFF
--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -145,37 +145,58 @@ PUSH_DOCKER_REPO ?= aquasec/tracee
 .PHONY: release
 release: \
 	$(OUTPUT_DIR) \
+	build-tracee-btfhub \
+	build-tracee-binary-static \
+	build-tracee-binary-shared \
+	archive \
 	| .check_tree \
 	.check_$(CMD_DOCKER) \
 	.check_$(CMD_TAR) \
 	.check_$(CMD_CHECKSUM) \
 	.check_$(CMD_GITHUB)
-#
-# SNAPSHOT
-#
 
 #
-# build official container image (CO-RE + BTFHUB).
+# build tracee
 #
-	$(MAKE) -f builder/Makefile.tracee-make alpine-prepare
-	$(MAKE) -f builder/Makefile.tracee-make alpine-make ARG="clean"
-#
+
+.PHONY: alpine-prepare
+alpine-prepare:
+	$(MAKE) -f builder/Makefile.tracee-make alpine-prepare && \
+		$(MAKE) -f builder/Makefile.tracee-make alpine-prepare ARG="clean"
+
+.PHONY: build-tracee-btfhub
+build-tracee-btfhub: alpine-prepare
+# build official container image (CO-RE + BTFHUB)
 	BTFHUB=1 SNAPSHOT=$(SNAPSHOT) $(MAKE) -f builder/Makefile.tracee-container build-tracee
+
 #
 # build binaries (tracee, tracee-ebpf, tracee-rules, rules)
 #
-	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare
-	$(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="clean"
+
+.PHONY: ubuntu-prepare
+ubuntu-prepare:
+	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare && \
+		$(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="clean"
+
+.PHONY: build-tracee-binary-static
+build-tracee-binary-static: ubuntu-prepare
 # static
-	BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee-ebpf"
-	BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee"
-	$(CMD_MV) dist/tracee-ebpf dist/tracee-ebpf-static
-	$(CMD_MV) dist/tracee dist/tracee-static
+	BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee-ebpf" && \
+		BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee" && \
+		$(CMD_MV) dist/tracee-ebpf dist/tracee-ebpf-static
+		$(CMD_MV) dist/tracee dist/tracee-static
+
+.PHONY: build-tracee-binary-shared
+build-tracee-binary-shared: ubuntu-prepare
 # shared libs
 	BTFHUB=0 STATIC=0 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="all"
+
+.PHONY: archive
+archive:
 # tarball
-	$(CMD_TAR) -cvzf $(OUT_ARCHIVE) $(RELEASE_FILES)
-	$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
+	$(CMD_TAR) -cvzf $(OUT_ARCHIVE) $(RELEASE_FILES) && \
+		$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
+
 #
 # note: TAGS created by release-snapshot workflow
 #


### PR DESCRIPTION
### 1. Explain what the PR does

82336fef5 **fix(ci): make release rule to have prerequisites**

```
These changes ensure that the 'release' rule will require the other
rules to be executed (splitting the commands into different rules). This
way, if any some of the rules fail, the build will be aborted right away.
```

### 2. Explain how to test it

### 3. Other comments

