### PR TITLE
`set_fs_pwd`: don't rely on sys_enter hook

### DIFF
--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -140,7 +140,7 @@ statfunc int init_program_data(program_data_t *p, void *ctx, u32 event_id)
     p->event->context.eventid = event_id;
     p->event->context.ts = get_current_time_in_ns();
     p->event->context.processor_id = (u16) bpf_get_smp_processor_id();
-    p->event->context.syscall = get_task_syscall_id(p->event->task);
+    p->event->context.syscall = get_current_task_syscall_id();
 
     u32 host_pid = p->event->context.task.host_pid;
     p->proc_info = bpf_map_lookup_elem(&proc_info_map, &host_pid);

--- a/pkg/ebpf/c/common/task.h
+++ b/pkg/ebpf/c/common/task.h
@@ -10,7 +10,7 @@
 // PROTOTYPES
 
 statfunc int get_task_flags(struct task_struct *task);
-statfunc int get_task_syscall_id(struct task_struct *task);
+statfunc int get_current_task_syscall_id(void);
 statfunc u32 get_task_mnt_ns_id(struct task_struct *task);
 statfunc u32 get_task_pid_ns_for_children_id(struct task_struct *task);
 statfunc u32 get_task_pid_ns_id(struct task_struct *task);
@@ -39,13 +39,13 @@ statfunc int get_task_flags(struct task_struct *task)
     return BPF_CORE_READ(task, flags);
 }
 
-statfunc int get_task_syscall_id(struct task_struct *task)
+statfunc int get_current_task_syscall_id(void)
 {
     // There is no originated syscall in kernel thread context
-    if (get_task_flags(task) & PF_KTHREAD) {
+    if (get_task_flags((struct task_struct *) bpf_get_current_task()) & PF_KTHREAD) {
         return NO_SYSCALL;
     }
-    struct pt_regs *regs = get_task_pt_regs(task);
+    struct pt_regs *regs = get_current_task_pt_regs();
     return get_syscall_id_from_regs(regs);
 }
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -684,7 +684,9 @@ enum bpf_func_id
     BPF_FUNC_sk_storage_get = 107,
     BPF_FUNC_ktime_get_boot_ns = 125,
     BPF_FUNC_copy_from_user = 148,
+    BPF_FUNC_get_current_task_btf = 158,
     BPF_FUNC_for_each_map_elem = 164,
+    BPF_FUNC_task_pt_regs = 175,
 };
 
 #define MODULE_NAME_LEN (64 - sizeof(unsigned long))

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -13054,19 +13054,9 @@ var CoreEvents = map[ID]Definition{
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SetFsPwd, required: true},
-				{handle: probes.SyscallEnter__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{
-					"sys_enter_init_tail",
-					"sys_enter_init",
-					[]uint32{
-						uint32(Chdir),
-					},
-				},
 			},
 		},
-		sets: []string{"syscalls"},
+		sets: []string{"syscalls", "fs", "fs_dir_ops"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "unresolved_path"},
 			{Type: "const char*", Name: "resolved_path"},

--- a/tests/e2e-inst-signatures/scripts/chdir_tester.c
+++ b/tests/e2e-inst-signatures/scripts/chdir_tester.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+
+int main(void) {
+    // Change current working directory using chdir
+    if (chdir("./test_link") == -1) {
+        perror("Failed to change directory");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/tests/e2e-inst-signatures/scripts/set_fs_pwd.sh
+++ b/tests/e2e-inst-signatures/scripts/set_fs_pwd.sh
@@ -1,14 +1,43 @@
 #!/bin/bash
 
+ARCH=$(uname -m)
+
 exit_err() {
     echo -n "ERROR: "
     echo "$@"
     exit 1
 }
 
-mkdir test_dir || exit_err "failed creating dir"
-ln -s test_dir test_link || exit_err "failed creating link"
-cd test_link || exit_err "failed changing directory"
-cd .. || exit_err "failed changing directory back"
+prog=chdir_tester
+prog32=chdir_tester_32
+dir=tests/e2e-inst-signatures/scripts
+
+gcc $dir/$prog.c -o $dir/$prog || exit_err "could not compile $prog.c"
+mkdir test_dir_64 || exit_err "failed creating dir"
+ln -s test_dir_64 test_link || exit_err "failed creating link"
+./$dir/$prog 2>&1 > /tmp/$prog.log || exit_err "could not run $prog"
 rm test_link || exit_err "failed removing link"
-rm -r test_dir || exit_err "failed removing dir"
+rm -r test_dir_64 || exit_err "failed removing dir"
+
+if [[ $ARCH == x86_64 ]]; then
+    gcc $dir/$prog.c -m32 -o $dir/$prog32 || exit_err "could not compile $prog.c"
+else
+    . /etc/os-release
+    case $ID in
+    "ubuntu")
+        arm-linux-gnueabi-gcc $dir/$prog.c -o $dir/$prog32 || exit_err "could not compile $prog.c"
+    ;;
+    "almalinux")
+        arm-linux-gnu-gcc $dir/$prog.c -o $dir/$prog32 || exit_err "could not compile $prog.c"
+    ;;
+    *)
+        echo "Unsupported OS: $ID"
+        exit 1
+    ;;
+    esac
+fi
+mkdir test_dir_32 || exit_err "failed creating dir"
+ln -s test_dir_32 test_link || exit_err "failed creating link"
+./$dir/$prog32 2>&1 > /tmp/$prog32.log || exit_err "could not run $prog32"
+rm test_link || exit_err "failed removing link"
+rm -r test_dir_32 || exit_err "failed removing dir"

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -139,7 +139,7 @@ for TEST in $TESTS; do
         --output option:parse-arguments \
         --log file:$SCRIPT_TMP_DIR/tracee-log-$$ \
         --signatures-dir "$SIG_DIR" \
-        --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,fsnotify_tester,process_execute,tracee-ebpf,writev,set_fs_pwd.sh \
+        --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,fsnotify_tester,process_execute,tracee-ebpf,writev,chdir_tester,chdir_tester_32 \
         --dnscache enable \
         --grpc-listen-addr unix:/tmp/tracee.sock \
         --events "$TEST" &

--- a/tests/e2e-install-deps.sh
+++ b/tests/e2e-install-deps.sh
@@ -280,6 +280,26 @@ install_libzstd_os_packages() {
     esac
 }
 
+install_gcc_arm32_target() {
+    case $ID in
+    "ubuntu")
+        wait_for_apt_locks
+        dpkg --add-architecture armhf
+        apt-get update
+        apt-get install -y gcc-arm-linux-gnueabi libc6:armhf
+        ln -s /lib/ld-linux-armhf.so.3 /lib/ld-linux.so.3
+    ;;
+    "almalinux")
+        yum install -y epel-release
+        yum install -y gcc-arm-linux-gnu
+    ;;
+    *)
+        echo "Unsupported OS: $ID"
+        exit 1
+    ;;
+    esac
+}
+
 # Main logic.
 
 # Note: I left commented out the commands that would (re)install clang-14. This
@@ -347,3 +367,8 @@ fi
 
 # for static builds libelf might require libzstd
 install_libzstd_os_packages
+
+# the set_fs_pwd test requires a compiler for arm 32 bit
+if [[ $ARCH == aarch64 ]]; then
+    install_gcc_arm32_target
+fi


### PR DESCRIPTION
### 1. Explain what the PR does

Get the argument for chdir from the task's registers instead of the arguments saved by sys_enter.

### 2. Explain how to test it

The test for this event was updated to also check compat binaries.

### 3. Other comments

Changed the behavior of the `get_task_pt_regs` function, see relevant commit.
