### PR TITLE
feat: remove default usage of parse-arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
 	github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f
-	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee
+	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241009193135-0b23713fa9f9
 	github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863
 	github.com/containerd/containerd v1.7.21
 	github.com/docker/docker v26.1.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
 github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
 github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f h1:O4UmMQViaaP1wKL1eXe7C6VylwrUmUB5mYM+roqnUZg=
 github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
-github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee h1:1KJy6Z2bSpmKQVPShU7hhbXgGVOgMwvzf9rjoWMTYEg=
-github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee/go.mod h1:SX08YRCsPFh8CvCvzkV8FSn1sqWAarNVEJq9RSZoF/8=
+github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241009193135-0b23713fa9f9 h1:sB84YYSDgUAYNSonXeMPweaN6dviCld8UNqcKDn1jBM=
+github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241009193135-0b23713fa9f9/go.mod h1:/eGxScU8+vnxYhchZ72Y0lv1HqTSooLvtGCt9x7450I=
 github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863 h1:domVTTQICTuCvX+ZW5EjvdUBz8EH7FedBj5lRqwpgf4=
 github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863/go.mod h1:Jwh9OOuiMHXDoGQY12N9ls5YB+j1FlRcXvFMvh1CmIU=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -331,9 +331,6 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	runner.Printer = p
 	runner.InstallPath = traceeInstallPath
 
