### PR TITLE
analyze: enable sigs consuming sigs

### DIFF
--- a/cmd/tracee/cmd/analyze.go
+++ b/cmd/tracee/cmd/analyze.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
-	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -106,7 +106,7 @@ tracee analyze --events anti_debugging events.json`,
 			signatureEvents = nil
 		}
 
-		sigs, _, err := signature.Find(
+		signatures, _, err := signature.Find(
 			rego.RuntimeTarget,
 			rego.PartialEval,
 			viper.GetStringSlice("signatures-dir"),
@@ -118,20 +118,20 @@ tracee analyze --events anti_debugging events.json`,
 			logger.Fatalw("Failed to find signature event", "err", err)
 		}
 
-		if len(sigs) == 0 {
+		if len(signatures) == 0 {
 			logger.Fatalw("No signature event loaded")
 		}
 
 		logger.Infow(
 			"Signatures loaded",
-			"total", len(sigs),
-			"signatures", getSigsNames(sigs),
+			"total", len(signatures),
+			"signatures", getSigsNames(signatures),
 		)
 
-		_ = initialize.CreateEventsFromSignatures(events.StartSignatureID, sigs)
+		_ = sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
 
 		engineConfig := engine.Config{
-			Signatures:          sigs,
+			Signatures:          signatures,
 			SignatureBufferSize: 1000,
 		}
 

--- a/cmd/tracee/cmd/analyze.go
+++ b/cmd/tracee/cmd/analyze.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
-	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/findings"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
 	"github.com/aquasecurity/tracee/pkg/signatures/signature"
@@ -77,127 +77,141 @@ tracee analyze --events anti_debugging events.json`,
 		bindViperFlag(cmd, "rego")
 		bindViperFlag(cmd, "signatures-dir")
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		logFlags := viper.GetStringSlice("log")
-
-		logCfg, err := flags.PrepareLogger(logFlags, true)
-		if err != nil {
-			logger.Fatalw("Failed to prepare logger", "error", err)
-		}
-		logger.Init(logCfg)
-
-		inputFile, err := os.Open(args[0])
-		if err != nil {
-			logger.Fatalw("Failed to get signatures-dir flag", "err", err)
-		}
-
-		// Rego command line flags
-
-		rego, err := flags.PrepareRego(viper.GetStringSlice("rego"))
-		if err != nil {
-			logger.Fatalw("Failed to parse rego flags", "err", err)
-		}
-
-		// Signature directory command line flags
-
-		signatureEvents := viper.GetStringSlice("events")
-		// if no event was passed, load all events
-		if len(signatureEvents) == 0 {
-			signatureEvents = nil
-		}
-
-		signatures, _, err := signature.Find(
-			rego.RuntimeTarget,
-			rego.PartialEval,
-			viper.GetStringSlice("signatures-dir"),
-			signatureEvents,
-			rego.AIO,
-		)
-
-		if err != nil {
-			logger.Fatalw("Failed to find signature event", "err", err)
-		}
-
-		if len(signatures) == 0 {
-			logger.Fatalw("No signature event loaded")
-		}
-
-		logger.Infow(
-			"Signatures loaded",
-			"total", len(signatures),
-			"signatures", getSigsNames(signatures),
-		)
-
-		_ = sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
-
-		engineConfig := engine.Config{
-			Signatures:          signatures,
-			SignatureBufferSize: 1000,
-		}
-
-		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-		defer stop()
-
-		engineOutput := make(chan *detect.Finding)
-		engineInput := make(chan protocol.Event)
-
-		source := engine.EventSources{Tracee: engineInput}
-		sigEngine, err := engine.NewEngine(engineConfig, source, engineOutput)
-		if err != nil {
-			logger.Fatalw("Failed to create engine", "err", err)
-		}
-
-		err = sigEngine.Init()
-		if err != nil {
-			logger.Fatalw("failed to initialize signature engine", "err", err)
-		}
-
-		go sigEngine.Start(ctx)
-
-		// producer
-		go produce(ctx, inputFile, engineInput)
-
-		// consumer
-		for {
-			select {
-			case finding, ok := <-engineOutput:
-				if !ok {
-					return
-				}
-				process(finding)
-			case <-ctx.Done():
-				goto drain
-			}
-		}
-	drain:
-		// drain
-		for {
-			select {
-			case finding, ok := <-engineOutput:
-				if !ok {
-					return
-				}
-				process(finding)
-			default:
-				return
-			}
-		}
-	},
+	Run:                   command,
 	DisableFlagsInUseLine: true,
 }
 
-func produce(ctx context.Context, inputFile *os.File, engineInput chan protocol.Event) {
-	// ensure the engineInput channel will be closed
-	defer close(engineInput)
+func command(cmd *cobra.Command, args []string) {
+	logFlags := viper.GetStringSlice("log")
 
+	logCfg, err := flags.PrepareLogger(logFlags, true)
+	if err != nil {
+		logger.Fatalw("Failed to prepare logger", "error", err)
+	}
+	logger.Init(logCfg)
+
+	inputFile, err := os.Open(args[0])
+	if err != nil {
+		logger.Fatalw("Failed to get signatures-dir flag", "err", err)
+	}
+
+	// Rego command line flags
+
+	rego, err := flags.PrepareRego(viper.GetStringSlice("rego"))
+	if err != nil {
+		logger.Fatalw("Failed to parse rego flags", "err", err)
+	}
+
+	// Signature directory command line flags
+
+	signatureEvents := viper.GetStringSlice("events")
+	// if no event was passed, load all events
+	if len(signatureEvents) == 0 {
+		signatureEvents = nil
+	}
+
+	signatures, _, err := signature.Find(
+		rego.RuntimeTarget,
+		rego.PartialEval,
+		viper.GetStringSlice("signatures-dir"),
+		signatureEvents,
+		rego.AIO,
+	)
+
+	if err != nil {
+		logger.Fatalw("Failed to find signature event", "err", err)
+	}
+
+	if len(signatures) == 0 {
+		logger.Fatalw("No signature event loaded")
+	}
+
+	logger.Infow(
+		"Signatures loaded",
+		"total", len(signatures),
+		"signatures", getSigsNames(signatures),
+	)
+
+	_ = sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
+
+	engineConfig := engine.Config{
+		Signatures:          signatures,
+		SignatureBufferSize: 1000,
+	}
+
+	// two seperate contexts.
+	// 1. signal notifiable context that can terminate both analyze and engine work
+	// 2. signal solely to notify internally inside analyze once file input is over
+	signalCtx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	fileReadCtx, stop := context.WithCancel(signalCtx)
+
+	engineOutput := make(chan *detect.Finding)
+	engineInput := make(chan protocol.Event)
+
+	source := engine.EventSources{Tracee: engineInput}
+	sigEngine, err := engine.NewEngine(engineConfig, source, engineOutput)
+	if err != nil {
+		logger.Fatalw("Failed to create engine", "err", err)
+	}
+
+	err = sigEngine.Init()
+	if err != nil {
+		logger.Fatalw("failed to initialize signature engine", "err", err)
+	}
+
+	go sigEngine.Start(signalCtx)
+
+	// producer
+	go produce(fileReadCtx, stop, inputFile, engineInput)
+
+	// consumer
+	for {
+		select {
+		case finding, ok := <-engineOutput:
+			if !ok {
+				return
+			}
+			process(finding)
+		case <-fileReadCtx.Done():
+			// ensure the engineInput channel will be closed
+			goto drain
+		case <-signalCtx.Done():
+			// ensure the engineInput channel will be closed
+			goto drain
+		}
+	}
+drain:
+	// drain
+	defer close(engineInput)
+	for {
+		select {
+		case finding, ok := <-engineOutput:
+			if !ok {
+				return
+			}
+
+			process(finding)
+		default:
+			return
+		}
+	}
+}
+
+func produce(ctx context.Context, cancel context.CancelFunc, inputFile *os.File, engineInput chan<- protocol.Event) {
 	scanner := bufio.NewScanner(inputFile)
 	scanner.Split(bufio.ScanLines)
 	for {
 		select {
 		case <-ctx.Done():
+			// if terminated from above
 			return
 		default:
 			if !scanner.Scan() { // if EOF or error close the done channel and return
+				if err := scanner.Err(); err != nil {
+					logger.Errorw("Error while scanning input file", "error", err)
+				}
+				// terminate analysis here and proceed to draining
+				cancel()
 				return
 			}
 
@@ -212,7 +226,7 @@ func produce(ctx context.Context, inputFile *os.File, engineInput chan protocol.
 }
 
 func process(finding *detect.Finding) {
-	event, err := tracee.FindingToEvent(finding)
+	event, err := findings.FindingToEvent(finding)
 	if err != nil {
 		logger.Fatalw("Failed to convert finding to event", "err", err)
 	}
@@ -232,15 +246,15 @@ func bindViperFlag(cmd *cobra.Command, flag string) {
 	}
 }
 
-func getSigsNames(sigs []detect.Signature) []string {
-	var sigsNames []string
-	for _, sig := range sigs {
+func getSigsNames(signatures []detect.Signature) []string {
+	var sigNames []string
+	for _, sig := range signatures {
 		sigMeta, err := sig.GetMetadata()
 		if err != nil {
 			logger.Warnw("Failed to get signature metadata", "err", err)
 			continue
 		}
-		sigsNames = append(sigsNames, sigMeta.Name)
+		sigNames = append(sigNames, sigMeta.Name)
 	}
-	return sigsNames
+	return sigNames
 }

--- a/cmd/tracee/cmd/list.go
+++ b/cmd/tracee/cmd/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aquasecurity/tracee/pkg/cmd"
-	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/signatures/signature"
@@ -41,7 +41,7 @@ var listCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		sigs, _, err := signature.Find(
+		signatures, _, err := signature.Find(
 			compile.TargetRego,
 			false,
 			sigsDir,
@@ -53,7 +53,7 @@ var listCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		initialize.CreateEventsFromSignatures(events.StartSignatureID, sigs)
+		sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
 
 		includeSigs := true
 		wideOutput := c.Flags().Lookup("wide").Value.String() == "true"

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags/server"
 	"github.com/aquasecurity/tracee/pkg/cmd/initialize"
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
 	"github.com/aquasecurity/tracee/pkg/cmd/printer"
 	"github.com/aquasecurity/tracee/pkg/config"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
@@ -56,7 +57,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 
 	// Signature directory command line flags
 
-	sigs, dataSources, err := signature.Find(
+	signatures, dataSources, err := signature.Find(
 		rego.RuntimeTarget,
 		rego.PartialEval,
 		viper.GetStringSlice("signatures-dir"),
@@ -67,7 +68,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 		return runner, err
 	}
 
-	sigNameToEventId := initialize.CreateEventsFromSignatures(events.StartSignatureID, sigs)
+	sigNameToEventId := sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
 
 	// Initialize a tracee config structure
 
@@ -334,7 +335,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	runner.TraceeConfig.EngineConfig = engine.Config{
 		Enabled:          true,
 		SigNameToEventID: sigNameToEventId,
-		Signatures:       sigs,
+		Signatures:       signatures,
 		// This used to be a flag, we have removed the flag from this binary to test
 		// if users do use it or not.
 		SignatureBufferSize: 1000,

--- a/pkg/cmd/initialize/sigs/sigs.go
+++ b/pkg/cmd/initialize/sigs/sigs.go
@@ -1,4 +1,4 @@
-package initialize
+package sigs
 
 import (
 	"strconv"

--- a/pkg/cmd/initialize/sigs/sigs_test.go
+++ b/pkg/cmd/initialize/sigs/sigs_test.go
@@ -1,10 +1,11 @@
-package initialize
+package sigs_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/signatures/signature"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -159,7 +160,7 @@ func Test_CreateEventsFromSigs(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			CreateEventsFromSignatures(test.startId, test.signatures)
+			sigs.CreateEventsFromSignatures(test.startId, test.signatures)
 
 			for _, expected := range test.expected {
 				eventDefID, ok := events.Core.GetDefinitionIDByName(expected.GetName())

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/containers"
 	"github.com/aquasecurity/tracee/pkg/dnscache"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/findings"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/proctree"
 	"github.com/aquasecurity/tracee/pkg/signatures/engine"
@@ -124,7 +125,7 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 					continue // might happen during initialization (ctrl+c seg faults)
 				}
 
-				event, err := FindingToEvent(finding)
+				event, err := findings.FindingToEvent(finding)
 				if err != nil {
 					t.handleError(err)
 					continue

--- a/pkg/events/findings/findings.go
+++ b/pkg/events/findings/findings.go
@@ -1,4 +1,4 @@
-package ebpf
+package findings
 
 import (
 	"github.com/aquasecurity/tracee/pkg/errfmt"

--- a/pkg/events/findings/findings.go
+++ b/pkg/events/findings/findings.go
@@ -1,6 +1,8 @@
 package findings
 
 import (
+	"maps"
+
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -172,7 +174,7 @@ func getMetadataFromSignatureMetadata(sigMetadata detect.SignatureMetadata) *tra
 	metadata.Description = sigMetadata.Description
 	metadata.Tags = sigMetadata.Tags
 
-	properties := sigMetadata.Properties
+	properties := maps.Clone(sigMetadata.Properties)
 	if sigMetadata.Properties == nil {
 		properties = make(map[string]interface{})
 	}

--- a/pkg/events/findings/findings_test.go
+++ b/pkg/events/findings/findings_test.go
@@ -1,4 +1,4 @@
-package ebpf
+package findings_test
 
 import (
 	"sort"
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/findings"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -100,7 +101,7 @@ func TestFindingToEvent(t *testing.T) {
 	}
 
 	finding := createFakeEventAndFinding()
-	got, err := FindingToEvent(&finding)
+	got, err := findings.FindingToEvent(&finding)
 
 	assert.NoError(t, err)
 

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/aquasecurity/tracee/pkg/events/findings"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/signatures/metrics"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -145,7 +146,12 @@ func (engine *Engine) unloadAllSignatures() {
 // matchHandler is a function that runs when a signature is matched
 func (engine *Engine) matchHandler(res *detect.Finding) {
 	_ = engine.stats.Detections.Increment()
+	e, err := findings.FindingToEvent(res)
+	if err != nil {
+		logger.Errorw("Failed to convert finding to event, will not feedback", "err", err)
+	}
 	engine.output <- res
+	engine.inputs.Tracee <- e.ToProtocol()
 }
 
 // checkCompletion is a function that runs at the end of each input source


### PR DESCRIPTION
### 1. Explain what the PR does
df567ebc7 **fix(analyze): enable sigs consuming sigs**
ad56d06f8 **fix(findings): clone properties before rewriting**
84ceba74a **chore: move finding event conversion to a package**
3b3299707 **chore: decouple sig init from init**

df567ebc7 **fix(analyze): enable sigs consuming sigs**

```
Signatures consuming other signatures relied on the single binary
reprocessing finding events into the pipeline. This did not occur in
analyze mode. Introduce that mechanism so that it now works.

Co-authored-by: Asaf Eitani <asaf.eitani@aquasec.com>
```

84ceba74a **chore: move finding event conversion to a package**

```
Opportunistic refactor. Logic does not relate to eBPF and does relate to
event data. Also allows importing this logic without importing eBPF
related code.
```

3b3299707 **chore: decouple sig init from init**

```
This allows initializing signature to event data without importing eBPF
initialization logic, which require specific compilation tags.

Co-authored-by: Asaf Eitani <asaf.eitani@aquasec.com>
```

### 2. Explain how to test it

Currently we have internal tests for it. Confirmed it was working using those.

### 3. Other comments

Resolve #4326
