### PR TITLE
Update scope.1.md, dont supprot wildcard *

### DIFF
--- a/docs/docs/flags/scope.1.md
+++ b/docs/docs/flags/scope.1.md
@@ -49,9 +49,6 @@ Available for the following string fields:
 - container: Select events from specific container IDs.
 - executable: Select events based on the executable path.
 
-Strings can be compared as a prefix if ending with '\*', or as a suffix if starting with '\*'.
-
-NOTE: Expressions containing '\*' token must be escaped!
 
 ### BOOLEAN OPERATOR (PREPENDED)
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
the PR is a remove of 2 lines in the docs about the scope cli commend
those line discussed about the option to use * as a wild card when filtering for comm,etc
and it didn't work so it does not have support 

### 2. Explain how to test it
you can test it by running such flags with tracee
--scope comm!=bash*
--scope comm!="bash*"
--scope 'comm!=bash*'
--scope 'comm!="bash*"'
--scope comm!=bash\*
--scope comm!='bash\*'
--scope comm!="bash*"
--scope 'comm!="bash*"'
