### PR TITLE
Generic syscall kprobes

### DIFF
--- a/pkg/ebpf/c/common/arch.h
+++ b/pkg/ebpf/c/common/arch.h
@@ -196,92 +196,85 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_SOCKETCALL             473
 
 #elif defined(bpf_target_arm64)
-    #define SYSCALL_READ                   63
-    #define SYSCALL_WRITE                  64
-    #define SYSCALL_OPEN                   UNDEFINED_SYSCALL
-    #define SYSCALL_CLOSE                  57
-    #define SYSCALL_FSTAT                  80
-    #define SYSCALL_LSEEK                  62
-    #define SYSCALL_MMAP                   222
-    #define SYSCALL_MPROTECT               226
-    #define SYSCALL_RT_SIGRETURN           139
-    #define SYSCALL_IOCTL                  29
-    #define SYSCALL_PREAD64                67
-    #define SYSCALL_PWRITE64               68
-    #define SYSCALL_READV                  65
-    #define SYSCALL_WRITEV                 66
-    #define SYSCALL_DUP                    23
-    #define SYSCALL_DUP2                   UNDEFINED_SYSCALL
-    #define SYSCALL_SOCKET                 198
-    #define SYSCALL_CONNECT                203
-    #define SYSCALL_ACCEPT                 202
-    #define SYSCALL_SENDTO                 206
-    #define SYSCALL_RECVFROM               207
-    #define SYSCALL_SENDMSG                211
-    #define SYSCALL_RECVMSG                212
-    #define SYSCALL_SHUTDOWN               210
-    #define SYSCALL_BIND                   200
-    #define SYSCALL_LISTEN                 201
-    #define SYSCALL_GETSOCKNAME            204
-    #define SYSCALL_GETPEERNAME            205
-    #define SYSCALL_SETSOCKOPT             208
-    #define SYSCALL_GETSOCKOPT             209
-    #define SYSCALL_EXECVE                 221
-    #define SYSCALL_EXIT                   93
-    #define SYSCALL_FCNTL                  25
-    #define SYSCALL_FLOCK                  32
-    #define SYSCALL_FSYNC                  82
-    #define SYSCALL_FDATASYNC              83
-    #define SYSCALL_FTRUNCATE              46
-    #define SYSCALL_GETDENTS               UNDEFINED_SYSCALL
-    #define SYSCALL_CHDIR                  49
-    #define SYSCALL_FCHDIR                 50
-    #define SYSCALL_FCHMOD                 52
-    #define SYSCALL_FCHOWN                 55
-    #define SYSCALL_FSTATFS                44
-    #define SYSCALL_READAHEAD              213
     #define SYSCALL_FSETXATTR              7
     #define SYSCALL_FGETXATTR              10
     #define SYSCALL_FLISTXATTR             13
     #define SYSCALL_FREMOVEXATTR           16
-    #define SYSCALL_GETDENTS64             61
-    #define SYSCALL_FADVISE64              223
-    #define SYSCALL_EXIT_GROUP             94
-    #define SYSCALL_EPOLL_WAIT             UNDEFINED_SYSCALL
     #define SYSCALL_EPOLL_CTL              21
+    #define SYSCALL_EPOLL_PWAIT            22
+    #define SYSCALL_DUP                    23
+    #define SYSCALL_DUP3                   24
+    #define SYSCALL_FCNTL                  25
     #define SYSCALL_INOTIFY_ADD_WATCH      27
     #define SYSCALL_INOTIFY_RM_WATCH       28
-    #define SYSCALL_OPENAT                 56
-    #define SYSCALL_MKDIRAT                34
+    #define SYSCALL_IOCTL                  29
+    #define SYSCALL_FLOCK                  32
     #define SYSCALL_MKNODAT                33
-    #define SYSCALL_FCHOWNAT               54
-    #define SYSCALL_FUTIMESAT              UNDEFINED_SYSCALL
-    #define SYSCALL_NEWFSTATAT             UNDEFINED_SYSCALL
+    #define SYSCALL_MKDIRAT                34
     #define SYSCALL_UNLINKAT               35
     #define SYSCALL_SYMLINKAT              36
