### PR TITLE
Analyze legacy output

### DIFF
--- a/cmd/tracee/cmd/analyze.go
+++ b/cmd/tracee/cmd/analyze.go
@@ -1,36 +1,23 @@
 package cmd
 
 import (
-	"bufio"
-	"context"
-	"encoding/json"
-	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/aquasecurity/tracee/pkg/analyze"
 	"github.com/aquasecurity/tracee/pkg/cmd/flags"
-	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
-	"github.com/aquasecurity/tracee/pkg/events"
-	"github.com/aquasecurity/tracee/pkg/events/findings"
 	"github.com/aquasecurity/tracee/pkg/logger"
-	"github.com/aquasecurity/tracee/pkg/signatures/engine"
-	"github.com/aquasecurity/tracee/pkg/signatures/signature"
-	"github.com/aquasecurity/tracee/types/detect"
-	"github.com/aquasecurity/tracee/types/protocol"
-	"github.com/aquasecurity/tracee/types/trace"
 )
 
 func init() {
-	rootCmd.AddCommand(analyze)
+	rootCmd.AddCommand(analyzeCmd)
 
 	// flags
 
 	// events
-	analyze.Flags().StringArrayP(
+	analyzeCmd.Flags().StringArrayP(
 		"events",
 		"e",
 		[]string{},
@@ -38,20 +25,20 @@ func init() {
 	)
 
 	// signatures-dir
-	analyze.Flags().StringArray(
+	analyzeCmd.Flags().StringArray(
 		"signatures-dir",
 		[]string{},
 		"Directory where to search for signatures in OPA (.rego) and Go plugin (.so) formats",
 	)
 
 	// rego
-	analyze.Flags().StringArray(
+	analyzeCmd.Flags().StringArray(
 		"rego",
 		[]string{},
 		"Control event rego settings",
 	)
 
-	analyze.Flags().StringArrayP(
+	analyzeCmd.Flags().StringArrayP(
 		"log",
 		"l",
 		[]string{"info"},
@@ -59,7 +46,7 @@ func init() {
 	)
 }
 
-var analyze = &cobra.Command{
+var analyzeCmd = &cobra.Command{
 	Use:     "analyze input.json",
 	Aliases: []string{},
 	Args:    cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
@@ -110,139 +97,14 @@ func command(cmd *cobra.Command, args []string) {
 		signatureEvents = nil
 	}
 
-	signatures, _, err := signature.Find(
-		rego.RuntimeTarget,
-		rego.PartialEval,
-		viper.GetStringSlice("signatures-dir"),
-		signatureEvents,
-		rego.AIO,
-	)
+	signatureDirs := viper.GetStringSlice("signatures-dir")
 
-	if err != nil {
-		logger.Fatalw("Failed to find signature event", "err", err)
-	}
-
-	if len(signatures) == 0 {
-		logger.Fatalw("No signature event loaded")
-	}
-
-	logger.Infow(
-		"Signatures loaded",
-		"total", len(signatures),
-		"signatures", getSigsNames(signatures),
-	)
-
-	sigNamesToIds := sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
-
-	engineConfig := engine.Config{
-		Signatures:          signatures,
-		SignatureBufferSize: 1000,
-		Enabled:             true, // simulate tracee single binary mode
-		SigNameToEventID:    sigNamesToIds,
-		ShouldDispatchEvent: func(eventIdInt32 int32) bool {
-			// in analyze mode we don't need to filter by policy
-			return true
-		},
-	}
-
-	// two seperate contexts.
-	// 1. signal notifiable context that can terminate both analyze and engine work
-	// 2. signal solely to notify internally inside analyze once file input is over
-	signalCtx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	fileReadCtx, stop := context.WithCancel(signalCtx)
-
-	engineOutput := make(chan *detect.Finding)
-	engineInput := make(chan protocol.Event)
-
-	source := engine.EventSources{Tracee: engineInput}
-	sigEngine, err := engine.NewEngine(engineConfig, source, engineOutput)
-	if err != nil {
-		logger.Fatalw("Failed to create engine", "err", err)
-	}
-
-	err = sigEngine.Init()
-	if err != nil {
-		logger.Fatalw("failed to initialize signature engine", "err", err)
-	}
-
-	go sigEngine.Start(signalCtx)
-
-	// producer
-	go produce(fileReadCtx, stop, inputFile, engineInput)
-
-	// consumer
-	for {
-		select {
-		case finding, ok := <-engineOutput:
-			if !ok {
-				return
-			}
-			process(finding)
-		case <-fileReadCtx.Done():
-			// ensure the engineInput channel will be closed
-			goto drain
-		case <-signalCtx.Done():
-			// ensure the engineInput channel will be closed
-			goto drain
-		}
-	}
-drain:
-	// drain
-	defer close(engineInput)
-	for {
-		select {
-		case finding, ok := <-engineOutput:
-			if !ok {
-				return
-			}
-
-			process(finding)
-		default:
-			return
-		}
-	}
-}
-
-func produce(ctx context.Context, cancel context.CancelFunc, inputFile *os.File, engineInput chan<- protocol.Event) {
-	scanner := bufio.NewScanner(inputFile)
-	scanner.Split(bufio.ScanLines)
-	for {
-		select {
-		case <-ctx.Done():
-			// if terminated from above
-			return
-		default:
-			if !scanner.Scan() { // if EOF or error close the done channel and return
-				if err := scanner.Err(); err != nil {
-					logger.Errorw("Error while scanning input file", "error", err)
-				}
-				// terminate analysis here and proceed to draining
-				cancel()
-				return
-			}
-
-			var e trace.Event
-			err := json.Unmarshal(scanner.Bytes(), &e)
-			if err != nil {
-				logger.Fatalw("Failed to unmarshal event", "err", err)
-			}
-			engineInput <- e.ToProtocol()
-		}
-	}
-}
-
-func process(finding *detect.Finding) {
-	event, err := findings.FindingToEvent(finding)
-	if err != nil {
-		logger.Fatalw("Failed to convert finding to event", "err", err)
-	}
-
-	jsonEvent, err := json.Marshal(event)
-	if err != nil {
-		logger.Fatalw("Failed to json marshal event", "err", err)
-	}
-
-	fmt.Println(string(jsonEvent))
+	analyze.Analyze(analyze.AnalyzeConfig{
+		Rego:            rego,
+		Input:           inputFile,
+		SignatureDirs:   signatureDirs,
+		SignatureEvents: signatureEvents,
+	})
 }
 
 func bindViperFlag(cmd *cobra.Command, flag string) {
@@ -250,17 +112,4 @@ func bindViperFlag(cmd *cobra.Command, flag string) {
 	if err != nil {
 		logger.Fatalw("Error binding viper flag", "flag", flag, "error", err)
 	}
-}
-
-func getSigsNames(signatures []detect.Signature) []string {
-	var sigNames []string
-	for _, sig := range signatures {
-		sigMeta, err := sig.GetMetadata()
-		if err != nil {
-			logger.Warnw("Failed to get signature metadata", "err", err)
-			continue
-		}
-		sigNames = append(sigNames, sigMeta.Name)
-	}
-	return sigNames
 }

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -1,0 +1,178 @@
+package analyze
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/aquasecurity/tracee/pkg/cmd/initialize/sigs"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/findings"
+	"github.com/aquasecurity/tracee/pkg/logger"
+	"github.com/aquasecurity/tracee/pkg/signatures/engine"
+	"github.com/aquasecurity/tracee/pkg/signatures/rego"
+	"github.com/aquasecurity/tracee/pkg/signatures/signature"
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+type AnalyzeConfig struct {
+	Rego            rego.Config
+	Input           *os.File
+	SignatureDirs   []string
+	SignatureEvents []string
+}
+
+func Analyze(cfg AnalyzeConfig) {
+	signatures, _, err := signature.Find(
+		cfg.Rego.RuntimeTarget,
+		cfg.Rego.PartialEval,
+		cfg.SignatureDirs,
+		cfg.SignatureEvents,
+		cfg.Rego.AIO,
+	)
+
+	if err != nil {
+		logger.Fatalw("Failed to find signature event", "err", err)
+	}
+
+	if len(signatures) == 0 {
+		logger.Fatalw("No signature event loaded")
+	}
+
+	logger.Infow(
+		"Signatures loaded",
+		"total", len(signatures),
+		"signatures", getSigsNames(signatures),
+	)
+
+	sigNamesToIds := sigs.CreateEventsFromSignatures(events.StartSignatureID, signatures)
+
+	engineConfig := engine.Config{
+		Signatures:          signatures,
+		SignatureBufferSize: 1000,
+		Enabled:             true, // simulate tracee single binary mode
+		SigNameToEventID:    sigNamesToIds,
+		ShouldDispatchEvent: func(eventIdInt32 int32) bool {
+			// in analyze mode we don't need to filter by policy
+			return true
+		},
+	}
+
+	// two seperate contexts.
+	// 1. signal notifiable context that can terminate both analyze and engine work
+	// 2. signal solely to notify internally inside analyze once file input is over
+	signalCtx, _ := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	fileReadCtx, stop := context.WithCancel(signalCtx)
+
+	engineOutput := make(chan *detect.Finding)
+	engineInput := make(chan protocol.Event)
+
+	source := engine.EventSources{Tracee: engineInput}
+	sigEngine, err := engine.NewEngine(engineConfig, source, engineOutput)
+	if err != nil {
+		logger.Fatalw("Failed to create engine", "err", err)
+	}
+
+	err = sigEngine.Init()
+	if err != nil {
+		logger.Fatalw("failed to initialize signature engine", "err", err)
+	}
+
+	go sigEngine.Start(signalCtx)
+
+	// producer
+	go produce(fileReadCtx, stop, cfg.Input, engineInput)
+
+	// consumer
+	for {
+		select {
+		case finding, ok := <-engineOutput:
+			if !ok {
+				return
+			}
+			process(finding)
+		case <-fileReadCtx.Done():
+			// ensure the engineInput channel will be closed
+			goto drain
+		case <-signalCtx.Done():
+			// ensure the engineInput channel will be closed
+			goto drain
+		}
+	}
+drain:
+	// drain
+	defer close(engineInput)
+	for {
+		select {
+		case finding, ok := <-engineOutput:
+			if !ok {
+				return
+			}
+
+			process(finding)
+		default:
+			return
+		}
+	}
+}
+
+func produce(ctx context.Context, cancel context.CancelFunc, inputFile *os.File, engineInput chan<- protocol.Event) {
+	scanner := bufio.NewScanner(inputFile)
+	scanner.Split(bufio.ScanLines)
+	for {
+		select {
+		case <-ctx.Done():
+			// if terminated from above
+			return
+		default:
+			if !scanner.Scan() { // if EOF or error close the done channel and return
+				if err := scanner.Err(); err != nil {
+					logger.Errorw("Error while scanning input file", "error", err)
+				}
+				// terminate analysis here and proceed to draining
+				cancel()
+				return
+			}
+
+			var e trace.Event
+			err := json.Unmarshal(scanner.Bytes(), &e)
+			if err != nil {
+				logger.Fatalw("Failed to unmarshal event", "err", err)
+			}
+			engineInput <- e.ToProtocol()
+		}
+	}
+}
+
+func process(finding *detect.Finding) {
+	event, err := findings.FindingToEvent(finding)
+	if err != nil {
+		logger.Fatalw("Failed to convert finding to event", "err", err)
+	}
+
+	jsonEvent, err := json.Marshal(event)
+	if err != nil {
+		logger.Fatalw("Failed to json marshal event", "err", err)
+	}
+
+	fmt.Println(string(jsonEvent))
+}
+
+func getSigsNames(signatures []detect.Signature) []string {
+	var sigNames []string
+	for _, sig := range signatures {
+		sigMeta, err := sig.GetMetadata()
+		if err != nil {
+			logger.Warnw("Failed to get signature metadata", "err", err)
+			continue
+		}
+		sigNames = append(sigNames, sigMeta.Name)
+	}
+	return sigNames
+}

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -129,7 +129,7 @@ func PrepareLogger(logOptions []string, newBinary bool) (logger.LoggingConfig, e
 				return logger.LoggingConfig{}, invalidLogOptionValue(nil, opt, newBinary)
 			}
 
-			w, err = createFile(vals[1])
+			w, err = CreateOutputFile(vals[1])
 			if err != nil {
 				return logger.LoggingConfig{}, err
 			}

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -99,7 +99,7 @@ func PreparePrinterConfig(printerKind string, outputPath string) (config.Printer
 	var err error
 
 	if outputPath != "stdout" && outputPath != "" && printerKind != "forward" && printerKind != "webhook" {
-		outFile, err = createFile(outputPath)
+		outFile, err = CreateOutputFile(outputPath)
 		if err != nil {
 			return config.PrinterConfig{}, err
 		}
@@ -239,7 +239,7 @@ func parseOption(outputParts []string, traceeConfig *config.OutputConfig, newBin
 }
 
 // creates *os.File for the given path
-func createFile(path string) (*os.File, error) {
+func CreateOutputFile(path string) (*os.File, error) {
 	fileInfo, err := os.Stat(path)
 	if err == nil && fileInfo.IsDir() {
 		return nil, errfmt.Errorf("cannot use a path of existing directory %s", path)

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -161,25 +161,32 @@ func getPrinterConfigs(printerMap map[string]string, traceeConfig *config.Output
 				return nil, err
 			}
 		}
-
-		outFile := os.Stdout
-		var err error
-
-		if outPath != "stdout" && printerKind != "forward" && printerKind != "webhook" {
-			outFile, err = createFile(outPath)
-			if err != nil {
-				return nil, err
-			}
+		printerCfg, err := makePrinterConfig(printerKind, outPath)
+		if err != nil {
+			return nil, err
 		}
-
-		printerConfigs = append(printerConfigs, config.PrinterConfig{
-			Kind:    printerKind,
-			OutPath: outPath,
-			OutFile: outFile,
-		})
+		printerConfigs = append(printerConfigs, printerCfg)
 	}
 
 	return printerConfigs, nil
+}
+
+func makePrinterConfig(printerKind string, outputPath string) (config.PrinterConfig, error) {
+	outFile := os.Stdout
+	var err error
+
+	if outputPath != "stdout" && printerKind != "forward" && printerKind != "webhook" {
+		outFile, err = createFile(outputPath)
+		if err != nil {
+			return config.PrinterConfig{}, err
+		}
+	}
+
+	return config.PrinterConfig{
+		Kind:    printerKind,
+		OutPath: outputPath,
+		OutFile: outFile,
+	}, nil
 }
 
 // parseFormat parses the given format and sets it in the given printerMap

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -94,6 +94,24 @@ func PrepareOutput(outputSlice []string, newBinary bool) (PrepareOutputResult, e
 	return outConfig, nil
 }
 
+func PreparePrinterConfig(printerKind string, outputPath string) (config.PrinterConfig, error) {
+	outFile := os.Stdout
+	var err error
+
+	if outputPath != "stdout" && outputPath != "" && printerKind != "forward" && printerKind != "webhook" {
+		outFile, err = createFile(outputPath)
+		if err != nil {
+			return config.PrinterConfig{}, err
+		}
+	}
+
+	return config.PrinterConfig{
+		Kind:    printerKind,
+		OutPath: outputPath,
+		OutFile: outFile,
+	}, nil
+}
+
 // setOption sets the given option in the given config
 func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 	switch option {
@@ -161,7 +179,7 @@ func getPrinterConfigs(printerMap map[string]string, traceeConfig *config.Output
 				return nil, err
 			}
 		}
-		printerCfg, err := makePrinterConfig(printerKind, outPath)
+		printerCfg, err := PreparePrinterConfig(printerKind, outPath)
 		if err != nil {
 			return nil, err
 		}
@@ -169,24 +187,6 @@ func getPrinterConfigs(printerMap map[string]string, traceeConfig *config.Output
 	}
 
 	return printerConfigs, nil
-}
-
-func makePrinterConfig(printerKind string, outputPath string) (config.PrinterConfig, error) {
-	outFile := os.Stdout
-	var err error
-
-	if outputPath != "stdout" && printerKind != "forward" && printerKind != "webhook" {
-		outFile, err = createFile(outputPath)
-		if err != nil {
-			return config.PrinterConfig{}, err
-		}
-	}
-
-	return config.PrinterConfig{
-		Kind:    printerKind,
-		OutPath: outputPath,
-		OutFile: outFile,
-	}, nil
 }
 
 // parseFormat parses the given format and sets it in the given printerMap

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -86,7 +86,7 @@ func TraceeEbpfPrepareOutput(outputSlice []string, newBinary bool) (PrepareOutpu
 
 		printerConfigs = append(printerConfigs, stdoutConfig)
 	} else {
-		file, err := createFile(outPath)
+		file, err := CreateOutputFile(outPath)
 		if err != nil {
 			return outConfig, err
 		}


### PR DESCRIPTION
### 1. Explain what the PR does

a4037e228 **feat(analyze): add legacy output**
97f335a2b **feat(analyze): implement printer outputs**
3a372d0de **chore(analyze): move analyze to pkg**
72b0427ef **chore(output): split printer config procedure**


a4037e228 **feat(analyze): add legacy output**

```
Add output format for flag marked as "legacy". The output will be the
same format as given for findings in the rawjson.tmpl template in
tracee-rules.
```

97f335a2b **feat(analyze): implement printer outputs**

```
Add rudimentary support to more complex outputs via tracee printers.
```

### 2. Explain how to test it



### 3. Other comments

Resolve #4369
