### PR TITLE
update syscall table: lookup_dcookie is removed

### DIFF
--- a/pkg/events/core_amd64.go
+++ b/pkg/events/core_amd64.go
@@ -1127,7 +1127,7 @@ var SyscallSymbolNames = map[ID][]KernelRestrictions{
 	209: {{Name: "io_submit"}},
 	210: {{Name: "io_cancel"}},
 	211: {{Name: SyscallNotImplemented + "get_thread_area"}},
-	212: {{Name: "lookup_dcookie"}},
+	212: {{Below: "6.7", Name: "lookup_dcookie"}},
 	213: {{Name: "epoll_create"}},
 	214: {{Name: SyscallNotImplemented + "epoll_ctl_old"}},
 	215: {{Name: SyscallNotImplemented + "epoll_wait_old"}},

--- a/pkg/events/core_arm64.go
+++ b/pkg/events/core_arm64.go
@@ -992,7 +992,7 @@ var SyscallSymbolNames = map[ID][]KernelRestrictions{
 	15:  {{Name: "lremovexattr"}},
 	16:  {{Name: "fremovexattr"}},
 	17:  {{Name: "getcwd"}},
-	18:  {{Name: "lookup_dcookie"}},
+	18:  {{Below: "6.7", Name: "lookup_dcookie"}},
 	19:  {{Name: "eventfd2"}},
 	20:  {{Name: "epoll_create1"}},
 	21:  {{Name: "epoll_ctl"}},


### PR DESCRIPTION
Kernels 6.7 and above does not have lookup_dcookie syscall anymore

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
update syscall table: lookup_dcookie is removed
<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
