### PR TITLE
chore(types): add Zero field to ArgMeta

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -138,6 +138,10 @@ type Argument struct {
 type ArgMeta struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
+
+	// Zero contains the zero value for Argument.Value.
+	// It is automatically initialized based on ArgMeta.Type when the Core DefinitionGroup is initialized.
+	Zero interface{} `json:"-"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.


### PR DESCRIPTION
Requirement for https://github.com/aquasecurity/tracee/pull/4336

### 1. Explain what the PR does

d40bc1f81 **chore(types): add Zero field to ArgMeta**

```
This is field for internal use which holds the zero value
of ArgMeta.Type.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
