### PR TITLE
Improve `save_args_to_submit_buf`

### DIFF
--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -153,6 +153,8 @@ typedef struct args {
     unsigned long args[6];
 } args_t;
 
+// NOTE: If any fields are added to argument_type_e, the array type_size_table
+// (and related defines) must be updated accordingly.
 enum argument_type_e
 {
     NONE_T = 0UL,


### PR DESCRIPTION
### 1. Explain what the PR does

cf34d1f4 **chore: improve save_args_to_submit_buf**

```
This replaces the switch case branches for a direct access to a type
size table and uses bitmasking to decide about the code path to take.

Improvements:

| dist/tracee.bpf.o     | Before (B) | After (B) | Diff (B) | (%)     |
|-----------------------|------------|-----------|----------|---------|
| Size in Bytes         | 14118048   | 14098024  | -20024   | -0.14%  |

| sys_exit_submit       | Before (B) | After (B) | Diff (B) | (%)     |
|-----------------------|------------|-----------|----------|---------|
| Interpr Size (xlated) | 25248      | 19200     | -6048    | -23.96% |
| JITed Size (jited)    | 16600      | 12161     | -4439    | -26.73% |
| Memlock               | 28672      | 20480     | -8192    | -28.57% |

| Metric (1k evts)    | Before (ns) | After (ns) | Diff (ns) | (%)    |
|---------------------|-------------|------------|-----------|--------|
| Minimum Time        | 184,797     | 167,025    | -17,772   | -9.62% |
| Maximum Time        | 217,418     | 201,527    | -15,891   | -7.31% |
| Average Time        | 201,117     | 189,893    | -11,224   | -5.58% |

An improvement of ~ -11.22ns in the average time to process 1 single
event.

Benchmarked on:
- AMD Ryzen 9 7950X 16-Core Processor
- 64GB RAM

Runned with:
tracee -e execve,init_module,process_vm_writev,ptrace,arch_prctl,chdir
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