-	// parse arguments must be enabled if the rule engine is part of the pipeline
-	runner.TraceeConfig.Output.ParseArguments = true
-
 	runner.TraceeConfig.EngineConfig = engine.Config{
 		Enabled:          true,
 		SigNameToEventID: sigNameToEventId,

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -614,8 +614,8 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 			// Populate the event with the names of the matched policies.
 			event.MatchedPolicies = t.policyManager.MatchedNames(event.MatchedPoliciesUser)
 
-			// Parse args here if the rule engine is not enabled (parsed there if it is).
-			if !t.config.EngineConfig.Enabled {
+			// Parse args here if the rule engine is NOT enabled (parsed there if it is).
+			if t.config.Output.ParseArguments && !t.config.EngineConfig.Enabled {
 				err := t.parseArguments(event)
 				if err != nil {
 					t.handleError(err)
@@ -727,15 +727,13 @@ func (t *Tracee) handleError(err error) {
 // cmd/tracee-rules), it happens on the "sink" stage of the pipeline (close to the
 // printers).
 func (t *Tracee) parseArguments(e *trace.Event) error {
-	if t.config.Output.ParseArguments {
-		err := events.ParseArgs(e)
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
+	err := events.ParseArgs(e)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
 
-		if t.config.Output.ParseArgumentsFDs {
-			return events.ParseArgsFDs(e, uint64(e.Timestamp), t.FDArgPathMap)
-		}
+	if t.config.Output.ParseArgumentsFDs {
+		return events.ParseArgsFDs(e, uint64(e.Timestamp), t.FDArgPathMap)
 	}
 
 	return nil

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"slices"
 	"strconv"
 	"sync"
 	"unsafe"
@@ -536,10 +537,13 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *trace.Event) (
 				// acting on the derived event.
 
 				eventCopy := *event
+				// shallow clone the event arguments (new slice is created) before deriving the copy,
+				// to ensure the original event arguments are not modified by the derivation stage.
+				argsCopy := slices.Clone(event.Args)
 				out <- event
 
 				// Note: event is being derived before any of its args are parsed.
-				derivatives, errors := t.eventDerivations.DeriveEvent(eventCopy)
+				derivatives, errors := t.eventDerivations.DeriveEvent(eventCopy, argsCopy)
 
 				for _, err := range errors {
 					t.handleError(err)

--- a/pkg/events/derive/derive_test.go
+++ b/pkg/events/derive/derive_test.go
@@ -2,6 +2,7 @@ package derive
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,7 +75,8 @@ func Test_DeriveEvent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			derived, errors := mockDerivationTable.DeriveEvent(tc.event)
+			argsCopy := slices.Clone(tc.event.Args)
+			derived, errors := mockDerivationTable.DeriveEvent(tc.event, argsCopy)
 			assert.Equal(t, tc.expectedDerived, derived)
 			assert.Equal(t, tc.expectedErrors, errors)
 		})

--- a/pkg/signatures/benchmark/signature/golang/anti_debugging.go
+++ b/pkg/signatures/benchmark/signature/golang/anti_debugging.go
@@ -3,6 +3,7 @@ package golang
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -12,6 +13,7 @@ import (
 type antiDebugging struct {
 	cb       detect.SignatureHandler
 	metadata detect.SignatureMetadata
+	logger   detect.Logger
 }
 
 func NewAntiDebuggingSignature() (detect.Signature, error) {
@@ -30,6 +32,7 @@ func NewAntiDebuggingSignature() (detect.Signature, error) {
 
 func (sig *antiDebugging) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
+	sig.logger = ctx.Logger
 	return nil
 }
 
@@ -52,22 +55,30 @@ func (sig *antiDebugging) OnEvent(event protocol.Event) error {
 	if ee.EventName != "ptrace" {
 		return nil
 	}
-	request, err := helpers.GetTraceeArgumentByName(ee, "request", helpers.GetArgOps{DefaultArgs: false})
+	requestArg, err := helpers.GetTraceeIntArgumentByName(ee, "request")
 	if err != nil {
 		return err
 	}
-	requestString, ok := request.Value.(string)
-	if !ok {
-		return fmt.Errorf("failed to cast request's value")
-	}
-	if requestString != "PTRACE_TRACEME" {
+
+	if uint64(requestArg) != parsers.PTRACE_TRACEME.Value() {
 		return nil
 	}
+
+	var ptraceRequestData string
+	requestString, err := parsers.ParsePtraceRequestArgument(uint64(requestArg))
+
+	if err != nil {
+		ptraceRequestData = fmt.Sprint(requestArg)
+		sig.logger.Debugw("anti_debugging sig: failed to parse ptrace request argument: %v", err)
+	} else {
+		ptraceRequestData = requestString.String()
+	}
+
 	sig.cb(&detect.Finding{
 		SigMetadata: sig.metadata,
 		Event:       event,
 		Data: map[string]interface{}{
-			"ptrace request": requestString,
+			"ptrace request": ptraceRequestData,
 		},
 	})
 	return nil

--- a/pkg/signatures/benchmark/signature/golang/code_injection.go
+++ b/pkg/signatures/benchmark/signature/golang/code_injection.go
@@ -65,11 +65,11 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	}
 	switch ee.EventName {
 	case "open", "openat":
-		flags, err := helpers.GetTraceeArgumentByName(ee, "flags", helpers.GetArgOps{DefaultArgs: false})
+		flags, err := helpers.GetTraceeIntArgumentByName(ee, "flags")
 		if err != nil {
 			return fmt.Errorf("%v %#v", err, ee)
 		}
-		if helpers.IsFileWrite(flags.Value.(string)) {
+		if helpers.IsFileWrite(flags) {
 			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname", helpers.GetArgOps{DefaultArgs: false})
 			if err != nil {
 				return err

--- a/pkg/signatures/regosig/aio.go
+++ b/pkg/signatures/regosig/aio.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/opa/compile"
 	"github.com/open-policy-agent/opa/rego"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -194,6 +195,12 @@ func (a *aio) OnEvent(event protocol.Event) error {
 	if !ok {
 		return fmt.Errorf("failed to cast event's payload")
 	}
+
+	err := events.ParseArgs(&ee)
+	if err != nil {
+		return fmt.Errorf("rego aio: failed to parse event data: %v", err)
+	}
+
 	input := rego.EvalInput(ee)
 
 	ctx := context.TODO()

--- a/pkg/signatures/regosig/traceerego_test.go
+++ b/pkg/signatures/regosig/traceerego_test.go
@@ -349,6 +349,7 @@ func OnEventSpec(t *testing.T, target string, partial bool) {
 				Payload: "just some stuff",
 			},
 			finding: nil,
+			error:   "failed to cast event's payload",
 		},
 	}
 

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,12 +12,12 @@ import (
 
 type AntiDebuggingPtraceme struct {
 	cb            detect.SignatureHandler
-	ptraceTraceMe string
+	ptraceTraceMe int
 }
 
 func (sig *AntiDebuggingPtraceme) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptraceTraceMe = "PTRACE_TRACEME"
+	sig.ptraceTraceMe = int(parsers.PTRACE_TRACEME.Value())
 	return nil
 }
 
@@ -52,7 +53,7 @@ func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/anti_debugging_ptraceme_test.go
+++ b/signatures/golang/anti_debugging_ptraceme_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_TRACEME"),
+							Value: interface{}(int64(parsers.PTRACE_TRACEME.Value())),
 						},
 					},
 				},
@@ -44,7 +45,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_TRACEME"),
+								Value: interface{}(int64(parsers.PTRACE_TRACEME.Value())),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +77,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: interface{}(int64(parsers.PTRACE_PEEKTEXT.Value())),
 						},
 					},
 				},

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -57,7 +57,7 @@ func (sig *AslrInspection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/aslr_inspection_test.go
+++ b/signatures/golang/aslr_inspection_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestAslrInspection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -94,7 +95,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},
@@ -111,7 +112,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -59,7 +59,7 @@ func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) erro
 		}
 		basename := path.Base(pathname)
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_notify_on_release_modification_test.go
+++ b/signatures/golang/cgroup_notify_on_release_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -56,7 +56,7 @@ func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_release_agent_modification_test.go
+++ b/signatures/golang/cgroup_release_agent_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -141,7 +142,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 					},
 				},
@@ -164,7 +165,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -58,7 +58,7 @@ func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/core_pattern_modification_test.go
+++ b/signatures/golang/core_pattern_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestCorePatternModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -59,7 +59,7 @@ func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/default_loader_modification_test.go
+++ b/signatures/golang/default_loader_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -141,7 +142,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -164,7 +165,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -61,7 +61,7 @@ func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/docker_abuse_test.go
+++ b/signatures/golang/docker_abuse_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +31,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +53,7 @@ func TestDockerAbuse(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -140,7 +141,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -164,7 +165,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -11,12 +11,12 @@ import (
 
 type DynamicCodeLoading struct {
 	cb        detect.SignatureHandler
-	alertText string
+	alertType trace.MemProtAlert
 }
 
 func (sig *DynamicCodeLoading) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.alertText = "Protection changed from W to E!"
+	sig.alertType = trace.ProtAlertMprotectWXToX
 	return nil
 }
 
@@ -52,12 +52,13 @@ func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "mem_prot_alert":
-		alert, err := helpers.GetTraceeStringArgumentByName(eventObj, "alert")
+		alert, err := helpers.GetTraceeUintArgumentByName(eventObj, "alert")
 		if err != nil {
 			return err
 		}
+		memProtAlert := trace.MemProtAlert(alert)
 
-		if alert == sig.alertText {
+		if memProtAlert == sig.alertType {
 			metadata, err := sig.GetMetadata()
 			if err != nil {
 				return err

--- a/signatures/golang/dynamic_code_loading_test.go
+++ b/signatures/golang/dynamic_code_loading_test.go
@@ -29,7 +29,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed from W to E!"),
+							Value: uint32(trace.ProtAlertMprotectWXToX),
 						},
 					},
 				},
@@ -44,7 +44,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "alert",
 								},
-								Value: interface{}("Protection changed from W to E!"),
+								Value: uint32(trace.ProtAlertMprotectWXToX),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +76,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed to Executable!"),
+							Value: uint32(trace.ProtAlertMmapWX),
 						},
 					},
 				},

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -70,7 +70,7 @@ func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/k8s_service_account_token_test.go
+++ b/signatures/golang/k8s_service_account_token_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +31,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +53,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -91,7 +92,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -115,7 +116,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -139,7 +140,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/kernel_module_loading_test.go
+++ b/signatures/golang/kernel_module_loading_test.go
@@ -60,7 +60,7 @@ func TestKernelModuleLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "type",
 							},