-    #define SYSCALL_READLINKAT             78
-    #define SYSCALL_FCHMODAT               53
-    #define SYSCALL_FACCESSAT              48
-    #define SYSCALL_SYNC_FILE_RANGE        84
-    #define SYSCALL_VMSPLICE               75
-    #define SYSCALL_UTIMENSAT              88
-    #define SYSCALL_EPOLL_PWAIT            22
-    #define SYSCALL_SIGNALFD               UNDEFINED_SYSCALL
+    #define SYSCALL_FSTATFS                44
+    #define SYSCALL_FTRUNCATE              46
     #define SYSCALL_FALLOCATE              47
-    #define SYSCALL_TIMERFD_SETTIME        86
-    #define SYSCALL_TIMERFD_GETTIME        87
-    #define SYSCALL_ACCEPT4                242
-    #define SYSCALL_SIGNALFD4              74
-    #define SYSCALL_DUP3                   24
+    #define SYSCALL_FACCESSAT              48
+    #define SYSCALL_CHDIR                  49
+    #define SYSCALL_FCHDIR                 50
+    #define SYSCALL_FCHMOD                 52
+    #define SYSCALL_FCHMODAT               53
+    #define SYSCALL_FCHOWNAT               54
+    #define SYSCALL_FCHOWN                 55
+    #define SYSCALL_OPENAT                 56
+    #define SYSCALL_CLOSE                  57
+    #define SYSCALL_GETDENTS64             61
+    #define SYSCALL_LSEEK                  62
+    #define SYSCALL_READ                   63
+    #define SYSCALL_WRITE                  64
+    #define SYSCALL_READV                  65
+    #define SYSCALL_WRITEV                 66
+    #define SYSCALL_PREAD64                67
+    #define SYSCALL_PWRITE64               68
     #define SYSCALL_PREADV                 69
     #define SYSCALL_PWRITEV                70
+    #define SYSCALL_SIGNALFD4              74
+    #define SYSCALL_VMSPLICE               75
+    #define SYSCALL_READLINKAT             78
+    #define SYSCALL_FSTAT                  80
+    #define SYSCALL_FSYNC                  82
+    #define SYSCALL_FDATASYNC              83
+    #define SYSCALL_SYNC_FILE_RANGE        84
+    #define SYSCALL_TIMERFD_SETTIME        86
+    #define SYSCALL_TIMERFD_GETTIME        87
+    #define SYSCALL_UTIMENSAT              88
+    #define SYSCALL_EXIT                   93
+    #define SYSCALL_EXIT_GROUP             94
+    #define SYSCALL_RT_SIGRETURN           139
+    #define SYSCALL_SOCKET                 198
+    #define SYSCALL_BIND                   200
+    #define SYSCALL_LISTEN                 201
+    #define SYSCALL_ACCEPT                 202
+    #define SYSCALL_CONNECT                203
+    #define SYSCALL_GETSOCKNAME            204
+    #define SYSCALL_GETPEERNAME            205
+    #define SYSCALL_SENDTO                 206
+    #define SYSCALL_RECVFROM               207
+    #define SYSCALL_SETSOCKOPT             208
+    #define SYSCALL_GETSOCKOPT             209
+    #define SYSCALL_SHUTDOWN               210
+    #define SYSCALL_SENDMSG                211
+    #define SYSCALL_RECVMSG                212
+    #define SYSCALL_READAHEAD              213
+    #define SYSCALL_EXECVE                 221
+    #define SYSCALL_MMAP                   222
+    #define SYSCALL_FADVISE64              223
+    #define SYSCALL_MPROTECT               226
     #define SYSCALL_PERF_EVENT_OPEN        241
+    #define SYSCALL_ACCEPT4                242
     #define SYSCALL_RECVMMSG               243
     #define SYSCALL_NAME_TO_HANDLE_AT      264
     #define SYSCALL_OPEN_BY_HANDLE_AT      265
     #define SYSCALL_SYNCFS                 267
-    #define SYSCALL_SENDMMSG               269
     #define SYSCALL_SETNS                  268
+    #define SYSCALL_SENDMMSG               269
     #define SYSCALL_FINIT_MODULE           273
     #define SYSCALL_EXECVEAT               281
     #define SYSCALL_PREADV2                286
@@ -305,6 +298,13 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_LANDLOCK_RESTRICT_SELF 446
     #define SYSCALL_PROCESS_MRELEASE       448
     #define SYSCALL_SOCKETCALL             UNDEFINED_SYSCALL
