### PR TITLE
fix(controlplane): filter unnecessary enriches

### DIFF
--- a/pkg/ebpf/controlplane/cgroups.go
+++ b/pkg/ebpf/controlplane/cgroups.go
@@ -47,8 +47,9 @@ func (ctrl *Controller) processCgroupMkdir(args []trace.Argument) error {
 		return errfmt.WrapError(err)
 	}
 
-	if !ctrl.enrichDisabled {
-		// If cgroupId belongs to a container, enrich now (in a goroutine)
+	if info.ContainerRoot && !ctrl.enrichDisabled {
+		// If cgroupId belongs to a container, and is the root (to avoid duplicate requests)
+		// enrich now (in a goroutine)
 		go func() {
 			_, err := ctrl.cgroupManager.EnrichCgroupInfo(cgroupId)
 			if err != nil {


### PR DESCRIPTION
### 1. Explain what the PR does

613986ac5 **fix(controlplane): filter unnecessary enriches**

```
The condition for enrichment in the control plane was faulty. It relied
on the previous check for container relevant cgroups + not dead dirs.
This, however, is obviously not enough. Therefore the condition for
enrichment trigger now includes checking if the cgroup is a container's
root directory.
```

### 2. Explain how to test it

`tracee -o json`
`docker run --rm -d ubuntu`
Enrichment should work as before, with no new errors.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
