### PR TITLE
feat(ebpf): make security_socket_bind not rely on sys_enter/exit

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2741,18 +2741,18 @@ int BPF_KPROBE(trace_security_socket_bind)
         return 0;
     }
 
-    // Load the arguments given to the bind syscall (which eventually invokes this function)
-    syscall_data_t *sys = &p.task_info->syscall_data;
-    if (!p.task_info->syscall_traced)
-        return 0;
-
-    switch (sys->id) {
+    struct pt_regs *task_regs = get_current_task_pt_regs();
+    int sockfd;
+    u32 sockfd_addr;
+    switch (p.event->context.syscall) {
         case SYSCALL_BIND:
-            save_to_submit_buf(&p.event->args_buf, (void *) &sys->args.args[0], sizeof(u32), 0);
+            sockfd = get_syscall_arg1(p.event->task, task_regs, false);
+            save_to_submit_buf(&p.event->args_buf, (void *) &sockfd, sizeof(u32), 0);
             break;
 #if defined(bpf_target_x86) // armhf makes use of SYSCALL_BIND
         case SYSCALL_SOCKETCALL:
-            save_to_submit_buf(&p.event->args_buf, (void *) sys->args.args[1], sizeof(u32), 0);
+            sockfd_addr = get_syscall_arg2(p.event->task, task_regs, false);
+            save_to_submit_buf(&p.event->args_buf, (void *) sockfd_addr, sizeof(u32), 0);
             break;
 #endif
         default:

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11667,10 +11667,6 @@ var CoreEvents = map[ID]Definition{
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.SecuritySocketBind, required: true},
-				{handle: probes.SyscallEnter__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Bind)}},
 			},
 		},
 		sets: []string{"default", "lsm_hooks", "net", "net_sock"},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
make security_socket_bind not rely on sys_enter/exit
<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

### 2. Explain how to test it
./tracee -e=security_socket_bind
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
