### PR TITLE
Fix `timespec_t` args not being submitted to userspace

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -394,7 +394,7 @@ statfunc int save_args_to_submit_buf(event_data_t *event, args_t *args)
         type = DEC_ARG(i, event->config.param_types);
 
         // bounds check for the verifier
-        if (unlikely(type >= ARG_TYPE_MAX_ARRAY))
+        if (unlikely(type > ARG_TYPE_MAX_ARRAY))
             continue; // skip types not defined in the type_size_table
         size = type_size_table[type];
 


### PR DESCRIPTION
Closes #4300 

### 1. Explain what the PR does

Fix an off-by-one bounds check on an argument type array that resulted in `timespec_t` args not being submitted.

### 2. Explain how to test it

Run `tracee -e nanosleep,clock_nanosleep -s comm=sleep`, run `sleep 1` in the background and see if `request` and `remain` args are `nil` or have a value.
