### PR TITLE
sched_process_exec: don't drop event in capture exec

### DIFF
--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -175,7 +175,8 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 						destinationFilePath,
 					)
 					if err != nil {
-						return errfmt.WrapError(err)
+						logger.Debugw("capture exec: failed copying file", "error", err)
+						continue
 					}
 					// mark this file as captured
 					t.capturedFiles[capturedFileID] = castedSourceFileCtime


### PR DESCRIPTION
Currently, as part of capturing executed files, tracee tries to copy the file. In case the copy fails, tracee drops the event. This patch changes the behavior to log a debug message and continue the normal flow.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
sched_process_exec: don't drop event in capture exec
<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

### 2. Explain how to test it
./tracee -e=sched_process_exec -c exec
<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
