### PR TITLE
perf: benchmark improve sig GetMetadata

### DIFF
--- a/pkg/signatures/benchmark/benchmark_test.go
+++ b/pkg/signatures/benchmark/benchmark_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/signatures/benchmark/signature/golang"
 	"github.com/aquasecurity/tracee/pkg/signatures/benchmark/signature/rego"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
@@ -230,6 +231,58 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 	}
 }
 
+func BenchmarkEngineMultipleMethodsGetMetadata(b *testing.B) {
+	benches := []struct {
+		name     string
+		sigFuncs []func() (detect.Signature, error)
+		Enabled  bool
+	}{
+		{
+			name:     "Performance sig GetMetadata() - static",
+			sigFuncs: []func() (detect.Signature, error){golang.NewPerformanceStatic},
+		},
+	}
+
+	for _, bc := range benches {
+		b.Run(bc.name, func(b *testing.B) {
+			var sigs []detect.Signature
+			for _, sig := range bc.sigFuncs {
+				s, _ := sig()
+				sigs = append(sigs, s)
+			}
+
+			for i := 0; i < b.N; i++ {
+				// Produce events without timing it
+				b.StopTimer()
+				inputs := ProduceEventsInMemory(inputEventsCount)
+				output := make(chan *detect.Finding, inputEventsCount*len(sigs))
+
+				config := engine.Config{
+					Signatures:          sigs,
+					Enabled:             true,
+					SigNameToEventID:    allocateEventIdsForSigs(events.StartSignatureID, sigs),
+					ShouldDispatchEvent: func(int32) bool { return true },
+				}
+
+				e, err := engine.NewEngine(config, inputs, output)
+				require.NoError(b, err, "constructing engine")
+
+				err = e.Init()
+				require.NoError(b, err, "initializing engine")
+				b.StartTimer()
+
+				// Start signatures engine and wait until all events are processed
+				e.Start(waitForEventsProcessed(inputs.Tracee))
+
+				b.StopTimer()
+
+				// Set engine to nil to help with garbage collection
+				e = nil
+				runtime.GC()
+			}
+		})
+	}
+}
 func waitForEventsProcessed(eventsCh chan protocol.Event) context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {

--- a/pkg/signatures/benchmark/helpers_test.go
+++ b/pkg/signatures/benchmark/helpers_test.go
@@ -4,7 +4,10 @@ import (
 	_ "embed"
 	"math/rand"
 
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
+	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -170,4 +173,21 @@ func ProduceEventsInMemoryRandom(n int, seed ...trace.Event) engine.EventSources
 	return engine.EventSources{
 		Tracee: eventsCh,
 	}
+}
+
+func allocateEventIdsForSigs(startId events.ID, sigs []detect.Signature) map[string]int32 {
+	namesToIds := make(map[string]int32)
+	newEventDefID := startId
+	// First allocate event IDs to all signatures
+	for _, s := range sigs {
+		m, err := s.GetMetadata()
+		if err != nil {
+			logger.Warnw("Failed to allocate id for signature", "error", err)
+			continue
+		}
+
+		namesToIds[m.EventName] = int32(newEventDefID)
+		newEventDefID++
+	}
+	return namesToIds
 }

--- a/pkg/signatures/benchmark/signature/golang/performance_static.go
+++ b/pkg/signatures/benchmark/signature/golang/performance_static.go
@@ -1,0 +1,123 @@
+package golang
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/aquasecurity/tracee/signatures/helpers"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type performanceStatic struct {
+	processMemFileRegexp *regexp.Regexp
+	cb                   detect.SignatureHandler
+}
+
+var performanceStaticRegexp = regexp.MustCompile(`^/proc/(?:\d+|self)/mem$`)
+
+var performanceStaticMetadata = detect.SignatureMetadata{
+	Name:        "Code injection",
+	EventName:   "test_event_name",
+	Description: "Possible process injection detected during runtime",
+	Tags:        []string{"linux", "container"},
+	Properties: map[string]interface{}{
+		"Severity":     3,
+		"MITRE ATT&CK": "Defense Evasion: Process Injection",
+	},
+}
+
+func NewPerformanceStatic() (detect.Signature, error) {
+	return &performanceStatic{
+		processMemFileRegexp: performanceStaticRegexp,
+	}, nil
+}
+
+func (sig *performanceStatic) Init(ctx detect.SignatureContext) error {
+	sig.cb = ctx.Callback
+
+	return nil
+}
+
+func (sig *performanceStatic) GetMetadata() (detect.SignatureMetadata, error) {
+	return performanceStaticMetadata, nil
+}
+
+func (sig *performanceStatic) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
+	return []detect.SignatureEventSelector{
+		{Source: "tracee", Name: "ptrace"},
+		{Source: "tracee", Name: "open"},
+		{Source: "tracee", Name: "openat"},
+		{Source: "tracee", Name: "execve"},
+	}, nil
+}
+
+func (sig *performanceStatic) OnEvent(event protocol.Event) error {
+	// event example:
+	// { "eventName": "ptrace", "args": [{"name": "request", "value": "PTRACE_POKETEXT" }]}
+	// { "eventName": "open", "args": [{"name": "flags", "value": "o_wronly" }, {"name": "pathname", "value": "/proc/self/mem" }]}
+	// { "eventName": "execve" args": [{"name": "envp", "value": ["FOO=BAR", "LD_PRELOAD=/something"] }, {"name": "argv", "value": ["ls"] }]}
+	ee, ok := event.Payload.(trace.Event)
+
+	if !ok {
+		return fmt.Errorf("failed to cast event's payload")
+	}
+	switch ee.EventName {
+	case "open", "openat":
+		flags, err := helpers.GetTraceeArgumentByName(ee, "flags", helpers.GetArgOps{DefaultArgs: false})
+		if err != nil {
+			return fmt.Errorf("%v %#v", err, ee)
+		}
+		if helpers.IsFileWrite(flags.Value.(string)) {
+			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname", helpers.GetArgOps{DefaultArgs: false})
+			if err != nil {
+				return err
+			}
+			if sig.processMemFileRegexp.MatchString(pathname.Value.(string)) {
+				metadata, err := sig.GetMetadata()
+				if err != nil {
+					return err
+				}
+				sig.cb(&detect.Finding{
+					SigMetadata: metadata,
+					Event:       event,
+					Data: map[string]interface{}{
+						"file flags": flags,
+						"file path":  pathname.Value.(string),
+					},
+				})
+			}
+		}
+	case "ptrace":
+		request, err := helpers.GetTraceeArgumentByName(ee, "request", helpers.GetArgOps{DefaultArgs: false})
+		if err != nil {
+			return err
+		}
+
+		requestString, ok := request.Value.(string)
+		if !ok {
+			return fmt.Errorf("failed to cast request's value")
+		}
+
+		if requestString == "PTRACE_POKETEXT" || requestString == "PTRACE_POKEDATA" {
+			metadata, err := sig.GetMetadata()
+			if err != nil {
+				return err
+			}
+			sig.cb(&detect.Finding{
+				SigMetadata: metadata,
+				Event:       event,
+				Data: map[string]interface{}{
+					"ptrace request": requestString,
+				},
+			})
+		}
+	}
+	return nil
+}
+
+func (sig *performanceStatic) OnSignal(s detect.Signal) error {
+	return nil
+}
+func (sig *performanceStatic) Close() {}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

cf550d1d3 **perf: benchmark improve sig GetMetadata**

```
In the signature interface, the GetMetadata method is frequently called.
Currently, every time the method is called, memory is allocated for
metadata. Two alternative methods were evaluated: using metadata 1) with
sync.Once and 2) statically.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

> GOOS=linux CC=clang GOARCH=arm64 CGO_CFLAGS="-I/vagrant/dist/libbpf -I/vagrant/3rdparty/libbpf/include/uapi" CGO_LDFLAGS="-L/vagrant/dist/libbpf/obj -lbpf " go test -benchmem -run=^$ -bench ^BenchmarkEngineMultipleMethodsGetMetadata$ github.com/aquasecurity/tracee/pkg/signatures/benchmark -benchtime=10000x

### 3. Other comments

```
current_method           	    10000            696962 ns/op          581334 B/op       5012 allocs/op
method_1_(sync.once)     	    10000            577382 ns/op          213181 B/op       2011 allocs/op
method_2_(statically)   	    10000            570819 ns/op          213310 B/op       2012 allocs/op
```

Using sync.Once or a static variable, we achieved approximately a 17% improvement compared to our current method, which allocates memory each time GetMetadata() is called.
<!--
Links? References? Anything pointing to more context about the change.
-->
