### PR TITLE
Fix Integration Tests

### DIFF
--- a/tests/testutils/logger.go
+++ b/tests/testutils/logger.go
@@ -15,7 +15,9 @@ import (
 // SetTestLogger create a logger which prints the logs to the returned channel.
 // This function is meant to be used by tests to check logs, and by that test the
 // flow of Tracee from outside.
-func SetTestLogger(l logger.Level) (loggerOutput <-chan []byte, restoreLogger func()) {
+func SetTestLogger(t *testing.T, l logger.Level) (loggerOutput <-chan []byte, restoreLogger func()) {
+	t.Logf("  --- setting test logger ---")
+
 	mw, logChan := newChannelWriter()
 	chanLogger := logger.NewLogger(
 		logger.LoggerConfig{
@@ -26,6 +28,7 @@ func SetTestLogger(l logger.Level) (loggerOutput <-chan []byte, restoreLogger fu
 	)
 	currentLogger := logger.GetLogger()
 	restoreLogger = func() {
+		t.Logf("  --- restoring default logger ---")
 		err := chanLogger.Sync()
 		logger.SetLogger(currentLogger)
 		mw.Close()


### PR DESCRIPTION
Close: #4156 

### 1. Explain what the PR does

74bfd7d41 **fix(tests): refactor Test_TraceeCapture**
4e1f89918 **fix(tests): Test_EventsDependencies**
f493e2890 **chore: turn logger thread-safe**


74bfd7d41 **fix(tests): refactor Test_TraceeCapture**

```
This test was failing when other tests were run before it and failed,
tracee running was not stopped and some garbage was left in the system.

Two major changes were made:

1. Do not fail the test before stopping tracee.
2. Always remove capture files after the test (do cleanup).
```

4e1f89918 **fix(tests): Test_EventsDependencies**

```
Test_EventsDependencies overrides the default logger to capture the logs
and check them as part of the test.

Before it was synced to pass in the github actions, what wasn't
happening locally or in a different environment.

Since the logger was not thread safe, it was causing the test to fail
(data race). That forced the previous commit which turned Logger into a
thread safe logger.

This fixes the problem refactoring it to override and restore the logger
in the correct steps.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