+    #define SYSCALL_OPEN                   UNDEFINED_SYSCALL
+    #define SYSCALL_DUP2                   UNDEFINED_SYSCALL
+    #define SYSCALL_GETDENTS               UNDEFINED_SYSCALL
+    #define SYSCALL_FUTIMESAT              UNDEFINED_SYSCALL
+    #define SYSCALL_NEWFSTATAT             UNDEFINED_SYSCALL
+    #define SYSCALL_EPOLL_WAIT             UNDEFINED_SYSCALL
+    #define SYSCALL_SIGNALFD               UNDEFINED_SYSCALL
 #endif
 
 statfunc bool has_syscall_fd_arg(uint syscall_id)

--- a/pkg/ebpf/c/common/arch.h
+++ b/pkg/ebpf/c/common/arch.h
@@ -127,6 +127,7 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_FCHDIR                 81
     #define SYSCALL_FCHMOD                 91
     #define SYSCALL_FCHOWN                 93
+    #define SYSCALL_PTRACE                 101
     #define SYSCALL_FSTATFS                138
     #define SYSCALL_READAHEAD              187
     #define SYSCALL_FSETXATTR              190
@@ -247,6 +248,7 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_UTIMENSAT              88
     #define SYSCALL_EXIT                   93
     #define SYSCALL_EXIT_GROUP             94
+    #define SYSCALL_PTRACE                 117
     #define SYSCALL_RT_SIGRETURN           139
     #define SYSCALL_SOCKET                 198
     #define SYSCALL_BIND                   200

--- a/pkg/ebpf/c/common/arch.h
+++ b/pkg/ebpf/c/common/arch.h
@@ -172,6 +172,7 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_SYNCFS                 306
     #define SYSCALL_SENDMMSG               307
     #define SYSCALL_SETNS                  308
+    #define SYSCALL_PROCESS_VM_WRITEV      311
     #define SYSCALL_FINIT_MODULE           313
     #define SYSCALL_EXECVEAT               322
     #define SYSCALL_PREADV2                327
@@ -277,6 +278,7 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_SYNCFS                 267
     #define SYSCALL_SETNS                  268
     #define SYSCALL_SENDMMSG               269
+    #define SYSCALL_PROCESS_VM_WRITEV      271
     #define SYSCALL_FINIT_MODULE           273
     #define SYSCALL_EXECVEAT               281
     #define SYSCALL_PREADV2                286

--- a/pkg/ebpf/c/common/arch.h
+++ b/pkg/ebpf/c/common/arch.h
@@ -129,6 +129,7 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_FCHOWN                 93
     #define SYSCALL_PTRACE                 101
     #define SYSCALL_FSTATFS                138
+    #define SYSCALL_ARCH_PRCTL             158
     #define SYSCALL_READAHEAD              187
     #define SYSCALL_FSETXATTR              190
     #define SYSCALL_FGETXATTR              193
@@ -309,6 +310,7 @@ statfunc struct pt_regs *get_current_task_pt_regs(void)
     #define SYSCALL_NEWFSTATAT             UNDEFINED_SYSCALL
     #define SYSCALL_EPOLL_WAIT             UNDEFINED_SYSCALL
     #define SYSCALL_SIGNALFD               UNDEFINED_SYSCALL
+    #define SYSCALL_ARCH_PRCTL             UNDEFINED_SYSCALL
 #endif
 
 statfunc bool has_syscall_fd_arg(uint syscall_id)

