### PR TITLE
[v0.21.0] release build fix

### DIFF
--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -13,6 +13,12 @@ ARG GO_VERSION=1.22.0
 ARG OPA_VERSION=v0.63.0
 
 
+# This workaround is required since OPA 0.65.0 (latest published release) has cve-2024-24790.
+# After solved we can rollback to the commented installation lines below.
+#
+# Stage 1: Set the base image to get the OPA binary
+FROM openpolicyagent/opa:0.66.0-dev-static as opa-extractor
+
 #
 # tracee-base
 #
@@ -30,10 +36,14 @@ RUN apk --no-cache update && \
     apk --no-cache add libc6-compat
 
 # install OPA
-ARG OPA_VERSION
-RUN altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_${altarch}_static && \
-    chmod 755 /usr/bin/opa
+
+# ARG OPA_VERSION
+# RUN altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
+# curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_${altarch}_static && \
+# chmod 755 /usr/bin/opa
+
+# Stage 2: Copy the OPA binary from the OPA extractor
+COPY --from=opa-extractor /opa /usr/bin/opa
 
 #
 # tracee-make-base

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -6,6 +6,14 @@ ARG BTFHUB=0
 ARG FLAVOR=tracee-ebpf-core
 
 #
+# Version
+#
+
+ARG GO_VERSION=1.22.0
+ARG OPA_VERSION=v0.63.0
+
+
+#
 # tracee-base
 #
 
@@ -22,9 +30,9 @@ RUN apk --no-cache update && \
     apk --no-cache add libc6-compat
 
 # install OPA
-
+ARG OPA_VERSION
 RUN altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.63.0/opa_linux_${altarch}_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_${altarch}_static && \
     chmod 755 /usr/bin/opa
 
 #
@@ -41,7 +49,7 @@ RUN apk --no-cache update && \
     apk --no-cache add bash git rsync && \
     apk --no-cache add coreutils findutils && \
     apk --no-cache add llvm14 clang14 && \
-    apk --no-cache add go make gcc && \
+    apk --no-cache add make gcc && \
     apk --no-cache add musl-dev && \
     apk --no-cache add linux-headers && \
     apk --no-cache add elfutils-dev && \
@@ -81,6 +89,17 @@ RUN apk --no-cache update && \
     ln -s /usr/lib/llvm14/bin/llvm-readelf /usr/bin/llvm-readelf && \
     ln -s /usr/lib/llvm14/bin/opt /usr/bin/opt
 
+# install GO
+ARG GO_VERSION
+RUN altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
+    curl -L -o go${GO_VERSION}.linux-${altarch}.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-${altarch}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${altarch}.tar.gz && \
+    echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile && \
+    echo 'export GOROOT=/usr/local/go' >> /etc/profile && \
+    echo 'export GOPATH=$HOME/go' >> /etc/profile && \
+    echo 'export GOTOOLCHAIN=auto' >> /etc/profile && \
+    echo 'export PATH=$PATH:$GOPATH/bin' >> /etc/profile
+
 # install bpftool from btfhub
 
 RUN cd /tmp && \
@@ -101,7 +120,8 @@ WORKDIR /tracee
 
 COPY . /tracee
 
-RUN make clean && \
+RUN source /etc/profile && \
+    make clean && \
     BTFHUB=$BTFHUB make tracee && \
     BTFHUB=$BTFHUB make tracee-ebpf && \
     make tracee-rules && \

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -56,6 +56,7 @@ RUN apk --no-cache update && \
     apk --no-cache add libelf-static && \
     apk --no-cache add zlib-static && \
     apk --no-cache add zstd-static && \
+    apk --no-cache add binutils-gold && \
     rm -f /usr/bin/cc && \
     rm -f /usr/bin/clang && \
     rm -f /usr/bin/clang++ && \

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -7,6 +7,13 @@ FROM ubuntu:jammy
 ARG uid=1000
 ARG gid=1000
 
+#
+# Version
+#
+
+ARG GO_VERSION=1.22.0
+ARG OPA_VERSION=v0.63.0
+
 # install needed environment
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
@@ -30,9 +37,8 @@ RUN cd /tmp && \
     ./3rdparty/bpftool.sh
 
 # install OPA
-
 RUN altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
-    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/v0.63.0/opa_linux_${altarch}_static && \
+    curl -L -o /usr/bin/opa https://github.com/open-policy-agent/opa/releases/download/${OPA_VERSION}/opa_linux_${altarch}_static && \
     chmod 755 /usr/bin/opa
 
 # extra tools for testing things
@@ -66,12 +72,11 @@ RUN export uid=$uid gid=$gid && \
     ln -s /home/tracee/.bashrc /home/tracee/.profile
 
 # install extra packages (if needed)
-
 RUN export DEBIAN_FRONTEND=noninteractive && \
     altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
     apt-get update && \
