### PR TITLE
fix: Remove unnecessary check for syscall wrapper in sys_enter tracepoint

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -89,28 +89,24 @@ int sys_enter_init(struct bpf_raw_tracepoint_args *ctx)
     syscall_data_t *sys = &(task_info->syscall_data);
     sys->id = ctx->args[1];
 
-    if (get_kconfig(ARCH_HAS_SYSCALL_WRAPPER)) {
-        struct pt_regs *regs = (struct pt_regs *) ctx->args[0];
+    struct pt_regs *regs = (struct pt_regs *) ctx->args[0];
 
-        if (is_x86_compat(task)) {
+    if (is_x86_compat(task)) {
 #if defined(bpf_target_x86)
-            sys->args.args[0] = BPF_CORE_READ(regs, bx);
-            sys->args.args[1] = BPF_CORE_READ(regs, cx);
-            sys->args.args[2] = BPF_CORE_READ(regs, dx);
-            sys->args.args[3] = BPF_CORE_READ(regs, si);
-            sys->args.args[4] = BPF_CORE_READ(regs, di);
-            sys->args.args[5] = BPF_CORE_READ(regs, bp);
+        sys->args.args[0] = BPF_CORE_READ(regs, bx);
+        sys->args.args[1] = BPF_CORE_READ(regs, cx);
+        sys->args.args[2] = BPF_CORE_READ(regs, dx);
+        sys->args.args[3] = BPF_CORE_READ(regs, si);
+        sys->args.args[4] = BPF_CORE_READ(regs, di);
+        sys->args.args[5] = BPF_CORE_READ(regs, bp);
 #endif // bpf_target_x86
-        } else {
-            sys->args.args[0] = PT_REGS_PARM1_CORE_SYSCALL(regs);
-            sys->args.args[1] = PT_REGS_PARM2_CORE_SYSCALL(regs);
-            sys->args.args[2] = PT_REGS_PARM3_CORE_SYSCALL(regs);
-            sys->args.args[3] = PT_REGS_PARM4_CORE_SYSCALL(regs);
-            sys->args.args[4] = PT_REGS_PARM5_CORE_SYSCALL(regs);
-            sys->args.args[5] = PT_REGS_PARM6_CORE_SYSCALL(regs);
-        }
     } else {
-        bpf_probe_read(sys->args.args, sizeof(6 * sizeof(u64)), (void *) ctx->args);
+        sys->args.args[0] = PT_REGS_PARM1_CORE_SYSCALL(regs);
+        sys->args.args[1] = PT_REGS_PARM2_CORE_SYSCALL(regs);
+        sys->args.args[2] = PT_REGS_PARM3_CORE_SYSCALL(regs);
+        sys->args.args[3] = PT_REGS_PARM4_CORE_SYSCALL(regs);
+        sys->args.args[4] = PT_REGS_PARM5_CORE_SYSCALL(regs);
+        sys->args.args[5] = PT_REGS_PARM6_CORE_SYSCALL(regs);
     }
 
     if (is_compat(task)) {


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The sys_enter raw tracepoint always provides direct access to pt_regs,
regardless of the architecture's use of a syscall wrapper. This PR removes
the redundant conditional check and simplifies the logic for extracting system
call arguments.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments
