### PR TITLE
container enrichment fixes and improvements

### DIFF
--- a/pkg/ebpf/events_enrich.go
+++ b/pkg/ebpf/events_enrich.go
@@ -174,7 +174,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 							// only one cgroup_mkdir should make it here
 							// report enrich success or error once
 							i := enrichInfo[cgroupId]
-							if i.err == nil {
+							if i.err == nil || i.result.ContainerId == "" {
 								logger.Debugw("done enriching in enrich queue", "cgroup_id", cgroupId)
 							} else {
 								logger.Errorw("failed enriching in enrich queue", "error", i.err, "cgroup_id", cgroupId)


### PR DESCRIPTION
### 1. Explain what the PR does

49079a0 **feat(enrich): improve containerd image info enrich**

```
Make the image info query in containerd enrichment more robust.
Procedure now begins by first querying the containerd image service,
and only then using the cri directly as a fallback.

Additionally, fix a typo in the CRI query which appended the image name
as its digest, even when found.
```

cb72aed96 **fix(enrich): silence noncontainer cgroup errors**

```
In case enrichment is requested on a non container cgroup, return the
metadata struct with an empty container id instead. User is responsible
for handling this "not-found" case by themselves.
Apply this in locations where enrichment is called (pipeline and control
plane).
```

### 2. Explain how to test it

Deploy tracee on a containerd emv
Enrichment should work as usual
Digests should appear correctly (`sha256:abcdef121324`)
No error messages of no containerid should follow

### 3. Other comments

Fix #4257 
Fix #3870
