### PR TITLE
fix: print err when parseArgument() fails

### DIFF
--- a/pkg/server/grpc/event_data.go
+++ b/pkg/server/grpc/event_data.go
@@ -76,7 +76,7 @@ func getEventValue(arg trace.Argument) (*pb.EventValue, error) {
 
 	eventValue, err := parseArgument(arg)
 	if err != nil {
-		return nil, errfmt.Errorf("can't convert event data: %s - %v - %T", arg.Name, arg.Value, arg.Value)
+		return nil, errfmt.Errorf("can't convert event data [%s]: %s - %v - %T", err, arg.Name, arg.Value, arg.Value)
 	}
 
 	return eventValue, nil


### PR DESCRIPTION
### 1. Explain what the PR does

dad7dae43 **fix: print err when parseArgument() fails**

```
When parseArgument() fails, error message should be printed to help
debugging.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