--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -191,6 +191,7 @@ statfunc int init_program_data(program_data_t *p, void *ctx, u32 event_id)
     p->event->config.submit_for_policies = ~0ULL;
 
     if (event_id != NO_EVENT_SUBMIT) {
+        p->event->config.submit_for_policies = 0;
         event_config_t *event_config = get_event_config(event_id, p->event->context.policies_version);
         if (event_config != NULL) {
             p->event->config.param_types = event_config->param_types;

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -206,6 +206,26 @@ struct sys_exit_tails {
 
 typedef struct sys_exit_tails sys_exit_tails_t;
 
+// store syscall specific programs for tail calls from the syscall handler
+struct generic_sys_enter_tails {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(max_entries, MAX_EVENT_ID);
+    __type(key, u32);
+    __type(value, u32);
+} generic_sys_enter_tails SEC(".maps");
+
+typedef struct generic_sys_enter_tails generic_sys_enter_tails_t;
+
+// store syscall specific programs for tail calls from the syscall handler
+struct generic_sys_exit_tails {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(max_entries, MAX_EVENT_ID);
+    __type(key, u32);
+    __type(value, u32);
+} generic_sys_exit_tails SEC(".maps");
+
+typedef struct generic_sys_exit_tails generic_sys_exit_tails_t;
+
 // store program for submitting syscalls from sys_enter
 struct sys_enter_submit_tail {
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -360,6 +360,7 @@ int trace_sys_exit(struct bpf_raw_tracepoint_args *ctx)
 
 // macros for syscall kprobes
 TRACE_SYSCALL(ptrace, SYSCALL_PTRACE)
+TRACE_SYSCALL(process_vm_writev, SYSCALL_PROCESS_VM_WRITEV)
 
 SEC("raw_tracepoint/sys_execve")
 int syscall__execve_enter(void *ctx)

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -358,6 +358,9 @@ int trace_sys_exit(struct bpf_raw_tracepoint_args *ctx)
     return 0;
 }
 
+// macros for syscall kprobes
+TRACE_SYSCALL(ptrace, SYSCALL_PTRACE)
+
 SEC("raw_tracepoint/sys_execve")
 int syscall__execve_enter(void *ctx)
 {

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -362,6 +362,9 @@ int trace_sys_exit(struct bpf_raw_tracepoint_args *ctx)
 TRACE_SYSCALL(ptrace, SYSCALL_PTRACE)
 TRACE_SYSCALL(process_vm_writev, SYSCALL_PROCESS_VM_WRITEV)
 TRACE_SYSCALL(arch_prctl, SYSCALL_ARCH_PRCTL)
+TRACE_SYSCALL(dup, SYSCALL_DUP)
+TRACE_SYSCALL(dup2, SYSCALL_DUP2)
+TRACE_SYSCALL(dup3, SYSCALL_DUP3)
 
 SEC("raw_tracepoint/sys_execve")
 int syscall__execve_enter(void *ctx)
@@ -536,7 +539,7 @@ statfunc int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd)
     return events_perf_submit(p, 0);
 }
 
-SEC("raw_tracepoint/sys_dup")
+SEC("kprobe/sys_dup")
 int sys_dup_exit_tail(void *ctx)
 {
     program_data_t p = {};

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -361,6 +361,7 @@ int trace_sys_exit(struct bpf_raw_tracepoint_args *ctx)
 // macros for syscall kprobes
 TRACE_SYSCALL(ptrace, SYSCALL_PTRACE)
 TRACE_SYSCALL(process_vm_writev, SYSCALL_PROCESS_VM_WRITEV)
+TRACE_SYSCALL(arch_prctl, SYSCALL_ARCH_PRCTL)
 
 SEC("raw_tracepoint/sys_execve")
 int syscall__execve_enter(void *ctx)

--- a/pkg/ebpf/probes/arch_amd64.go
+++ b/pkg/ebpf/probes/arch_amd64.go
@@ -1,0 +1,8 @@
+//go:build amd64
+// +build amd64
+
+package probes
+
+const SyscallPrefix = "__x64_sys_"
+const SyscallPrefixCompat = "__ia32_sys_"
+const SyscallPrefixCompat2 = "__ia32_compat_sys_"

--- a/pkg/ebpf/probes/arch_arm64.go
+++ b/pkg/ebpf/probes/arch_arm64.go
@@ -1,0 +1,8 @@
+//go:build arm64
+// +build arm64
+
+package probes
+
+const SyscallPrefix = "__arm64_sys_"
+const SyscallPrefixCompat = "NOT_SUPPORTED"
+const SyscallPrefixCompat2 = "NOT_SUPPORTED"

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -228,6 +228,8 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		PtraceRet:                  NewTraceProbe(SyscallExit, "ptrace", "trace_ret_ptrace"),
 		ProcessVmWritev:            NewTraceProbe(SyscallEnter, "process_vm_writev", "trace_process_vm_writev"),
 		ProcessVmWritevRet:         NewTraceProbe(SyscallExit, "process_vm_writev", "trace_ret_process_vm_writev"),
+		ArchPrctl:                  NewTraceProbe(SyscallEnter, "arch_prctl", "trace_arch_prctl"),
+		ArchPrctlRet:               NewTraceProbe(SyscallExit, "arch_prctl", "trace_ret_arch_prctl"),
 
 		TestUnavailableHook: NewTraceProbe(KProbe, "non_existing_func", "empty_kprobe"),
 		ExecTest:            NewTraceProbe(RawTracepoint, "raw_syscalls:sched_process_exec", "tracepoint__exec_test"),

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -226,6 +226,8 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		SecuritySettime64:          NewTraceProbe(KProbe, "security_settime64", "trace_security_settime64"),
 		Ptrace:                     NewTraceProbe(SyscallEnter, "ptrace", "trace_ptrace"),
 		PtraceRet:                  NewTraceProbe(SyscallExit, "ptrace", "trace_ret_ptrace"),
+		ProcessVmWritev:            NewTraceProbe(SyscallEnter, "process_vm_writev", "trace_process_vm_writev"),
+		ProcessVmWritevRet:         NewTraceProbe(SyscallExit, "process_vm_writev", "trace_ret_process_vm_writev"),
 
 		TestUnavailableHook: NewTraceProbe(KProbe, "non_existing_func", "empty_kprobe"),
 		ExecTest:            NewTraceProbe(RawTracepoint, "raw_syscalls:sched_process_exec", "tracepoint__exec_test"),

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -230,6 +230,12 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		ProcessVmWritevRet:         NewTraceProbe(SyscallExit, "process_vm_writev", "trace_ret_process_vm_writev"),
 		ArchPrctl:                  NewTraceProbe(SyscallEnter, "arch_prctl", "trace_arch_prctl"),
 		ArchPrctlRet:               NewTraceProbe(SyscallExit, "arch_prctl", "trace_ret_arch_prctl"),
+		Dup:                        NewTraceProbe(SyscallEnter, "dup", "trace_dup"),
+		DupRet:                     NewTraceProbe(SyscallExit, "dup", "trace_ret_dup"),
+		Dup2:                       NewTraceProbe(SyscallEnter, "dup2", "trace_dup2"),
+		Dup2Ret:                    NewTraceProbe(SyscallExit, "dup2", "trace_ret_dup2"),
+		Dup3:                       NewTraceProbe(SyscallEnter, "dup3", "trace_dup3"),
+		Dup3Ret:                    NewTraceProbe(SyscallExit, "dup3", "trace_ret_dup3"),
 
 		TestUnavailableHook: NewTraceProbe(KProbe, "non_existing_func", "empty_kprobe"),
 		ExecTest:            NewTraceProbe(RawTracepoint, "raw_syscalls:sched_process_exec", "tracepoint__exec_test"),

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -224,6 +224,8 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		ExecuteAtFinishedCompatARM: NewTraceProbe(KretProbe, "__arm64_compat_sys_execveat", "trace_execute_finished"),
 		SecurityTaskSetrlimit:      NewTraceProbe(KProbe, "security_task_setrlimit", "trace_security_task_setrlimit"),
 		SecuritySettime64:          NewTraceProbe(KProbe, "security_settime64", "trace_security_settime64"),
+		Ptrace:                     NewTraceProbe(SyscallEnter, "ptrace", "trace_ptrace"),
+		PtraceRet:                  NewTraceProbe(SyscallExit, "ptrace", "trace_ret_ptrace"),
 
 		TestUnavailableHook: NewTraceProbe(KProbe, "non_existing_func", "empty_kprobe"),
 		ExecTest:            NewTraceProbe(RawTracepoint, "raw_syscalls:sched_process_exec", "tracepoint__exec_test"),

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -156,6 +156,12 @@ const (
 	ProcessVmWritevRet
 	ArchPrctl
 	ArchPrctlRet
+	Dup
+	DupRet
+	Dup2
+	Dup2Ret
+	Dup3
+	Dup3Ret
 )
 
 // Test probe handles

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -152,6 +152,8 @@ const (
 	SecuritySettime64
 	Ptrace
 	PtraceRet
+	ProcessVmWritev
+	ProcessVmWritevRet
 )
 
 // Test probe handles

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -154,6 +154,8 @@ const (
 	PtraceRet
 	ProcessVmWritev
 	ProcessVmWritevRet
+	ArchPrctl
+	ArchPrctlRet
 )
 
 // Test probe handles

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -150,6 +150,8 @@ const (
 	ExecuteAtFinishedCompatARM
 	SecurityTaskSetrlimit
 	SecuritySettime64
+	Ptrace
+	PtraceRet
 )
 
 // Test probe handles

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -4026,14 +4026,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(ArchPrctl)}},
-				{"sys_enter_submit_tail", "sys_enter_submit", []uint32{uint32(ArchPrctl)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(ArchPrctl)}},
-				{"sys_exit_submit_tail", "sys_exit_submit", []uint32{uint32(ArchPrctl)}},
+				{handle: probes.ArchPrctl, required: true},
+				{handle: probes.ArchPrctlRet, required: true},
 			},
 		},
 	},

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -2690,14 +2690,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Ptrace)}},
-				{"sys_enter_submit_tail", "sys_enter_submit", []uint32{uint32(Ptrace)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Ptrace)}},
-				{"sys_exit_submit_tail", "sys_exit_submit", []uint32{uint32(Ptrace)}},
+				{handle: probes.Ptrace, required: true},
+				{handle: probes.PtraceRet, required: true},
 			},
 		},
 	},

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -7819,14 +7819,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(ProcessVmWritev)}},
-				{"sys_enter_submit_tail", "sys_enter_submit", []uint32{uint32(ProcessVmWritev)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(ProcessVmWritev)}},
-				{"sys_exit_submit_tail", "sys_exit_submit", []uint32{uint32(ProcessVmWritev)}},
+				{handle: probes.ProcessVmWritev, required: true},
+				{handle: probes.ProcessVmWritevRet, required: true},
 			},
 		},
 	},

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -1006,14 +1006,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup)}},
-				{"sys_enter_submit_tail", "sys_enter_submit", []uint32{uint32(Dup)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Dup)}},
-				{"sys_exit_submit_tail", "sys_exit_submit", []uint32{uint32(Dup)}},
+				{handle: probes.Dup, required: true},
+				{handle: probes.DupRet, required: true},
 			},
 		},
 	},
