### PR TITLE
Handle zero-value types for unavailable fields - ArgMeta

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
 	github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee
-	github.com/aquasecurity/tracee/types v0.0.0-20240607205742-90c301111aee
+	github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863
 	github.com/containerd/containerd v1.7.21
 	github.com/docker/docker v26.1.5+incompatible
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f h1:O4UmMQV
 github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee h1:1KJy6Z2bSpmKQVPShU7hhbXgGVOgMwvzf9rjoWMTYEg=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee/go.mod h1:SX08YRCsPFh8CvCvzkV8FSn1sqWAarNVEJq9RSZoF/8=
-github.com/aquasecurity/tracee/types v0.0.0-20240607205742-90c301111aee h1:PDQn0NcQnF/O8wX2zDak0TteAR89IMUTcCm1IwVmo0M=
-github.com/aquasecurity/tracee/types v0.0.0-20240607205742-90c301111aee/go.mod h1:Jwh9OOuiMHXDoGQY12N9ls5YB+j1FlRcXvFMvh1CmIU=
+github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863 h1:domVTTQICTuCvX+ZW5EjvdUBz8EH7FedBj5lRqwpgf4=
+github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863/go.mod h1:Jwh9OOuiMHXDoGQY12N9ls5YB+j1FlRcXvFMvh1CmIU=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/bufferdecoder/decoder.go
+++ b/pkg/bufferdecoder/decoder.go
@@ -106,10 +106,12 @@ func (decoder *EbpfDecoder) DecodeArguments(args []trace.Argument, argnum int, e
 		}
 		args[idx] = arg
 	}