-    curl -L -o /tmp/golang.tar.xz https://go.dev/dl/go1.21.5.linux-${altarch}.tar.gz && \
-    tar -C /usr/local -xzf /tmp/golang.tar.xz && \
+    curl -L -o go${GO_VERSION}.linux-${altarch}.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-${altarch}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${altarch}.tar.gz && \
     update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 1 && \
     update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1
 

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -75,8 +75,8 @@ RUN export uid=$uid gid=$gid && \
 RUN export DEBIAN_FRONTEND=noninteractive && \
     altarch=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') && \
     apt-get update && \
-    curl -L -o go${GO_VERSION}.linux-${altarch}.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-${altarch}.tar.gz && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-${altarch}.tar.gz && \
+    curl -L -o /tmp/golang.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-${altarch}.tar.gz && \
+    tar -C /usr/local -xzf /tmp/golang.tar.gz && \
     update-alternatives --install /usr/bin/go go /usr/local/go/bin/go 1 && \
     update-alternatives --install /usr/bin/gofmt gofmt /usr/local/go/bin/gofmt 1
 

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -160,7 +160,7 @@ release: \
 	$(MAKE) -f builder/Makefile.tracee-make alpine-prepare
 	$(MAKE) -f builder/Makefile.tracee-make alpine-make ARG="clean"
 #
-	BTFHUB=1 $(MAKE) -f builder/Makefile.tracee-container build-tracee
+	BTFHUB=1 SNAPSHOT=$(SNAPSHOT) $(MAKE) -f builder/Makefile.tracee-container build-tracee
 #
 # build binaries (tracee, tracee-ebpf, tracee-rules, rules)
 #

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -154,6 +154,41 @@ release: \
 	.check_$(CMD_TAR) \
 	.check_$(CMD_CHECKSUM) \
 	.check_$(CMD_GITHUB)
+#
+# note: TAGS created by release-snapshot workflow
+#
+
+#
+# RELEASE
+#
+
+ifneq ("$(SNAPSHOT)", "1")
+#
+# create release notes (x86_64 only, other arches will be added after release)
+#
+ifeq ($(ARCH),x86_64)
+	$(CMD_TOUCH) $(RELEASE_NOTES)
+	echo '## Docker Image' >> $(RELEASE_NOTES)
+	echo '- `docker pull docker.io/$(PUSH_DOCKER_REPO):$(IMAGE_TAG)`' >> $(RELEASE_NOTES);
+	echo '  ' >> $(RELEASE_NOTES);
+	echo '## Docker Images (per architecture)  ' >> $(RELEASE_NOTES)
+	echo '- `docker pull docker.io/$(PUSH_DOCKER_REPO):x86_64-$(IMAGE_TAG)`' >> $(RELEASE_NOTES);
+	echo '- `docker pull docker.io/$(PUSH_DOCKER_REPO):aarch64-$(IMAGE_TAG)`' >> $(RELEASE_NOTES);
+endif
+#
+# release it (x86_64 only, other arches will be added after release)
+#
+ifeq ($(ARCH),x86_64)
+	$(CMD_GITHUB) release create $(SNAPSHOT_VERSION) $(OUT_ARCHIVE) $(OUT_CHECKSUMS) --title $(SNAPSHOT_VERSION) --notes-file $(RELEASE_NOTES)
+endif
+#
+# add artifacts to the already created release (by x86_64 arch)
+#
+ifeq ($(ARCH),aarch64)
+	$(CMD_GITHUB) release upload $(SNAPSHOT_VERSION) $(OUT_ARCHIVE) $(OUT_CHECKSUMS)
+endif
+
+endif
 
 #
 # build tracee
@@ -196,42 +231,6 @@ archive:
 # tarball
 	$(CMD_TAR) -cvzf $(OUT_ARCHIVE) $(RELEASE_FILES) && \
 		$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
-
-#
-# note: TAGS created by release-snapshot workflow
-#
-
-#
-# RELEASE
-#
-
-ifneq ("$(SNAPSHOT)", "1")
-#
-# create release notes (x86_64 only, other arches will be added after release)
-#
-ifeq ($(ARCH),x86_64)
-	$(CMD_TOUCH) $(RELEASE_NOTES)
-	echo '## Docker Image' >> $(RELEASE_NOTES)
-	echo '- `docker pull docker.io/$(PUSH_DOCKER_REPO):$(IMAGE_TAG)`' >> $(RELEASE_NOTES);
-	echo '  ' >> $(RELEASE_NOTES);
-	echo '## Docker Images (per architecture)  ' >> $(RELEASE_NOTES)
-	echo '- `docker pull docker.io/$(PUSH_DOCKER_REPO):x86_64-$(IMAGE_TAG)`' >> $(RELEASE_NOTES);
-	echo '- `docker pull docker.io/$(PUSH_DOCKER_REPO):aarch64-$(IMAGE_TAG)`' >> $(RELEASE_NOTES);
-endif
-#
-# release it (x86_64 only, other arches will be added after release)
-#
-ifeq ($(ARCH),x86_64)
-	$(CMD_GITHUB) release create $(SNAPSHOT_VERSION) $(OUT_ARCHIVE) $(OUT_CHECKSUMS) --title $(SNAPSHOT_VERSION) --notes-file $(RELEASE_NOTES)
-endif
-#
-# add artifacts to the already created release (by x86_64 arch)
-#
-ifeq ($(ARCH),aarch64)
-	$(CMD_GITHUB) release upload $(SNAPSHOT_VERSION) $(OUT_ARCHIVE) $(OUT_CHECKSUMS)
-endif
-
-endif
 
 .PHONY: clean
 clean:

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -145,37 +145,58 @@ PUSH_DOCKER_REPO ?= aquasec/tracee
 .PHONY: release
 release: \
 	$(OUTPUT_DIR) \
