### PR TITLE
fix(tests): remove named pipe if it exists

### DIFF
--- a/tests/integration/capture_test.go
+++ b/tests/integration/capture_test.go
@@ -246,7 +246,11 @@ func readWritevCaptureTest(t *testing.T, captureDir string, workingDir string) e
 
 func readWritePipe(t *testing.T, captureDir string, workingDir string) error {
 	namedPipe := fmt.Sprintf("%s/pipe_test", workingDir)
-	err := syscall.Mkfifo(namedPipe, 0666)
+	err := os.Remove(namedPipe)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	err = syscall.Mkfifo(namedPipe, 0666)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### 1. Explain what the PR does

0d4e979bc **fix(tests): remove named pipe if it exists**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

This guarantees that the named pipe creation won't fail when `readWritePipe()` is called.
