### PR TITLE
fix(ebpf): set pipeline chan size from config

### DIFF
--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -19,8 +19,8 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 	out := make(chan *trace.Event, t.config.PipelineChannelSize)
 	errc := make(chan error, 1)
 
-	engineOutput := make(chan *detect.Finding, 10000)
-	engineInput := make(chan protocol.Event, 10000)
+	engineOutput := make(chan *detect.Finding, t.config.PipelineChannelSize)
+	engineInput := make(chan protocol.Event, t.config.PipelineChannelSize)
 	engineOutputEvents := make(chan *trace.Event, t.config.PipelineChannelSize)
 	source := engine.EventSources{Tracee: engineInput}
 


### PR DESCRIPTION
### 1. Explain what the PR does

5ee8cafcf **fix(ebpf): set pipeline chan size from config**

```
Make all pipeline channels have the size set from the config option.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
