### PR TITLE
Fix deps deadlock

### DIFF
--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -27,7 +26,7 @@ func (t *Tracee) UpdateKallsyms() error {
 
 	// Wrap long method names.
 	evtDefSymDeps := func(id events.ID) []events.KSymbol {
-		depsNode, _ := dependencies.GetManagerInstance().GetEvent(id)
+		depsNode, _ := t.eventsDependencies.GetEvent(id)
 		deps := depsNode.GetDependencies()
 		return deps.GetKSymbols()
 	}

--- a/pkg/events/dependencies/manager_test.go
+++ b/pkg/events/dependencies/manager_test.go
@@ -80,10 +80,6 @@ func TestManager_AddEvent(t *testing.T) {
 			t.Run(testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
-				defer func() {
-					ResetManagerFromTests()
-					t.Logf("  --- reset dependencies ---")
-				}()
 
 				var eventsAdditions []events.ID
 				m.SubscribeAdd(
@@ -141,10 +137,6 @@ func TestManager_AddEvent(t *testing.T) {
 			t.Run(testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
-				defer func() {
-					ResetManagerFromTests()
-					t.Logf("  --- reset dependencies ---")
-				}()
 
 				var eventsAdditions, eventsRemove []events.ID
 				// Count additions
@@ -344,10 +336,6 @@ func TestManager_RemoveEvent(t *testing.T) {
 			testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
-				defer func() {
-					ResetManagerFromTests()
-					t.Logf("  --- reset dependencies ---")
-				}()
 
 				var eventsRemoved []events.ID
 				m.SubscribeRemove(
@@ -523,10 +511,6 @@ func TestManager_UnselectEvent(t *testing.T) {
 			testCase.name, func(t *testing.T) {
 				// Create a new Manager instance
 				m := NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
-				defer func() {
-					ResetManagerFromTests()
-					t.Logf("  --- reset dependencies ---")
-				}()
 
 				var eventsRemoved []events.ID
 				m.SubscribeRemove(

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/tests/testutils"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -146,10 +145,6 @@ func Test_EventsDependencies(t *testing.T) {
 					cancel()
 					t.Fatal(err)
 				}
-				defer func() {
-					dependencies.ResetManagerFromTests()
-					t.Logf("  --- reset dependencies ---")
-				}()
 
 				stream := trc.SubscribeAll()
 				defer trc.Unsubscribe(stream)

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 	k8s "github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/policy/v1beta1"
 	"github.com/aquasecurity/tracee/pkg/utils"
@@ -1732,10 +1731,6 @@ func Test_EventFilters(t *testing.T) {
 				cancel()
 				t.Fatal(err)
 			}
-			defer func() {
-				dependencies.ResetManagerFromTests()
-				t.Logf("  --- reset dependencies ---")
-			}()
 
 			stream := trc.SubscribeAll()
 			defer trc.Unsubscribe(stream)


### PR DESCRIPTION
Close: #4172 

### 1. Explain what the PR does

2f8a61a0f **chore: run dependencies tests in parallel**
3616c30e9 **fix: dependencies manager deadlock**


2f8a61a0f **chore: run dependencies tests in parallel**

```
It also reformats some tests blocks.
```

3616c30e9 **fix: dependencies manager deadlock**

```
Since this turns the manager thread-safe, it takes the opportunity to
remove the temporary singleton pattern, reintroducing the manager as a
Tracee's member.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
