### PR TITLE
fix: set engine to nil - sig benchmark

### DIFF
--- a/pkg/signatures/benchmark/benchmark_test.go
+++ b/pkg/signatures/benchmark/benchmark_test.go
@@ -3,6 +3,7 @@ package benchmark
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -100,6 +101,10 @@ func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 
 				// Start signatures engine and wait until all events are processed
 				e.Start(waitForEventsProcessed(inputs.Tracee))
+
+				// Set engine to nil to help with garbage collection
+				e = nil
+				runtime.GC()
 			}
 		})
 	}
@@ -149,6 +154,10 @@ func BenchmarkEngineWithMultipleSignatures(b *testing.B) {
 
 				// Start signatures engine and wait until all events are processed
 				e.Start(waitForEventsProcessed(inputs.Tracee))
+
+				// Set engine to nil to help with garbage collection
+				e = nil
+				runtime.GC()
 			}
 		})
 	}
@@ -211,6 +220,10 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 
 					// Start signatures engine and wait until all events are processed
 					e.Start(waitForEventsProcessed(inputs.Tracee))
+
+					// Set engine to nil to help with garbage collection
+					e = nil
+					runtime.GC()
 				}
 			})
 		}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

0d193c0bc **fix: set engine to nil - sig benchmark**

```
In order to avoid engine leak, set engine to nil and force GC.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

Thanks to @geyslan for spotting the Engine leak in every benchmark iteration. When a large benchtime value is used, the tasks get stuck.