### PR TITLE
Remove irrelevant context from uprobe based events

### DIFF
--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -128,6 +128,17 @@ func (t *Tracee) registerEventProcessors() {
 	// NOTE: Make sure to convert time related args (of your event) in here.
 	t.RegisterEventProcessor(events.SchedProcessFork, t.processSchedProcessFork)
 	t.RegisterEventProcessor(events.All, t.normalizeEventCtxTimes)
+
+	//
+	// Uprobe based events processors
+	//
+
+	// Remove task context
+	t.RegisterEventProcessor(events.HiddenKernelModule, t.removeIrrelevantContext)
+	t.RegisterEventProcessor(events.HookedSyscall, t.removeIrrelevantContext)
+	t.RegisterEventProcessor(events.HookedSeqOps, t.removeIrrelevantContext)
+	t.RegisterEventProcessor(events.PrintNetSeqOps, t.removeIrrelevantContext)
+	t.RegisterEventProcessor(events.PrintMemDump, t.removeIrrelevantContext)
 }
 
 func initKernelReadFileTypes() {

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -442,6 +443,49 @@ func (t *Tracee) processSharedObjectLoaded(event *trace.Event) error {
 		)
 
 		return t.addHashArg(event, &fileKey)
+	}
+
+	return nil
+}
+
+//
+// Context related functions
+//
+
+func (t *Tracee) removeContext(event *trace.Event) error {
+	event.ThreadStartTime = 0
+	event.ProcessorID = 0
+	event.ProcessID = 0
+	event.CgroupID = 0
+	event.ThreadID = 0
+	event.ParentProcessID = 0
+	event.HostProcessID = 0
+	event.HostThreadID = 0
+	event.HostParentProcessID = 0
+	event.UserID = 0
+	event.MountNS = 0
+	event.PIDNS = 0
+	event.ProcessName = ""
+	event.Executable = trace.File{}
+	event.HostName = ""
+	event.ContainerID = ""
+	event.Container = trace.Container{}
+	event.Kubernetes = trace.Kubernetes{}
+	event.Syscall = ""
+	event.StackAddresses = []uint64{}
+	event.ContextFlags = trace.ContextFlags{}
+	event.ThreadEntityId = 0
+	event.ProcessEntityId = 0
+	event.ParentEntityId = 0
+
+	return nil
+}
+
+func (t *Tracee) removeIrrelevantContext(event *trace.Event) error {
+	// Uprobe events are created in the context of tracee's process,
+	// but that context is meaningless. Remove it.
+	if event.ProcessID == os.Getpid() {
+		return t.removeContext(event)
 	}
 
 	return nil


### PR DESCRIPTION
### 1. Explain what the PR does

Uprobe events are created with the context of tracee's process, even though it is irrelevant for the event.
This PR removes such irrelevant context from the appropriate events, by resetting all context information.
This cloes #4285.

### 2. Explain how to test it

Generate any uprobe based event (e.g. hidden_kernel_module) and see how all context information is empty.
