### PR TITLE
improve flag parsing performance

### DIFF
--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -13,6 +13,18 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
+func emptyString(arg *trace.Argument) {
+	arg.Type = "string"
+	arg.Value = ""
+}
+
+func parseOrEmptyString(arg *trace.Argument, sysArg parsers.SystemFunctionArgument, err error) {
+	emptyString(arg)
+	if err == nil {
+		arg.Value = sysArg.String()
+	}
+}
+
 func ParseArgs(event *trace.Event) error {
 	for _, arg := range event.Args {
 		if ptr, isUintptr := arg.Value.(uintptr); isUintptr {
@@ -20,18 +32,6 @@ func ParseArgs(event *trace.Event) error {
 			if err != nil {
 				return err
 			}
-		}
-	}
-
-	emptyString := func(arg *trace.Argument) {
-		arg.Type = "string"
-		arg.Value = ""
-	}
-
-	parseOrEmptyString := func(arg *trace.Argument, sysArg parsers.SystemFunctionArgument, err error) {
-		emptyString(arg)
-		if err == nil {
-			arg.Value = sysArg.String()
 		}
 	}
 

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -26,12 +26,11 @@ func parseOrEmptyString(arg *trace.Argument, sysArg parsers.SystemFunctionArgume
 }
 
 func ParseArgs(event *trace.Event) error {
-	for _, arg := range event.Args {
-		if ptr, isUintptr := arg.Value.(uintptr); isUintptr {
-			err := SetArgValue(event, arg.Name, "0x"+strconv.FormatUint(uint64(ptr), 16))
-			if err != nil {
-				return err
-			}
+	for i := range event.Args {
+		if ptr, isUintptr := event.Args[i].Value.(uintptr); isUintptr {
+			v := []byte{'0', 'x'}
+			v = strconv.AppendUint(v, uint64(ptr), 16)
+			event.Args[i].Value = string(v)
 		}
 	}
 

--- a/pkg/events/parse_args_bench_test.go
+++ b/pkg/events/parse_args_bench_test.go
@@ -1,0 +1,280 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+var events = []*trace.Event{
+	{
+		EventID: int(MemProtAlert),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "alert"}, Value: uint32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "prev_prot"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SysEnter),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "syscall"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SysExit),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "ret"}, Value: int64(0)},
+		},
+	},
+	{
+		EventID: int(CapCapable),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "cap"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecurityMmapFile),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: uint64(0)},
+		},
+	},
+	{
+		EventID: int(DoMmap),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: uint64(0)},
+		},
+	},
+	{
+		EventID: int(Mmap),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: uint64(0)},
+		},
+	},
+	{
+		EventID: int(Mprotect),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: uint64(0)},
+		},
+	},
+	{
+		EventID: int(PkeyMprotect),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: uint64(0)},
+		},
+	},
+	{
+		EventID: int(SecurityFileMprotect),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prot"}, Value: uint64(0)},
+			{ArgMeta: trace.ArgMeta{Name: "prev_prot"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Ptrace),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "request"}, Value: int64(0)},
+		},
+	},
+	{
+		EventID: int(Prctl),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "option"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Socketcall),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "call"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Socket),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "domain"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "type"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecuritySocketCreate),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "family"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "type"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecuritySocketConnect),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "family"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "type"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Access),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Faccessat),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Execveat),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "flags"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Open),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "flags"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Openat),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "flags"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecurityFileOpen),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "flags"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Mknod),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: uint32(0)},
+		},
+	},
+	{
+		EventID: int(Mknodat),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: uint32(0)},
+		},
+	},
+	{
+		EventID: int(Chmod),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: uint32(0)},
+		},
+	},
+	{
+		EventID: int(Fchmod),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: uint32(0)},
+		},
+	},
+	{
+		EventID: int(Fchmodat),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: uint32(0)},
+		},
+	},
+	{
+		EventID: int(SecurityInodeMknod),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mode"}, Value: uint32(0)},
+		},
+	},
+	{
+		EventID: int(Clone),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "flags"}, Value: uint64(0)},
+		},
+	},
+	{
+		EventID: int(Bpf),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "cmd"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecurityBPF),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "cmd"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecurityKernelReadFile),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "type"}, Value: trace.KernelReadType(0)},
+		},
+	},
+	{
+		EventID: int(SecurityPostReadFile),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "type"}, Value: trace.KernelReadType(0)},
+		},
+	},
+	{
+		EventID: int(SchedProcessExec),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "stdin_type"}, Value: uint16(0)},
+		},
+	},
+	{
+		EventID: int(DirtyPipeSplice),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "in_file_type"}, Value: uint16(0)},
+		},
+	},
+	{
+		EventID: int(SecuritySocketSetsockopt),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "level"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "optname"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Setsockopt),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "level"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "optname"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(Getsockopt),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "level"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "optname"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(BpfAttach),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "prog_type"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "prog_helpers"}, Value: []uint64{}},
+			{ArgMeta: trace.ArgMeta{Name: "attach_type"}, Value: int32(0)},
+		},
+	},
+	{
+		EventID: int(SecurityBpfProg),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "type"}, Value: int32(0)},
+			{ArgMeta: trace.ArgMeta{Name: "helpers"}, Value: []uint64{}},
+		},
+	},
+	{
+		EventID: int(SecurityPathNotify),
+		Args: []trace.Argument{
+			{ArgMeta: trace.ArgMeta{Name: "mask"}, Value: uint64(0)},
+			{ArgMeta: trace.ArgMeta{Name: "obj_type"}, Value: uint32(0)},
+		},
+	},
+}
+
+func BenchmarkParseArgs(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		for _, event := range events {
+			err := ParseArgs(event)
+			if err != nil {
+				b.Errorf("Error parsing args: %v", err)
+			}
+		}
+	}
+}

