### PR TITLE
chore: release bpf object memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/IBM/fluent-forward-go v0.2.2
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240715144951-c8f76d124d7d
+	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
 	github.com/aquasecurity/tracee/api v0.0.0-20240613134034-89d2d4fc7689
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee
 	github.com/aquasecurity/tracee/types v0.0.0-20240607205742-90c301111aee

--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,8 @@ github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdII
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240715144951-c8f76d124d7d h1:+CNq6qH8KW9n9JQt4vnaKM03PilwkVEPAsrjQDKeXno=
-github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240715144951-c8f76d124d7d/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
+github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca h1:OPbvwFFvR11c1bgOLhBq1R5Uk3hwUjHW2KfrdyJan9Y=
+github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
 github.com/aquasecurity/tracee/api v0.0.0-20240613134034-89d2d4fc7689 h1:mAOehSHrqAZ4lvn3AYgDxn+aDTKrv81ghNnGlteDB00=
 github.com/aquasecurity/tracee/api v0.0.0-20240613134034-89d2d4fc7689/go.mod h1:km0QNkaoOVxU/IYF/Pw/ju/2SO1mYn+HJOIyMDtnfkE=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee h1:1KJy6Z2bSpmKQVPShU7hhbXgGVOgMwvzf9rjoWMTYEg=

--- a/pkg/cmd/tracee.go
+++ b/pkg/cmd/tracee.go
@@ -53,6 +53,10 @@ func (r Runner) Run(ctx context.Context) error {
 		},
 	)
 
+	// Need to force nil to allow the garbage
+	// collector to free the BPF object
+	r.TraceeConfig.BPFObjBytes = nil
+
 	// Initialize tracee
 
 	err = t.Init(ctx)

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1392,6 +1392,10 @@ func (t *Tracee) initBPF() error {
 		return errfmt.WrapError(err)
 	}
 
+	// Need to force nil to allow the garbage
+	// collector to free the BPF object
+	t.config.BPFObjBytes = nil
+
 	// Populate eBPF maps with initial data
 
 	err = t.populateBPFMaps()


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

12c4a512a **chore: release bpf object memory**

```
These are the two references to the BPF object read from the file. Both
need to be set to nil for the Go garbage collector to reclaim the
memory.
```


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

To observe a real change in RSS, it's necessary to run Tracee with `GOGC=5` to trigger the GC cycle more frequently. This approach allows for a clearer view of the improvement in RSS size.

`sudo env GOGC=5 ./dist/tracee --events kill`

RSS size before this commit:
```
ps -p `pgrep tracee` -o pid,vsz,rss,cmd
    PID    VSZ   RSS CMD
  29655 2269948 101512 ./dist/tracee --events kill
```

RSS size in this commit:
```
ps -p `pgrep tracee` -o pid,vsz,rss,cmd
    PID    VSZ   RSS CMD
  26268 2265800 87796 ./dist/tracee --events kill
```

With this chore, we achieve around a 14MB reduction in RSS, which corresponds to the size of each BPF object. This reduction was possible after a small fix in this libbpfgo [PR#451](https://github.com/aquasecurity/libbpfgo/pull/451)

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
