### PR TITLE
move PolicyManager to policy pkg

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -118,7 +118,7 @@ type Tracee struct {
 	// Streams
 	streamsManager *streams.StreamsManager
 	// policyManager manages policy state
-	policyManager *policyManager
+	policyManager *policy.PolicyManager
 
 	// Ksymbols needed to be kept alive in table.
 	// This does not mean they are required for tracee to function.
@@ -223,7 +223,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		return nil, errfmt.Errorf("validation error: %v", err)
 	}
 
-	policyManager := newPolicyManager()
+	policyManager := policy.NewPolicyManager()
 
 	// Create Tracee
 

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -1,4 +1,4 @@
-package ebpf
+package policy
 
 import (
 	"sync"
@@ -7,8 +7,8 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
-// policyManager is a thread-safe struct that manages the enabled policies for each rule
-type policyManager struct {
+// PolicyManager is a thread-safe struct that manages the enabled policies for each rule
+type PolicyManager struct {
 	mutex sync.Mutex
 	rules map[events.ID]*eventState
 }
@@ -19,8 +19,8 @@ type eventState struct {
 	enabled    bool
 }
 
-func newPolicyManager() *policyManager {
-	return &policyManager{
+func NewPolicyManager() *PolicyManager {
+	return &PolicyManager{
 		mutex: sync.Mutex{},
 		rules: make(map[events.ID]*eventState),
 	}
@@ -28,7 +28,7 @@ func newPolicyManager() *policyManager {
 
 // IsEnabled tests if a event, or a policy per event is enabled (in the future it will also check if a policy is enabled)
 // TODO: add metrics about an event being enabled/disabled, or a policy being enabled/disabled?
-func (pm *policyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+func (pm *PolicyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) bool {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -40,7 +40,7 @@ func (pm *policyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) boo
 }
 
 // IsRuleEnabled returns true if a given event policy is enabled for a given rule
-func (pm *policyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+func (pm *PolicyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -48,7 +48,7 @@ func (pm *policyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID)
 }
 
 // not synchronized, use IsRuleEnabled instead
-func (pm *policyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+func (pm *PolicyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
 	state, ok := pm.rules[ruleId]
 	if !ok {
 		return false
@@ -58,7 +58,7 @@ func (pm *policyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID)
 }
 
 // IsEventEnabled returns true if a given event policy is enabled for a given rule
-func (pm *policyManager) IsEventEnabled(evenId events.ID) bool {
+func (pm *PolicyManager) IsEventEnabled(evenId events.ID) bool {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -66,7 +66,7 @@ func (pm *policyManager) IsEventEnabled(evenId events.ID) bool {
 }
 
 // not synchronized, use IsEventEnabled instead
-func (pm *policyManager) isEventEnabled(evenId events.ID) bool {
+func (pm *PolicyManager) isEventEnabled(evenId events.ID) bool {
 	state, ok := pm.rules[evenId]
 	if !ok {
 		return false
@@ -76,7 +76,7 @@ func (pm *policyManager) isEventEnabled(evenId events.ID) bool {
 }
 
 // EnableRule enables a rule for a given event policy
-func (pm *policyManager) EnableRule(policyId int, ruleId events.ID) {
+func (pm *PolicyManager) EnableRule(policyId int, ruleId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -93,7 +93,7 @@ func (pm *policyManager) EnableRule(policyId int, ruleId events.ID) {
 }
 
 // DisableRule disables a rule for a given event policy
-func (pm *policyManager) DisableRule(policyId int, ruleId events.ID) {
+func (pm *PolicyManager) DisableRule(policyId int, ruleId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -110,7 +110,7 @@ func (pm *policyManager) DisableRule(policyId int, ruleId events.ID) {
 }
 
 // EnableEvent enables a given event
-func (pm *policyManager) EnableEvent(eventId events.ID) {
+func (pm *PolicyManager) EnableEvent(eventId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -124,7 +124,7 @@ func (pm *policyManager) EnableEvent(eventId events.ID) {
 }
 
 // DisableEvent disables a given event
-func (pm *policyManager) DisableEvent(eventId events.ID) {
+func (pm *PolicyManager) DisableEvent(eventId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 

--- a/pkg/policy/policy_manager_test.go
+++ b/pkg/policy/policy_manager_test.go
@@ -1,4 +1,4 @@
-package ebpf
+package policy
 
 import (
 	"sync"
@@ -7,13 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/policy"
 )
 
 func TestPolicyManagerEnableRule(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)
@@ -39,7 +38,7 @@ func TestPolicyManagerEnableRule(t *testing.T) {
 func TestPolicyManagerDisableRule(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)
@@ -77,13 +76,13 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 		events.FileModification,
 	}
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableRule(i, e)
 			}
@@ -93,7 +92,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableRule(i, e)
 			}
@@ -103,12 +102,12 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.PolicyMax; i++ {
+	for i := 0; i < PolicyMax; i++ {
 		for _, e := range eventsToEnable {
-			assert.True(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
+			assert.True(t, policyManager.IsRuleEnabled(PolicyAll, e))
 		}
 		for _, e := range eventsToDisable {
-			assert.False(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
+			assert.False(t, policyManager.IsRuleEnabled(PolicyAll, e))
 		}
 	}
 }
@@ -116,7 +115,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 func TestPolicyManagerEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	assert.False(t, policyManager.isEventEnabled(events.SecurityBPF))
 	assert.False(t, policyManager.isEventEnabled(events.SecurityFileOpen))
@@ -134,7 +133,7 @@ func TestPolicyManagerEnableEvent(t *testing.T) {
 func TestPolicyManagerDisableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policyManager.EnableEvent(events.SecurityBPF)
 	policyManager.EnableEvent(events.SecurityFileOpen)
@@ -171,7 +170,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 		events.FileModification,
 	}
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	// activate events
 	for _, e := range eventsToDisable {
@@ -182,7 +181,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableEvent(e)
 			}
@@ -192,7 +191,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableEvent(e)
 			}
@@ -202,7 +201,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.PolicyMax; i++ {
+	for i := 0; i < PolicyMax; i++ {
 		for _, e := range eventsToEnable {
 			assert.True(t, policyManager.IsEventEnabled(e))
 		}
@@ -215,7 +214,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityBPF))
 
@@ -227,7 +226,7 @@ func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityFileOpen))
 
@@ -239,7 +238,7 @@ func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 func TestPolicyManagerIsEnabled(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)


### PR DESCRIPTION
### 1. Explain what the PR does

209a44f9e **chore: move policy manager into policy pkg**

```
Place PolicyManager in its proper home, the policy package.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
