### PR TITLE
feat(ebpf): make mem_prot_alert not rely on sys_enter/exit

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11347,14 +11347,6 @@ var CoreEvents = map[ID]Definition{
 			probes: []Probe{
 				{handle: probes.SecurityMmapAddr, required: true},
 				{handle: probes.SecurityFileMProtect, required: true},
-				{handle: probes.SyscallEnter__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{
-					"sys_enter_init_tail",
-					"sys_enter_init",
-					[]uint32{uint32(Mmap), uint32(Mprotect), uint32(PkeyMprotect)},
-				},
 			},
 		},
 		sets: []string{},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
make mem_prot_alert not rely on sys_enter/exit
<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

### 2. Explain how to test it
./tracee -e=mem_prot_alert
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
