### PR TITLE
[v0.22.0] fix(build): cyclic dependency in makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 # dependencies, like source files, changed)
 .check*
 
+# .eval_* files are placeholders as .check* above, but focused on
+# the evaluation of the target, not failing the build if the target
+# is not found
+.eval_*
+
 # needed for the makefile btfhub building logic
 *.md5
 


### PR DESCRIPTION
### 1. Explain what the PR does

02adacf5c **fix(build): cyclic dependency in makefile**

```
$(GOENV_MK) is a body level include, so using it as a prerequisite and
as a target dependency caused a cyclic dependency.

Use .eval_goenv rule (and placeholder file) to evaluate variables to be
stored in goenv.mk and use the placeholder as a prerequisite for the
targets that need the goenv.mk content.

commit: dd763f4 (main), cherry-pick
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
