### PR TITLE
Changelog optimization

### DIFF
--- a/pkg/changelog/changelog.go
+++ b/pkg/changelog/changelog.go
@@ -85,9 +85,9 @@ func (clv *Changelog[T]) Get(targetTime time.Time) T {
 
 // GetAll returns all the values of the changelog.
 func (clv *Changelog[T]) GetAll() []T {
-	values := make([]T, len(clv.changes))
-	for i := range clv.changes {
-		values[i] = clv.changes[i].value
+	values := make([]T, 0, len(clv.changes))
+	for _, change := range clv.changes {
+		values = append(values, change.value)
 	}
 	return values
 }

--- a/pkg/changelog/changelog_benchmark_test.go
+++ b/pkg/changelog/changelog_benchmark_test.go
@@ -1,0 +1,233 @@
+package changelog
+
+import (
+	"testing"
+	"time"
+)
+
+func Benchmark_enforceSizeBoundary(b *testing.B) {
+	testCases := []struct {
+		name      string
+		changelog Changelog[int]
+	}{
+		{
+			name: "No change needed",
+			changelog: Changelog[int]{
+				changes: []item[int]{
+					{value: 1, timestamp: getTimeFromSec(1)},
+					{value: 2, timestamp: getTimeFromSec(2)},
+				},
+				timestamps: map[time.Time]struct{}{
+					getTimeFromSec(1): {},
+					getTimeFromSec(2): {},
+				},
+				maxSize: 5,
+			},
+		},
+		{
+			name: "Trim excess with duplicates",
+			changelog: Changelog[int]{
+				changes: []item[int]{
+					{value: 1, timestamp: getTimeFromSec(1)},
+					{value: 1, timestamp: getTimeFromSec(2)},
+					{value: 2, timestamp: getTimeFromSec(3)},
+					{value: 3, timestamp: getTimeFromSec(4)},
+					{value: 3, timestamp: getTimeFromSec(5)},
+				},
+				timestamps: map[time.Time]struct{}{
+					getTimeFromSec(1): {},
+					getTimeFromSec(2): {},
+					getTimeFromSec(3): {},
+					getTimeFromSec(4): {},
+					getTimeFromSec(5): {},
+				},
+				maxSize: 3,
+			},
+		},
+		{
+			name: "Remove oldest entries",
+			changelog: Changelog[int]{
+				changes: []item[int]{
+					{value: 1, timestamp: getTimeFromSec(1)},
+					{value: 2, timestamp: getTimeFromSec(2)},
+					{value: 3, timestamp: getTimeFromSec(3)},
+					{value: 4, timestamp: getTimeFromSec(4)},
+				},
+				timestamps: map[time.Time]struct{}{
+					getTimeFromSec(1): {},
+					getTimeFromSec(2): {},
+					getTimeFromSec(3): {},
+					getTimeFromSec(4): {},
+				},
+				maxSize: 2,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				clv := tc.changelog // Create a copy for each iteration
+				clv.enforceSizeBoundary()
+			}
+		})
+	}
+}
+
+func Benchmark_setAt(b *testing.B) {
+	// Test cases where the Changelog needs to enforce the size boundary
+	testCasesAllScenarios := []struct {
+		value int
+		time  time.Time
+	}{
+		{
+			value: 42,
+			time:  getTimeFromSec(0),
+		},
+		{
+			value: 72,
+			time:  getTimeFromSec(1),
+		},
+		{
+			value: 642,
+			time:  getTimeFromSec(2),
+		},
+		{
+			value: 672,
+			time:  getTimeFromSec(3), // will trigger removal of oldest entry
+		},
+		{
+			value: 642,
+			time:  getTimeFromSec(4), // will trigger coalescing of duplicate values
+		},
+		{
+			value: 672,
+			time:  getTimeFromSec(5), // will trigger coalescing of duplicate values
+		},
+		{
+			value: 6642,
+			time:  getTimeFromSec(6), // will trigger removal of oldest entry
+		},
+		{
+			value: 672,
+			time:  getTimeFromSec(7), // will trigger coalescing of duplicate values
+		},
+		{
+			value: 642,
+			time:  getTimeFromSec(8), // will trigger coalescing of duplicate values
+		},
+		{
+			value: 6672,
+			time:  getTimeFromSec(9), // will trigger removal of oldest entry
+		},
+		{
+			value: 9642,
+			time:  getTimeFromSec(10), // will trigger removal of oldest entry
+		},
+		{
+			value: 0,
+			time:  getTimeFromSec(0), // will just update the value
+		},
+		{
+			value: 0,
+			time:  getTimeFromSec(1), // will just update the value
+		},
+		{
+			value: 0,
+			time:  getTimeFromSec(2), // will just update the value
+		},
+		{
+			value: 0,
+			time:  getTimeFromSec(3), // will just update the value
+		},
+	}
+
+	b.Run("All Scenarios", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			clv := NewChangelog[int](3)
+			b.StartTimer()
+			for _, tc := range testCasesAllScenarios {
+				clv.setAt(tc.value, tc.time)
+			}
+		}
+	})
+
+	// Test cases where the changelog is within the maximum size limit
+	testCasesWithinLimit := []struct {
+		value int
+		time  time.Time
+	}{
+		{
+			value: 0,
+			time:  getTimeFromSec(0),
+		},
+		{
+			value: 1,
+			time:  getTimeFromSec(1),
+		},
+		{
+			value: 2,
+			time:  getTimeFromSec(2),
+		},
+		{
+			value: 3,
+			time:  getTimeFromSec(3),
+		},
+		{
+			value: 4,
+			time:  getTimeFromSec(4),
+		},
+		{
+			value: 5,
+			time:  getTimeFromSec(5),
+		},
+		{
+			value: 6,
+			time:  getTimeFromSec(6),
+		},
+		{
+			value: 7,
+			time:  getTimeFromSec(7),
+		},
+		{
+			value: 8,
+			time:  getTimeFromSec(8),
+		},
+		{
+			value: 9,
+			time:  getTimeFromSec(9),
+		},
+		{
+			value: 10,
+			time:  getTimeFromSec(10),
+		},
+		{
+			value: 11,
+			time:  getTimeFromSec(11),
+		},
+		{
+			value: 12,
+			time:  getTimeFromSec(12),
+		},
+		{
+			value: 13,
+			time:  getTimeFromSec(13),
+		},
+		{
+			value: 14,
+			time:  getTimeFromSec(14),
+		},
+	}
+
+	b.Run("Within Limit", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			clv := NewChangelog[int](15)
+			b.StartTimer()
+			for _, tc := range testCasesWithinLimit {
+				clv.setAt(tc.value, tc.time)
+			}
+		}
+	})
+}