-							Value: interface{}("kernel-module"),
+							Value: trace.KernelReadKernelModule,
 						},
 					},
 				},
@@ -75,7 +75,7 @@ func TestKernelModuleLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "type",
 								},
-								Value: interface{}("kernel-module"),
+								Value: trace.KernelReadKernelModule,
 							},
 						},
 					}.ToProtocol(),
@@ -107,7 +107,7 @@ func TestKernelModuleLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "type",
 							},
-							Value: interface{}("firmware"),
+							Value: trace.KernelReadFirmware,
 						},
 					},
 				},

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -65,7 +65,7 @@ func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) erro
 			}
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/kubernetes_certificate_theft_attempt_test.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +31,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +53,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -138,7 +139,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -162,7 +163,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -186,7 +187,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -85,7 +85,7 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ld_preload_test.go
+++ b/signatures/golang/ld_preload_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestLdPreload(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -194,7 +195,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -217,7 +218,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -58,7 +58,7 @@ func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_kcore_read_test.go
+++ b/signatures/golang/proc_kcore_read_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestProcKcoreRead(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -94,7 +95,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -61,7 +61,7 @@ func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_access_test.go
+++ b/signatures/golang/proc_mem_access_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestProcMemAccess(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +112,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -61,7 +61,7 @@ func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_code_injection_test.go
+++ b/signatures/golang/proc_mem_code_injection_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +112,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,14 +12,14 @@ import (
 
 type PtraceCodeInjection struct {
 	cb             detect.SignatureHandler
-	ptracePokeText string
-	ptracePokeData string
+	ptracePokeText int
+	ptracePokeData int
 }
 
 func (sig *PtraceCodeInjection) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptracePokeText = "PTRACE_POKETEXT"
-	sig.ptracePokeData = "PTRACE_POKEDATA"
+	sig.ptracePokeText = int(parsers.PTRACE_POKETEXT.Value())
+	sig.ptracePokeData = int(parsers.PTRACE_POKEDATA.Value())
 	return nil
 }
 
@@ -54,7 +55,7 @@ func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ptrace_code_injection_test.go
+++ b/signatures/golang/ptrace_code_injection_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKETEXT"),
+							Value: int32(parsers.PTRACE_POKETEXT.Value()),
 						},
 					},
 				},
