### PR TITLE
[v0.22.3] feat(ebpf): restrict set_fs_pwd to (f)chdir syscall (#4359)

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -5088,6 +5088,9 @@ int BPF_KPROBE(trace_set_fs_pwd)
     if (!init_program_data(&p, ctx, SET_FS_PWD))
         return 0;
 
+    if (p.event->context.syscall != SYSCALL_CHDIR && p.event->context.syscall != SYSCALL_FCHDIR)
+        return 0;
+
     if (!evaluate_scope_filters(&p))
         return 0;
 


### PR DESCRIPTION
### 1. Explain what the PR does

f0c672d20 **feat(ebpf): restrict set_fs_pwd to (f)chdir syscall (#4359)**

```
commit: ab6344f (main), cherry-pick
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
