### PR TITLE
perf: remove sys_enter/exit dependency from default event set

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -2286,7 +2286,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "creat",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_ops"},
+		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "umode_t", Name: "mode"},
@@ -2406,7 +2406,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "chmod",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "umode_t", Name: "mode"},
@@ -2430,7 +2430,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "fchmod",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "fd"},
 			{Type: "umode_t", Name: "mode"},
@@ -2454,7 +2454,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "chown",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "uid_t", Name: "owner"},
@@ -2479,7 +2479,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "fchown",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "fd"},
 			{Type: "uid_t", Name: "owner"},
@@ -2504,7 +2504,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "lchown",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "uid_t", Name: "owner"},
@@ -2757,7 +2757,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setuid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "uid_t", Name: "uid"},
 		},
@@ -2780,7 +2780,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setgid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "gid_t", Name: "gid"},
 		},
@@ -2845,7 +2845,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setpgid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "pid_t", Name: "pid"},
 			{Type: "pid_t", Name: "pgid"},
@@ -2911,7 +2911,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setsid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params:  []trace.ArgMeta{},
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -2932,7 +2932,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setreuid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "uid_t", Name: "ruid"},
 			{Type: "uid_t", Name: "euid"},
@@ -2956,7 +2956,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setregid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "gid_t", Name: "rgid"},
 			{Type: "gid_t", Name: "egid"},
@@ -3028,7 +3028,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setresuid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "uid_t", Name: "ruid"},
 			{Type: "uid_t", Name: "euid"},
@@ -3078,7 +3078,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setresgid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "gid_t", Name: "rgid"},
 			{Type: "gid_t", Name: "egid"},
@@ -3151,7 +3151,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setfsuid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "uid_t", Name: "fsuid"},
 		},
@@ -3174,7 +3174,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setfsgid",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc", "proc_ids"},
+		sets:    []string{"syscalls", "proc", "proc_ids"},
 		params: []trace.ArgMeta{
 			{Type: "gid_t", Name: "fsgid"},
 		},
@@ -4405,7 +4405,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "init_module",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "system", "system_module"},
+		sets:    []string{"syscalls", "system", "system_module"},
 		params: []trace.ArgMeta{
 			{Type: "void*", Name: "module_image"},
 			{Type: "unsigned long", Name: "len"},
@@ -6484,7 +6484,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "fchownat",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "dirfd"},
 			{Type: "const char*", Name: "pathname"},
@@ -6691,7 +6691,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "fchmodat",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_attr"},
+		sets:    []string{"syscalls", "fs", "fs_file_attr"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "dirfd"},
 			{Type: "const char*", Name: "pathname"},
@@ -7708,7 +7708,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "setns",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc"},
+		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "fd"},
 			{Type: "int", Name: "nstype"},
@@ -7757,7 +7757,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "process_vm_readv",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "proc"},
+		sets:    []string{"syscalls", "proc"},
 		params: []trace.ArgMeta{
 			{Type: "pid_t", Name: "pid"},
 			{Type: "const struct iovec*", Name: "local_iov"},
@@ -7834,7 +7834,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "finit_module",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "system", "system_module"},
+		sets:    []string{"syscalls", "system", "system_module"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "fd"},
 			{Type: "const char*", Name: "param_values"},
@@ -7987,7 +7987,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "memfd_create",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs", "fs_file_ops"},
+		sets:    []string{"syscalls", "fs", "fs_file_ops"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "name"},
 			{Type: "unsigned int", Name: "flags"},
@@ -8530,7 +8530,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "move_mount",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{"default", "syscalls", "fs"},
+		sets:    []string{"syscalls", "fs"},
 		params: []trace.ArgMeta{
 			{Type: "int", Name: "from_dfd"},
 			{Type: "const char*", Name: "from_path"},
@@ -11337,7 +11337,7 @@ var CoreEvents = map[ID]Definition{
 				{handle: probes.CommitCreds, required: true},
 			},
 		},
-		sets: []string{},
+		sets: []string{"default"},
 		params: []trace.ArgMeta{
 			{Type: "slim_cred_t", Name: "old_cred"},
 			{Type: "slim_cred_t", Name: "new_cred"},
@@ -12429,7 +12429,7 @@ var CoreEvents = map[ID]Definition{
 				{handle: probes.ModuleLoad, required: true},
 			},
 		},