@@ -1030,14 +1024,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup2)}},
-				{"sys_enter_submit_tail", "sys_enter_submit", []uint32{uint32(Dup2)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Dup2)}},
-				{"sys_exit_submit_tail", "sys_exit_submit", []uint32{uint32(Dup2)}},
+				{handle: probes.Dup2, required: true},
+				{handle: probes.Dup2Ret, required: true},
 			},
 		},
 	},
@@ -7325,14 +7313,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
-			},
-			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup3)}},
-				{"sys_enter_submit_tail", "sys_enter_submit", []uint32{uint32(Dup3)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Dup3)}},
-				{"sys_exit_submit_tail", "sys_exit_submit", []uint32{uint32(Dup3)}},
+				{handle: probes.Dup3, required: true},
+				{handle: probes.Dup3Ret, required: true},
 			},
 		},
 	},
@@ -11884,13 +11866,15 @@ var CoreEvents = map[ID]Definition{
 		version: NewVersion(1, 0, 0),
 		dependencies: Dependencies{
 			probes: []Probe{
-				{handle: probes.SyscallEnter__Internal, required: true},
-				{handle: probes.SyscallExit__Internal, required: true},
+				{handle: probes.Dup, required: true},
+				{handle: probes.DupRet, required: true},
+				{handle: probes.Dup2, required: false},
+				{handle: probes.Dup2Ret, required: false},
+				{handle: probes.Dup3, required: true},
+				{handle: probes.Dup3Ret, required: true},
 			},
 			tailCalls: []TailCall{
-				{"sys_enter_init_tail", "sys_enter_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
-				{"sys_exit_init_tail", "sys_exit_init", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
-				{"sys_exit_tails", "sys_dup_exit_tail", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
+				{"generic_sys_exit_tails", "sys_dup_exit_tail", []uint32{uint32(Dup), uint32(Dup2), uint32(Dup3)}},
 			},
 		},
 		sets: []string{},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

feat: Add syscall kprobe support

We currently use sys_enter/sys_exit tracepoints to trace syscalls.
These impact performance on hot paths.

This change introduces BPF program attachment to syscall entry/exit using kprobes,
offering a more efficient mechanism. 
It handles varying symbol prefixes across architectures and includes 32-bit compat support.


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

Close #4211 
