### PR TITLE
Tidying Policy Manager

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -231,7 +231,6 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	}
 
 	cfg.Policies = policies
-	policy.Snapshots().Store(cfg.Policies)
 
 	// Output command line flags
 

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/utils/environment"
 )
 
@@ -126,7 +125,6 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 		return runner, err
 	}
 	cfg.Policies = policies
-	policy.Snapshots().Store(cfg.Policies)
 
 	broadcast, err := printer.NewBroadcast(
 		output.PrinterConfigs,

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -118,7 +118,7 @@ type Tracee struct {
 	// Streams
 	streamsManager *streams.StreamsManager
 	// policyManager manages policy state
-	policyManager *policyManager
+	policyManager *policy.PolicyManager
 
 	// Ksymbols needed to be kept alive in table.
 	// This does not mean they are required for tracee to function.
@@ -223,7 +223,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		return nil, errfmt.Errorf("validation error: %v", err)
 	}
 
-	policyManager := newPolicyManager()
+	policyManager := policy.NewPolicyManager()
 
 	// Create Tracee
 

--- a/pkg/events/derive/symbols_collision.go
+++ b/pkg/events/derive/symbols_collision.go
@@ -26,12 +26,14 @@ import (
 // `sched_process_exec` event for handling.
 //
 
-func SymbolsCollision(soLoader sharedobjs.DynamicSymbolsLoader, policies *policy.Policies,
+func SymbolsCollision(
+	soLoader sharedobjs.DynamicSymbolsLoader,
+	pManager *policy.PolicyManager,
 ) DeriveFunction {
 	symbolsCollisionFilters := map[string]filters.Filter[*filters.StringFilter]{}
 
 	// pick white and black lists from the filters (TODO: change this)
-	for it := policies.CreateAllIterator(); it.HasNext(); {
+	for it := pManager.CreateAllIterator(); it.HasNext(); {
 		p := it.Next()
 		f := p.DataFilter.GetEventFilters(events.SymbolsCollision)
 		maps.Copy(symbolsCollisionFilters, f)

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -493,12 +493,12 @@ func TestSymbolsCollision(t *testing.T) {
 			}
 
 			ps := policy.NewPolicies()
-			policy.Snapshots().Store(ps)
 			err := ps.Set(p)
 			require.NoError(t, err)
+			pManager := policy.NewPolicyManager(ps)
 
 			// Pick derive function from mocked tests
-			deriveFunc := SymbolsCollision(mockLoader, ps)
+			deriveFunc := SymbolsCollision(mockLoader, pManager)
 
 			mockLoader.addSOSymbols(
 				testSOInstance{

--- a/pkg/events/derive/symbols_loaded.go
+++ b/pkg/events/derive/symbols_loaded.go
@@ -20,11 +20,11 @@ import (
 
 func SymbolsLoaded(
 	soLoader sharedobjs.DynamicSymbolsLoader,
-	policies *policy.Policies,
+	pManager *policy.PolicyManager,
 ) DeriveFunction {
 	symbolsLoadedFilters := map[string]filters.Filter[*filters.StringFilter]{}
 
-	for it := policies.CreateAllIterator(); it.HasNext(); {
+	for it := pManager.CreateAllIterator(); it.HasNext(); {
 		p := it.Next()
 		f := p.DataFilter.GetEventFilters(events.SymbolsLoaded)
 		maps.Copy(symbolsLoadedFilters, f)

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -80,8 +80,10 @@ func (ps *Policies) Count() int {
 	return ps.count()
 }
 
+// Deprecated: Version returns the version of the Policies.
+// Will be removed soon.
 func (ps *Policies) Version() uint16 {
-	return ps.version
+	return 1 // version will be removed soon
 }
 
 // WithContainerFilterEnabled returns a bitmap of policies that have at least one container filter type enabled.

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -9,7 +9,7 @@ import (
 
 // PolicyManager is a thread-safe struct that manages the enabled policies for each rule
 type PolicyManager struct {
-	mutex sync.Mutex
+	mu    sync.RWMutex
 	rules map[events.ID]*eventState
 }
 
@@ -21,7 +21,7 @@ type eventState struct {
 
 func NewPolicyManager() *PolicyManager {
 	return &PolicyManager{
-		mutex: sync.Mutex{},
+		mu:    sync.RWMutex{},
 		rules: make(map[events.ID]*eventState),
 	}
 }
@@ -29,8 +29,8 @@ func NewPolicyManager() *PolicyManager {
 // IsEnabled tests if a event, or a policy per event is enabled (in the future it will also check if a policy is enabled)
 // TODO: add metrics about an event being enabled/disabled, or a policy being enabled/disabled?
 func (pm *PolicyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) bool {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 
 	if !pm.isEventEnabled(ruleId) {
 		return false
@@ -41,8 +41,8 @@ func (pm *PolicyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) boo
 
 // IsRuleEnabled returns true if a given event policy is enabled for a given rule
 func (pm *PolicyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 
 	return pm.isRuleEnabled(matchedPolicies, ruleId)
 }
@@ -59,8 +59,8 @@ func (pm *PolicyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID)
 
 // IsEventEnabled returns true if a given event policy is enabled for a given rule
 func (pm *PolicyManager) IsEventEnabled(evenId events.ID) bool {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
 
 	return pm.isEventEnabled(evenId)
 }
@@ -77,8 +77,8 @@ func (pm *PolicyManager) isEventEnabled(evenId events.ID) bool {
 
 // EnableRule enables a rule for a given event policy
 func (pm *PolicyManager) EnableRule(policyId int, ruleId events.ID) {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
 	state, ok := pm.rules[ruleId]
 	if !ok {
@@ -94,8 +94,8 @@ func (pm *PolicyManager) EnableRule(policyId int, ruleId events.ID) {
 
 // DisableRule disables a rule for a given event policy
 func (pm *PolicyManager) DisableRule(policyId int, ruleId events.ID) {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
 	state, ok := pm.rules[ruleId]
 	if !ok {
@@ -111,8 +111,8 @@ func (pm *PolicyManager) DisableRule(policyId int, ruleId events.ID) {
 
 // EnableEvent enables a given event
 func (pm *PolicyManager) EnableEvent(eventId events.ID) {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
 	state, ok := pm.rules[eventId]
 	if !ok {
@@ -125,8 +125,8 @@ func (pm *PolicyManager) EnableEvent(eventId events.ID) {
 
 // DisableEvent disables a given event
 func (pm *PolicyManager) DisableEvent(eventId events.ID) {
-	pm.mutex.Lock()
-	defer pm.mutex.Unlock()
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
 
 	state, ok := pm.rules[eventId]
 	if !ok {

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -1,4 +1,4 @@
-package ebpf
+package policy
 
 import (
 	"sync"
@@ -7,8 +7,8 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
-// policyManager is a thread-safe struct that manages the enabled policies for each rule
-type policyManager struct {
+// PolicyManager is a thread-safe struct that manages the enabled policies for each rule
+type PolicyManager struct {
 	mutex sync.Mutex
 	rules map[events.ID]*eventState
 }
@@ -19,8 +19,8 @@ type eventState struct {
 	enabled    bool
 }
 
-func newPolicyManager() *policyManager {
-	return &policyManager{
+func NewPolicyManager() *PolicyManager {
+	return &PolicyManager{
 		mutex: sync.Mutex{},
 		rules: make(map[events.ID]*eventState),
 	}
@@ -28,7 +28,7 @@ func newPolicyManager() *policyManager {
 
 // IsEnabled tests if a event, or a policy per event is enabled (in the future it will also check if a policy is enabled)
 // TODO: add metrics about an event being enabled/disabled, or a policy being enabled/disabled?
-func (pm *policyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+func (pm *PolicyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) bool {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -40,7 +40,7 @@ func (pm *policyManager) IsEnabled(matchedPolicies uint64, ruleId events.ID) boo
 }
 
 // IsRuleEnabled returns true if a given event policy is enabled for a given rule
-func (pm *policyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+func (pm *PolicyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -48,7 +48,7 @@ func (pm *policyManager) IsRuleEnabled(matchedPolicies uint64, ruleId events.ID)
 }
 
 // not synchronized, use IsRuleEnabled instead
-func (pm *policyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
+func (pm *PolicyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID) bool {
 	state, ok := pm.rules[ruleId]
 	if !ok {
 		return false
@@ -58,7 +58,7 @@ func (pm *policyManager) isRuleEnabled(matchedPolicies uint64, ruleId events.ID)
 }
 
 // IsEventEnabled returns true if a given event policy is enabled for a given rule
-func (pm *policyManager) IsEventEnabled(evenId events.ID) bool {
+func (pm *PolicyManager) IsEventEnabled(evenId events.ID) bool {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -66,7 +66,7 @@ func (pm *policyManager) IsEventEnabled(evenId events.ID) bool {
 }
 
 // not synchronized, use IsEventEnabled instead
-func (pm *policyManager) isEventEnabled(evenId events.ID) bool {
+func (pm *PolicyManager) isEventEnabled(evenId events.ID) bool {
 	state, ok := pm.rules[evenId]
 	if !ok {
 		return false
@@ -76,7 +76,7 @@ func (pm *policyManager) isEventEnabled(evenId events.ID) bool {
 }
 
 // EnableRule enables a rule for a given event policy
-func (pm *policyManager) EnableRule(policyId int, ruleId events.ID) {
+func (pm *PolicyManager) EnableRule(policyId int, ruleId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -93,7 +93,7 @@ func (pm *policyManager) EnableRule(policyId int, ruleId events.ID) {
 }
 
 // DisableRule disables a rule for a given event policy
-func (pm *policyManager) DisableRule(policyId int, ruleId events.ID) {
+func (pm *PolicyManager) DisableRule(policyId int, ruleId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -110,7 +110,7 @@ func (pm *policyManager) DisableRule(policyId int, ruleId events.ID) {
 }
 
 // EnableEvent enables a given event
-func (pm *policyManager) EnableEvent(eventId events.ID) {
+func (pm *PolicyManager) EnableEvent(eventId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 
@@ -124,7 +124,7 @@ func (pm *policyManager) EnableEvent(eventId events.ID) {
 }
 
 // DisableEvent disables a given event
-func (pm *policyManager) DisableEvent(eventId events.ID) {
+func (pm *PolicyManager) DisableEvent(eventId events.ID) {
 	pm.mutex.Lock()
 	defer pm.mutex.Unlock()
 

--- a/pkg/policy/policy_manager_test.go
+++ b/pkg/policy/policy_manager_test.go
@@ -1,4 +1,4 @@
-package ebpf
+package policy
 
 import (
 	"sync"
@@ -7,13 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/policy"
 )
 
 func TestPolicyManagerEnableRule(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)
@@ -39,7 +38,7 @@ func TestPolicyManagerEnableRule(t *testing.T) {
 func TestPolicyManagerDisableRule(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)
@@ -77,13 +76,13 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 		events.FileModification,
 	}
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableRule(i, e)
 			}
@@ -93,7 +92,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableRule(i, e)
 			}
@@ -103,12 +102,12 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.PolicyMax; i++ {
+	for i := 0; i < PolicyMax; i++ {
 		for _, e := range eventsToEnable {
-			assert.True(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
+			assert.True(t, policyManager.IsRuleEnabled(PolicyAll, e))
 		}
 		for _, e := range eventsToDisable {
-			assert.False(t, policyManager.IsRuleEnabled(policy.PolicyAll, e))
+			assert.False(t, policyManager.IsRuleEnabled(PolicyAll, e))
 		}
 	}
 }
@@ -116,7 +115,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 func TestPolicyManagerEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	assert.False(t, policyManager.isEventEnabled(events.SecurityBPF))
 	assert.False(t, policyManager.isEventEnabled(events.SecurityFileOpen))
@@ -134,7 +133,7 @@ func TestPolicyManagerEnableEvent(t *testing.T) {
 func TestPolicyManagerDisableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policyManager.EnableEvent(events.SecurityBPF)
 	policyManager.EnableEvent(events.SecurityFileOpen)
@@ -171,7 +170,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 		events.FileModification,
 	}
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	// activate events
 	for _, e := range eventsToDisable {
@@ -182,7 +181,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToEnable {
 				policyManager.EnableEvent(e)
 			}
@@ -192,7 +191,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		for i := 0; i < policy.PolicyMax; i++ {
+		for i := 0; i < PolicyMax; i++ {
 			for _, e := range eventsToDisable {
 				policyManager.DisableEvent(e)
 			}
@@ -202,7 +201,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < policy.PolicyMax; i++ {
+	for i := 0; i < PolicyMax; i++ {
 		for _, e := range eventsToEnable {
 			assert.True(t, policyManager.IsEventEnabled(e))
 		}
@@ -215,7 +214,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityBPF))
 
@@ -227,7 +226,7 @@ func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityFileOpen))
 
@@ -239,7 +238,7 @@ func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 func TestPolicyManagerIsEnabled(t *testing.T) {
 	t.Parallel()
 
-	policyManager := newPolicyManager()
+	policyManager := NewPolicyManager()
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)

--- a/pkg/policy/policy_manager_test.go
+++ b/pkg/policy/policy_manager_test.go
@@ -12,7 +12,7 @@ import (
 func TestPolicyManagerEnableRule(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)
@@ -38,7 +38,7 @@ func TestPolicyManagerEnableRule(t *testing.T) {
 func TestPolicyManagerDisableRule(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)
@@ -76,7 +76,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 		events.FileModification,
 	}
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	var wg sync.WaitGroup
 
@@ -115,7 +115,7 @@ func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {
 func TestPolicyManagerEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	assert.False(t, policyManager.isEventEnabled(events.SecurityBPF))
 	assert.False(t, policyManager.isEventEnabled(events.SecurityFileOpen))
@@ -133,7 +133,7 @@ func TestPolicyManagerEnableEvent(t *testing.T) {
 func TestPolicyManagerDisableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	policyManager.EnableEvent(events.SecurityBPF)
 	policyManager.EnableEvent(events.SecurityFileOpen)
@@ -170,7 +170,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 		events.FileModification,
 	}
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	// activate events
 	for _, e := range eventsToDisable {
@@ -214,7 +214,7 @@ func TestPolicyManagerEnableAndDisableEventConcurrent(t *testing.T) {
 func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityBPF))
 
@@ -226,7 +226,7 @@ func TestEnableRuleAlsoEnableEvent(t *testing.T) {
 func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	assert.False(t, policyManager.IsEventEnabled(events.SecurityFileOpen))
 
@@ -238,7 +238,7 @@ func TestDisableRuleAlsoEnableEvent(t *testing.T) {
 func TestPolicyManagerIsEnabled(t *testing.T) {
 	t.Parallel()
 
-	policyManager := NewPolicyManager()
+	policyManager := NewPolicyManager(nil)
 
 	policy1Mached := uint64(0b10)
 	policy2Mached := uint64(0b100)

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/tests/testutils"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -127,7 +126,6 @@ func Test_EventsDependencies(t *testing.T) {
 					},
 				}
 				testConfig.Policies = testutils.BuildPoliciesFromEvents(testCaseInst.events)
-				policy.Snapshots().Store(testConfig.Policies)
 
 				ctx, cancel := context.WithCancel(context.Background())
 

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
-	"github.com/aquasecurity/tracee/pkg/policy"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -1717,7 +1716,6 @@ func Test_EventFilters(t *testing.T) {
 				},
 			}
 			config.Policies = testutils.NewPolicies(tc.policyFiles)
-			policy.Snapshots().Store(config.Policies)
 
 			ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
### 1. Explain what the PR does

93aaaf98a **chore: tidy up policy manager and related code**
857d8ed16 **chore(policy): change manager mutex type to rw**
209a44f9e **chore: move policy manager into policy pkg**


9341d3510 **chore: tidy up policy manager and related code**

```
- Remove Snapshot() use. In the future it could be managed by the policy
  manager itself.
- After PolicyManager initialization (first stages), Policies are not
  accessed directly anymore, but through the PolicyManager.
- t.config.Policies is now only transient and used for PolicyManager
  initialization.
- Policy version is deprecated and to be removed soon.
```

209a44f9e **chore: move policy manager into policy pkg**

```
Place PolicyManager in its proper home, the policy package.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
