### PR TITLE
fix: create a Finding copy with Data copied too

### DIFF
--- a/cmd/tracee-rules/output.go
+++ b/cmd/tracee-rules/output.go
@@ -59,7 +59,12 @@ func setupOutput(w io.Writer, webhook string, webhookTemplate string, contentTyp
 		for res := range out {
 			switch res.Event.Payload.(type) {
 			case trace.Event:
-				if err := tOutput.Execute(w, res); err != nil {
+				f := &detect.Finding{
+					Event:       res.Event,
+					SigMetadata: res.SigMetadata,
+					Data:        res.GetData(),
+				}
+				if err := tOutput.Execute(w, f); err != nil {
 					logger.Errorw("Writing to output: " + err.Error())
 				}
 			default:


### PR DESCRIPTION
### 1. Explain what the PR does

499ae1ce2 **fix: create a Finding copy with Data copied too**

```
This avoids template internal (json parsing) datarace when iterating the
map and attempting to modify it.

Co-authored-by: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
