### PR TITLE
chore(cap): check if cap is supported before set/unset

### DIFF
--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -409,17 +409,23 @@ func (c *Capabilities) setProc() error {
 
 func (c *Capabilities) set(t RingType, values ...cap.Value) error {
 	for _, v := range values {
-		c.all[v][t] = true
+		m, exists := c.all[v]
+		if !exists {
+			return fmt.Errorf("failed to set capability %v: not supported", v)
+		}
+		m[t] = true
 	}
-
 	return nil
 }
 
 func (c *Capabilities) unset(t RingType, values ...cap.Value) error {
 	for _, v := range values {
-		c.all[v][t] = false
+		m, exists := c.all[v]
+		if !exists {
+			return fmt.Errorf("failed to unset capability %v: not supported", v)
+		}
+		m[t] = false
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

93b17685d **chore(cap): check if cap is supported before set/unset**

```
set or unset a capability without proper checking can result in a panic.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

Test the following code in an older kernel version <5.8.
```
err = capabilities.GetInstance().Specific(
	func() error {
		return nil
	},
	cap.BPF,
	cap.PERFMON,
)
if err != nil {
	return errfmt.WrapError(err)
}
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

If `CAP_BPF`+`CAP_PERFMON` is used on kernel version <5.8, we get a `panic: assignment to entry in nil map` when set/unset the map that was initialized. It happens because both cap are supported only on kernel version >=5.8.
