### PR TITLE
chore: introduce eventFlags to policy manager

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -343,7 +343,10 @@ func New(cfg config.Config) (*Tracee, error) {
 			utils.SetBit(&emit, uint(p.ID))
 			t.selectEvent(e, events.EventState{Submit: submit, Emit: emit})
 
-			t.policyManager.EnableRule(p.ID, e)
+			err := t.policyManager.EnableRule(p.ID, e)
+			if err != nil {
+				logger.Errorw("Failed to enable rule", "policy", p.ID, "event", e, "error", err)
+			}
 		}
 	}
 
@@ -2057,7 +2060,10 @@ func (t *Tracee) EnableRule(policyNames []string, ruleId string) error {
 			return err
 		}
 
-		t.policyManager.EnableRule(p.ID, eventID)
+		err = t.policyManager.EnableRule(p.ID, eventID)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -2076,7 +2082,10 @@ func (t *Tracee) DisableRule(policyNames []string, ruleId string) error {
 			return err
 		}
 
-		t.policyManager.DisableRule(p.ID, eventID)
+		err = t.policyManager.DisableRule(p.ID, eventID)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/policy/event_flags.go
+++ b/pkg/policy/event_flags.go
@@ -1,0 +1,89 @@
+package policy
+
+import "github.com/aquasecurity/tracee/pkg/utils"
+
+// eventFlags is a struct that holds the flags of an event.
+type eventFlags struct {
+	// policiesSubmit is a bitmask with the policies that require the event,
+	// if matched, to be submitted to the userland from the ebpf program.
+	// It is computed on policies updates.
+	policiesSubmit uint64
+
+	// policiesEmit is a bitmask with the policies that require the event,
+	// if matched, to be emitted in the pipeline sink stage.
+	// It is computed on policies updates.
+	policiesEmit uint64
+
+	// enabled indicates if the event is enabled.
+	// It is *NOT* computed on policies updates, so its value remains the same
+	// until changed via the API.
+	enabled bool
+}
+
+//
+// constructor
+//
+
+type eventFlagsOption func(*eventFlags)
+
+func eventFlagsWithSubmit(submit uint64) eventFlagsOption {
+	return func(es *eventFlags) {
+		es.policiesSubmit = submit
+	}
+}
+
+func eventFlagsWithEmit(emit uint64) eventFlagsOption {
+	return func(es *eventFlags) {
+		es.policiesEmit = emit
+	}
+}
+
+func eventFlagsWithEnabled(enabled bool) eventFlagsOption {
+	return func(es *eventFlags) {
+		es.enabled = enabled
+	}
+}
+
+func newEventFlags(options ...eventFlagsOption) *eventFlags {
+	// default values
+	ef := &eventFlags{
+		policiesSubmit: 0,
+		policiesEmit:   0,
+		enabled:        false,
+	}
+
+	// apply options
+	for _, option := range options {
+		option(ef)
+	}
+
+	return ef
+}
+
+//
+// methods
+//
+
+func (ef *eventFlags) enableSubmission(policyId int) {
+	utils.SetBit(&ef.policiesSubmit, uint(policyId))
+}
+
+func (ef *eventFlags) enableEmission(policyId int) {
+	utils.SetBit(&ef.policiesEmit, uint(policyId))
+}
+
+func (ef *eventFlags) disableSubmission(policyId int) {
+	utils.ClearBit(&ef.policiesSubmit, uint(policyId))
+}
+
+func (ef *eventFlags) disableEmission(policyId int) {
+	utils.ClearBit(&ef.policiesEmit, uint(policyId))
+}
+
+func (ef *eventFlags) enableEvent() {
+	ef.enabled = true
+}
+
+func (ef *eventFlags) disableEvent() {
+	ef.enabled = false
+}

