### PR TITLE
Proctree improvements (RSS/Performance)

### DIFF
--- a/docs/docs/advanced/data-sources/builtin/process-tree.md
+++ b/docs/docs/advanced/data-sources/builtin/process-tree.md
@@ -35,6 +35,8 @@ Example:
       both         | process tree is built from both events and signals.
   --proctree process-cache=8192   | will cache up to 8192 processes in the tree (LRU cache).
   --proctree thread-cache=4096    | will cache up to 4096 threads in the tree (LRU cache).
+  --proctree process-cache-ttl=60 | will set the process cache element TTL to 60 seconds.
+  --proctree thread-cache-ttl=60  | will set the thread cache element TTL to 60 seconds.
   --proctree disable-procfs-query | Will disable procfs quering during runtime
 
 Use comma OR use the flag multiple times to choose multiple options:

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -16,6 +16,9 @@ proctree:
     cache:
         process: 8192
         thread: 4096
+    cache-ttl:
+        process: 60
+        thread: 60
 
 capabilities:
     bypass: false

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -67,6 +67,9 @@ proctree:
     cache:
         process: 8192
         thread: 8192
+    cache-ttl:
+        process: 120
+        thread: 120
 # cri:
 #     - runtime:
 #         name: docker

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -8,6 +8,9 @@ proctree:
     # cache:
     #     process: 8192
     #     thread: 4096
