### PR TITLE
chore(tests): increase Tracee startup timeout

### DIFF
--- a/tests/testutils/tracee.go
+++ b/tests/testutils/tracee.go
@@ -16,7 +16,7 @@ import (
 const (
 	readinessPollTime           = 200 * time.Millisecond
 	httpRequestTimeout          = 1 * time.Second
-	TraceeDefaultStartupTimeout = 5 * time.Second
+	TraceeDefaultStartupTimeout = 10 * time.Second
 )
 
 var (


### PR DESCRIPTION
Continuation of https://github.com/aquasecurity/tracee/pull/4306.

The use of t.Fatal hid the real issue of timeout. In the future this should be managed to   rollback test execution gracefully and fail without fatal.

### 1. Explain what the PR does

### 2. Explain how to test it

### 3. Other comments
