### PR TITLE
[v0.22.3] chore!: rollback proctree to simple LRU (#4299)

### DIFF
--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -16,9 +16,6 @@ proctree:
     cache:
         process: 8192
         thread: 4096
-    cache-ttl:
-        process: 60
-        thread: 60
 
 capabilities:
     bypass: false

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -67,9 +67,6 @@ proctree:
     cache:
         process: 8192
         thread: 8192
-    cache-ttl:
-        process: 120
-        thread: 120
 # cri:
 #     - runtime:
 #         name: docker

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -8,9 +8,6 @@ proctree:
     # cache:
     #     process: 8192
     #     thread: 4096
-    # cache-ttl:
-    #     process: 120
-    #     thread: 120
 
 capabilities:
     bypass: false

--- a/pkg/cmd/cobra/config.go
+++ b/pkg/cmd/cobra/config.go
@@ -173,17 +173,11 @@ func (c *RegoConfig) flags() []string {
 //
 
 type ProcTreeConfig struct {
-	Source   string                 `mapstructure:"source"`
-	Cache    ProcTreeCacheConfig    `mapstructure:"cache"`
-	CacheTTL ProcTreeCacheTTLConfig `mapstructure:"cache-ttl"`
+	Source string              `mapstructure:"source"`
+	Cache  ProcTreeCacheConfig `mapstructure:"cache"`
 }
 
 type ProcTreeCacheConfig struct {
-	Process int `mapstructure:"process"`
-	Thread  int `mapstructure:"thread"`
-}
-
-type ProcTreeCacheTTLConfig struct {
 	Process int `mapstructure:"process"`
 	Thread  int `mapstructure:"thread"`
 }
@@ -203,12 +197,6 @@ func (c *ProcTreeConfig) flags() []string {
 	}
 	if c.Cache.Thread != 0 {
 		flags = append(flags, fmt.Sprintf("thread-cache=%d", c.Cache.Thread))
-	}
-	if c.CacheTTL.Process != 0 {
-		flags = append(flags, fmt.Sprintf("process-cache-ttl=%d", c.CacheTTL.Process))
-	}
-	if c.CacheTTL.Thread != 0 {
-		flags = append(flags, fmt.Sprintf("thread-cache-ttl=%d", c.CacheTTL.Thread))
 	}
 
 	return flags

--- a/pkg/cmd/cobra/config_test.go
+++ b/pkg/cmd/cobra/config_test.go
@@ -97,17 +97,12 @@ proctree:
     cache:
         process: 8192
         thread: 4096
-    cache-ttl:
-        process: 5
-        thread: 10
 `,
 			key: "proctree",
 			expectedFlags: []string{
 				"source=events",
 				"process-cache=8192",
 				"thread-cache=4096",
-				"process-cache-ttl=5",
-				"thread-cache-ttl=10",
 			},
 		},
 		{
@@ -594,20 +589,6 @@ func TestProcTreeConfigFlags(t *testing.T) {
 			expected: []string{
 				"process-cache=8192",
 				"thread-cache=4096",
-			},
-		},
-		{
-			name: "process cache ttl set",
-			config: ProcTreeConfig{
-				Source: "",
-				CacheTTL: ProcTreeCacheTTLConfig{
-					Process: 5,
-					Thread:  10,
-				},
-			},
-			expected: []string{
-				"process-cache-ttl=5",
-				"thread-cache-ttl=10",
 			},
 		},
 		{

--- a/pkg/cmd/flags/proctree.go
+++ b/pkg/cmd/flags/proctree.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/proctree"
@@ -21,8 +20,6 @@ Example:
       both         | process tree is built from both events and signals.
   --proctree process-cache=8192   | will cache up to 8192 processes in the tree (LRU cache).
   --proctree thread-cache=4096    | will cache up to 4096 threads in the tree (LRU cache).
-  --proctree process-cache-ttl=60 | will set the process cache element TTL to 60 seconds.
-  --proctree thread-cache-ttl=60  | will set the thread cache element TTL to 60 seconds.
   --proctree disable-procfs-query | Will disable procfs queries during runtime
 
 Use comma OR use the flag multiple times to choose multiple options:
@@ -38,8 +35,6 @@ func PrepareProcTree(cacheSlice []string) (proctree.ProcTreeConfig, error) {
 		Source:               proctree.SourceNone, // disabled by default
 		ProcessCacheSize:     proctree.DefaultProcessCacheSize,
 		ThreadCacheSize:      proctree.DefaultThreadCacheSize,
-		ProcessCacheTTL:      proctree.DefaultProcessCacheTTL,
-		ThreadCacheTTL:       proctree.DefaultThreadCacheTTL,
 		ProcfsInitialization: true,
 		ProcfsQuerying:       true,
 	}
@@ -96,24 +91,6 @@ func PrepareProcTree(cacheSlice []string) (proctree.ProcTreeConfig, error) {
 					config.ThreadCacheSize = size
 				}
 				cacheSet = true
-				continue
-			}
-			if strings.HasPrefix(value, "process-cache-ttl=") {
-				num := strings.TrimPrefix(value, "process-cache-ttl=")
-				ttl, err := strconv.Atoi(num)
-				if err != nil {
-					return config, err
-				}
-				config.ProcessCacheTTL = time.Duration(ttl) * time.Second
-				continue
-			}
-			if strings.HasPrefix(value, "thread-cache-ttl=") {
-				num := strings.TrimPrefix(value, "thread-cache-ttl=")
-				ttl, err := strconv.Atoi(num)
-				if err != nil {
-					return config, err
-				}
-				config.ThreadCacheTTL = time.Duration(ttl) * time.Second
 				continue
 			}
 			if strings.HasPrefix(value, "disable-procfs-query") {

--- a/pkg/proctree/proctree.go
+++ b/pkg/proctree/proctree.go
@@ -5,8 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2/expirable"
+	lru "github.com/hashicorp/golang-lru/v2"
 
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	traceetime "github.com/aquasecurity/tracee/pkg/time"
 )
@@ -68,19 +69,17 @@ type ProcTreeConfig struct {
 	Source               SourceType
 	ProcessCacheSize     int
 	ThreadCacheSize      int
-	ProcessCacheTTL      time.Duration
-	ThreadCacheTTL       time.Duration
 	ProcfsInitialization bool // Determine whether to scan procfs data for process tree initialization
 	ProcfsQuerying       bool // Determine whether to query procfs for missing information during runtime
 }
 
 // ProcessTree is a tree of processes and threads.
 type ProcessTree struct {
-	processes      *expirable.LRU[uint32, *Process] // hash -> process
-	threads        *expirable.LRU[uint32, *Thread]  // hash -> threads
-	procfsChan     chan int                         // channel of pids to read from procfs
-	procfsOnce     *sync.Once                       // busy loop debug message throttling
-	ctx            context.Context                  // context for the process tree
+	processes      *lru.Cache[uint32, *Process] // hash -> process
+	threads        *lru.Cache[uint32, *Thread]  // hash -> threads
+	procfsChan     chan int                     // channel of pids to read from procfs
+	procfsOnce     *sync.Once                   // busy loop debug message throttling
+	ctx            context.Context              // context for the process tree
 	procfsQuery    bool
 	timeNormalizer traceetime.TimeNormalizer
 }
@@ -91,22 +90,26 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig, timeNormalizer t
 	thrEvicted := 0
 
 	// Create caches for processes.
-	processes := expirable.NewLRU[uint32, *Process](
+	processes, err := lru.NewWithEvict[uint32, *Process](
 		config.ProcessCacheSize,
-		func(k uint32, v *Process) {
+		func(uint32, *Process) {
 			procEvited++
 		},
-		config.ProcessCacheTTL,
 	)
+	if err != nil {
+		return nil, errfmt.WrapError(err)
+	}
 
 	// Create caches for threads.
-	threads := expirable.NewLRU[uint32, *Thread](
+	threads, err := lru.NewWithEvict[uint32, *Thread](
 		config.ThreadCacheSize,
-		func(k uint32, v *Thread) {
+		func(uint32, *Thread) {
 			thrEvicted++
 		},
-		config.ThreadCacheTTL,
 	)
+	if err != nil {
+		return nil, errfmt.WrapError(err)
+	}
 
 	// Report cache stats if debug is enabled.
 	go func() {


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

d7083d7ce **chore!: rollback proctree to simple LRU (#4299)**

```
The expirable LRU cache is not intended to be used in the ProcessTree
type since the TTL would impact its correctness on some scenarios.

Despite TTL can be disabled by setting it to 0, it is not a good idea
due to the potential performance impact of its implementation. See the
comparison between the simple LRU and the expirable LRU below:

| Benchmark                              | Exp LRU |  Simple |    %   |
|                                        |  TTL 0  |   LRU   |  Impr. |
|                                        | (ns/op) | (ns/op) |    *   |
|----------------------------------------|---------|---------|--------|
| GetProcessByHash-Concurrency1          | 4.264   | 6.301   | -47.8% |
| GetProcessByHash-Concurrency2          | 14.91   | 19.85   | -33.2% |
| GetProcessByHash-Concurrency4          | 74.03   | 63.22   | 14.6%  |
| GetProcessByHash-Concurrency8          | 247.2   | 174.7   | 29.3%  |
| GetOrCreateProcessByHash-Concurrency1  | 37.02   | 8.370   | 77.4%  |
| GetOrCreateProcessByHash-Concurrency2  | 80.84   | 23.37   | 71.1%  |
| GetOrCreateProcessByHash-Concurrency4  | 181.6   | 75.67   | 58.4%  |
| GetOrCreateProcessByHash-Concurrency8  | 408.3   | 194.5   | 52.4%  |
| GetThreadByHash-Concurrency1           | 38.13   | 7.675   | 79.9%  |
| GetThreadByHash-Concurrency2           | 79.98   | 22.71   | 71.6%  |
| GetThreadByHash-Concurrency4           | 177.1   | 60.76   | 65.7%  |
| GetThreadByHash-Concurrency8           | 403.2   | 190.0   | 52.9%  |
| GetOrCreateThreadByHash-Concurrency1   | 38.16   | 7.996   | 79.0%  |
| GetOrCreateThreadByHash-Concurrency2   | 79.82   | 23.73   | 70.3%  |
| GetOrCreateThreadByHash-Concurrency4   | 177.1   | 67.13   | 62.1%  |
| GetOrCreateThreadByHash-Concurrency8   | 405.1   | 151.3   | 62.7%  |

Therefore, this commit reverts the ProcessTree to use the simple LRU
cache until a better solution is designed.

* Part of the performance improvement is also due to the removal of the
outer lock done by 44e59d3a9731166b5345a3c9c396544810e46a65.

commit: 34be604 (main), cherry-pick
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