+    # cache-ttl:
+    #     process: 120
+    #     thread: 120
 
 capabilities:
     bypass: false

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -173,11 +173,17 @@ func (c *RegoConfig) flags() []string {
 //
 
 type ProcTreeConfig struct {
-	Source string              `mapstructure:"source"`
-	Cache  ProcTreeCacheConfig `mapstructure:"cache"`
+	Source   string                 `mapstructure:"source"`
+	Cache    ProcTreeCacheConfig    `mapstructure:"cache"`
+	CacheTTL ProcTreeCacheTTLConfig `mapstructure:"cache-ttl"`
 }
 
 type ProcTreeCacheConfig struct {
+	Process int `mapstructure:"process"`
+	Thread  int `mapstructure:"thread"`
+}
+
+type ProcTreeCacheTTLConfig struct {
 	Process int `mapstructure:"process"`
 	Thread  int `mapstructure:"thread"`
 }
@@ -197,6 +203,12 @@ func (c *ProcTreeConfig) flags() []string {
 	}
 	if c.Cache.Thread != 0 {
 		flags = append(flags, fmt.Sprintf("thread-cache=%d", c.Cache.Thread))
+	}
+	if c.CacheTTL.Process != 0 {
+		flags = append(flags, fmt.Sprintf("process-cache-ttl=%d", c.CacheTTL.Process))
+	}
+	if c.CacheTTL.Thread != 0 {
+		flags = append(flags, fmt.Sprintf("thread-cache-ttl=%d", c.CacheTTL.Thread))
 	}
 
 	return flags

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -97,12 +97,17 @@ proctree:
     cache:
         process: 8192
         thread: 4096
+    cache-ttl:
+        process: 5
+        thread: 10
 `,
 			key: "proctree",
 			expectedFlags: []string{
 				"source=events",
 				"process-cache=8192",
 				"thread-cache=4096",
+				"process-cache-ttl=5",
+				"thread-cache-ttl=10",
 			},
 		},
 		{
@@ -589,6 +594,20 @@ func TestProcTreeConfigFlags(t *testing.T) {
 			expected: []string{
 				"process-cache=8192",
 				"thread-cache=4096",
+			},
+		},
+		{
+			name: "process cache ttl set",
+			config: ProcTreeConfig{
+				Source: "",
+				CacheTTL: ProcTreeCacheTTLConfig{
+					Process: 5,
+					Thread:  10,
+				},
+			},
+			expected: []string{
+				"process-cache-ttl=5",
+				"thread-cache-ttl=10",
 			},
 		},
 		{

--- a/pkg/proctree/proctree.go
+++ b/pkg/proctree/proctree.go
@@ -78,7 +78,6 @@ type ProcessTree struct {
 	procfsChan     chan int                     // channel of pids to read from procfs
 	procfsOnce     *sync.Once                   // busy loop debug message throttling
 	ctx            context.Context              // context for the process tree
-	mutex          *sync.RWMutex                // mutex for the process tree
 	procfsQuery    bool
 	timeNormalizer traceetime.TimeNormalizer
 }
@@ -141,7 +140,6 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig, timeNormalizer t
 		processes:      processes,
 		threads:        threads,
 		ctx:            ctx,
-		mutex:          &sync.RWMutex{},
 		procfsQuery:    config.ProcfsQuerying,
 		timeNormalizer: timeNormalizer,
 	}
@@ -160,17 +158,12 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig, timeNormalizer t
 
 // GetProcessByHash returns a process by its hash.
 func (pt *ProcessTree) GetProcessByHash(hash uint32) (*Process, bool) {
-	pt.mutex.RLock()
-	defer pt.mutex.RUnlock()
 	process, ok := pt.processes.Get(hash)
 	return process, ok
 }
 
 // GetOrCreateProcessByHash returns a process by its hash, or creates a new one if it doesn't exist.
 func (pt *ProcessTree) GetOrCreateProcessByHash(hash uint32) *Process {
-	pt.mutex.RLock()
-	defer pt.mutex.RUnlock()
-
 	process, ok := pt.processes.Get(hash)
 	if !ok {
 		// Each process must have a thread with thread ID matching its process ID.
@@ -199,17 +192,12 @@ func (pt *ProcessTree) GetOrCreateProcessByHash(hash uint32) *Process {
 
 // GetThreadByHash returns a thread by its hash.
 func (pt *ProcessTree) GetThreadByHash(hash uint32) (*Thread, bool) {
-	pt.mutex.RLock()
-	defer pt.mutex.RUnlock()
 	thread, ok := pt.threads.Get(hash)
 	return thread, ok
 }
 
 // GetOrCreateThreadByHash returns a thread by its hash, or creates a new one if it doesn't exist.
 func (pt *ProcessTree) GetOrCreateThreadByHash(hash uint32) *Thread {
-	pt.mutex.RLock()
-	defer pt.mutex.RUnlock()
-
 	thread, ok := pt.threads.Get(hash)
 	if !ok {
 		// Create a new thread

--- a/pkg/proctree/proctree_bench_test.go
+++ b/pkg/proctree/proctree_bench_test.go
@@ -1,0 +1,133 @@
+package proctree
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	traceetime "github.com/aquasecurity/tracee/pkg/time"
+)
+
+func BenchmarkProcessTree(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config := ProcTreeConfig{
+		Source:               SourceBoth,
+		ProcessCacheSize:     DefaultProcessCacheSize,
+		ThreadCacheSize:      DefaultThreadCacheSize,
+		ProcfsInitialization: false,
+		ProcfsQuerying:       false,
+	}
+
+	timeNormalizer := traceetime.NewRelativeTimeNormalizer(0)
+	pt, err := NewProcessTree(ctx, config, timeNormalizer)
+	if err != nil {
+		b.Fatalf("failed to create ProcessTree: %v", err)
+	}
+
+	benchmarks := []struct {
+		name      string
+		benchFunc func(b *testing.B, pt *ProcessTree, concurrency int)
+	}{
+		{"GetProcessByHash", benchmarkGetProcessByHash},
+		{"GetOrCreateProcessByHash", benchmarkGetOrCreateProcessByHash},
+		{"GetThreadByHash", benchmarkGetThreadByHash},
+		{"GetOrCreateThreadByHash", benchmarkGetOrCreateThreadByHash},
+	}
+
+	concurrencyLevels := []int{1, 2, 4, 8}
+
+	for _, bm := range benchmarks {
+		for _, concurrency := range concurrencyLevels {
+			b.Run(bm.name+"-Concurrency"+strconv.Itoa(concurrency), func(b *testing.B) {
+				bm.benchFunc(b, pt, concurrency)
+			})
+		}
+	}
+}
+
+func benchmarkGetProcessByHash(b *testing.B, pt *ProcessTree, concurrency int) {
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	startSignal := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-startSignal
+			for n := 0; n < b.N; n++ {
+				pt.GetProcessByHash(uint32(i))
+			}
+		}(i)
+	}
+
+	b.ResetTimer()
+	close(startSignal)
+	wg.Wait()
+}
+
+func benchmarkGetOrCreateProcessByHash(b *testing.B, pt *ProcessTree, concurrency int) {
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	startSignal := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-startSignal
+			for n := 0; n < b.N; n++ {
+				pt.GetOrCreateProcessByHash(uint32(i))
+			}
+		}(i)
+	}
+
+	b.ResetTimer()
+	close(startSignal)
+	wg.Wait()
+}
+
+func benchmarkGetThreadByHash(b *testing.B, pt *ProcessTree, concurrency int) {
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	startSignal := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-startSignal
+			for n := 0; n < b.N; n++ {
+				pt.GetThreadByHash(uint32(i))
+			}
+		}(i)
+	}
+
+	b.ResetTimer()
+	close(startSignal)
+	wg.Wait()
+}
+
+func benchmarkGetOrCreateThreadByHash(b *testing.B, pt *ProcessTree, concurrency int) {
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	startSignal := make(chan struct{})
+
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-startSignal
+			for n := 0; n < b.N; n++ {
+				pt.GetOrCreateThreadByHash(uint32(i))
+			}
+		}(i)
+	}
+
+	b.ResetTimer()
+	close(startSignal)
+	wg.Wait()
+}

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -228,7 +228,7 @@ func (pt *ProcessTree) FeedFromExec(feed ExecFeed) error {
 
 	execTimestamp := traceetime.NsSinceEpochToTime(feed.TimeStamp)
 	basename := filepath.Base(feed.CmdPath)
-	comm := basename[:min(len(basename), COMM_LEN)]
+	comm := string([]byte(basename[:min(len(basename), COMM_LEN)]))
 	process.GetInfo().SetNameAt(
 		comm,
 		execTimestamp,

--- a/pkg/proctree/proctree_test.go
+++ b/pkg/proctree/proctree_test.go
@@ -1,0 +1,62 @@
+package proctree
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	traceetime "github.com/aquasecurity/tracee/pkg/time"
+)
+
+func TestProcessTreeConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	config := ProcTreeConfig{
+		Source:               SourceBoth,
+		ProcessCacheSize:     DefaultProcessCacheSize,
+		ThreadCacheSize:      DefaultThreadCacheSize,
+		ProcfsInitialization: false,
+		ProcfsQuerying:       false,
+	}
+
+	timeNormalizer := traceetime.NewRelativeTimeNormalizer(0)
+	pt, err := NewProcessTree(ctx, config, timeNormalizer)
+	if err != nil {
+		t.Fatalf("failed to create ProcessTree: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	startSignal := make(chan struct{})
+
+	testFunc := func(hash uint32) {
+		defer wg.Done()
+
+		<-startSignal // Wait for the signal to start
+
+		// Public methods
+		pt.GetProcessByHash(hash)
+		pt.GetOrCreateProcessByHash(hash)
+		pt.GetThreadByHash(hash)
+		pt.GetOrCreateThreadByHash(hash)
+	}
+
+	// Run tests concurrently for different hashes
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go testFunc(uint32(i))
+	}
+
+	// Run tests concurrently for the same hash
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go testFunc(42)
+	}
+
+	// Signal all goroutines to start at the same time
+	close(startSignal)
+
+	wg.Wait()
+}


### PR DESCRIPTION
### 1. Explain what the PR does

4b896202e **fix: create a new fresh string for comm**
cb89e2f9f **perf: use proctree expirable lru cache**
976704fcf **perf: remove mutex, add concurrency tests**
36ca022df **chore: benchmark proctree**


4b896202e **fix: create a new fresh string for comm**

```
comm had the same inner address as the original string which it was
created from (basename). This caused the original underlying bytes to
be preserved and not garbage collected.

Converting it to a byte slice and then back to a string guarantees that
a new string is created releasing the original reference.
```

cb89e2f9f **perf: use proctree expirable lru cache**

```
hashicorp LRU increases RSS over time. This change uses the proctree
lru cache to an expirable one, which will remove entries after a
certain time.

Two flags/options were added to the proctree command to control the
cache TTLs. The default is 120 seconds.

flags:

  --proctree process-cache-ttl=60
  --proctree thread-cache-ttl=60

yaml config:

    cache-ttl:
        process: 60
        thread: 60
```

976704fcf **perf: remove mutex, add concurrency tests**

```
Public proctree methods already make use of the mutex of the inner lru
cache. This commit removes the outer mutex and adds concurrency tests
to ensure that the proctree is safe to use concurrently.
```

### 2. Explain how to test it

#### Run tracee

`sudo ./dist/tracee -e execve --proctree source=both --proctree process-cache-ttl=60 --proctree thread-cache-ttl=60 -o none`

#### Stress it

`i=0; while ((i < 300000)); do ls >/dev/null; ((i++)) ; done`

#### Measurements

We consider looking at only the `000000c0000000000` segment, narrowing down to where the proctree allocates memory. Not doing this would give us the full RSS which contains the perf buffer segments that are allocated per cpu.

```
PROCTREE MAIN
-------------

000000c000000000   53248   50932   50932 rw---   [ anon ] - right after 5s of running
000000c000000000  393216  388064  388064 rw---   [ anon ] - right after stress (stress stopped)
000000c000000000  393216  388072  388072 rw---   [ anon ] - +2min after
000000c000000000  393216  310312  310312 rw---   [ anon ] - +2min after
000000c000000000  393216  310056  310056 rw---   [ anon ] - +2min after
```

*A reduction of 78008 KB (after 6min) but without further decrease.

``` 
NEW PROCTREE (using an expirable cache with 60s TTL)
------------

000000c000000000   53248   50864   50864 rw---   [ anon ] - right after 5s of running
000000c000000000  397312  394204  394204 rw---   [ anon ] - right after stress (stress stopped)
000000c000000000  397312   73280   73280 rw---   [ anon ] - +2min after
000000c000000000  397312   49988   49988 rw---   [ anon ] - +2min after
000000c000000000  397312   48580   48580 rw---   [ anon ] - +2min after
```

*A reduction of 345624 KB (after stress and cache expiring).

---

976704fcf **perf: remove mutex, add concurrency tests**

That reduced lock contention.

`/home/gg/.goenv/versions/1.22.4/bin/go test -benchmem -run=^$ -tags ebpf -bench ^BenchmarkProcessTree$ github.com/aquasecurity/tracee/pkg/proctree -benchtime=1000000x -race`

```
| Benchmark                                |   new   |   old   | % Improv |
|                                          | (ns/op) | (ns/op) |          |
|------------------------------------------|---------|---------|----------|
| GetProcessByHash-Concurrency1-32         |  176.1  |  297.5  | 40.81%   |
| GetProcessByHash-Concurrency2-32         |  583.1  | 1513.0  | 61.46%   |
| GetProcessByHash-Concurrency4-32         | 1103.0  | 2404.0  | 54.12%   |
| GetProcessByHash-Concurrency8-32         | 3222.0  | 3605.0  | 10.62%   |
| GetOrCreateProcessByHash-Concurrency1-32 |  298.9  |  333.4  | 10.36%   |
| GetOrCreateProcessByHash-Concurrency2-32 |  759.7  | 1723.0  | 55.90%   |
| GetOrCreateProcessByHash-Concurrency4-32 | 1343.0  | 3133.0  | 57.14%   |
| GetOrCreateProcessByHash-Concurrency8-32 | 3532.0  | 5780.0  | 38.89%   |
| GetThreadByHash-Concurrency1-32          |  291.1  |  372.4  | 21.83%   |
| GetThreadByHash-Concurrency2-32          |  695.9  | 2630.0  | 73.54%   |
| GetThreadByHash-Concurrency4-32          | 1574.0  | 2503.0  | 37.12%   |
| GetThreadByHash-Concurrency8-32          | 3282.0  | 3301.0  |  0.58%   |
| GetOrCreateThreadByHash-Concurrency1-32  |  300.2  |  336.5  | 10.80%   |
| GetOrCreateThreadByHash-Concurrency2-32  |  837.1  | 2537.0  | 67.01%   |
| GetOrCreateThreadByHash-Concurrency4-32  | 1764.0  | 1704.0  | -3.52%   |
| GetOrCreateThreadByHash-Concurrency8-32  | 3946.0  | 5282.0  | 25.28%   |
```
##### Measurements Conclusion

With this PR, after stress and cache expiring, we have a decrease around 267616KB (310056KB [old final cache] - 48580KB [new final cache]) in the size of proctree and significant improvement in CPU time of the public methods of proctree.

### 3. Other comments