@@ -44,7 +45,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKETEXT"),
+								Value: int32(parsers.PTRACE_POKETEXT.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +77,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKEDATA"),
+							Value: int32(parsers.PTRACE_POKEDATA.Value()),
 						},
 					},
 				},
@@ -91,7 +92,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKEDATA"),
+								Value: int32(parsers.PTRACE_POKEDATA.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -123,7 +124,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: int32(parsers.PTRACE_PEEKTEXT.Value()),
 						},
 					},
 				},

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -65,7 +65,7 @@ func (sig *RcdModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/rcd_modification_test.go
+++ b/signatures/golang/rcd_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +110,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -288,7 +289,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -311,7 +312,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -57,7 +57,7 @@ func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sched_debug_recon_test.go
+++ b/signatures/golang/sched_debug_recon_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestSchedDebugRecon(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +112,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -65,7 +65,7 @@ func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/scheduled_task_modification_test.go
+++ b/signatures/golang/scheduled_task_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +110,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -288,7 +289,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -311,7 +312,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -59,7 +59,7 @@ func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 	switch eventObj.EventName {
 	case "security_file_open":
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sudoers_modification_test.go
+++ b/signatures/golang/sudoers_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -115,7 +116,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -247,7 +248,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -270,7 +271,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -52,7 +52,7 @@ func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) err
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/system_request_key_config_modification_test.go
+++ b/signatures/golang/system_request_key_config_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/test_helpers.go
+++ b/signatures/golang/test_helpers.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/aquasecurity/tracee/pkg/events/parsers"
+
+func buildFlagArgValue(flags ...parsers.SystemFunctionArgument) int32 {
+	var res int32
+	for _, flagVal := range flags {
+		res = res | int32(flagVal.Value())
+	}
+	return res
+}

--- a/tests/e2e-inst-signatures/e2e-bpf_attach.go
+++ b/tests/e2e-inst-signatures/e2e-bpf_attach.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -48,14 +49,14 @@ func (sig *e2eBpfAttach) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		attachType, err := helpers.GetTraceeStringArgumentByName(eventObj, "attach_type")
+		attachType, err := helpers.GetTraceeIntArgumentByName(eventObj, "attach_type")
 		if err != nil {
 			return err
 		}
 
 		// check expected values from test for detection
 
-		if symbolName != "security_file_open" || attachType != "kprobe" {
+		if symbolName != "security_file_open" || attachType != int(parsers.BPFProgTypeKprobe) {
 			return nil
 		}
 


### PR DESCRIPTION
Close: https://github.com/aquasecurity/tracee/issues/2177

### 1. Explain what the PR does

47451f562 **feat(cmd): disable arg parsing by default**
cb48e1fca **fix: possible overwrite of Args on Derive stage**
3cfe5c5a4 **chore(ebpf): copy event before parsing it**
0fce1839b **feat(rego): parse event arguments in sig**
ec478cc6a **feat(sigs): refactor to use nonparsed arguments**
ddc219a3a **chore(go.mod): bump sig helpers to 0b23713f**


3cfe5c5a4 **chore(ebpf): copy event before parsing it**

```
Refactor 'event feeding to engine' logic to copy the event before
parsing it, cloning its arguments.
```

0fce1839b **feat(rego): parse event arguments in sig**

```
Removing default argument parsing will break rego signatures, whose
implementation depends on parsed arguments. In order to keep the option
of readability in REGO signatures, events will be parsed by default in
the context of evaluating these kind of signatures.
This will also ensure that they will not be broken depending on the
selection of parse-arguments.

Co-authored-by: Geyslan Gregório <geyslan@gmail.com>
```

ec478cc6a **feat(sigs): refactor to use nonparsed arguments**

```
Co-authored-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it

`-e ptrace -o json`

```json
{"timestamp":1727372470993574813,"threadStartTime":1727372470988592715,"processorId":30,"processId":250996,"cgroupId":15795,"threadId":250996,"parentProcessId":250785,"hostProcessId":250996,"hostThreadId":250996,"hostParentProcessId":250785,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"101","eventName":"ptrace","matchedPolicies":[""],"argsNum":4,"returnValue":0,"syscall":"ptrace","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":1253568537,"processEntityId":1253568537,"parentEntityId":1331977861,"args":[{"name":"request","type":"long","value":24},{"name":"pid","type":"pid_t","value":250999},{"name":"addr","type":"void*","value":0},{"name":"data","type":"void*","value":0}]}
```

`-e ptrace -o json -o option:parse-arguments`

```json
{"timestamp":1727372519574101498,"threadStartTime":1727372519569629604,"processorId":2,"processId":252379,"cgroupId":15795,"threadId":252379,"parentProcessId":250785,"hostProcessId":252379,"hostThreadId":252379,"hostParentProcessId":250785,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"101","eventName":"ptrace","matchedPolicies":[""],"argsNum":4,"returnValue":0,"syscall":"ptrace","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":611073971,"processEntityId":611073971,"parentEntityId":1331977861,"args":[{"name":"request","type":"string","value":"PTRACE_SYSCALL"},{"name":"pid","type":"pid_t","value":252382},{"name":"addr","type":"void*","value":"0x0"},{"name":"data","type":"void*","value":"0x0"}]}
```

`-e ptrace,anti_debugging -o json`

```json
{"timestamp":1727372566359065181,"threadStartTime":1727372566357715045,"processorId":23,"processId":253398,"cgroupId":15795,"threadId":253398,"parentProcessId":250785,"hostProcessId":253398,"hostThreadId":253398,"hostParentProcessId":250785,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"101","eventName":"ptrace","matchedPolicies":[""],"argsNum":4,"returnValue":80,"syscall":"ptrace","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":1514910604,"processEntityId":1514910604,"parentEntityId":1331977861,"args":[{"name":"request","type":"long","value":16910},{"name":"pid","type":"pid_t","value":253400},{"name":"addr","type":"void*","value":88},{"name":"data","type":"void*","value":140729822389936}]}
{"timestamp":1727372566359036587,"threadStartTime":1727372566359015597,"processorId":18,"processId":253400,"cgroupId":15795,"threadId":253400,"parentProcessId":253398,"hostProcessId":253400,"hostThreadId":253400,"hostParentProcessId":253398,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"6018","eventName":"anti_debugging","matchedPolicies":[""],"argsNum":1,"returnValue":0,"syscall":"ptrace","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":3776954121,"processEntityId":3776954121,"parentEntityId":1514910604,"args":[{"name":"triggeredBy","type":"unknown","value":{"args":[{"name":"request","type":"long","value":0},{"name":"pid","type":"pid_t","value":0},{"name":"addr","type":"void*","value":0},{"name":"data","type":"void*","value":0}],"id":101,"name":"ptrace","returnValue":0}}],"metadata":{"Version":"1","Description":"A process used anti-debugging techniques to block a debugger. Malware use anti-debugging to stay invisible and inhibit analysis of their behavior.","Tags":null,"Properties":{"Category":"defense-evasion","Kubernetes_Technique":"","Severity":1,"Technique":"Debugger Evasion","external_id":"T1622","id":"attack-pattern--e4dc8c01-417f-458d-9ee0-bb0617c1b391","signatureID":"TRC-102","signatureName":"Anti-Debugging detected"}}}
```

`-e ptrace,anti_debugging -o json -o option:parse-arguments`

```json
{"timestamp":1727372641521767935,"threadStartTime":1727372641521707790,"processorId":3,"processId":254357,"cgroupId":15795,"threadId":254357,"parentProcessId":254355,"hostProcessId":254357,"hostThreadId":254357,"hostParentProcessId":254355,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"101","eventName":"ptrace","matchedPolicies":[""],"argsNum":4,"returnValue":0,"syscall":"ptrace","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":991543686,"processEntityId":991543686,"parentEntityId":706525229,"args":[{"name":"request","type":"string","value":"PTRACE_TRACEME"},{"name":"pid","type":"pid_t","value":0},{"name":"addr","type":"void*","value":"0x0"},{"name":"data","type":"void*","value":"0x0"}]}
{"timestamp":1727372641521767935,"threadStartTime":1727372641521707790,"processorId":3,"processId":254357,"cgroupId":15795,"threadId":254357,"parentProcessId":254355,"hostProcessId":254357,"hostThreadId":254357,"hostParentProcessId":254355,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"strace","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"6018","eventName":"anti_debugging","matchedPolicies":[""],"argsNum":1,"returnValue":0,"syscall":"ptrace","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":991543686,"processEntityId":991543686,"parentEntityId":706525229,"args":[{"name":"triggeredBy","type":"unknown","value":{"args":[{"name":"request","type":"long","value":0},{"name":"pid","type":"pid_t","value":0},{"name":"addr","type":"void*","value":0},{"name":"data","type":"void*","value":0}],"id":101,"name":"ptrace","returnValue":0}}],"metadata":{"Version":"1","Description":"A process used anti-debugging techniques to block a debugger. Malware use anti-debugging to stay invisible and inhibit analysis of their behavior.","Tags":null,"Properties":{"Category":"defense-evasion","Kubernetes_Technique":"","Severity":1,"Technique":"Debugger Evasion","external_id":"T1622","id":"attack-pattern--e4dc8c01-417f-458d-9ee0-bb0617c1b391","signatureID":"TRC-102","signatureName":"Anti-Debugging detected"}}}
```

`-e clone -o json`

```json
{"timestamp":1727373613518714532,"threadStartTime":1727359148914395690,"processorId":18,"processId":56508,"cgroupId":13230,"threadId":56508,"parentProcessId":16017,"hostProcessId":56508,"hostThreadId":56508,"hostParentProcessId":16017,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"Isolated Web Co","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"56","eventName":"clone","matchedPolicies":[""],"argsNum":5,"returnValue":266682,"syscall":"clone","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":1636448302,"processEntityId":1636448302,"parentEntityId":77461819,"args":[{"name":"flags","type":"unsigned long","value":4001536},{"name":"stack","type":"void*","value":139882651930416},{"name":"parent_tid","type":"int*","value":139882651933072},{"name":"child_tid","type":"int*","value":139882651933072},{"name":"tls","type":"unsigned long","value":139882651932352}]}
```

`-e clone -o json -o option:parse-arguments`

```json
{"timestamp":1727373700925146906,"threadStartTime":1727373700925174018,"processorId":2,"processId":17283,"cgroupId":13230,"threadId":267890,"parentProcessId":16017,"hostProcessId":17283,"hostThreadId":267890,"hostParentProcessId":16017,"userId":1000,"mountNamespace":4026531841,"pidNamespace":4026531836,"processName":"Isolated Web Co","executable":{"path":""},"hostName":"hb0","containerId":"","container":{},"kubernetes":{},"eventId":"56","eventName":"clone","matchedPolicies":[""],"argsNum":5,"returnValue":0,"syscall":"clone","stackAddresses":null,"contextFlags":{"containerStarted":false,"isCompat":false},"threadEntityId":691270545,"processEntityId":3906119074,"parentEntityId":77461819,"args":[{"name":"flags","type":"string","value":"CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID"},{"name":"stack","type":"void*","value":"0x7f096eb7cf30"},{"name":"parent_tid","type":"int*","value":"0x7f096eb7d990"},{"name":"child_tid","type":"int*","value":"0x7f096eb7d990"},{"name":"tls","type":"unsigned long","value":139678488975040}]}
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
