### PR TITLE
fix: Ensure correct event dependency for process_execute_failed

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -12984,6 +12984,7 @@ var CoreEvents = map[ID]Definition{
 			probes: []Probe{
 				{handle: probes.ExecBinprm, required: false},
 				{handle: probes.ExecBinprmRet, required: false},
+				{handle: probes.SyscallEnter__Internal, required: true},
 			},
 			tailCalls: []TailCall{
 				{"prog_array", "trace_execute_failed1", []uint32{TailProcessExecuteFailed1}},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The process_execute_failed event was not functioning correctly due to a missing dependency on the sys_enter probe.
This commit attaches the required probe, allowing the event to trigger as expected.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