### PR DESCRIPTION
### 1. Explain what the PR does

8cee7a26f **perf(changelog): optimize enforceSizeBoundary**
3bc61a882 **chore(changelog): avoid unnecessary initialization**


8cee7a26f **perf(changelog): optimize enforceSizeBoundary**

```
These optimizations make the enforceSizeBoundary function more
efficient across various scenarios, leading to overall better
performance while maintaining the same behaviour (*).

Running tool: /home/gg/.goenv/versions/1.22.4/bin/go test -benchmem
-run=^$ -tags ebpf
-bench ^(BenchmarkEnforceSizeBoundaryOld|BenchmarkEnforceSizeBoundary)$
github.com/aquasecurity/tracee/pkg/changelog -benchtime=100000000x

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/changelog
cpu: AMD Ryzen 9 7950X 16-Core Processor

| Test Case              | Old (ns/op) | New (ns/op) |   (%)  |
|------------------------|-------------|-------------|--------|
| No change needed       | 1.446       | 1.434       |  0.83% |
| Trim excess duplicates | 30.18       | 21.97       | 27.21% |
| Remove oldest entries  | 27.29       | 21.39       | 21.60% |

Since enforceSizeBoundary is called by setAt, the performance
improvements will be reflected in the latter:

-bench ^(setAtOld|setAt)$

| Test Case          | Old (ns/op) | New (ns/op) |   (%)  |
|--------------------|-------------|-------------|--------|
| All Scenarios      | 1267        | 1163        | 8.21%  |
| Within Limit       | 1770        | 1747        | 1.30%  |

Tests were fixed and added to ensure the correctness of the
implementation. Benchmarks were also added to track the performance
improvements.

(*) The behaviour of the function is the same, but the implementation
fixes a bug that when coalescing duplicate values, the removal of the
oldest entry was not being done correctly. Instead of removing the
oldest entry, the function was removing the newest one.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

This is part of the proctree effort.
