### PR TITLE
feat(ebpf): use bpf_task_pt_regs when available

### DIFF
--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -140,7 +140,7 @@ statfunc int init_program_data(program_data_t *p, void *ctx, u32 event_id)
     p->event->context.eventid = event_id;
     p->event->context.ts = get_current_time_in_ns();
     p->event->context.processor_id = (u16) bpf_get_smp_processor_id();
-    p->event->context.syscall = get_task_syscall_id(p->event->task);
+    p->event->context.syscall = get_current_task_syscall_id();
 
     u32 host_pid = p->event->context.task.host_pid;
     p->proc_info = bpf_map_lookup_elem(&proc_info_map, &host_pid);

--- a/pkg/ebpf/c/common/task.h
+++ b/pkg/ebpf/c/common/task.h
@@ -10,7 +10,7 @@
 // PROTOTYPES
 
 statfunc int get_task_flags(struct task_struct *task);
-statfunc int get_task_syscall_id(struct task_struct *task);
+statfunc int get_current_task_syscall_id(void);
 statfunc u32 get_task_mnt_ns_id(struct task_struct *task);
 statfunc u32 get_task_pid_ns_for_children_id(struct task_struct *task);
 statfunc u32 get_task_pid_ns_id(struct task_struct *task);
@@ -39,13 +39,13 @@ statfunc int get_task_flags(struct task_struct *task)
     return BPF_CORE_READ(task, flags);
 }
 
-statfunc int get_task_syscall_id(struct task_struct *task)
+statfunc int get_current_task_syscall_id(void)
 {
     // There is no originated syscall in kernel thread context
-    if (get_task_flags(task) & PF_KTHREAD) {
+    if (get_task_flags((struct task_struct *) bpf_get_current_task()) & PF_KTHREAD) {
         return NO_SYSCALL;
     }
-    struct pt_regs *regs = get_task_pt_regs(task);
+    struct pt_regs *regs = get_current_task_pt_regs();
     return get_syscall_id_from_regs(regs);
 }
 

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -684,7 +684,9 @@ enum bpf_func_id
     BPF_FUNC_sk_storage_get = 107,
     BPF_FUNC_ktime_get_boot_ns = 125,
     BPF_FUNC_copy_from_user = 148,
+    BPF_FUNC_get_current_task_btf = 158,
     BPF_FUNC_for_each_map_elem = 164,
+    BPF_FUNC_task_pt_regs = 175,
 };
 
 #define MODULE_NAME_LEN (64 - sizeof(unsigned long))


### PR DESCRIPTION

Thanks @oshaked1 for writing this commit!

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
Tracee's `get_task_pt_regs` function mimics the logic of this helper, but relies on assuming some values defined in the kernel. This commit changes this function to use the helper if it is available. This helper must receive a task_struct with BTF info obtained from `bpf_get_current_task_btf`. From my experimentation, the verifier cannot determine whether a task_struct contains BTF info if it was stored outside of the stack. This means that this function cannot acutally retrieve the registers of any task except for the current one. The function name was changed to reflect this requirement, and it no longer receives a task_struct as a parameter.
<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->


### 2. Explain how to test it
./tracee
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

Closes #4239
