### PR TITLE
fix: Prevent loading syscall-specific BPF programs for non-syscall events

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -686,27 +686,11 @@ func (t *Tracee) initTailCall(tailCall events.TailCall) error {
 		return errfmt.Errorf("could not get BPF program FD for %s: %v", tailCallProgName, err)
 	}
 
-	once := &sync.Once{}
-
 	// Pick all indexes (event, or syscall, IDs) the BPF program should be related to.
 	for _, index := range tailCallIndexes {
-		// Special treatment for indexes of syscall events.
-		if events.Core.GetDefinitionByID(events.ID(index)).IsSyscall() {
-			// Optimization: enable enter/exit probes only if at least one syscall is enabled.
-			once.Do(func() {
-				err := t.probes.Attach(probes.SyscallEnter__Internal, t.kernelSymbols)
-				if err != nil {
-					logger.Errorw("error attaching to syscall enter", "error", err)
-				}
-				err = t.probes.Attach(probes.SyscallExit__Internal, t.kernelSymbols)
-				if err != nil {
-					logger.Errorw("error attaching to syscall enter", "error", err)
-				}
-			})
-			// Workaround: Do not map eBPF program to unsupported syscalls (arm64, e.g.)
-			if index >= uint32(events.Unsupported) {
-				continue
-			}
+		// Workaround: Do not map eBPF program to unsupported syscalls (arm64, e.g.)
+		if index >= uint32(events.Unsupported) {
+			continue
 		}
 		// Update given eBPF map with the eBPF program file descriptor at given index.
 		err := bpfMap.Update(unsafe.Pointer(&index), unsafe.Pointer(&bpfProgFD))


### PR DESCRIPTION
### 1. Explain what the PR does

Previously, tracee incorrectly assumed all tailcall indexes were syscall IDs, leading to unnecessary loading of syscall-specific BPF programs. This caused a resource leak due to unused tracepoint attachments. The issue is now fixed by only removing the code which attaches these programs, as we explicitly define it in the event dependencies.

### 2. Explain how to test it

Run tracee with
`sudo ./dist/tracee -e sched_process_exec`
Before this fix, sys_enter and sys_exit events were attached, after this fix they are not anymore.
Use the following command to verify:
`sudo bpftool link`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
