### PR TITLE
fix: improve performance of readStringVarFromBuff

### DIFF
--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -1,7 +1,6 @@
 package bufferdecoder
 
 import (
-	"bytes"
 	"encoding/binary"
 	"net"
 	"strconv"
@@ -373,21 +372,29 @@ func readStringFromBuff(ebpfMsgDecoder *EbpfDecoder) (string, error) {
 func readStringVarFromBuff(decoder *EbpfDecoder, max int) (string, error) {
 	var err error
 	var char int8
-	res := make([]byte, max)
+	res := make([]byte, 0, max)
+
 	err = decoder.DecodeInt8(&char)
 	if err != nil {
 		return "", errfmt.Errorf("error reading null terminated string: %v", err)
 	}
-	var count int
-	for count = 1; char != 0 && count < max; count++ {
+
+	count := 1 // first char is already decoded
+	for char != 0 && count < max {
 		res = append(res, byte(char))
+
+		// decode next char
 		err = decoder.DecodeInt8(&char)
 		if err != nil {
 			return "", errfmt.Errorf("error reading null terminated string: %v", err)
 		}
+		count++
 	}
-	res = bytes.TrimLeft(res[:], "\000")
-	decoder.cursor += max - count // move cursor to end of buffer
+
+	// The exact reason for this Trim is not known, so remove it for now,
+	// since it increases processing time.
+	// res = bytes.TrimLeft(res[:], "\000")
+	decoder.cursor += max - count // move cursor to the end of the buffer
 	return string(res), nil
 }
 

--- a/pkg/bufferdecoder/eventsreader_bench_test.go
+++ b/pkg/bufferdecoder/eventsreader_bench_test.go
@@ -1,0 +1,56 @@
+package bufferdecoder
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkReadStringVarFromBuff_ShortString(b *testing.B) {
+	buffer := []byte{'H', 'e', 'l', 'l', 'o', 0}
+	max := 10
+	var str string
+
+	for i := 0; i < b.N; i++ {
+		decoder := New(buffer)
+		str, _ = readStringVarFromBuff(decoder, max)
+	}
+	_ = str
+}
+
+func BenchmarkReadStringVarFromBuff_MediumString(b *testing.B) {
+	buffer := []byte{'T', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't', 0}
+	max := 20
+	var str string
+
+	for i := 0; i < b.N; i++ {
+		decoder := New(buffer)
+		str, _ = readStringVarFromBuff(decoder, max)
+	}
+	_ = str
+}
+
+func BenchmarkReadStringVarFromBuff_LongString(b *testing.B) {
+	buffer := append(bytes.Repeat([]byte{'A'}, 10000), 0)
+	max := 10000
+	var str string
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decoder := New(buffer)
+		str, _ = readStringVarFromBuff(decoder, max)
+	}
+	_ = str
+}
+
+func BenchmarkReadStringVarFromBuff_LongStringLowMax(b *testing.B) {
+	buffer := bytes.Repeat([]byte{'A'}, 10000)
+	max := 100
+	var str string
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decoder := New(buffer)
+		str, _ = readStringVarFromBuff(decoder, max)
+	}
+	_ = str
+}


### PR DESCRIPTION
Close: #4081 

### 1. Explain what the PR does

28ec9535a **fix: improve performance of readStringVarFromBuff**

```
Optimize readStringVarFromBuff for better performance and memory usage.

- The optimizations were tested using new benchmarks:
  - Short: 33.26% faster, 42.86% less memory usage, 1 fewer allocation.
  - Medium: 28.34% faster, 54.55% less memory usage, 1 fewer allocation.
  - Long: 26.90% faster, 73.42% less memory usage, 3 fewer allocations.
  - Long: with Low Max: 19.12% faster, 48.15% less memory usage, 1 fewer
    allocation.

The overall improvements show significant gains in both execution speed
and memory efficiency. For more check eventsreader_bench_test.go.

Changes:
- Preallocated the buffer with a reasonable initial capacity to avoid
  repeated slice resizing.
- Removed TrimLeft call since conversion logic already stops at the
  first nul byte decoded.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
