### PR TITLE
process_execute_failed: don't rely on sys_enter

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -12954,7 +12954,6 @@ var CoreEvents = map[ID]Definition{
 			probes: []Probe{
 				{handle: probes.ExecBinprm, required: false},
 				{handle: probes.ExecBinprmRet, required: false},
-				{handle: probes.SyscallEnter__Internal, required: true},
 			},
 			tailCalls: []TailCall{
 				{"prog_array", "trace_execute_failed1", []uint32{TailProcessExecuteFailed1}},


### PR DESCRIPTION
### 1. Explain what the PR does

Use task registers to extract `argv` and `envp` instead of getting them from sys_enter.