### PR TITLE
fix(engine): restrict finding feedback

### DIFF
--- a/cmd/tracee/cmd/analyze.go
+++ b/cmd/tracee/cmd/analyze.go
@@ -132,11 +132,17 @@ func command(cmd *cobra.Command, args []string) {
 		"signatures", getSigsNames(signatures),
 	)
 
-	_ = sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
+	sigNamesToIds := sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
 
 	engineConfig := engine.Config{
 		Signatures:          signatures,
 		SignatureBufferSize: 1000,
+		Enabled:             true, // simulate tracee single binary mode
+		SigNameToEventID:    sigNamesToIds,
+		ShouldDispatchEvent: func(eventIdInt32 int32) bool {
+			// in analyze mode we don't need to filter by policy
+			return true
+		},
 	}
 
 	// two seperate contexts.

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -146,12 +146,18 @@ func (engine *Engine) unloadAllSignatures() {
 // matchHandler is a function that runs when a signature is matched
 func (engine *Engine) matchHandler(res *detect.Finding) {
 	_ = engine.stats.Detections.Increment()
+	engine.output <- res
+	if !engine.config.Enabled {
+		return
+		// next section is relevant only for engine-in-pipeline and analyze
+	}
 	e, err := findings.FindingToEvent(res)
 	if err != nil {
 		logger.Errorw("Failed to convert finding to event, will not feedback", "err", err)
+		return
 	}
-	engine.output <- res
-	engine.inputs.Tracee <- e.ToProtocol()
+	prot := e.ToProtocol()
+	engine.inputs.Tracee <- prot
 }
 
 // checkCompletion is a function that runs at the end of each input source


### PR DESCRIPTION
1. Findings were previously wrongly fedback to the engine even after an error in converting to events. This issue was resolved.
2. Finding feedbacks in general are now restricted by the engine config being set to single-binary mode (which now logically includes analyze mode).

### 2. Explain how to test it

tracee-rules shouldn't crash or emit errors when using a signature plugin that relies on signature feedback. The signature will not work.
In analyze the signature will work just as before.