+	build-tracee-btfhub \
+	build-tracee-binary-static \
+	build-tracee-binary-shared \
+	archive \
 	| .check_tree \
 	.check_$(CMD_DOCKER) \
 	.check_$(CMD_TAR) \
 	.check_$(CMD_CHECKSUM) \
 	.check_$(CMD_GITHUB)
-#
-# SNAPSHOT
-#
 
 #
-# build official container image (CO-RE + BTFHUB).
+# build tracee
 #
-	$(MAKE) -f builder/Makefile.tracee-make alpine-prepare
-	$(MAKE) -f builder/Makefile.tracee-make alpine-make ARG="clean"
-#
+
+.PHONY: alpine-prepare
+alpine-prepare:
+	$(MAKE) -f builder/Makefile.tracee-make alpine-prepare && \
+		$(MAKE) -f builder/Makefile.tracee-make alpine-prepare ARG="clean"
+
+.PHONY: build-tracee-btfhub
+build-tracee-btfhub: alpine-prepare
+# build official container image (CO-RE + BTFHUB)
 	BTFHUB=1 SNAPSHOT=$(SNAPSHOT) $(MAKE) -f builder/Makefile.tracee-container build-tracee
+
 #
 # build binaries (tracee, tracee-ebpf, tracee-rules, rules)
 #
-	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare
-	$(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="clean"
+
+.PHONY: ubuntu-prepare
+ubuntu-prepare:
+	$(MAKE) -f builder/Makefile.tracee-make ubuntu-prepare && \
+		$(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="clean"
+
+.PHONY: build-tracee-binary-static
+build-tracee-binary-static: ubuntu-prepare
 # static
-	BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee-ebpf"
-	BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee"
-	$(CMD_MV) dist/tracee-ebpf dist/tracee-ebpf-static
-	$(CMD_MV) dist/tracee dist/tracee-static
+	BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee-ebpf" && \
+		BTFHUB=0 STATIC=1 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee" && \
+		$(CMD_MV) dist/tracee-ebpf dist/tracee-ebpf-static
+		$(CMD_MV) dist/tracee dist/tracee-static
+
+.PHONY: build-tracee-binary-shared
+build-tracee-binary-shared: ubuntu-prepare
 # shared libs
 	BTFHUB=0 STATIC=0 $(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="all"
+
+.PHONY: archive
+archive:
 # tarball
-	$(CMD_TAR) -cvzf $(OUT_ARCHIVE) $(RELEASE_FILES)
-	$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
+	$(CMD_TAR) -cvzf $(OUT_ARCHIVE) $(RELEASE_FILES) && \
+		$(CMD_CHECKSUM) $(OUT_ARCHIVE) > $(OUT_CHECKSUMS)
+
 #
 # note: TAGS created by release-snapshot workflow
 #

--- a/builder/Makefile.tracee-container
+++ b/builder/Makefile.tracee-container
@@ -101,7 +101,14 @@ ifeq ($(BTFHUB),)
 BTFHUB=0
 endif
 
-TRACEE_CONT_NAME = tracee:latest
+SNAPSHOT ?= 0
+TAG ?= latest
+
+ifeq ($(SNAPSHOT),1)
+	TAG=dev
+endif
+
+TRACEE_CONT_NAME = tracee:$(TAG)
 TRACEE_CONT_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
 
 .PHONY: build-tracee


### PR DESCRIPTION
### 1. Explain what the PR does

2195c5ee4 **fix(build): mv gh release logic to release rule (#4145)**
2101b63b8 **fix(build): extract OPA 0.66 from OPA dev image**
ce88fbb09 **fix(ci): make release rule to have prerequisites (#4141)**
432fb25fc **fix: arm64 clang issue**
9bff2616b **chore: golang binary move to tmp**
657a88d59 **chore: install last version of golang**
fba6c4409 **chore(ci): use dev tag for docker image building (#4138)**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
