### PR TITLE
register normalizeTimeArg processor only when proctree is on

### DIFF
--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -79,26 +79,24 @@ func (t *Tracee) RegisterEventProcessor(id events.ID, proc func(evt *trace.Event
 // registerEventProcessors registers all event processors, each to a specific event id.
 func (t *Tracee) registerEventProcessors() {
 	//
-	// Event Timestamps Normalization
-	//
-
-	// Convert all time relate args to nanoseconds since epoch.
-	// NOTE: Make sure to convert time related args (of your event) in here, so that
-	// any later code has access to normalized time arguments.
-	t.RegisterEventProcessor(events.SchedProcessFork, t.normalizeTimeArg(
-		"start_time",
-		"parent_start_time",
-		"parent_process_start_time",
-		"leader_start_time",
-	))
-
-	//
 	// Process Tree Processors
 	//
 
 	// Processors registered when proctree source "events" is enabled.
 	switch t.config.ProcTree.Source {
 	case proctree.SourceEvents, proctree.SourceBoth:
+		// Event Timestamps Normalization
+		//
+		// Convert all time relate args to nanoseconds since epoch.
+		// NOTE: Make sure to convert time related args (of your event) in here, so that
+		// any later code has access to normalized time arguments.
+		t.RegisterEventProcessor(events.SchedProcessFork, t.normalizeTimeArg(
+			"start_time",
+			"parent_start_time",
+			"parent_process_start_time",
+			"leader_start_time",
+		))
+
 		t.RegisterEventProcessor(events.SchedProcessFork, t.procTreeForkProcessor)
 		t.RegisterEventProcessor(events.SchedProcessExec, t.procTreeExecProcessor)
 		t.RegisterEventProcessor(events.SchedProcessExit, t.procTreeExitProcessor)

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -361,9 +361,13 @@ func (t *Tracee) normalizeTimeArg(argNames ...string) func(event *trace.Event) e
 			if arg == nil {
 				return errfmt.Errorf("couldn't find argument %s of event %s", argName, event.EventName)
 			}
+			if arg.Value == nil {
+				continue
+			}
+
 			argTime, ok := arg.Value.(uint64)
 			if !ok {
-				return errfmt.Errorf("argument %s of event %s is not of type uint64", argName, event.EventName)
+				return errfmt.Errorf("argument %s of event %s is not uint64, it is %T", argName, event.EventName, arg.Value)
 			}
 			arg.Value = time.BootToEpochNS(argTime)
 		}


### PR DESCRIPTION
Close: #4330

### 1. Explain what the PR does

0b35baa4d **fix(ebpf): register processor conditionally**

```
Register SchedProcessFork processors, including normalizeTimeArg,
only if proctree is enabled.
```

206e16072 **fix(ebpf): try to assert only when it is not nil**

```
The normalizeTimeArg function was not checking if the value was nil
before asserting it as an uint64.

This also adds the type to the error message.
```

### 2. Explain how to test it

`sudo ./dist/tracee -e sched_process_fork`
`sudo ./dist/tracee --proctree source=both -e sched_process_fork` to have related args filled.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