--- a/pkg/policy/event_flags_test.go
+++ b/pkg/policy/event_flags_test.go
@@ -1,0 +1,91 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/tracee/pkg/utils"
+)
+
+// TestNewEventFlags tests the newEventFlags function.
+func TestNewEventFlags(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags()
+	emit := uint64(0)
+	submit := uint64(0)
+
+	assert.Equal(t, emit, ef.policiesSubmit)
+	assert.Equal(t, submit, ef.policiesEmit)
+	assert.False(t, ef.enabled)
+
+	submit = uint64(1 << 0)
+	emit = uint64(1<<1 | 1<<2)
+	efWithOptions := newEventFlags(
+		eventFlagsWithSubmit(submit),
+		eventFlagsWithEmit(emit),
+		eventFlagsWithEnabled(true),
+	)
+	assert.Equal(t, submit, efWithOptions.policiesSubmit)
+	assert.Equal(t, emit, efWithOptions.policiesEmit)
+	assert.True(t, efWithOptions.enabled)
+}
+
+// TestEnableSubmission tests the enableSubmission function.
+func TestEnableSubmission(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags()
+	ef.enableSubmission(1)
+	assert.True(t, utils.HasBit(ef.policiesSubmit, 1))
+}
+
+// TestEnableEmission tests the enableEmission function.
+func TestEnableEmission(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags()
+	ef.enableEmission(1)
+	assert.True(t, utils.HasBit(ef.policiesEmit, 1))
+
+	ef.enableEmission(-1)
+}
+
+// TestDisableSubmission tests the disableSubmission function.
+func TestDisableSubmission(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags()
+	ef.enableSubmission(42)
+	ef.disableSubmission(42)
+	assert.False(t, utils.HasBit(ef.policiesSubmit, 42))
+}
+
+// TestDisableEmission tests the disableEmission function.
+func TestDisableEmission(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags()
+	ef.enableEmission(42)
+	ef.disableEmission(42)
+	assert.False(t, utils.HasBit(ef.policiesEmit, 42))
+}
+
+// TestEnableEvent tests the enableEvent function.
+func TestEnableEvent(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags(eventFlagsWithEnabled(false))
+	ef.enableEvent()
+	assert.True(t, ef.enabled)
+}
+
+// TestDisableEvent tests the disableEvent function.
+func TestDisableEvent(t *testing.T) {
+	t.Parallel()
+
+	ef := newEventFlags(eventFlagsWithEnabled(true))
+	ef.disableEvent()
+	assert.False(t, ef.enabled)
+}

--- a/pkg/policy/policy_manager_test.go
+++ b/pkg/policy/policy_manager_test.go
@@ -22,17 +22,22 @@ func TestPolicyManagerEnableRule(t *testing.T) {
 	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
 	assert.False(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
 
-	policyManager.EnableRule(1, events.SecurityBPF)
+	err := policyManager.EnableRule(1, events.SecurityBPF)
+	assert.NoError(t, err)
 
 	assert.True(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
 	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
 	assert.True(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
 
-	policyManager.EnableRule(2, events.SecurityBPF)
+	err = policyManager.EnableRule(2, events.SecurityBPF)
+	assert.NoError(t, err)
 
 	assert.True(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
 	assert.True(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
 	assert.True(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+
+	err = policyManager.EnableRule(-1, events.SecurityBPF)
+	assert.Error(t, err)
 }
 
 func TestPolicyManagerDisableRule(t *testing.T) {
@@ -44,17 +49,22 @@ func TestPolicyManagerDisableRule(t *testing.T) {
 	policy2Mached := uint64(0b100)
 	policy1And2Mached := uint64(0b110)
 
-	policyManager.EnableRule(1, events.SecurityBPF)
+	err := policyManager.EnableRule(1, events.SecurityBPF)
+	assert.NoError(t, err)
 
 	assert.True(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
 	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
 	assert.True(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
 
-	policyManager.DisableRule(1, events.SecurityBPF)
+	err = policyManager.DisableRule(1, events.SecurityBPF)
+	assert.NoError(t, err)
 
 	assert.False(t, policyManager.IsRuleEnabled(policy1Mached, events.SecurityBPF))
 	assert.False(t, policyManager.IsRuleEnabled(policy2Mached, events.SecurityBPF))
 	assert.False(t, policyManager.IsRuleEnabled(policy1And2Mached, events.SecurityBPF))
+
+	err = policyManager.DisableRule(-1, events.SecurityBPF)
+	assert.Error(t, err)
 }
 
 func TestPolicyManagerEnableAndDisableRuleConcurrent(t *testing.T) {


### PR DESCRIPTION

### 1. Explain what the PR does

19320445b **chore: introduce eventFlags to policy manager**

```
It replaces the inner eventState type being a holder for the flags of an
event with a proper API.

In next efforts, it will replace the event state map embedded in Tracee.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
