### PR TITLE
chore: make dependencies manager a singleton

### DIFF
--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -26,7 +27,7 @@ func (t *Tracee) UpdateKallsyms() error {
 
 	// Wrap long method names.
 	evtDefSymDeps := func(id events.ID) []events.KSymbol {
-		depsNode, _ := t.eventsDependencies.GetEvent(id)
+		depsNode, _ := dependencies.GetManagerInstance().GetEvent(id)
 		deps := depsNode.GetDependencies()
 		return deps.GetKSymbols()
 	}

--- a/pkg/events/dependencies/manager_test.go
+++ b/pkg/events/dependencies/manager_test.go
@@ -81,6 +81,11 @@ func TestManager_AddEvent(t *testing.T) {
 			t.Run(testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := dependencies.NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
+				defer func() {
+					dependencies.ResetManagerFromTests()
+					t.Logf("  --- reset dependencies ---")
+				}()
+
 				var eventsAdditions []events.ID
 				m.SubscribeAdd(
 					dependencies.EventNodeType,
@@ -136,6 +141,11 @@ func TestManager_AddEvent(t *testing.T) {
 			t.Run(testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := dependencies.NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
+				defer func() {
+					dependencies.ResetManagerFromTests()
+					t.Logf("  --- reset dependencies ---")
+				}()
+
 				var eventsAdditions, eventsRemove []events.ID
 				// Count additions
 				m.SubscribeAdd(
@@ -331,6 +341,10 @@ func TestManager_RemoveEvent(t *testing.T) {
 			testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := dependencies.NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
+				defer func() {
+					dependencies.ResetManagerFromTests()
+					t.Logf("  --- reset dependencies ---")
+				}()
 
 				var eventsRemoved []events.ID
 				m.SubscribeRemove(
@@ -505,6 +519,10 @@ func TestManager_UnselectEvent(t *testing.T) {
 			testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := dependencies.NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
+				defer func() {
+					dependencies.ResetManagerFromTests()
+					t.Logf("  --- reset dependencies ---")
+				}()
 
 				var eventsRemoved []events.ID
 				m.SubscribeRemove(

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/tests/testutils"
@@ -147,6 +148,10 @@ func Test_EventsDependencies(t *testing.T) {
 					cancel()
 					t.Fatal(err)
 				}
+				defer func() {
+					dependencies.ResetManagerFromTests()
+					t.Logf("  --- reset dependencies ---")
+				}()
 
 				stream := trc.SubscribeAll()
 				defer trc.Unsubscribe(stream)

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
@@ -1733,6 +1734,10 @@ func Test_EventFilters(t *testing.T) {
 				cancel()
 				t.Fatal(err)
 			}
+			defer func() {
+				dependencies.ResetManagerFromTests()
+				t.Logf("  --- reset dependencies ---")
+			}()
 
 			stream := trc.SubscribeAll()
 			defer trc.Unsubscribe(stream)


### PR DESCRIPTION
### 1. Explain what the PR does

83c39cf83 **chore: mv dependencies tests to same pkg**
5b6c9fce4 **chore: make dependencies manager a singleton (temp)**


5b6c9fce4 **chore: make dependencies manager a singleton (temp)**

```
This tidies up the dependencies manager by making it a singleton,
temporarily. It's a necessary step to decouple the manager from the
Tracee object without touching much code, allowing it to be accessed
from other parts of the codebase and be detached from other logic.

It introduces an also temporary ResetManagerFromTests() to reset the
manager state between tests.

When elements are decoupled and redesign, the manager will not be a
singleton anymore, but it will be accessed via dependency injection.

NOTE: It continues being not thread-safe. This will be addressed in a
future PR.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