+
 	// Fill missing arguments metadata
 	for i := 0; i < len(evtParams); i++ {
 		if args[i].Value == nil {
 			args[i].ArgMeta = evtParams[i]
+			args[i].Value = args[i].Zero
 		}
 	}
 	return nil

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -10388,7 +10388,7 @@ var CoreEvents = map[ID]Definition{
 		syscall: true,
 		sets:    []string{"syscalls", "32bit_unique"},
 		params: []trace.ArgMeta{
-			{Type: "old_old_uid_t", Name: "uid"},
+			{Type: "old_uid_t", Name: "uid"},
 		},
 		dependencies: Dependencies{
 			probes: []Probe{

--- a/pkg/events/definition_group.go
+++ b/pkg/events/definition_group.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
+	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
@@ -123,6 +124,11 @@ func (d *DefinitionGroup) AddBatch(givenDefs map[ID]Definition) error {
 	defer d.mutex.Unlock()
 
 	for id, def := range givenDefs {
+		for i := range def.params {
+			// set zero value in the argument definition once,
+			// so it can be reused without recalculation later.
+			def.params[i].Zero = parse.ArgZeroValueFromType(def.params[i].Type)
+		}
 		err := d.add(id, def)
 		if err != nil {
 			return err

--- a/pkg/events/parse/params.go
+++ b/pkg/events/parse/params.go
@@ -1,6 +1,8 @@
 package parse
 
 import (
+	"strings"
+
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -22,6 +24,132 @@ func ArgVal[T any](args []trace.Argument, argName string) (T, error) {
 		}
 	}
 	return *new(T), errfmt.Errorf("argument %s not found", argName)
+}
+
+func ArgZeroValueFromType(t string) interface{} {
+	switch t {
+	case "char":
+		return byte(0)
+	case "bytes":
+		return []byte{}
+	case "s8":
+		return int8(0)
+	case "u8":
+		return uint8(0)
+	case "s16",
+		"short":
+		return int16(0)
+	case "u16",
+		"unsigned short",
+		"old_gid_t",
+		"old_uid_t",
+		"umode_t":
+		return uint16(0)
+	case "s32",
+		"int",
+		"pid_t",
+		"key_t",
+		"clockid_t",
+		"const clockid_t",
+		"timer_t",
+		"mqd_t",
+		"key_serial_t":
+		return int32(0)
+	case "u32",
+		"unsigned int",
+		"dev_t",
+		"uid_t",
+		"gid_t",
+		"size_t",
+		"mode_t",
+		"qid_t",
+		"landlock_rule_type":
+		return uint32(0)
+	case "int[2]":
+		return [2]int32{}
+	case "s64",
+		"long",
+		"long long",
+		"off_t",
+		"loff_t":
+		return int64(0)
+	case "u64",
+		"unsigned long",
+		"unsigned long long",
+		"const unsigned long",
+		"const unsigned long long",
+		"aio_context_t":
+		return uint64(0)
+	case "unsigned long[]":
+		return []uint64{}
+	case "char*",
+		"const char*",
+		"const char *":
+		return string("")
+	case "const char**",
+		"const char **":
+		return []string{}
+	case "bool":
+		return false
+	case "float":
+		return float32(0)
+	case "float64":
+		return float64(0)
+	case "slim_cred_t":
+		return trace.SlimCred{}
+	case "trace.ProtoIPv4":
+		return trace.ProtoIPv4{}
+	case "trace.ProtoIPv6":
+		return trace.ProtoIPv6{}
+	case "trace.ProtoTCP":
+		return trace.ProtoTCP{}
+	case "trace.ProtoUDP":
+		return trace.ProtoUDP{}
+	case "trace.ProtoICMP":
+		return trace.ProtoICMP{}
+	case "trace.ProtoICMPv6":
+		return trace.ProtoICMPv6{}
+	case "trace.PktMeta":
+		return trace.PktMeta{}
+	case "trace.ProtoDNS":
+		return trace.ProtoDNS{}
+	case "[]trace.DnsQueryData":
+		return []trace.DnsQueryData{}
+	case "[]trace.DnsResponseData":
+		return []trace.DnsResponseData{}
+	case "trace.ProtoHTTP":
+		return trace.ProtoHTTP{}
+	case "trace.ProtoHTTPRequest":
+		return trace.ProtoHTTPRequest{}
+	case "trace.ProtoHTTPResponse":
+		return trace.ProtoHTTPResponse{}
+	case "trace.PacketMetadata":
+		return trace.PacketMetadata{}
+	case "[]trace.HookedSymbolData":
+		return []trace.HookedSymbolData{}
+	case "map[string]trace.HookedSymbolData":
+		return map[string]trace.HookedSymbolData{}
+	default:
+		//
+		// pointer types
+		//
+		switch {
+		case strings.HasSuffix(t, "*"),
+			strings.HasSuffix(t, " *restrict"):
+			return uintptr(0)
+		}
+		switch t {
+		case "cap_user_header_t",
+			"cap_user_data_t",
+			"const cap_user_data_t",
+			"io_context_t",
+			"sighandler_t":
+			return uintptr(0)
+		}
+
+		// unknown type
+		return nil
+	}
 }
 
 // ArgIndex find the index of an argument by name

--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -1,5 +1,7 @@
 module github.com/aquasecurity/tracee/signatures/helpers
 
-go 1.22
+go 1.22.0
 
-require github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d
+toolchain go1.22.4
+
+require github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863

--- a/signatures/helpers/go.sum
+++ b/signatures/helpers/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d h1:6CQjy5G6Cj/VKm8RP1uZnBZxDgfyGo15HfWFnYrkGro=
-github.com/aquasecurity/tracee/types v0.0.0-20240122122429-7f84f526758d/go.mod h1:J0f9nzJWrFmFgMoK0s4Yirfh82vfKMatXytd1YdfU2I=
+github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863 h1:domVTTQICTuCvX+ZW5EjvdUBz8EH7FedBj5lRqwpgf4=
+github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863/go.mod h1:Jwh9OOuiMHXDoGQY12N9ls5YB+j1FlRcXvFMvh1CmIU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Close: #4335

### 1. Explain what the PR does

2f31471ef **fix(events): setuid16 arg name typo**
473762535 **fix: handle zero-value types for unavailable fields**
41eeb29f2 **chore(go.mod): bump types to latest version**


2f31471ef **fix(events): setuid16 arg name typo**

```
'git log --grep old_old_uid_t' in Linux kernel code didn't return any
results.
```

473762535 **fix: handle zero-value types for unavailable fields**

```
Some event arguments, such as "interpreter_*" from sched_process_exec,
were not being populated because the kernel might not always provide
them. This was causing errors during the gRPC proto conversion, as
the values couldn't be asserted - they were nil.

With this change, ArgMeta now holds the Zero value of the type, ensuring
that assignment is always possible without requiring additional parsing
in the pipeline.

This also might help parsing since the Zero field will always have
value, making it easier to assert its type instead of checking for
Name field (string).
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