--- a/pkg/events/parse_args_bench_test.go
+++ b/pkg/events/parse_args_bench_test.go
@@ -278,3 +278,22 @@ func BenchmarkParseArgs(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkParseArgs_Uintptr(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		ptraceEvent := &trace.Event{
+			EventID: int(Ptrace),
+			Args: []trace.Argument{
+				{ArgMeta: trace.ArgMeta{Name: "request"}, Value: int64(0)},
+				{ArgMeta: trace.ArgMeta{Name: "pid"}, Value: int32(0)},
+				{ArgMeta: trace.ArgMeta{Name: "addr"}, Value: ^uintptr(0)},
+				{ArgMeta: trace.ArgMeta{Name: "data"}, Value: ^uintptr(0)},
+			},
+		}
+
+		err := ParseArgs(ptraceEvent)
+		if err != nil {
+			b.Errorf("Error parsing args: %v", err)
+		}
+	}
+}

--- a/pkg/events/parse_args_test.go
+++ b/pkg/events/parse_args_test.go
@@ -13,6 +13,78 @@ import (
 func TestParseArgs(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Parse pointer value", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name         string
+			args         []trace.Argument
+			expectedArgs []trace.Argument
+		}{
+			{
+				name: "ptrace addr arg",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "addr",
+							Type: "void*",
+						},
+						Value: ^uintptr(0),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "addr",
+							Type: "void*",
+						},
+						Value: "0xffffffffffffffff",
+					},
+				},
+			},
+			{
+				name: "ptrace addr arg",
+				args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "addr",
+							Type: "void*",
+						},
+						Value: uintptr(0x42424242),
+					},
+				},
+				expectedArgs: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "addr",
+							Type: "void*",
+						},
+						Value: "0x42424242",
+					},
+				},
+			},
+		}
+
+		for _, testCase := range testCases {
+			testCase := testCase
+
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				event := trace.Event{
+					EventID: int(Ptrace),
+					Args:    testCase.args,
+				}
+				err := ParseArgs(&event)
+				require.NoError(t, err)
+				for _, expArg := range testCase.expectedArgs {
+					arg := GetArg(&event, expArg.Name)
+					assert.Equal(t, expArg, *arg)
+				}
+			})
+		}
+	})
+
 	t.Run("Parse setsockopt value", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
### 1. Explain what the PR does

8d86c0c5d **chore(events): optimize ParseArgs for uintptr conv**
d4144ae50 **chore(events): improve flag parsing performance**


8d86c0c5d **chore(events): optimize ParseArgs for uintptr conv**

```
- Improved execution time by 20.78% and reduced byte operations by 55%.
- Changed loop to iterate by index for direct modification of
  argument values instead of iterating again via SetArgValue.
- Replaced string concatenation with strconv.AppendUint for efficient
  string construction.

Running tool: /home/gg/.goenv/versions/1.22.4/bin/go test -benchmem
-run=^$ -tags ebpf
-bench ^(BenchmarkParseArgs_Uintptr|BenchmarkParseArgs_Old)$
github.com/aquasecurity/tracee/pkg/events -benchtime=10000000x -race

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/events
cpu: AMD Ryzen 9 7950X 16-Core Processor
=== RUN   BenchmarkParseArgs_Uintptr
BenchmarkParseArgs_Uintptr
BenchmarkParseArgs_Uintptr-32     10000000               609.9 ns/op           144 B/op          7 allocs/op
=== RUN   BenchmarkParseArgs_Old
BenchmarkParseArgs_Old
BenchmarkParseArgs_Old-32         10000000               769.7 ns/op           320 B/op          8 allocs/op
PASS
ok      github.com/aquasecurity/tracee/pkg/events       14.829s
```

d4144ae50 **chore(events): improve flag parsing performance**

```
Move helpers functions out of the ParseArgs method which reduces the
overhead of defining closures on each call to ParseArgs.

It reduces ~13,3% of processing time in 10mi iterations, as benchmarked
below:

Running tool: /home/gg/.goenv/versions/1.22.4/bin/go test -benchmem
-run=^$ -tags ebpf -bench ^(BenchmarkParseArgs|BenchmarkParseArgsOld)$
github.com/aquasecurity/tracee/pkg/events -benchtime=10000000x -race

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/events
cpu: AMD Ryzen 9 7950X 16-Core Processor
=== RUN   BenchmarkParseArgs
BenchmarkParseArgs
BenchmarkParseArgs-32           10000000 2190 ns/op  0 B/op  0 allocs/op
=== RUN   BenchmarkParseArgsOld
BenchmarkParseArgsOld
BenchmarkParseArgsOld-32        10000000 2526 ns/op  0 B/op  0 allocs/op
PASS
ok      github.com/aquasecurity/tracee/pkg/events       48.189s
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

Note that the benchmark measurements are non-deterministic.