-		sets: []string{},
+		sets: []string{"default"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "name"},
 			{Type: "const char*", Name: "version"},
@@ -12602,7 +12602,7 @@ var CoreEvents = map[ID]Definition{
 				{handle: probes.SecurityInodeRename, required: true},
 			},
 		},
-		sets: []string{},
+		sets: []string{"default"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "old_path"},
 			{Type: "const char*", Name: "new_path"},
@@ -13049,7 +13049,7 @@ var CoreEvents = map[ID]Definition{
 		name:    "chmod_common",
 		version: NewVersion(1, 0, 0),
 		syscall: true,
-		sets:    []string{},
+		sets:    []string{"default"},
 		params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
 			{Type: "umode_t", Name: "mode"},

--- a/signatures/golang/illegitimate_shell_test.go
+++ b/signatures/golang/illegitimate_shell_test.go
@@ -23,14 +23,14 @@ func TestIllegitimateShell(t *testing.T) {
 			Name: "should trigger detection",
 			Events: []trace.Event{
 				{
-					EventName:   "security_bprm_check",
-					ProcessName: "apache2",
+					EventName:   "sched_process_exec",
+					ProcessName: "dash",
 					Args: []trace.Argument{
 						{
 							ArgMeta: trace.ArgMeta{
-								Name: "pathname",
+								Name: "prev_comm",
 							},
-							Value: interface{}("/bin/dash"),
+							Value: interface{}("apache2"),
 						},
 					},
 				},
@@ -39,14 +39,14 @@ func TestIllegitimateShell(t *testing.T) {
 				"TRC-1016": {
 					Data: nil,
 					Event: trace.Event{
-						EventName:   "security_bprm_check",
-						ProcessName: "apache2",
+						EventName:   "sched_process_exec",
+						ProcessName: "dash",
 						Args: []trace.Argument{
 							{
 								ArgMeta: trace.ArgMeta{
-									Name: "pathname",
+									Name: "prev_comm",
 								},
-								Value: interface{}("/bin/dash"),
+								Value: interface{}("apache2"),
 							},
 						},
 					}.ToProtocol(),
@@ -69,17 +69,17 @@ func TestIllegitimateShell(t *testing.T) {
 			},
 		},
 		{
-			Name: "should not trigger detection - wrong path",
+			Name: "should not trigger detection - not a shell",
 			Events: []trace.Event{
 				{
-					EventName:   "security_bprm_check",
-					ProcessName: "apache2",
+					EventName:   "sched_process_exec",
+					ProcessName: "ls",
 					Args: []trace.Argument{
 						{
 							ArgMeta: trace.ArgMeta{
-								Name: "pathname",
+								Name: "prev_comm",
 							},
-							Value: interface{}("/bin/ls"),
+							Value: interface{}("apache2"),
 						},
 					},
 				},
@@ -90,14 +90,14 @@ func TestIllegitimateShell(t *testing.T) {
 			Name: "should not trigger detection - wrong process name",
 			Events: []trace.Event{
 				{
-					EventName:   "security_bprm_check",
-					ProcessName: "bash",
+					EventName:   "sched_process_exec",
+					ProcessName: "dash",
 					Args: []trace.Argument{
 						{
 							ArgMeta: trace.ArgMeta{
-								Name: "pathname",
+								Name: "prev_comm",
 							},
-							Value: interface{}("/bin/dash"),
+							Value: interface{}("bash"),
 						},
 					},
 				},

--- a/signatures/golang/kernel_module_loading.go
+++ b/signatures/golang/kernel_module_loading.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -38,8 +37,7 @@ func (sig *KernelModuleLoading) GetMetadata() (detect.SignatureMetadata, error) 
 
 func (sig *KernelModuleLoading) GetSelectedEvents() ([]detect.SignatureEventSelector, error) {
 	return []detect.SignatureEventSelector{
-		{Source: "tracee", Name: "init_module", Origin: "*"},
-		{Source: "tracee", Name: "security_kernel_read_file", Origin: "*"},
+		{Source: "tracee", Name: "module_load", Origin: "*"},
 	}, nil
 }
 
@@ -50,31 +48,7 @@ func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
 	}
 
 	switch eventObj.EventName {
-	case "init_module":
-		metadata, err := sig.GetMetadata()
-		if err != nil {
-			return err
-		}
-		sig.cb(&detect.Finding{
-			SigMetadata: metadata,
-			Event:       event,
-			Data:        nil,
-		})
-	case "security_kernel_read_file":
-		loadedType, err := helpers.GetTraceeArgumentByName(eventObj, "type", helpers.GetArgOps{})
-		if err != nil {
-			return err
-		}
-
-		kernelReadType, ok := loadedType.Value.(trace.KernelReadType)
-		if !ok {
-			return nil
-		}
-
-		if kernelReadType != trace.KernelReadKernelModule {
-			return nil
-		}
-
+	case "module_load":
 		metadata, err := sig.GetMetadata()
 		if err != nil {
 			return err

--- a/signatures/golang/kernel_module_loading_test.go
+++ b/signatures/golang/kernel_module_loading_test.go
@@ -20,17 +20,17 @@ func TestKernelModuleLoading(t *testing.T) {
 		Findings map[string]*detect.Finding
 	}{
 		{
-			Name: "should trigger detection - init_module",
+			Name: "should trigger detection - module_load",
 			Events: []trace.Event{
 				{
-					EventName: "init_module",
+					EventName: "module_load",
 				},
 			},
 			Findings: map[string]*detect.Finding{
 				"TRC-1017": {
 					Data: nil,
 					Event: trace.Event{
-						EventName: "init_module",
+						EventName: "module_load",
 					}.ToProtocol(),
 					SigMetadata: detect.SignatureMetadata{
 						ID:          "TRC-1017",
@@ -49,70 +49,6 @@ func TestKernelModuleLoading(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			Name: "should trigger detection - security_kernel_read_file",
-			Events: []trace.Event{
-				{
-					EventName: "security_kernel_read_file",
-					Args: []trace.Argument{
-						{
-							ArgMeta: trace.ArgMeta{
-								Name: "type",
-							},
-							Value: trace.KernelReadKernelModule,
-						},
-					},
-				},
-			},
-			Findings: map[string]*detect.Finding{
-				"TRC-1017": {
-					Data: nil,
-					Event: trace.Event{
-						EventName: "security_kernel_read_file",
-						Args: []trace.Argument{
-							{
-								ArgMeta: trace.ArgMeta{
-									Name: "type",
-								},
-								Value: trace.KernelReadKernelModule,
-							},
-						},
-					}.ToProtocol(),
-					SigMetadata: detect.SignatureMetadata{
-						ID:          "TRC-1017",
-						Version:     "1",
-						Name:        "Kernel module loading detected",
-						EventName:   "kernel_module_loading",
-						Description: "Loading of a kernel module was detected. Kernel modules are binaries meant to run in the kernel. Adversaries may try and load kernel modules to extend their capabilities and avoid detection by running in the kernel and not user space.",
-						Properties: map[string]interface{}{
-							"Severity":             2,
-							"Category":             "persistence",
-							"Technique":            "Kernel Modules and Extensions",
-							"Kubernetes_Technique": "",
-							"id":                   "attack-pattern--a1b52199-c8c5-438a-9ded-656f1d0888c6",
-							"external_id":          "T1547.006",
-						},
-					},
-				},
-			},
-		},
-		{
-			Name: "should not trigger detection - security_kernel_read_file wrong type",
-			Events: []trace.Event{
-				{
-					EventName: "security_kernel_read_file",
-					Args: []trace.Argument{
-						{
-							ArgMeta: trace.ArgMeta{
-								Name: "type",
-							},
-							Value: trace.KernelReadFirmware,
-						},
-					},
-				},
-			},
-			Findings: map[string]*detect.Finding{},
 		},
 	}
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

This PR removes the dependency of the default event set on sys_enter/sys_exit probes to improve performance when no specific event is selected.

To do that, update default event set and signatures that were depend on events that used these probes.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
