### PR TITLE
optimize parser options check

### DIFF
--- a/pkg/events/parsers/data_parsers.go
+++ b/pkg/events/parsers/data_parsers.go
@@ -18,16 +18,15 @@ type SystemFunctionArgument interface {
 	Value() uint64
 }
 
-// OptionsAreContainedInArgument checks whether the argument (rawArgument)
+// optionsAreContainedInArgument checks whether the argument (rawArgument)
 // contains all of the 'options' such as with flags passed to the clone flag.
-// This function takes an arbitrary number of SystemCallArguments. It will
-// only return true if each and every option is present in rawArgument.
+// This function takes an arbitrary number of uint64.
+// It will only return true if each and every option is present in rawArgument.
 // Typically linux syscalls have multiple options specified in a single
 // argument via bitmasks = which this function checks for.
-func OptionsAreContainedInArgument(rawArgument uint64, options ...SystemFunctionArgument) bool {
+func optionsAreContainedInArgument(rawArgument uint64, options ...uint64) bool {
 	for _, opt := range options {
-		optValue := opt.Value()
-		if rawArgument&optValue != optValue {
+		if rawArgument&opt != opt {
 			return false
 		}
 	}
@@ -81,76 +80,76 @@ func ParseCloneFlags(rawValue uint64) (CloneFlagArgument, error) {
 	}
 
 	var f []string
-	if OptionsAreContainedInArgument(rawValue, CLONE_VM) {
+	if optionsAreContainedInArgument(rawValue, CLONE_VM.Value()) {
 		f = append(f, CLONE_VM.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_FS) {
+	if optionsAreContainedInArgument(rawValue, CLONE_FS.Value()) {
 		f = append(f, CLONE_FS.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_FILES) {
+	if optionsAreContainedInArgument(rawValue, CLONE_FILES.Value()) {
 		f = append(f, CLONE_FILES.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_SIGHAND) {
+	if optionsAreContainedInArgument(rawValue, CLONE_SIGHAND.Value()) {
 		f = append(f, CLONE_SIGHAND.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_PIDFD) {
+	if optionsAreContainedInArgument(rawValue, CLONE_PIDFD.Value()) {
 		f = append(f, CLONE_PIDFD.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_PTRACE) {
+	if optionsAreContainedInArgument(rawValue, CLONE_PTRACE.Value()) {
 		f = append(f, CLONE_PTRACE.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_VFORK) {
+	if optionsAreContainedInArgument(rawValue, CLONE_VFORK.Value()) {
 		f = append(f, CLONE_VFORK.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_PARENT) {
+	if optionsAreContainedInArgument(rawValue, CLONE_PARENT.Value()) {
 		f = append(f, CLONE_PARENT.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_THREAD) {
+	if optionsAreContainedInArgument(rawValue, CLONE_THREAD.Value()) {
 		f = append(f, CLONE_THREAD.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWNS) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWNS.Value()) {
 		f = append(f, CLONE_NEWNS.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_SYSVSEM) {
+	if optionsAreContainedInArgument(rawValue, CLONE_SYSVSEM.Value()) {
 		f = append(f, CLONE_SYSVSEM.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_SETTLS) {
+	if optionsAreContainedInArgument(rawValue, CLONE_SETTLS.Value()) {
 		f = append(f, CLONE_SETTLS.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_PARENT_SETTID) {
+	if optionsAreContainedInArgument(rawValue, CLONE_PARENT_SETTID.Value()) {
 		f = append(f, CLONE_PARENT_SETTID.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_CHILD_CLEARTID) {
+	if optionsAreContainedInArgument(rawValue, CLONE_CHILD_CLEARTID.Value()) {
 		f = append(f, CLONE_CHILD_CLEARTID.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_DETACHED) {
+	if optionsAreContainedInArgument(rawValue, CLONE_DETACHED.Value()) {
 		f = append(f, CLONE_DETACHED.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_UNTRACED) {
+	if optionsAreContainedInArgument(rawValue, CLONE_UNTRACED.Value()) {
 		f = append(f, CLONE_UNTRACED.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_CHILD_SETTID) {
+	if optionsAreContainedInArgument(rawValue, CLONE_CHILD_SETTID.Value()) {
 		f = append(f, CLONE_CHILD_SETTID.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWCGROUP) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWCGROUP.Value()) {
 		f = append(f, CLONE_NEWCGROUP.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWUTS) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWUTS.Value()) {
 		f = append(f, CLONE_NEWUTS.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWIPC) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWIPC.Value()) {
 		f = append(f, CLONE_NEWIPC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWUSER) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWUSER.Value()) {
 		f = append(f, CLONE_NEWUSER.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWPID) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWPID.Value()) {
 		f = append(f, CLONE_NEWPID.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_NEWNET) {
+	if optionsAreContainedInArgument(rawValue, CLONE_NEWNET.Value()) {
 		f = append(f, CLONE_NEWNET.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, CLONE_IO) {
+	if optionsAreContainedInArgument(rawValue, CLONE_IO.Value()) {
 		f = append(f, CLONE_IO.String())
 	}
 	if len(f) == 0 {
@@ -208,61 +207,61 @@ func ParseOpenFlagArgument(rawValue uint64) (OpenFlagArgument, error) {
 
 	// access mode
 	switch {
-	case OptionsAreContainedInArgument(rawValue, O_WRONLY):
+	case optionsAreContainedInArgument(rawValue, O_WRONLY.Value()):
 		f = append(f, O_WRONLY.String())
-	case OptionsAreContainedInArgument(rawValue, O_RDWR):
+	case optionsAreContainedInArgument(rawValue, O_RDWR.Value()):
 		f = append(f, O_RDWR.String())
 	default:
 		f = append(f, O_RDONLY.String())
 	}
 
 	// file creation and status flags
-	if OptionsAreContainedInArgument(rawValue, O_CREAT) {
+	if optionsAreContainedInArgument(rawValue, O_CREAT.Value()) {
 		f = append(f, O_CREAT.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_EXCL) {
+	if optionsAreContainedInArgument(rawValue, O_EXCL.Value()) {
 		f = append(f, O_EXCL.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_NOCTTY) {
+	if optionsAreContainedInArgument(rawValue, O_NOCTTY.Value()) {
 		f = append(f, O_NOCTTY.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_TRUNC) {
+	if optionsAreContainedInArgument(rawValue, O_TRUNC.Value()) {
 		f = append(f, O_TRUNC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_APPEND) {
+	if optionsAreContainedInArgument(rawValue, O_APPEND.Value()) {
 		f = append(f, O_APPEND.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_NONBLOCK) {
+	if optionsAreContainedInArgument(rawValue, O_NONBLOCK.Value()) {
 		f = append(f, O_NONBLOCK.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_SYNC) {
+	if optionsAreContainedInArgument(rawValue, O_SYNC.Value()) {
 		f = append(f, O_SYNC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, FASYNC) {
+	if optionsAreContainedInArgument(rawValue, FASYNC.Value()) {
 		f = append(f, FASYNC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_LARGEFILE) {
+	if optionsAreContainedInArgument(rawValue, O_LARGEFILE.Value()) {
 		f = append(f, O_LARGEFILE.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_DIRECTORY) {
+	if optionsAreContainedInArgument(rawValue, O_DIRECTORY.Value()) {
 		f = append(f, O_DIRECTORY.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_NOFOLLOW) {
+	if optionsAreContainedInArgument(rawValue, O_NOFOLLOW.Value()) {
 		f = append(f, O_NOFOLLOW.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_CLOEXEC) {
+	if optionsAreContainedInArgument(rawValue, O_CLOEXEC.Value()) {
 		f = append(f, O_CLOEXEC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_DIRECT) {
+	if optionsAreContainedInArgument(rawValue, O_DIRECT.Value()) {
 		f = append(f, O_DIRECT.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_NOATIME) {
+	if optionsAreContainedInArgument(rawValue, O_NOATIME.Value()) {
 		f = append(f, O_NOATIME.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_PATH) {
+	if optionsAreContainedInArgument(rawValue, O_PATH.Value()) {
 		f = append(f, O_PATH.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, O_TMPFILE) {
+	if optionsAreContainedInArgument(rawValue, O_TMPFILE.Value()) {
 		f = append(f, O_TMPFILE.String())
 	}
 
@@ -303,13 +302,13 @@ func ParseAccessMode(rawValue uint64) (AccessModeArgument, error) {
 	if rawValue == 0x0 {
 		f = append(f, F_OK.String())
 	} else {
-		if OptionsAreContainedInArgument(rawValue, R_OK) {
+		if optionsAreContainedInArgument(rawValue, R_OK.Value()) {
 			f = append(f, R_OK.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, W_OK) {
+		if optionsAreContainedInArgument(rawValue, W_OK.Value()) {
 			f = append(f, W_OK.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, X_OK) {
+		if optionsAreContainedInArgument(rawValue, X_OK.Value()) {
 			f = append(f, X_OK.String())
 		}
 	}
@@ -353,31 +352,31 @@ func ParseExecFlag(rawValue uint64) (ExecFlagArgument, error) {
 	}
 
 	var f []string
-	if OptionsAreContainedInArgument(rawValue, AT_EMPTY_PATH) {
+	if optionsAreContainedInArgument(rawValue, AT_EMPTY_PATH.Value()) {
 		f = append(f, AT_EMPTY_PATH.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_SYMLINK_NOFOLLOW) {
+	if optionsAreContainedInArgument(rawValue, AT_SYMLINK_NOFOLLOW.Value()) {
 		f = append(f, AT_SYMLINK_NOFOLLOW.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_EACCESS) {
+	if optionsAreContainedInArgument(rawValue, AT_EACCESS.Value()) {
 		f = append(f, AT_EACCESS.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_REMOVEDIR) {
+	if optionsAreContainedInArgument(rawValue, AT_REMOVEDIR.Value()) {
 		f = append(f, AT_REMOVEDIR.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_NO_AUTOMOUNT) {
+	if optionsAreContainedInArgument(rawValue, AT_NO_AUTOMOUNT.Value()) {
 		f = append(f, AT_NO_AUTOMOUNT.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_STATX_SYNC_TYPE) {
+	if optionsAreContainedInArgument(rawValue, AT_STATX_SYNC_TYPE.Value()) {
 		f = append(f, AT_STATX_SYNC_TYPE.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_STATX_FORCE_SYNC) {
+	if optionsAreContainedInArgument(rawValue, AT_STATX_FORCE_SYNC.Value()) {
 		f = append(f, AT_STATX_FORCE_SYNC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_STATX_DONT_SYNC) {
+	if optionsAreContainedInArgument(rawValue, AT_STATX_DONT_SYNC.Value()) {
 		f = append(f, AT_STATX_DONT_SYNC.String())
 	}
-	if OptionsAreContainedInArgument(rawValue, AT_RECURSIVE) {
+	if optionsAreContainedInArgument(rawValue, AT_RECURSIVE.Value()) {
 		f = append(f, AT_RECURSIVE.String())
 	}
 	if len(f) == 0 {
@@ -1315,10 +1314,10 @@ func ParseSocketType(rawValue uint64) (SocketTypeArgument, error) {
 		f = append(f, strconv.Itoa(int(rawValue)))
 	}
 
-	if OptionsAreContainedInArgument(rawValue, SOCK_NONBLOCK) {
+	if optionsAreContainedInArgument(rawValue, SOCK_NONBLOCK.Value()) {
 		f = append(f, "SOCK_NONBLOCK")
 	}
-	if OptionsAreContainedInArgument(rawValue, SOCK_CLOEXEC) {
+	if optionsAreContainedInArgument(rawValue, SOCK_CLOEXEC.Value()) {
 		f = append(f, "SOCK_CLOEXEC")
 	}
 
@@ -1364,62 +1363,62 @@ func ParseInodeMode(rawValue uint64) (InodeModeArgument, error) {
 
 	// File Type
 	switch {
-	case OptionsAreContainedInArgument(rawValue, S_IFSOCK):
+	case optionsAreContainedInArgument(rawValue, S_IFSOCK.Value()):
 		f = append(f, S_IFSOCK.String())
-	case OptionsAreContainedInArgument(rawValue, S_IFLNK):
+	case optionsAreContainedInArgument(rawValue, S_IFLNK.Value()):
 		f = append(f, S_IFLNK.String())
-	case OptionsAreContainedInArgument(rawValue, S_IFREG):
+	case optionsAreContainedInArgument(rawValue, S_IFREG.Value()):
 		f = append(f, S_IFREG.String())
-	case OptionsAreContainedInArgument(rawValue, S_IFBLK):
+	case optionsAreContainedInArgument(rawValue, S_IFBLK.Value()):
 		f = append(f, S_IFBLK.String())
-	case OptionsAreContainedInArgument(rawValue, S_IFDIR):
+	case optionsAreContainedInArgument(rawValue, S_IFDIR.Value()):
 		f = append(f, S_IFDIR.String())
-	case OptionsAreContainedInArgument(rawValue, S_IFCHR):
+	case optionsAreContainedInArgument(rawValue, S_IFCHR.Value()):
 		f = append(f, S_IFCHR.String())
-	case OptionsAreContainedInArgument(rawValue, S_IFIFO):
+	case optionsAreContainedInArgument(rawValue, S_IFIFO.Value()):
 		f = append(f, S_IFIFO.String())
 	}
 
 	// File Mode
 	// Owner
-	if OptionsAreContainedInArgument(rawValue, S_IRWXU) {
+	if optionsAreContainedInArgument(rawValue, S_IRWXU.Value()) {
 		f = append(f, S_IRWXU.String())
 	} else {
-		if OptionsAreContainedInArgument(rawValue, S_IRUSR) {
+		if optionsAreContainedInArgument(rawValue, S_IRUSR.Value()) {
 			f = append(f, S_IRUSR.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, S_IWUSR) {
+		if optionsAreContainedInArgument(rawValue, S_IWUSR.Value()) {
 			f = append(f, S_IWUSR.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, S_IXUSR) {
+		if optionsAreContainedInArgument(rawValue, S_IXUSR.Value()) {
 			f = append(f, S_IXUSR.String())
 		}
 	}
 	// Group
-	if OptionsAreContainedInArgument(rawValue, S_IRWXG) {
+	if optionsAreContainedInArgument(rawValue, S_IRWXG.Value()) {
 		f = append(f, S_IRWXG.String())
 	} else {
-		if OptionsAreContainedInArgument(rawValue, S_IRGRP) {
+		if optionsAreContainedInArgument(rawValue, S_IRGRP.Value()) {
 			f = append(f, S_IRGRP.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, S_IWGRP) {
+		if optionsAreContainedInArgument(rawValue, S_IWGRP.Value()) {
 			f = append(f, S_IWGRP.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, S_IXGRP) {
+		if optionsAreContainedInArgument(rawValue, S_IXGRP.Value()) {
 			f = append(f, S_IXGRP.String())
 		}
 	}
 	// Others
-	if OptionsAreContainedInArgument(rawValue, S_IRWXO) {
+	if optionsAreContainedInArgument(rawValue, S_IRWXO.Value()) {
 		f = append(f, S_IRWXO.String())
 	} else {
-		if OptionsAreContainedInArgument(rawValue, S_IROTH) {
+		if optionsAreContainedInArgument(rawValue, S_IROTH.Value()) {
 			f = append(f, S_IROTH.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, S_IWOTH) {
+		if optionsAreContainedInArgument(rawValue, S_IWOTH.Value()) {
 			f = append(f, S_IWOTH.String())
 		}
-		if OptionsAreContainedInArgument(rawValue, S_IXOTH) {
+		if optionsAreContainedInArgument(rawValue, S_IXOTH.Value()) {
 			f = append(f, S_IXOTH.String())
 		}
 	}
@@ -1469,7 +1468,7 @@ func ParseMmapProt(rawValue uint64) MmapProtArgument {
 
 	var sb strings.Builder
 	for _, a := range mmapProtArgs {
-		if OptionsAreContainedInArgument(rawValue, a) {
+		if optionsAreContainedInArgument(rawValue, a.Value()) {
 			if sb.Len() > 0 {
 				sb.WriteByte('|')
 			}

--- a/pkg/events/parsers/data_parsers.go
+++ b/pkg/events/parsers/data_parsers.go
@@ -18,18 +18,21 @@ type SystemFunctionArgument interface {
 	Value() uint64
 }
 
-// OptionAreContainedInArgument checks whether the argument (rawArgument)
+// OptionsAreContainedInArgument checks whether the argument (rawArgument)
 // contains all of the 'options' such as with flags passed to the clone flag.
-// This function takes an arbitrary number of SystemCallArguments.It will
+// This function takes an arbitrary number of SystemCallArguments. It will
 // only return true if each and every option is present in rawArgument.
 // Typically linux syscalls have multiple options specified in a single
 // argument via bitmasks = which this function checks for.
-func OptionAreContainedInArgument(rawArgument uint64, options ...SystemFunctionArgument) bool {
-	var isPresent = true
-	for _, option := range options {
-		isPresent = isPresent && (option.Value()&rawArgument == option.Value())
+func OptionsAreContainedInArgument(rawArgument uint64, options ...SystemFunctionArgument) bool {
+	for _, opt := range options {
+		optValue := opt.Value()
+		if rawArgument&optValue != optValue {
+			return false
+		}
 	}
-	return isPresent
+
+	return true
 }
 
 type CloneFlagArgument struct {
@@ -78,76 +81,76 @@ func ParseCloneFlags(rawValue uint64) (CloneFlagArgument, error) {
 	}
 
 	var f []string
-	if OptionAreContainedInArgument(rawValue, CLONE_VM) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_VM) {
 		f = append(f, CLONE_VM.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_FS) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_FS) {
 		f = append(f, CLONE_FS.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_FILES) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_FILES) {
 		f = append(f, CLONE_FILES.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_SIGHAND) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_SIGHAND) {
 		f = append(f, CLONE_SIGHAND.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_PIDFD) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_PIDFD) {
 		f = append(f, CLONE_PIDFD.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_PTRACE) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_PTRACE) {
 		f = append(f, CLONE_PTRACE.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_VFORK) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_VFORK) {
 		f = append(f, CLONE_VFORK.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_PARENT) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_PARENT) {
 		f = append(f, CLONE_PARENT.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_THREAD) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_THREAD) {
 		f = append(f, CLONE_THREAD.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWNS) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWNS) {
 		f = append(f, CLONE_NEWNS.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_SYSVSEM) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_SYSVSEM) {
 		f = append(f, CLONE_SYSVSEM.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_SETTLS) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_SETTLS) {
 		f = append(f, CLONE_SETTLS.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_PARENT_SETTID) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_PARENT_SETTID) {
 		f = append(f, CLONE_PARENT_SETTID.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_CHILD_CLEARTID) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_CHILD_CLEARTID) {
 		f = append(f, CLONE_CHILD_CLEARTID.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_DETACHED) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_DETACHED) {
 		f = append(f, CLONE_DETACHED.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_UNTRACED) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_UNTRACED) {
 		f = append(f, CLONE_UNTRACED.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_CHILD_SETTID) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_CHILD_SETTID) {
 		f = append(f, CLONE_CHILD_SETTID.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWCGROUP) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWCGROUP) {
 		f = append(f, CLONE_NEWCGROUP.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWUTS) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWUTS) {
 		f = append(f, CLONE_NEWUTS.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWIPC) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWIPC) {
 		f = append(f, CLONE_NEWIPC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWUSER) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWUSER) {
 		f = append(f, CLONE_NEWUSER.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWPID) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWPID) {
 		f = append(f, CLONE_NEWPID.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_NEWNET) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_NEWNET) {
 		f = append(f, CLONE_NEWNET.String())
 	}
-	if OptionAreContainedInArgument(rawValue, CLONE_IO) {
+	if OptionsAreContainedInArgument(rawValue, CLONE_IO) {
 		f = append(f, CLONE_IO.String())
 	}
 	if len(f) == 0 {
@@ -205,61 +208,61 @@ func ParseOpenFlagArgument(rawValue uint64) (OpenFlagArgument, error) {
 
 	// access mode
 	switch {
-	case OptionAreContainedInArgument(rawValue, O_WRONLY):
+	case OptionsAreContainedInArgument(rawValue, O_WRONLY):
 		f = append(f, O_WRONLY.String())
-	case OptionAreContainedInArgument(rawValue, O_RDWR):
+	case OptionsAreContainedInArgument(rawValue, O_RDWR):
 		f = append(f, O_RDWR.String())
 	default:
 		f = append(f, O_RDONLY.String())
 	}
 
 	// file creation and status flags
-	if OptionAreContainedInArgument(rawValue, O_CREAT) {
+	if OptionsAreContainedInArgument(rawValue, O_CREAT) {
 		f = append(f, O_CREAT.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_EXCL) {
+	if OptionsAreContainedInArgument(rawValue, O_EXCL) {
 		f = append(f, O_EXCL.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_NOCTTY) {
+	if OptionsAreContainedInArgument(rawValue, O_NOCTTY) {
 		f = append(f, O_NOCTTY.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_TRUNC) {
+	if OptionsAreContainedInArgument(rawValue, O_TRUNC) {
 		f = append(f, O_TRUNC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_APPEND) {
+	if OptionsAreContainedInArgument(rawValue, O_APPEND) {
 		f = append(f, O_APPEND.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_NONBLOCK) {
+	if OptionsAreContainedInArgument(rawValue, O_NONBLOCK) {
 		f = append(f, O_NONBLOCK.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_SYNC) {
+	if OptionsAreContainedInArgument(rawValue, O_SYNC) {
 		f = append(f, O_SYNC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, FASYNC) {
+	if OptionsAreContainedInArgument(rawValue, FASYNC) {
 		f = append(f, FASYNC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_LARGEFILE) {
+	if OptionsAreContainedInArgument(rawValue, O_LARGEFILE) {
 		f = append(f, O_LARGEFILE.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_DIRECTORY) {
+	if OptionsAreContainedInArgument(rawValue, O_DIRECTORY) {
 		f = append(f, O_DIRECTORY.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_NOFOLLOW) {
+	if OptionsAreContainedInArgument(rawValue, O_NOFOLLOW) {
 		f = append(f, O_NOFOLLOW.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_CLOEXEC) {
+	if OptionsAreContainedInArgument(rawValue, O_CLOEXEC) {
 		f = append(f, O_CLOEXEC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_DIRECT) {
+	if OptionsAreContainedInArgument(rawValue, O_DIRECT) {
 		f = append(f, O_DIRECT.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_NOATIME) {
+	if OptionsAreContainedInArgument(rawValue, O_NOATIME) {
 		f = append(f, O_NOATIME.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_PATH) {
+	if OptionsAreContainedInArgument(rawValue, O_PATH) {
 		f = append(f, O_PATH.String())
 	}
-	if OptionAreContainedInArgument(rawValue, O_TMPFILE) {
+	if OptionsAreContainedInArgument(rawValue, O_TMPFILE) {
 		f = append(f, O_TMPFILE.String())
 	}
 
@@ -300,13 +303,13 @@ func ParseAccessMode(rawValue uint64) (AccessModeArgument, error) {
 	if rawValue == 0x0 {
 		f = append(f, F_OK.String())
 	} else {
-		if OptionAreContainedInArgument(rawValue, R_OK) {
+		if OptionsAreContainedInArgument(rawValue, R_OK) {
 			f = append(f, R_OK.String())
 		}
-		if OptionAreContainedInArgument(rawValue, W_OK) {
+		if OptionsAreContainedInArgument(rawValue, W_OK) {
 			f = append(f, W_OK.String())
 		}
-		if OptionAreContainedInArgument(rawValue, X_OK) {
+		if OptionsAreContainedInArgument(rawValue, X_OK) {
 			f = append(f, X_OK.String())
 		}
 	}
@@ -350,31 +353,31 @@ func ParseExecFlag(rawValue uint64) (ExecFlagArgument, error) {
 	}
 
 	var f []string
-	if OptionAreContainedInArgument(rawValue, AT_EMPTY_PATH) {
+	if OptionsAreContainedInArgument(rawValue, AT_EMPTY_PATH) {
 		f = append(f, AT_EMPTY_PATH.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_SYMLINK_NOFOLLOW) {
+	if OptionsAreContainedInArgument(rawValue, AT_SYMLINK_NOFOLLOW) {
 		f = append(f, AT_SYMLINK_NOFOLLOW.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_EACCESS) {
+	if OptionsAreContainedInArgument(rawValue, AT_EACCESS) {
 		f = append(f, AT_EACCESS.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_REMOVEDIR) {
+	if OptionsAreContainedInArgument(rawValue, AT_REMOVEDIR) {
 		f = append(f, AT_REMOVEDIR.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_NO_AUTOMOUNT) {
+	if OptionsAreContainedInArgument(rawValue, AT_NO_AUTOMOUNT) {
 		f = append(f, AT_NO_AUTOMOUNT.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_STATX_SYNC_TYPE) {
+	if OptionsAreContainedInArgument(rawValue, AT_STATX_SYNC_TYPE) {
 		f = append(f, AT_STATX_SYNC_TYPE.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_STATX_FORCE_SYNC) {
+	if OptionsAreContainedInArgument(rawValue, AT_STATX_FORCE_SYNC) {
 		f = append(f, AT_STATX_FORCE_SYNC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_STATX_DONT_SYNC) {
+	if OptionsAreContainedInArgument(rawValue, AT_STATX_DONT_SYNC) {
 		f = append(f, AT_STATX_DONT_SYNC.String())
 	}
-	if OptionAreContainedInArgument(rawValue, AT_RECURSIVE) {
+	if OptionsAreContainedInArgument(rawValue, AT_RECURSIVE) {
 		f = append(f, AT_RECURSIVE.String())
 	}
 	if len(f) == 0 {
@@ -1312,10 +1315,10 @@ func ParseSocketType(rawValue uint64) (SocketTypeArgument, error) {
 		f = append(f, strconv.Itoa(int(rawValue)))
 	}
 
-	if OptionAreContainedInArgument(rawValue, SOCK_NONBLOCK) {
+	if OptionsAreContainedInArgument(rawValue, SOCK_NONBLOCK) {
 		f = append(f, "SOCK_NONBLOCK")
 	}
-	if OptionAreContainedInArgument(rawValue, SOCK_CLOEXEC) {
+	if OptionsAreContainedInArgument(rawValue, SOCK_CLOEXEC) {
 		f = append(f, "SOCK_CLOEXEC")
 	}
 
@@ -1361,62 +1364,62 @@ func ParseInodeMode(rawValue uint64) (InodeModeArgument, error) {
 
 	// File Type
 	switch {
-	case OptionAreContainedInArgument(rawValue, S_IFSOCK):
+	case OptionsAreContainedInArgument(rawValue, S_IFSOCK):
 		f = append(f, S_IFSOCK.String())
-	case OptionAreContainedInArgument(rawValue, S_IFLNK):
+	case OptionsAreContainedInArgument(rawValue, S_IFLNK):
 		f = append(f, S_IFLNK.String())
-	case OptionAreContainedInArgument(rawValue, S_IFREG):
+	case OptionsAreContainedInArgument(rawValue, S_IFREG):
 		f = append(f, S_IFREG.String())
-	case OptionAreContainedInArgument(rawValue, S_IFBLK):
+	case OptionsAreContainedInArgument(rawValue, S_IFBLK):
 		f = append(f, S_IFBLK.String())
-	case OptionAreContainedInArgument(rawValue, S_IFDIR):
+	case OptionsAreContainedInArgument(rawValue, S_IFDIR):
 		f = append(f, S_IFDIR.String())
-	case OptionAreContainedInArgument(rawValue, S_IFCHR):
+	case OptionsAreContainedInArgument(rawValue, S_IFCHR):
 		f = append(f, S_IFCHR.String())
-	case OptionAreContainedInArgument(rawValue, S_IFIFO):
+	case OptionsAreContainedInArgument(rawValue, S_IFIFO):
 		f = append(f, S_IFIFO.String())
 	}
 
 	// File Mode
 	// Owner
-	if OptionAreContainedInArgument(rawValue, S_IRWXU) {
+	if OptionsAreContainedInArgument(rawValue, S_IRWXU) {
 		f = append(f, S_IRWXU.String())
 	} else {
-		if OptionAreContainedInArgument(rawValue, S_IRUSR) {
+		if OptionsAreContainedInArgument(rawValue, S_IRUSR) {
 			f = append(f, S_IRUSR.String())
 		}
-		if OptionAreContainedInArgument(rawValue, S_IWUSR) {
+		if OptionsAreContainedInArgument(rawValue, S_IWUSR) {
 			f = append(f, S_IWUSR.String())
 		}
-		if OptionAreContainedInArgument(rawValue, S_IXUSR) {
+		if OptionsAreContainedInArgument(rawValue, S_IXUSR) {
 			f = append(f, S_IXUSR.String())
 		}
 	}
 	// Group
-	if OptionAreContainedInArgument(rawValue, S_IRWXG) {
+	if OptionsAreContainedInArgument(rawValue, S_IRWXG) {
 		f = append(f, S_IRWXG.String())
 	} else {
-		if OptionAreContainedInArgument(rawValue, S_IRGRP) {
+		if OptionsAreContainedInArgument(rawValue, S_IRGRP) {
 			f = append(f, S_IRGRP.String())
 		}
-		if OptionAreContainedInArgument(rawValue, S_IWGRP) {
+		if OptionsAreContainedInArgument(rawValue, S_IWGRP) {
 			f = append(f, S_IWGRP.String())
 		}
-		if OptionAreContainedInArgument(rawValue, S_IXGRP) {
+		if OptionsAreContainedInArgument(rawValue, S_IXGRP) {
 			f = append(f, S_IXGRP.String())
 		}
 	}
 	// Others
-	if OptionAreContainedInArgument(rawValue, S_IRWXO) {
+	if OptionsAreContainedInArgument(rawValue, S_IRWXO) {
 		f = append(f, S_IRWXO.String())
 	} else {
-		if OptionAreContainedInArgument(rawValue, S_IROTH) {
+		if OptionsAreContainedInArgument(rawValue, S_IROTH) {
 			f = append(f, S_IROTH.String())
 		}
-		if OptionAreContainedInArgument(rawValue, S_IWOTH) {
+		if OptionsAreContainedInArgument(rawValue, S_IWOTH) {
 			f = append(f, S_IWOTH.String())
 		}
-		if OptionAreContainedInArgument(rawValue, S_IXOTH) {
+		if OptionsAreContainedInArgument(rawValue, S_IXOTH) {
 			f = append(f, S_IXOTH.String())
 		}
 	}
@@ -1466,7 +1469,7 @@ func ParseMmapProt(rawValue uint64) MmapProtArgument {
 
 	var sb strings.Builder
 	for _, a := range mmapProtArgs {
-		if OptionAreContainedInArgument(rawValue, a) {
+		if OptionsAreContainedInArgument(rawValue, a) {
 			if sb.Len() > 0 {
 				sb.WriteByte('|')
 			}

--- a/pkg/events/parsers/data_parsers.go
+++ b/pkg/events/parsers/data_parsers.go
@@ -34,6 +34,12 @@ func optionsAreContainedInArgument(rawArgument uint64, options ...uint64) bool {
 	return true
 }
 
+// optionIsContainedInArgument checks whether the argument (rawArgument)
+// contains the 'option'.
+func optionIsContainedInArgument(rawArgument uint64, option uint64) bool {
+	return rawArgument&option == option
+}
+
 type CloneFlagArgument struct {
 	rawValue    uint64
 	stringValue string
@@ -80,76 +86,76 @@ func ParseCloneFlags(rawValue uint64) (CloneFlagArgument, error) {
 	}
 
 	var f []string
-	if optionsAreContainedInArgument(rawValue, CLONE_VM.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_VM.Value()) {
 		f = append(f, CLONE_VM.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_FS.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_FS.Value()) {
 		f = append(f, CLONE_FS.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_FILES.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_FILES.Value()) {
 		f = append(f, CLONE_FILES.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_SIGHAND.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_SIGHAND.Value()) {
 		f = append(f, CLONE_SIGHAND.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_PIDFD.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_PIDFD.Value()) {
 		f = append(f, CLONE_PIDFD.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_PTRACE.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_PTRACE.Value()) {
 		f = append(f, CLONE_PTRACE.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_VFORK.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_VFORK.Value()) {
 		f = append(f, CLONE_VFORK.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_PARENT.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_PARENT.Value()) {
 		f = append(f, CLONE_PARENT.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_THREAD.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_THREAD.Value()) {
 		f = append(f, CLONE_THREAD.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWNS.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWNS.Value()) {
 		f = append(f, CLONE_NEWNS.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_SYSVSEM.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_SYSVSEM.Value()) {
 		f = append(f, CLONE_SYSVSEM.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_SETTLS.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_SETTLS.Value()) {
 		f = append(f, CLONE_SETTLS.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_PARENT_SETTID.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_PARENT_SETTID.Value()) {
 		f = append(f, CLONE_PARENT_SETTID.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_CHILD_CLEARTID.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_CHILD_CLEARTID.Value()) {
 		f = append(f, CLONE_CHILD_CLEARTID.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_DETACHED.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_DETACHED.Value()) {
 		f = append(f, CLONE_DETACHED.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_UNTRACED.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_UNTRACED.Value()) {
 		f = append(f, CLONE_UNTRACED.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_CHILD_SETTID.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_CHILD_SETTID.Value()) {
 		f = append(f, CLONE_CHILD_SETTID.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWCGROUP.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWCGROUP.Value()) {
 		f = append(f, CLONE_NEWCGROUP.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWUTS.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWUTS.Value()) {
 		f = append(f, CLONE_NEWUTS.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWIPC.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWIPC.Value()) {
 		f = append(f, CLONE_NEWIPC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWUSER.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWUSER.Value()) {
 		f = append(f, CLONE_NEWUSER.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWPID.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWPID.Value()) {
 		f = append(f, CLONE_NEWPID.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_NEWNET.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_NEWNET.Value()) {
 		f = append(f, CLONE_NEWNET.String())
 	}
-	if optionsAreContainedInArgument(rawValue, CLONE_IO.Value()) {
+	if optionIsContainedInArgument(rawValue, CLONE_IO.Value()) {
 		f = append(f, CLONE_IO.String())
 	}
 	if len(f) == 0 {
@@ -207,61 +213,61 @@ func ParseOpenFlagArgument(rawValue uint64) (OpenFlagArgument, error) {
 
 	// access mode
 	switch {
-	case optionsAreContainedInArgument(rawValue, O_WRONLY.Value()):
+	case optionIsContainedInArgument(rawValue, O_WRONLY.Value()):
 		f = append(f, O_WRONLY.String())
-	case optionsAreContainedInArgument(rawValue, O_RDWR.Value()):
+	case optionIsContainedInArgument(rawValue, O_RDWR.Value()):
 		f = append(f, O_RDWR.String())
 	default:
 		f = append(f, O_RDONLY.String())
 	}
 
 	// file creation and status flags
-	if optionsAreContainedInArgument(rawValue, O_CREAT.Value()) {
+	if optionIsContainedInArgument(rawValue, O_CREAT.Value()) {
 		f = append(f, O_CREAT.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_EXCL.Value()) {
+	if optionIsContainedInArgument(rawValue, O_EXCL.Value()) {
 		f = append(f, O_EXCL.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_NOCTTY.Value()) {
+	if optionIsContainedInArgument(rawValue, O_NOCTTY.Value()) {
 		f = append(f, O_NOCTTY.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_TRUNC.Value()) {
+	if optionIsContainedInArgument(rawValue, O_TRUNC.Value()) {
 		f = append(f, O_TRUNC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_APPEND.Value()) {
+	if optionIsContainedInArgument(rawValue, O_APPEND.Value()) {
 		f = append(f, O_APPEND.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_NONBLOCK.Value()) {
+	if optionIsContainedInArgument(rawValue, O_NONBLOCK.Value()) {
 		f = append(f, O_NONBLOCK.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_SYNC.Value()) {
+	if optionIsContainedInArgument(rawValue, O_SYNC.Value()) {
 		f = append(f, O_SYNC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, FASYNC.Value()) {
+	if optionIsContainedInArgument(rawValue, FASYNC.Value()) {
 		f = append(f, FASYNC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_LARGEFILE.Value()) {
+	if optionIsContainedInArgument(rawValue, O_LARGEFILE.Value()) {
 		f = append(f, O_LARGEFILE.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_DIRECTORY.Value()) {
+	if optionIsContainedInArgument(rawValue, O_DIRECTORY.Value()) {
 		f = append(f, O_DIRECTORY.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_NOFOLLOW.Value()) {
+	if optionIsContainedInArgument(rawValue, O_NOFOLLOW.Value()) {
 		f = append(f, O_NOFOLLOW.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_CLOEXEC.Value()) {
+	if optionIsContainedInArgument(rawValue, O_CLOEXEC.Value()) {
 		f = append(f, O_CLOEXEC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_DIRECT.Value()) {
+	if optionIsContainedInArgument(rawValue, O_DIRECT.Value()) {
 		f = append(f, O_DIRECT.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_NOATIME.Value()) {
+	if optionIsContainedInArgument(rawValue, O_NOATIME.Value()) {
 		f = append(f, O_NOATIME.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_PATH.Value()) {
+	if optionIsContainedInArgument(rawValue, O_PATH.Value()) {
 		f = append(f, O_PATH.String())
 	}
-	if optionsAreContainedInArgument(rawValue, O_TMPFILE.Value()) {
+	if optionIsContainedInArgument(rawValue, O_TMPFILE.Value()) {
 		f = append(f, O_TMPFILE.String())
 	}
 
@@ -302,13 +308,13 @@ func ParseAccessMode(rawValue uint64) (AccessModeArgument, error) {
 	if rawValue == 0x0 {
 		f = append(f, F_OK.String())
 	} else {
-		if optionsAreContainedInArgument(rawValue, R_OK.Value()) {
+		if optionIsContainedInArgument(rawValue, R_OK.Value()) {
 			f = append(f, R_OK.String())
 		}
-		if optionsAreContainedInArgument(rawValue, W_OK.Value()) {
+		if optionIsContainedInArgument(rawValue, W_OK.Value()) {
 			f = append(f, W_OK.String())
 		}
-		if optionsAreContainedInArgument(rawValue, X_OK.Value()) {
+		if optionIsContainedInArgument(rawValue, X_OK.Value()) {
 			f = append(f, X_OK.String())
 		}
 	}
@@ -352,31 +358,31 @@ func ParseExecFlag(rawValue uint64) (ExecFlagArgument, error) {
 	}
 
 	var f []string
-	if optionsAreContainedInArgument(rawValue, AT_EMPTY_PATH.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_EMPTY_PATH.Value()) {
 		f = append(f, AT_EMPTY_PATH.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_SYMLINK_NOFOLLOW.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_SYMLINK_NOFOLLOW.Value()) {
 		f = append(f, AT_SYMLINK_NOFOLLOW.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_EACCESS.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_EACCESS.Value()) {
 		f = append(f, AT_EACCESS.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_REMOVEDIR.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_REMOVEDIR.Value()) {
 		f = append(f, AT_REMOVEDIR.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_NO_AUTOMOUNT.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_NO_AUTOMOUNT.Value()) {
 		f = append(f, AT_NO_AUTOMOUNT.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_STATX_SYNC_TYPE.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_STATX_SYNC_TYPE.Value()) {
 		f = append(f, AT_STATX_SYNC_TYPE.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_STATX_FORCE_SYNC.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_STATX_FORCE_SYNC.Value()) {
 		f = append(f, AT_STATX_FORCE_SYNC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_STATX_DONT_SYNC.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_STATX_DONT_SYNC.Value()) {
 		f = append(f, AT_STATX_DONT_SYNC.String())
 	}
-	if optionsAreContainedInArgument(rawValue, AT_RECURSIVE.Value()) {
+	if optionIsContainedInArgument(rawValue, AT_RECURSIVE.Value()) {
 		f = append(f, AT_RECURSIVE.String())
 	}
 	if len(f) == 0 {
@@ -1314,10 +1320,10 @@ func ParseSocketType(rawValue uint64) (SocketTypeArgument, error) {
 		f = append(f, strconv.Itoa(int(rawValue)))
 	}
 
-	if optionsAreContainedInArgument(rawValue, SOCK_NONBLOCK.Value()) {
+	if optionIsContainedInArgument(rawValue, SOCK_NONBLOCK.Value()) {
 		f = append(f, "SOCK_NONBLOCK")
 	}
-	if optionsAreContainedInArgument(rawValue, SOCK_CLOEXEC.Value()) {
+	if optionIsContainedInArgument(rawValue, SOCK_CLOEXEC.Value()) {
 		f = append(f, "SOCK_CLOEXEC")
 	}
 
@@ -1363,62 +1369,62 @@ func ParseInodeMode(rawValue uint64) (InodeModeArgument, error) {
 
 	// File Type
 	switch {
-	case optionsAreContainedInArgument(rawValue, S_IFSOCK.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFSOCK.Value()):
 		f = append(f, S_IFSOCK.String())
-	case optionsAreContainedInArgument(rawValue, S_IFLNK.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFLNK.Value()):
 		f = append(f, S_IFLNK.String())
-	case optionsAreContainedInArgument(rawValue, S_IFREG.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFREG.Value()):
 		f = append(f, S_IFREG.String())
-	case optionsAreContainedInArgument(rawValue, S_IFBLK.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFBLK.Value()):
 		f = append(f, S_IFBLK.String())
-	case optionsAreContainedInArgument(rawValue, S_IFDIR.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFDIR.Value()):
 		f = append(f, S_IFDIR.String())
-	case optionsAreContainedInArgument(rawValue, S_IFCHR.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFCHR.Value()):
 		f = append(f, S_IFCHR.String())
-	case optionsAreContainedInArgument(rawValue, S_IFIFO.Value()):
+	case optionIsContainedInArgument(rawValue, S_IFIFO.Value()):
 		f = append(f, S_IFIFO.String())
 	}
 
 	// File Mode
 	// Owner
-	if optionsAreContainedInArgument(rawValue, S_IRWXU.Value()) {
+	if optionIsContainedInArgument(rawValue, S_IRWXU.Value()) {
 		f = append(f, S_IRWXU.String())
 	} else {
-		if optionsAreContainedInArgument(rawValue, S_IRUSR.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IRUSR.Value()) {
 			f = append(f, S_IRUSR.String())
 		}
-		if optionsAreContainedInArgument(rawValue, S_IWUSR.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IWUSR.Value()) {
 			f = append(f, S_IWUSR.String())
 		}
-		if optionsAreContainedInArgument(rawValue, S_IXUSR.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IXUSR.Value()) {
 			f = append(f, S_IXUSR.String())
 		}
 	}
 	// Group
-	if optionsAreContainedInArgument(rawValue, S_IRWXG.Value()) {
+	if optionIsContainedInArgument(rawValue, S_IRWXG.Value()) {
 		f = append(f, S_IRWXG.String())
 	} else {
-		if optionsAreContainedInArgument(rawValue, S_IRGRP.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IRGRP.Value()) {
 			f = append(f, S_IRGRP.String())
 		}
-		if optionsAreContainedInArgument(rawValue, S_IWGRP.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IWGRP.Value()) {
 			f = append(f, S_IWGRP.String())
 		}
-		if optionsAreContainedInArgument(rawValue, S_IXGRP.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IXGRP.Value()) {
 			f = append(f, S_IXGRP.String())
 		}
 	}
 	// Others
-	if optionsAreContainedInArgument(rawValue, S_IRWXO.Value()) {
+	if optionIsContainedInArgument(rawValue, S_IRWXO.Value()) {
 		f = append(f, S_IRWXO.String())
 	} else {
-		if optionsAreContainedInArgument(rawValue, S_IROTH.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IROTH.Value()) {
 			f = append(f, S_IROTH.String())
 		}
-		if optionsAreContainedInArgument(rawValue, S_IWOTH.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IWOTH.Value()) {
 			f = append(f, S_IWOTH.String())
 		}
-		if optionsAreContainedInArgument(rawValue, S_IXOTH.Value()) {
+		if optionIsContainedInArgument(rawValue, S_IXOTH.Value()) {
 			f = append(f, S_IXOTH.String())
 		}
 	}
@@ -1468,7 +1474,7 @@ func ParseMmapProt(rawValue uint64) MmapProtArgument {
 
 	var sb strings.Builder
 	for _, a := range mmapProtArgs {
-		if optionsAreContainedInArgument(rawValue, a.Value()) {
+		if optionIsContainedInArgument(rawValue, a.Value()) {
 			if sb.Len() > 0 {
 				sb.WriteByte('|')
 			}

--- a/pkg/events/parsers/data_parsers_bench_test.go
+++ b/pkg/events/parsers/data_parsers_bench_test.go
@@ -26,50 +26,50 @@ func BenchmarkParseMmapProt(b *testing.B) {
 
 var optionsAreContainedInArgumentTestTable = []struct {
 	rawArgument uint64
-	options     []SystemFunctionArgument
+	options     []uint64
 }{
 	{
 		rawArgument: 0x0,
-		options:     []SystemFunctionArgument{CLONE_CHILD_CLEARTID},
+		options:     []uint64{CLONE_CHILD_CLEARTID.Value()},
 	},
 	{
 		rawArgument: PTRACE_TRACEME.Value(),
-		options:     []SystemFunctionArgument{PTRACE_TRACEME},
+		options:     []uint64{PTRACE_TRACEME.Value()},
 	},
 	{
 		rawArgument: PTRACE_TRACEME.Value(),
-		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_TRACEME},
+		options:     []uint64{PTRACE_TRACEME.Value(), PTRACE_ATTACH.Value()},
 	},
 	{
 		rawArgument: PTRACE_PEEKTEXT.Value(),
-		options:     []SystemFunctionArgument{PTRACE_TRACEME},
+		options:     []uint64{PTRACE_TRACEME.Value()},
 	},
 	{
 		rawArgument: PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
-		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK},
+		options:     []uint64{PTRACE_TRACEME.Value(), PTRACE_GETSIGMASK.Value()},
 	},
 	{
 		rawArgument: BPF_MAP_CREATE.Value(),
-		options:     []SystemFunctionArgument{BPF_MAP_CREATE},
+		options:     []uint64{BPF_MAP_CREATE.Value()},
 	},
 	{
 		rawArgument: CAP_CHOWN.Value(),
-		options:     []SystemFunctionArgument{CAP_CHOWN},
+		options:     []uint64{CAP_CHOWN.Value()},
 	},
 	{
 		rawArgument: PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
-		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK},
+		options:     []uint64{PTRACE_TRACEME.Value(), PTRACE_GETSIGMASK.Value()},
 	},
 	{
 		rawArgument: 0x0,
-		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK, PTRACE_ATTACH, PTRACE_DETACH},
+		options:     []uint64{PTRACE_TRACEME.Value(), PTRACE_GETSIGMASK.Value(), PTRACE_ATTACH.Value(), PTRACE_DETACH.Value()},
 	},
 }
 
-func BenchmarkOptionsAreContainedInArgument(b *testing.B) {
+func Benchmark_optionsAreContainedInArgument(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, tc := range optionsAreContainedInArgumentTestTable {
-			_ = OptionsAreContainedInArgument(tc.rawArgument, tc.options...)
+			_ = optionsAreContainedInArgument(tc.rawArgument, tc.options...)
 		}
 	}
 }

--- a/pkg/events/parsers/data_parsers_bench_test.go
+++ b/pkg/events/parsers/data_parsers_bench_test.go
@@ -73,3 +73,19 @@ func Benchmark_optionsAreContainedInArgument(b *testing.B) {
 		}
 	}
 }
+
+func Benchmark_optionsAreContainedInArgumentWithOnlyOne(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range optionsAreContainedInArgumentTestTable {
+			_ = optionsAreContainedInArgument(tc.rawArgument, tc.options[0])
+		}
+	}
+}
+
+func Benchmark_optionIsContainedInArgument(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range optionsAreContainedInArgumentTestTable {
+			_ = optionIsContainedInArgument(tc.rawArgument, tc.options[0])
+		}
+	}
+}

--- a/pkg/events/parsers/data_parsers_bench_test.go
+++ b/pkg/events/parsers/data_parsers_bench_test.go
@@ -23,3 +23,53 @@ func BenchmarkParseMmapProt(b *testing.B) {
 		}
 	}
 }
+
+var optionsAreContainedInArgumentTestTable = []struct {
+	rawArgument uint64
+	options     []SystemFunctionArgument
+}{
+	{
+		rawArgument: 0x0,
+		options:     []SystemFunctionArgument{CLONE_CHILD_CLEARTID},
+	},
+	{
+		rawArgument: PTRACE_TRACEME.Value(),
+		options:     []SystemFunctionArgument{PTRACE_TRACEME},
+	},
+	{
+		rawArgument: PTRACE_TRACEME.Value(),
+		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_TRACEME},
+	},
+	{
+		rawArgument: PTRACE_PEEKTEXT.Value(),
+		options:     []SystemFunctionArgument{PTRACE_TRACEME},
+	},
+	{
+		rawArgument: PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
+		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK},
+	},
+	{
+		rawArgument: BPF_MAP_CREATE.Value(),
+		options:     []SystemFunctionArgument{BPF_MAP_CREATE},
+	},
+	{
+		rawArgument: CAP_CHOWN.Value(),
+		options:     []SystemFunctionArgument{CAP_CHOWN},
+	},
+	{
+		rawArgument: PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
+		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK},
+	},
+	{
+		rawArgument: 0x0,
+		options:     []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK, PTRACE_ATTACH, PTRACE_DETACH},
+	},
+}
+
+func BenchmarkOptionsAreContainedInArgument(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range optionsAreContainedInArgumentTestTable {
+			_ = OptionsAreContainedInArgument(tc.rawArgument, tc.options...)
+		}
+	}
+}

--- a/pkg/events/parsers/data_parsers_test.go
+++ b/pkg/events/parsers/data_parsers_test.go
@@ -40,6 +40,12 @@ func Test_optionsAreContainedInArgument(t *testing.T) {
 			expectedContained: true,
 		},
 		{
+			testName:          "just not present",
+			rawArgument:       PTRACE_TRACEME.Value(),
+			options:           []uint64{PTRACE_TRACEME.Value()},
+			expectedContained: true,
+		},
+		{
 			testName:          "present1",
 			rawArgument:       PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
 			options:           []uint64{PTRACE_TRACEME.Value(), PTRACE_GETSIGMASK.Value()},
@@ -74,6 +80,53 @@ func Test_optionsAreContainedInArgument(t *testing.T) {
 	for _, ts := range attachTests {
 		t.Run(ts.testName, func(test *testing.T) {
 			isContained := optionsAreContainedInArgument(ts.rawArgument, ts.options...)
+			assert.Equal(test, ts.expectedContained, isContained)
+		})
+	}
+}
+
+func Test_optionIsContainedInArgument(t *testing.T) {
+	attachTests := []struct {
+		testName          string
+		rawArgument       uint64
+		option            uint64
+		expectedContained bool
+	}{
+		{
+			testName:          "no options present",
+			rawArgument:       0x0,
+			option:            CLONE_CHILD_CLEARTID.Value(),
+			expectedContained: false,
+		},
+		{
+			testName:          "present in self",
+			rawArgument:       PTRACE_TRACEME.Value(),
+			option:            PTRACE_TRACEME.Value(),
+			expectedContained: true,
+		},
+		{
+			testName:          "just not present",
+			rawArgument:       PTRACE_PEEKTEXT.Value(),
+			option:            PTRACE_TRACEME.Value(),
+			expectedContained: true,
+		},
+		{
+			testName:          "present",
+			rawArgument:       PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
+			option:            PTRACE_GETSIGMASK.Value(),
+			expectedContained: true,
+		},
+		{
+			testName:          "not present",
+			rawArgument:       CAP_CHOWN.Value(),
+			option:            CAP_DAC_OVERRIDE.Value(),
+			expectedContained: false,
+		},
+	}
+
+	for _, ts := range attachTests {
+		t.Run(ts.testName, func(test *testing.T) {
+			isContained := optionIsContainedInArgument(ts.rawArgument, ts.option)
 			assert.Equal(test, ts.expectedContained, isContained)
 		})
 	}

--- a/pkg/events/parsers/data_parsers_test.go
+++ b/pkg/events/parsers/data_parsers_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOptionsAreContainedInArgument(t *testing.T) {
+func Test_optionsAreContainedInArgument(t *testing.T) {
 	attachTests := []struct {
 		testName          string
 		rawArgument       uint64
-		options           []SystemFunctionArgument
+		options           []uint64
 		expectedContained bool
 		expectedValue     uint64
 		expectedString    string
@@ -18,62 +18,62 @@ func TestOptionsAreContainedInArgument(t *testing.T) {
 		{
 			testName:          "no options present",
 			rawArgument:       0x0,
-			options:           []SystemFunctionArgument{CLONE_CHILD_CLEARTID},
+			options:           []uint64{CLONE_CHILD_CLEARTID.Value()},
 			expectedContained: false,
 		},
 		{
 			testName:          "present in self",
 			rawArgument:       PTRACE_TRACEME.Value(),
-			options:           []SystemFunctionArgument{PTRACE_TRACEME},
+			options:           []uint64{PTRACE_TRACEME.Value()},
 			expectedContained: true,
 		},
 		{
 			testName:          "present in self multiple",
 			rawArgument:       PTRACE_TRACEME.Value(),
-			options:           []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_TRACEME},
+			options:           []uint64{PTRACE_TRACEME.Value(), PTRACE_TRACEME.Value()},
 			expectedContained: true,
 		},
 		{
 			testName:          "just not present",
 			rawArgument:       PTRACE_PEEKTEXT.Value(),
-			options:           []SystemFunctionArgument{PTRACE_TRACEME},
+			options:           []uint64{PTRACE_TRACEME.Value()},
 			expectedContained: true,
 		},
 		{
 			testName:          "present1",
 			rawArgument:       PTRACE_TRACEME.Value() | PTRACE_GETSIGMASK.Value(),
-			options:           []SystemFunctionArgument{PTRACE_TRACEME, PTRACE_GETSIGMASK},
+			options:           []uint64{PTRACE_TRACEME.Value(), PTRACE_GETSIGMASK.Value()},
 			expectedContained: true,
 		},
 		{
 			testName:          "present2",
 			rawArgument:       BPF_MAP_CREATE.Value(),
-			options:           []SystemFunctionArgument{BPF_MAP_CREATE},
+			options:           []uint64{BPF_MAP_CREATE.Value()},
 			expectedContained: true,
 		},
 		{
 			testName:          "present3",
 			rawArgument:       CAP_CHOWN.Value(),
-			options:           []SystemFunctionArgument{CAP_CHOWN},
+			options:           []uint64{CAP_CHOWN.Value()},
 			expectedContained: true,
 		},
 		{
 			testName:          "not present1",
 			rawArgument:       CAP_CHOWN.Value(),
-			options:           []SystemFunctionArgument{CAP_DAC_OVERRIDE},
+			options:           []uint64{CAP_DAC_OVERRIDE.Value()},
 			expectedContained: false,
 		},
 		{
 			testName:          "not present2",
 			rawArgument:       CAP_CHOWN.Value() | CAP_DAC_READ_SEARCH.Value(),
-			options:           []SystemFunctionArgument{CAP_DAC_OVERRIDE, CAP_DAC_READ_SEARCH},
+			options:           []uint64{CAP_DAC_OVERRIDE.Value(), CAP_DAC_READ_SEARCH.Value()},
 			expectedContained: false,
 		},
 	}
 
 	for _, ts := range attachTests {
 		t.Run(ts.testName, func(test *testing.T) {
-			isContained := OptionsAreContainedInArgument(ts.rawArgument, ts.options...)
+			isContained := optionsAreContainedInArgument(ts.rawArgument, ts.options...)
 			assert.Equal(test, ts.expectedContained, isContained)
 		})
 	}

--- a/pkg/events/parsers/data_parsers_test.go
+++ b/pkg/events/parsers/data_parsers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOptionsContainedInArgument(t *testing.T) {
+func TestOptionsAreContainedInArgument(t *testing.T) {
 	attachTests := []struct {
 		testName          string
 		rawArgument       uint64
@@ -57,11 +57,23 @@ func TestOptionsContainedInArgument(t *testing.T) {
 			options:           []SystemFunctionArgument{CAP_CHOWN},
 			expectedContained: true,
 		},
+		{
+			testName:          "not present1",
+			rawArgument:       CAP_CHOWN.Value(),
+			options:           []SystemFunctionArgument{CAP_DAC_OVERRIDE},
+			expectedContained: false,
+		},
+		{
+			testName:          "not present2",
+			rawArgument:       CAP_CHOWN.Value() | CAP_DAC_READ_SEARCH.Value(),
+			options:           []SystemFunctionArgument{CAP_DAC_OVERRIDE, CAP_DAC_READ_SEARCH},
+			expectedContained: false,
+		},
 	}
 
 	for _, ts := range attachTests {
 		t.Run(ts.testName, func(test *testing.T) {
-			isContained := OptionAreContainedInArgument(ts.rawArgument, ts.options...)
+			isContained := OptionsAreContainedInArgument(ts.rawArgument, ts.options...)
 			assert.Equal(test, ts.expectedContained, isContained)
 		})
 	}


### PR DESCRIPTION
### 1. Explain what the PR does

d7fa48d0e **chore(parsers): add optionIsContainedInArgument**
c830bf91e **chore(parsers): opti optionsAreContainedInArgument**
b15d55997 **chore(parsers): impr OptionsAreContainedInArgument**


d7fa48d0e **chore(parsers): add optionIsContainedInArgument**

```
Currently all usages of the `optionsAreContainedInArgument` function
are using only one option. Then, `optionIsContainedInArgument` comes as
a simplification of the previous function.

Even though `optionsAreContainedInArgument` is not used anymore, it is
still being kept for now, since some parser might need to check for
multiple options in the future.

=== RUN   Benchmark_optionsAreContainedInArgumentWithOnlyOne
Benchmark_optionsAreContainedInArgumentWithOnlyOne
Benchmark_optionsAreContainedInArgumentWithOnlyOne-32            5000000               174.8 ns/op             0 B/op          0 allocs/op
=== RUN   Benchmark_optionIsContainedInArgument
Benchmark_optionIsContainedInArgument
Benchmark_optionIsContainedInArgument-32                         5000000               140.4 ns/op             0 B/op          0 allocs/op
PASS
```

c830bf91e **chore(parsers): opti optionsAreContainedInArgument**

```
optionsAreContainedInArgument now receives a variadic argument of type
uint64 instead of SystemFunctionArgument.

=== RUN   BenchmarkOptionsAreContainedInArgumentPrev
BenchmarkOptionsAreContainedInArgumentPrev
BenchmarkOptionsAreContainedInArgumentPrev-32          5000000               387.7 ns/op             0 B/op          0 allocs/op
=== RUN   BenchmarkOptionsAreContainedInArgument
BenchmarkOptionsAreContainedInArgument
BenchmarkOptionsAreContainedInArgument-32              5000000               152.3 ns/op             0 B/op
```

b15d55997 **chore(parsers): impr OptionsAreContainedInArgument**

```
Optimize OptionsAreContainedInArgument function to return as soon as it
detects a non-contained option.

Running tool: /home/gg/.goenv/versions/1.22.4/bin/go test -benchmem
-run=^$ -tags ebpf
-bench ^(BenchmarkOptionsAreContainedInArgumentOld|BenchmarkOptionsAreContainedInArgument)$
github.com/aquasecurity/tracee/pkg/events/parsers -benchtime=1000000x -race

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/events/parsers
cpu: AMD Ryzen 9 7950X 16-Core Processor
=== RUN   BenchmarkOptionsAreContainedInArgumentOld
BenchmarkOptionsAreContainedInArgumentOld
BenchmarkOptionsAreContainedInArgumentOld-32             1000000               500.4 ns/op             0 B/op          0 allocs/op
=== RUN   BenchmarkOptionsAreContainedInArgument
BenchmarkOptionsAreContainedInArgument
BenchmarkOptionsAreContainedInArgument-32                1000000               351.3 ns/op             0 B/op          0 allocs/op
PASS
ok      github.com/aquasecurity/tracee/pkg/events/parsers       1.861s
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
