### PR TITLE
fix(tests): possible out of range in integration

### DIFF
--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -771,7 +771,7 @@ func Test_EventFilters(t *testing.T) {
 			},
 			useSyscaller: false,
 			coolDown:     0,
-			test:         ExpectAllInOrderSequentially,
+			test:         ExpectAtLeastOneForEach,
 		},
 		{
 			name: "pid: trace new (should be empty)",
@@ -1504,7 +1504,7 @@ func Test_EventFilters(t *testing.T) {
 			},
 			useSyscaller: true,
 			coolDown:     0,
-			test:         ExpectAllInOrderSequentially,
+			test:         ExpectAtLeastOneForEach, // syscaller might emit its own events, so we expect at least one of each
 		},
 		{
 			name: "event: trace execve event set in a specific policy from fakeprog1 command",


### PR DESCRIPTION
Close: #4255

### 1. Explain what the PR does

5cf2d9d1b **fix(tests): use ExpectAtLeastOneForEach**

```
Two test cases were using ExpectAllInOrderSequentially helper function
and passing by luck, since they emit more events than expected only
beyond the expected events boundary.

For that cases we should use ExpectAtLeastOneForEach helper function
instead.
```

34be7e038 **fix(tests): possible out of range in integration**

```
ExpectAllInOrderSequentially might try to access an index out of range
depending on the number of events that are being checked.

More about in issue #4255.
``` in issue #4255.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
