### PR TITLE
Policies tidying more

### DIFF
--- a/pkg/cmd/cobra/helper.go
+++ b/pkg/cmd/cobra/helper.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
 )
 
-func createPoliciesFromK8SPolicy(policies []k8s.PolicyInterface) (*policy.Policies, error) {
+func createPoliciesFromK8SPolicy(policies []k8s.PolicyInterface) ([]*policy.Policy, error) {
 	policyScopeMap, policyEventsMap, err := flags.PrepareFilterMapsFromPolicies(policies)
 	if err != nil {
 		return nil, err
@@ -16,7 +16,7 @@ func createPoliciesFromK8SPolicy(policies []k8s.PolicyInterface) (*policy.Polici
 	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
 }
 
-func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, error) {
+func createPoliciesFromPolicyFiles(policyFlags []string) ([]*policy.Policy, error) {
 	policyFiles, err := v1beta1.PoliciesFromPaths(policyFlags)
 	if err != nil {
 		return nil, err
@@ -30,7 +30,7 @@ func createPoliciesFromPolicyFiles(policyFlags []string) (*policy.Policies, erro
 	return flags.CreatePolicies(policyScopeMap, policyEventsMap, true)
 }
 
-func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) (*policy.Policies, error) {
+func createPoliciesFromCLIFlags(scopeFlags, eventFlags []string) ([]*policy.Policy, error) {
 	policyScopeMap, err := flags.PrepareScopeMapFromFlags(scopeFlags)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
-	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/policy"
 )
 
@@ -103,7 +102,7 @@ func PrepareFilterMapsFromPolicies(policies []k8s.PolicyInterface) (PolicyScopeM
 }
 
 // CreatePolicies creates a Policies object from the scope and events maps.
-func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMap, newBinary bool) (*policy.Policies, error) {
+func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMap, newBinary bool) ([]*policy.Policy, error) {
 	eventsNameToID := events.Core.NamesToIDs()
 	// remove internal events since they shouldn't be accessible by users
 	for event, id := range eventsNameToID {
@@ -112,7 +111,7 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 		}
 	}
 
-	policies := policy.NewPolicies()
+	policies := make([]*policy.Policy, 0, len(policyScopeMap))
 	for policyIdx, policyScopeFilters := range policyScopeMap {
 		p := policy.NewPolicy()
 		p.ID = policyIdx
@@ -316,10 +315,7 @@ func CreatePolicies(policyScopeMap PolicyScopeMap, policyEventsMap PolicyEventMa
 			return nil, err
 		}
 
-		err = policies.Set(p)
-		if err != nil {
-			logger.Warnw("Setting policy", "error", err)
-		}
+		policies = append(policies, p)
 	}
 
 	return policies, nil

--- a/pkg/cmd/urfave/urfave.go
+++ b/pkg/cmd/urfave/urfave.go
@@ -124,11 +124,21 @@ func GetTraceeRunner(c *cli.Context, version string) (cmd.Runner, error) {
 	if err != nil {
 		return runner, err
 	}
-	cfg.Policies = policies
+	cfg.InitialPolicies = policies
+
+	containerFilterEnabled := func() bool {
+		for _, p := range cfg.InitialPolicies {
+			if p.ContainerFilterEnabled() {
+				return true
+			}
+		}
+
+		return false
+	}
 
 	broadcast, err := printer.NewBroadcast(
 		output.PrinterConfigs,
-		cmd.GetContainerMode(policies.ContainerFilterEnabled(), cfg.NoContainersEnrich),
+		cmd.GetContainerMode(containerFilterEnabled(), cfg.NoContainersEnrich),
 	)
 	if err != nil {
 		return runner, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,9 +13,12 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils/environment"
 )
 
-// Config is a struct containing user defined configuration of tracee
+// Config is a struct containing user defined configuration to initialize Tracee
+//
+// NOTE: In the future, Tracee config will be changed at run time and will require
+// proper management.
 type Config struct {
-	Policies           *policy.Policies
+	InitialPolicies    []*policy.Policy
 	Capture            *CaptureConfig
 	Capabilities       *CapabilitiesConfig
 	Output             *OutputConfig

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -235,7 +235,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		eventsState:     make(map[events.ID]events.EventState),
 		eventSignatures: make(map[events.ID]bool),
 		streamsManager:  streams.NewStreamsManager(),
-		policyManager:   policy.NewPolicyManager(cfg.Policies),
+		policyManager:   policy.NewPolicyManager(cfg.InitialPolicies...),
 		eventsDependencies: dependencies.NewDependenciesManager(
 			func(id events.ID) events.Dependencies {
 				return events.Core.GetDefinitionByID(id).GetDependencies()
@@ -243,10 +243,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		requiredKsyms: []string{},
 	}
 
-	// In the future Tracee Config will be changed in runtime, and will demand a proper
-	// object to manage it. config.Config is currently a transient object that should be
-	// used only to create the Tracee instance.
-	t.config.Policies = nil // policies must be managed by the policy manager
+	t.config.InitialPolicies = []*policy.Policy{} // clear initial policies to avoid wrong references
 
 	// TODO: As dynamic event addition or removal becomes a thing, we should subscribe all the watchers
 	// before selecting them. There is no reason to select the event in the New function anyhow.

--- a/pkg/events/derive/symbols_collision_test.go
+++ b/pkg/events/derive/symbols_collision_test.go
@@ -492,10 +492,7 @@ func TestSymbolsCollision(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			ps := policy.NewPolicies()
-			err := ps.Set(p)
-			require.NoError(t, err)
-			pManager := policy.NewPolicyManager(ps)
+			pManager := policy.NewPolicyManager(p)
 
 			// Pick derive function from mocked tests
 			deriveFunc := SymbolsCollision(mockLoader, pManager)

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -112,7 +112,7 @@ func updateOuterMap(m *bpf.Module, mapName string, mapVersion uint16, innerMap *
 }
 
 // createNewFilterMapsVersion creates a new version of the filter maps.
-func (ps *Policies) createNewFilterMapsVersion(bpfModule *bpf.Module) error {
+func (ps *policies) createNewFilterMapsVersion(bpfModule *bpf.Module) error {
 	mapsNames := map[string]string{ // inner map name: outer map name
 		UIDFilterMap:         UIDFilterMapVersion,
 		PIDFilterMap:         PIDFilterMapVersion,
@@ -125,7 +125,7 @@ func (ps *Policies) createNewFilterMapsVersion(bpfModule *bpf.Module) error {
 		BinaryFilterMap:      BinaryFilterMapVersion,
 	}
 
-	polsVersion := ps.Version()
+	polsVersion := ps.version()
 	for innerMapName, outerMapName := range mapsNames {
 		// TODO: This only spawns new inner filter maps. Their termination must
 		// be tackled by the versioning mechanism.
@@ -156,12 +156,12 @@ func (ps *Policies) createNewFilterMapsVersion(bpfModule *bpf.Module) error {
 }
 
 // createNewEventsMapVersion creates a new version of the events map.
-func (ps *Policies) createNewEventsMapVersion(
+func (ps *policies) createNewEventsMapVersion(
 	bpfModule *bpf.Module,
 	eventsState map[events.ID]events.EventState,
 	eventsParams map[events.ID][]bufferdecoder.ArgType,
 ) error {
-	polsVersion := ps.Version()
+	polsVersion := ps.version()
 	innerMapName := "events_map"
 	outerMapName := "events_map_version"
 
@@ -203,7 +203,7 @@ func (ps *Policies) createNewEventsMapVersion(
 }
 
 // updateUIntFilterBPF updates the BPF maps for the given uint equalities.
-func (ps *Policies) updateUIntFilterBPF(uintEqualities map[uint64]equality, innerMapName string) error {
+func (ps *policies) updateUIntFilterBPF(uintEqualities map[uint64]equality, innerMapName string) error {
 	// UInt equalities
 	// 1. uid_filter        u32, eq_t
 	// 2. pid_filter        u32, eq_t
@@ -238,7 +238,7 @@ const (
 )
 
 // updateStringFilterBPF updates the BPF maps for the given string equalities.
-func (ps *Policies) updateStringFilterBPF(strEqualities map[string]equality, innerMapName string) error {
+func (ps *policies) updateStringFilterBPF(strEqualities map[string]equality, innerMapName string) error {
 	// String equalities
 	// 1. uts_ns_filter  string_filter_t, eq_t
 	// 2. comm_filter    string_filter_t, eq_t
@@ -267,7 +267,7 @@ func (ps *Policies) updateStringFilterBPF(strEqualities map[string]equality, inn
 }
 
 // updateProcTreeFilterBPF updates the BPF maps for the given process tree equalities.
-func (ps *Policies) updateProcTreeFilterBPF(procTreeEqualities map[uint32]equality, innerMapName string) error {
+func (ps *policies) updateProcTreeFilterBPF(procTreeEqualities map[uint32]equality, innerMapName string) error {
 	// ProcessTree equality
 	// 1. process_tree_filter  u32, eq_t
 
@@ -361,7 +361,7 @@ const (
 )
 
 // updateBinaryFilterBPF updates the BPF maps for the given binary equalities.
-func (ps *Policies) updateBinaryFilterBPF(binEqualities map[filters.NSBinary]equality, innerMapName string) error {
+func (ps *policies) updateBinaryFilterBPF(binEqualities map[filters.NSBinary]equality, innerMapName string) error {
 	// BinaryNS equality
 	// 1. binary_filter  binary_t, eq_t
 
@@ -444,10 +444,10 @@ func populateProcInfoMap(bpfModule *bpf.Module, binEqualities map[filters.NSBina
 	return nil
 }
 
-// UpdateBPF updates the BPF maps with the policies filters.
+// updateBPF updates the BPF maps with the policies filters.
 // createNewMaps indicates whether new maps should be created or not.
 // updateProcTree indicates whether the process tree map should be updated or not.
-func (ps *Policies) UpdateBPF(
+func (ps *policies) updateBPF(
 	bpfModule *bpf.Module,
 	cts *containers.Containers,
 	eventsState map[events.ID]events.EventState,
@@ -553,8 +553,8 @@ func (ps *Policies) UpdateBPF(
 }
 
 // createNewPoliciesConfigMap creates a new version of the policies config map
-func (ps *Policies) createNewPoliciesConfigMap(bpfModule *bpf.Module) error {
-	version := ps.Version()
+func (ps *policies) createNewPoliciesConfigMap(bpfModule *bpf.Module) error {
+	version := ps.version()
 	newInnerMap, err := createNewInnerMap(bpfModule, PoliciesConfigMap, version)
 	if err != nil {
 		return errfmt.WrapError(err)
@@ -623,7 +623,7 @@ func (pc *PoliciesConfig) UpdateBPF(bpfConfigMap *bpf.BPFMapLow) error {
 }
 
 // computePoliciesConfig computes the policies config from the policies.
-func (ps *Policies) computePoliciesConfig() *PoliciesConfig {
+func (ps *policies) computePoliciesConfig() *PoliciesConfig {
 	cfg := &PoliciesConfig{}
 
 	for _, p := range ps.allFromMap() {

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -455,9 +455,6 @@ func (ps *policies) updateBPF(
 	createNewMaps bool,
 	updateProcTree bool,
 ) (*PoliciesConfig, error) {
-	ps.rwmu.Lock()
-	defer ps.rwmu.Unlock()
-
 	if createNewMaps {
 		// Create new events map version
 		if err := ps.createNewEventsMapVersion(bpfModule, eventsState, eventsParams); err != nil {

--- a/pkg/policy/equality.go
+++ b/pkg/policy/equality.go
@@ -88,7 +88,7 @@ func updateEqualities[T comparable](
 
 // computeFilterEqualities computes the equalities for each filter type in the policies
 // updating the provided filtersEqualities struct.
-func (ps *Policies) computeFilterEqualities(
+func (ps *policies) computeFilterEqualities(
 	fEqs *filtersEqualities,
 	cts *containers.Containers,
 ) error {
@@ -161,7 +161,7 @@ func (ps *Policies) computeFilterEqualities(
 
 // computeProcTreeEqualities computes the equalities for the process tree filter
 // in the policies updating the provided eqs map.
-func (ps *Policies) computeProcTreeEqualities(eqs map[uint32]equality) {
+func (ps *policies) computeProcTreeEqualities(eqs map[uint32]equality) {
 	for _, p := range ps.allFromMap() {
 		policyID := uint(p.ID)
 

--- a/pkg/policy/policies_compute.go
+++ b/pkg/policy/policies_compute.go
@@ -9,7 +9,7 @@ import (
 // and sets the related bitmap that is used to prevent the iteration of the entire map.
 //
 // It must be called at every runtime policies changes.
-func (ps *Policies) compute() {
+func (ps *policies) compute() {
 	ps.calculateGlobalMinMax()
 	ps.updateContainerFilterEnabled()
 	ps.updateUserlandPolicies()
@@ -23,7 +23,7 @@ func (ps *Policies) compute() {
 //
 // The scope filter types relevant for this function are just UIDFilter and
 // PIDFilter.
-func (ps *Policies) calculateGlobalMinMax() {
+func (ps *policies) calculateGlobalMinMax() {
 	var (
 		uidMinFilterCount int
 		uidMaxFilterCount int
@@ -106,7 +106,7 @@ func (ps *Policies) calculateGlobalMinMax() {
 	}
 }
 
-func (ps *Policies) updateContainerFilterEnabled() {
+func (ps *policies) updateContainerFilterEnabled() {
 	ps.containerFiltersEnabled = 0
 
 	for _, p := range ps.allFromMap() {
@@ -117,7 +117,7 @@ func (ps *Policies) updateContainerFilterEnabled() {
 }
 
 // updateUserlandPolicies sets the userlandPolicies list and the filterableInUserland bitmap.
-func (ps *Policies) updateUserlandPolicies() {
+func (ps *policies) updateUserlandPolicies() {
 	userlandList := []*Policy{}
 	ps.filterableInUserland = 0
 

--- a/pkg/policy/policies_iterator.go
+++ b/pkg/policy/policies_iterator.go
@@ -2,19 +2,19 @@ package policy
 
 import "github.com/aquasecurity/tracee/pkg/utils"
 
-// PoliciesIterator is an iterator for Policies.
-type PoliciesIterator struct {
+// policiesIterator is an iterator for Policies.
+type policiesIterator struct {
 	policies []*Policy
 	index    int
 }
 
 // HasNext returns true if there are more policies to iterate.
-func (i *PoliciesIterator) HasNext() bool {
+func (i *policiesIterator) HasNext() bool {
 	return i.index < len(i.policies)
 }
 
 // Next returns the next policy in the iteration.
-func (i *PoliciesIterator) Next() *Policy {
+func (i *policiesIterator) Next() *Policy {
 	if !i.HasNext() {
 		return nil
 	}
@@ -25,19 +25,19 @@ func (i *PoliciesIterator) Next() *Policy {
 	return p
 }
 
-// CreateUserlandIterator returns a new iterator for a reduced list of policies
+// createUserlandIterator returns a new iterator for a reduced list of policies
 // which must be filtered in userland (ArgFilter, RetFilter, ScopeFilter,
 // UIDFilter and PIDFilter).
-func (ps *Policies) CreateUserlandIterator() utils.Iterator[*Policy] {
-	return &PoliciesIterator{
+func (ps *policies) createUserlandIterator() utils.Iterator[*Policy] {
+	return &policiesIterator{
 		policies: ps.userlandPolicies,
 		index:    0,
 	}
 }
 
-// CreateAllIterator returns a new iterator for all policies.
-func (ps *Policies) CreateAllIterator() utils.Iterator[*Policy] {
-	return &PoliciesIterator{
+// createAllIterator returns a new iterator for all policies.
+func (ps *policies) createAllIterator() utils.Iterator[*Policy] {
+	return &policiesIterator{
 		policies: ps.policiesList,
 		index:    0,
 	}

--- a/pkg/policy/policies_test.go
+++ b/pkg/policy/policies_test.go
@@ -17,7 +17,7 @@ import (
 func TestPoliciesClone(t *testing.T) {
 	t.Parallel()
 
-	policies := NewPolicies()
+	ps := NewPolicies()
 
 	p1 := NewPolicy()
 	p1.Name = "p1"
@@ -32,15 +32,15 @@ func TestPoliciesClone(t *testing.T) {
 	err = p2.DataFilter.Parse("read.data.fd", "=dataval", events.Core.NamesToIDs())
 	require.NoError(t, err)
 
-	err = policies.Add(p1)
+	err = ps.add(p1)
 	require.NoError(t, err)
-	err = policies.Add(p2)
+	err = ps.add(p2)
 	require.NoError(t, err)
 
-	copy := policies.Clone()
+	copy := ps.Clone()
 
 	opt1 := cmp.AllowUnexported(
-		Policies{},
+		policies{},
 		sync.Mutex{},
 		sync.RWMutex{},
 		atomic.Int32{},
@@ -64,8 +64,8 @@ func TestPoliciesClone(t *testing.T) {
 		},
 		cmp.Ignore(),
 	)
-	if !cmp.Equal(policies, copy, opt1, opt2) {
-		diff := cmp.Diff(policies, copy, opt1, opt2)
+	if !cmp.Equal(ps, copy, opt1, opt2) {
+		diff := cmp.Diff(ps, copy, opt1, opt2)
 		t.Errorf("Clone did not produce an identical copy\ndiff: %s", diff)
 	}
 
@@ -74,14 +74,14 @@ func TestPoliciesClone(t *testing.T) {
 	p3.Name = "p3"
 	err = p3.CommFilter.Parse("=comm")
 	require.NoError(t, err)
-	err = copy.Add(p3)
+	err = copy.add(p3)
 	require.NoError(t, err)
 
-	p1, err = copy.LookupByName("p1")
+	p1, err = copy.lookupByName("p1")
 	require.NoError(t, err)
 	p1.Name = "p1-modified"
 
-	if cmp.Equal(policies, copy, opt1, opt2) {
-		t.Errorf("Changes to copied policy affected the original: %+v", policies)
+	if cmp.Equal(ps, copy, opt1, opt2) {
+		t.Errorf("Changes to copied policy affected the original: %+v", ps)
 	}
 }

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/pkg/containers"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/utils"
 )
 
@@ -24,9 +25,12 @@ type eventState struct {
 	enabled    bool
 }
 
-func NewPolicyManager(ps *Policies) *PolicyManager {
-	if ps == nil {
-		ps = NewPolicies()
+func NewPolicyManager(policies ...*Policy) *PolicyManager {
+	ps := NewPolicies()
+	for _, p := range policies {
+		if err := ps.Set(p); err != nil {
+			logger.Errorw("failed to set policy", "error", err)
+		}
 	}
 
 	return &PolicyManager{

--- a/pkg/policy/snapshots_test.go
+++ b/pkg/policy/snapshots_test.go
@@ -21,7 +21,7 @@ func resetSnapshots() {
 }
 
 func setPruneFunc() {
-	Snapshots().SetPruneFunc(func(ps *Policies) []error {
+	Snapshots().SetPruneFunc(func(ps *policies) []error {
 		errs := []error{}
 		for _, bpfMap := range ps.bpfInnerMaps {
 			err := syscall.Close(bpfMap.FileDescriptor())
@@ -37,7 +37,7 @@ func setPruneFunc() {
 func TestStoreSnapshot(t *testing.T) {
 	resetSnapshots()
 
-	ps := &Policies{}
+	ps := &policies{}
 	Snapshots().Store(ps)
 	assert.Equal(t, uint16(1), uint16(ps.version))
 
@@ -50,7 +50,7 @@ func TestStoreSnapshot(t *testing.T) {
 func TestGetSnapshot(t *testing.T) {
 	resetSnapshots()
 
-	ps := &Policies{}
+	ps := &policies{}
 	Snapshots().Store(ps)
 
 	// get the snapshot for the version just stored
@@ -66,10 +66,10 @@ func TestGetSnapshot(t *testing.T) {
 func TestGetLastSnapshot(t *testing.T) {
 	resetSnapshots()
 
-	ps1 := &Policies{}
+	ps1 := &policies{}
 	Snapshots().Store(ps1)
 
-	ps2 := &Policies{}
+	ps2 := &policies{}
 	Snapshots().Store(ps2)
 
 	// after storing two snapshots, the last one should be ps2
@@ -84,7 +84,7 @@ func TestCircularBufferOverwrite(t *testing.T) {
 
 	// create and store maxSnapshots
 	for i := 0; i < maxSnapshots; i++ {
-		ps := &Policies{}
+		ps := &policies{}
 		Snapshots().Store(ps)
 		assert.Equal(t, uint16(i+1), uint16(ps.version))
 	}
@@ -94,7 +94,7 @@ func TestCircularBufferOverwrite(t *testing.T) {
 	assert.NoError(t, err)
 
 	// store one more snapshot to overwrite the first snapshot in the buffer
-	psOverwrite := &Policies{}
+	psOverwrite := &policies{}
 	Snapshots().Store(psOverwrite)
 	assert.Equal(t, uint16(maxSnapshots+1), psOverwrite.version)
 
@@ -149,7 +149,7 @@ func TestConcurrentSnapshots(t *testing.T) {
 				<-startStoreCh
 
 				// store a snapshot
-				ps := &Policies{}
+				ps := &policies{}
 				Snapshots().Store(ps)
 
 				if atomic.CompareAndSwapInt32(&readyForRetrieve, 0, 1) {
@@ -209,14 +209,14 @@ func TestWrapAround(t *testing.T) {
 	snaps.lastVersion = math.MaxUint16 - 1
 
 	// store a snapshot, this should increase version to math.MaxUint16
-	ps1 := &Policies{}
+	ps1 := &policies{}
 	Snapshots().Store(ps1)
 
 	// verify that the version is set to math.MaxUint16
 	assert.Equal(t, uint16(math.MaxUint16), uint16(ps1.version))
 
 	// store another snapshot, this should trigger the wrap-around and reset the version to 1
-	ps2 := &Policies{}
+	ps2 := &policies{}
 	Snapshots().Store(ps2)
 
 	// verify that the wrap-around occurred
@@ -235,7 +235,7 @@ func TestPruneSnapshotsOlderThan(t *testing.T) {
 	// Helper function to store numSnapshots snapshots immediately
 	storeSnapshots := func() {
 		for i := 0; i < numSnapshots; i++ {
-			ps := &Policies{}
+			ps := &policies{}
 			Snapshots().Store(ps)
 		}
 	}

--- a/pkg/policy/snapshots_test.go
+++ b/pkg/policy/snapshots_test.go
@@ -1,3 +1,5 @@
+//go:build exclude
+
 package policy
 
 import (

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -123,7 +123,7 @@ func Test_EventsDependencies(t *testing.T) {
 					BypassCaps: true,
 				},
 			}
-			testConfig.Policies = testutils.BuildPoliciesFromEvents(testCaseInst.events)
+			testConfig.InitialPolicies = testutils.BuildPoliciesFromEvents(testCaseInst.events)
 
 			ctx, cancel := context.WithCancel(context.Background())
 

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1714,7 +1714,7 @@ func Test_EventFilters(t *testing.T) {
 					BypassCaps: true,
 				},
 			}
-			config.Policies = testutils.NewPolicies(tc.policyFiles)
+			config.InitialPolicies = testutils.NewPolicies(tc.policyFiles)
 
 			ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
### 1. Explain what the PR does

c0c711b28 **chore: disable snapshots tests**
da4b19f42 **chore: remove mutex from policies**
9a27046c4 **chore: hide type from the public API**
9f36a4f2e **chore: PolicyManager init refactoring**


c0c711b28 **chore: disable snapshots tests**

```
Snapshots is currently not used and will be revamped in the future.
```

da4b19f42 **chore: remove mutex from policies**

```
policies is now fully under the umbrella of PolicyManager, which already
has a mutex.
```

9a27046c4 **chore: hide type from the public API**

```
Policies -> policies
```

9f36a4f2e **chore: PolicyManager init refactoring**

```
This tidy up continues the work started in previous commits,
by refactoring the PolicyManager initialization code to receive a
Policy slice instead of the Policies object itself.

The changes to flags.CreatePolicies() are a reflection of the new
PolicyManager initialization.

"Tidyings are the cute, fuzzy little refactorings that nobody could
possibly hate on." - @KentBeck
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
