### PR TITLE
chore(parsers): optimize ParseMmapProt

### DIFF
--- a/pkg/events/parsers/data_parsers_bench_test.go
+++ b/pkg/events/parsers/data_parsers_bench_test.go
@@ -1,0 +1,25 @@
+package parsers
+
+import "testing"
+
+var parseMmapProtBenchTestArgs = []struct {
+	rawValue uint64
+}{
+	{
+		rawValue: PROT_NONE.Value(),
+	},
+	{
+		rawValue: PROT_EXEC.Value(),
+	},
+	{
+		rawValue: PROT_EXEC.Value() | PROT_READ.Value(),
+	},
+}
+
+func BenchmarkParseMmapProt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tt := range parseMmapProtBenchTestArgs {
+			ParseMmapProt(tt.rawValue)
+		}
+	}
+}

--- a/pkg/events/parsers/data_parsers_test.go
+++ b/pkg/events/parsers/data_parsers_test.go
@@ -359,3 +359,44 @@ func TestParseFsNotifyObjType(t *testing.T) {
 		})
 	}
 }
+
+func TestParseMmapProt(t *testing.T) {
+	testCases := []struct {
+		name          string
+		parseValue    uint64
+		expectedSting string
+	}{
+		{
+			name:          "Single value",
+			parseValue:    PROT_NONE.Value(),
+			expectedSting: "PROT_NONE",
+		},
+		{
+			name:          "Single value",
+			parseValue:    PROT_READ.Value(),
+			expectedSting: "PROT_READ",
+		},
+		{
+			name:          "Multiple values",
+			parseValue:    PROT_READ.Value() | PROT_WRITE.Value() | PROT_EXEC.Value(),
+			expectedSting: "PROT_READ|PROT_WRITE|PROT_EXEC",
+		},
+		{
+			name:          "Multiple values with unknown",
+			parseValue:    PROT_READ.Value() | PROT_WRITE.Value() | PROT_EXEC.Value() | 10000000,
+			expectedSting: "PROT_READ|PROT_WRITE|PROT_EXEC",
+		},
+		{
+			name:          "Non existing value",
+			parseValue:    10000000,
+			expectedSting: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			flags := ParseMmapProt(testCase.parseValue)
+			assert.Equal(t, testCase.expectedSting, flags.String())
+		})
+	}
+}


### PR DESCRIPTION
### 1. Explain what the PR does

ae857dafa **chore(parsers): optimize ParseMmapProt**

```
Refactor ParseMmapProt to use mmapProtArgs slice.

- Introduced mmapProtArgs slice for cleaner and more maintainable code.
- Replaced multiple if statements with a loop and string builder.
- Improved performance: reduced allocs/op from 17 to 15, and B/op from
  392 to 352.
- Execution time slightly improved from 1603 ns/op to 1536 ns/op
  (benchmark file used included).
- Reduced function size from 1534 to 677 bytes (55.8% less), what
  should improve locality and reduce cache misses.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
