### PR TITLE
[v0.22.1] container enrichment fixes and improvements

### DIFF
--- a/pkg/ebpf/events_enrich.go
+++ b/pkg/ebpf/events_enrich.go
@@ -174,7 +174,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *trace.E
 							// only one cgroup_mkdir should make it here
 							// report enrich success or error once
 							i := enrichInfo[cgroupId]
-							if i.err == nil {
+							if i.err == nil || i.result.ContainerId == "" {
 								logger.Debugw("done enriching in enrich queue", "cgroup_id", cgroupId)
 							} else {
 								logger.Errorw("failed enriching in enrich queue", "error", i.err, "cgroup_id", cgroupId)


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

3f810f7c7 **feat(enrich): improve containerd image info enrich**

```
Make the image info query in containerd enrichment more robust.
Procedure now begins by first querying the containerd image service,
and only then using the cri directly as a fallback.

Additionally, fix a typo in the CRI query which appended the image name
as its digest, even when found.

commit: 126133a (main), cherry-pick
```

8b74d3959 **fix(enrich): silence noncontainer cgroup errors**

```
In case enrichment is requested on a non container cgroup, return the
metadata struct with an empty container id instead. User is responsible
for handling this "not-found" case by themselves.
Apply this in locations where enrichment is called (pipeline and control
plane).

commit: e4215bd (main), cherry-pick
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
