### PR TITLE
change grpc-liste-addr flag to grpc, add suport for unix and tcp ontop

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -313,7 +313,7 @@ func initCmd() error {
 	rootCmd.Flags().String(
 		server.GRPCListenEndpointFlag,
 		"", // disabled by default
-		"<protocol:addr>\t\t\tListening address of the grpc server eg: tcp:4466, unix:/tmp/tracee.sock (default: disabled)",
+		"<protocol:addr>\t\t\tListening address of the grpc server eg: tcp or tcp:4466, unix or unix:/tmp/tracee.sock (default: disabled)",
 	)
 	err = viper.BindPFlag(server.GRPCListenEndpointFlag, rootCmd.Flags().Lookup(server.GRPCListenEndpointFlag))
 	if err != nil {

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -37,11 +37,11 @@ A complete config file with all available options can be found [here](https://gi
   metrics-endpoint: true
   ```
 
-- **`--grpc-listen-addr`**: Specifies the address for the gRPC server.
+- **`--grpc`**: Specifies the address for the gRPC server.
 
   YAML:
   ```yaml
-  grpc-listen-addr: tcp:50051
+  grpc: tcp:50051
   ```
 
 

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -28,7 +28,7 @@ capabilities:
 
 metrics-endpoint: true
 
-grpc-listen-addr: tcp:50051
+grpc: tcp:50051
 
 dnscache: enable
 

--- a/pkg/cmd/flags/grpc.go
+++ b/pkg/cmd/flags/grpc.go
@@ -8,9 +8,16 @@ import (
 	"github.com/aquasecurity/tracee/pkg/server/grpc"
 )
 
+var defaultUNIXAddr = "unix:/tmp/tracee.sock"
+var defaultTCPAddr = "tcp:4466"
+
 func PrepareGRPCServer(listenAddr string) (*grpc.Server, error) {
 	if len(listenAddr) == 0 {
 		return nil, nil
+	} else if listenAddr == "unix" {
+		listenAddr = defaultUNIXAddr
+	} else if listenAddr == "tcp" {
+		listenAddr = defaultTCPAddr
 	}
 
 	addr := strings.SplitN(listenAddr, ":", 2)

--- a/pkg/cmd/flags/server/server.go
+++ b/pkg/cmd/flags/server/server.go
@@ -11,7 +11,7 @@ const (
 	HealthzEndpointFlag    = "healthz"
 	PProfEndpointFlag      = "pprof"
 	HTTPListenEndpointFlag = "http-listen-addr"
-	GRPCListenEndpointFlag = "grpc-listen-addr"
+	GRPCListenEndpointFlag = "grpc"
 	PyroscopeAgentFlag     = "pyroscope"
 )
 

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -141,7 +141,7 @@ for TEST in $TESTS; do
         --signatures-dir "$SIG_DIR" \
         --scope comm=echo,mv,ls,tracee,proctreetester,ping,ds_writer,fsnotify_tester,process_execute,tracee-ebpf,writev,set_fs_pwd.sh \
         --dnscache enable \
-        --grpc-listen-addr unix:/tmp/tracee.sock \
+        --grpc unix:/tmp/tracee.sock \
         --events "$TEST" &
 
     # Wait tracee to start


### PR DESCRIPTION
<!--

**Checklist**:

1. Ensure the PR addresses an issue so it can be properly tracked and closed if resolved.
2. Tag your PR with at least one `kind/xxx` label.
3. Tag your PR with at least one `area/xxx` label.
4. Avoid using `kind/feature` unless you're explicitly adding a release-worthy feature.
5. Add a `milestone/v0.x.y` label if the change is meant for milestone `0.x.y`.
6. Verify that all tests pass before requesting a review.
7. Avoid explicitly tagging maintainers for review unless necessary—it may delay your PR.
8. Stay on top of rebases to ensure smooth merges.

**PS:** **DO NOT SKIP THIS CHECKLIST.** Go back, review, and confirm compliance before proceeding!

-->

---

### 1. PR Summary

- Changed the `--grpc-listen-addr` flag to `--grpc` for improved clarity and usability.
- Added support for both `unix` and `tcp` protocols:
  - Example for `unix`: `tracee --grpc unix`
  - Example for `tcp`: `tracee --grpc tcp`

---

### 2. How to Test

You can test these changes by compiling `tracee` and running it with the new `--grpc` flag. Examples:

1. **Using Unix sockets:**
   ```
   tracee --grpc unix
   ```
   Equivalent to:
   ```
   tracee --grpc unix:/tmp/tracee.sock
   ```

2. **Using TCP:**
   ```
   tracee --grpc tcp
   ```

Both options should function correctly and reflect the expected behavior.

---

### 3. Additional Comments

This PR closes #4388.