### PR TITLE
feat(caps): base ebpf capabilities

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -76,7 +76,11 @@ func main() {
 			// happens after Find() is called) in that case.
 
 			bypass := c.Bool("allcaps") || !isRoot()
-			err = capabilities.Initialize(bypass)
+			err = capabilities.Initialize(
+				capabilities.Config{
+					Bypass: bypass,
+				},
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/capabilities/capabilities_test.go
+++ b/pkg/capabilities/capabilities_test.go
@@ -33,7 +33,9 @@ func Test_Initialize_And_GetInstance_Concurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			err := Initialize(true)
+			err := Initialize(Config{
+				Bypass: true,
+			})
 			assert.NoError(t, err)
 		}()
 	}

--- a/pkg/containers/path_resolver_test.go
+++ b/pkg/containers/path_resolver_test.go
@@ -67,7 +67,11 @@ func TestPathResolver_ResolveAbsolutePath(t *testing.T) {
 		testMntNS := 1
 		testFilePath := "/tmp/tmp.so"
 
-		err := capabilities.Initialize(true) // initialize capabilities
+		err := capabilities.Initialize(
+			capabilities.Config{
+				Bypass: true,
+			},
+		) // initialize capabilities
 		assert.NoError(t, err)
 
 		for _, testCase := range testCases {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -275,7 +275,16 @@ func New(cfg config.Config) (*Tracee, error) {
 
 	// Initialize capabilities rings soon
 
-	err = capabilities.Initialize(t.config.Capabilities.BypassCaps)
+	useBaseEbpf := func(cfg config.Config) bool {
+		return cfg.Output.StackAddresses
+	}
+
+	err = capabilities.Initialize(
+		capabilities.Config{
+			Bypass:   t.config.Capabilities.BypassCaps,
+			BaseEbpf: useBaseEbpf(t.config),
+		},
+	)
 	if err != nil {
 		return t, errfmt.WrapError(err)
 	}


### PR DESCRIPTION
### 1. Explain what the PR does

6bd0b3956 **feat(caps): base ebpf capabilities**

```
Add the ability to add the ebpf capabilities to the base ring, instead
of allocating a specific ring. When the feature is enabled, requests for
the eBPF ring will seamlessly avoid a ring switch, and the callback will
be called as is.
```

### 2. Explain how to test it

Stack addresses should remain working.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
