### PR TITLE
chore(grpc): bump api to latest 715b629

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/IBM/fluent-forward-go v0.2.2
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
-	github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f
+	github.com/aquasecurity/tracee/api v0.0.0-20241202151435-715b6290fb6a
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241009193135-0b23713fa9f9
 	github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863
 	github.com/containerd/containerd v1.7.21

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVb
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca h1:OPbvwFFvR11c1bgOLhBq1R5Uk3hwUjHW2KfrdyJan9Y=
 github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
-github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f h1:O4UmMQViaaP1wKL1eXe7C6VylwrUmUB5mYM+roqnUZg=
-github.com/aquasecurity/tracee/api v0.0.0-20240905132323-d1eaeef6a19f/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
+github.com/aquasecurity/tracee/api v0.0.0-20241202151435-715b6290fb6a h1:5SmeDGWshkjCXTmIDvYx/MsrnOuYw01XnCEKdNkrBF0=
+github.com/aquasecurity/tracee/api v0.0.0-20241202151435-715b6290fb6a/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241009193135-0b23713fa9f9 h1:sB84YYSDgUAYNSonXeMPweaN6dviCld8UNqcKDn1jBM=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241009193135-0b23713fa9f9/go.mod h1:/eGxScU8+vnxYhchZ72Y0lv1HqTSooLvtGCt9x7450I=
 github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863 h1:domVTTQICTuCvX+ZW5EjvdUBz8EH7FedBj5lRqwpgf4=

--- a/pkg/server/grpc/tracee.go
+++ b/pkg/server/grpc/tracee.go
@@ -12,6 +12,7 @@ import (
 
 	pb "github.com/aquasecurity/tracee/api/v1beta1"
 	tracee "github.com/aquasecurity/tracee/pkg/ebpf"
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/pkg/streams"
@@ -721,9 +722,9 @@ func convertTraceeEventToProto(e trace.Event) (*pb.Event, error) {
 	k8s := getK8s(e)
 	idExternal := getExternalID(e)
 
-	var eventContext *pb.Context
+	var eventWorkload *pb.Workload
 	if process != nil || container != nil || k8s != nil {
-		eventContext = &pb.Context{
+		eventWorkload = &pb.Workload{
 			Process:   process,
 			Container: container,
 			K8S:       k8s,
@@ -740,16 +741,21 @@ func convertTraceeEventToProto(e trace.Event) (*pb.Event, error) {
 		threat = getThreat(e.Metadata.Description, e.Metadata.Properties)
 	}
 
+	triggerEvent, err := getTriggerBy(e.Args)
+	if err != nil {
+		return nil, err
+	}
+
 	event := &pb.Event{
 		Id:   idExternal,
 		Name: e.EventName,
 		Policies: &pb.Policies{
 			Matched: e.MatchedPolicies,
 		},
-		Context: eventContext,
-		Threat:  threat,
-
-		Data: eventData,
+		Workload:    eventWorkload,
+		Data:        eventData,
+		Threat:      threat,
+		TriggeredBy: triggerEvent,
 	}
 
 	if e.Timestamp != 0 {
@@ -930,6 +936,68 @@ func getThreat(description string, metadata map[string]interface{}) *pb.Threat {
 		Name:       name,
 		Properties: properties,
 	}
+}
+
+func getTriggerBy(args []trace.Argument) (*pb.TriggeredBy, error) {
+	var triggeredByArg *trace.Argument
+	triggerEvent := &pb.TriggeredBy{}
+
+	for i := range args {
+		if args[i].ArgMeta.Name == "triggeredBy" {
+			triggeredByArg = &args[i]
+			break
+		}
+	}
+	if triggeredByArg == nil {
+		return triggerEvent, nil
+	}
+
+	m, ok := triggeredByArg.Value.(map[string]interface{})
+	if !ok {
+		return nil, errfmt.Errorf("error getting triggering event: %v", triggeredByArg.Value)
+	}
+
+	id, ok := m["id"].(int)
+	if !ok {
+		return nil, errfmt.Errorf("error getting id of triggering event: %v", m)
+	}
+	triggerEvent.Id = uint32(id)
+
+	name, ok := m["name"].(string)
+	if !ok {
+		return nil, errfmt.Errorf("error getting name of triggering event: %v", m)
+	}
+	triggerEvent.Name = name
+
+	triggerEventArgs, ok := m["args"].([]trace.Argument)
+	if !ok {
+		return nil, errfmt.Errorf("error getting args of triggering event: %v", m)
+	}
+
+	data := make([]*pb.EventValue, 0)
+
+	for _, arg := range triggerEventArgs {
+		eventValue, err := getEventValue(arg)
+		if err != nil {
+			return nil, err
+		}
+
+		eventValue.Name = arg.ArgMeta.Name
+		data = append(data, eventValue)
+	}
+
+	if events.Core.GetDefinitionByID(events.ID(id)).IsSyscall() {
+		data = append(data, &pb.EventValue{
+			Name: "returnValue",
+			Value: &pb.EventValue_Int64{
+				Int64: int64(m["returnValue"].(int)),
+			},
+		})
+	}
+
+	triggerEvent.Data = data
+
+	return triggerEvent, nil
 }
 
 func getSeverity(metadata map[string]interface{}) pb.Severity {

--- a/pkg/server/grpc/tracee_test.go
+++ b/pkg/server/grpc/tracee_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
-func Test_convertEventWithProcessContext(t *testing.T) {
+func Test_convertEventWithProcessWorkload(t *testing.T) {
 	t.Parallel()
 
 	unixTime := int(time.Now().UnixNano())
@@ -40,22 +40,22 @@ func Test_convertEventWithProcessContext(t *testing.T) {
 	protoEvent, err := convertTraceeEventToProto(traceEvent)
 	assert.NoError(t, err)
 
-	assert.Equal(t, uint32(1), protoEvent.Context.Process.Pid.Value)
-	assert.Equal(t, uint32(2), protoEvent.Context.Process.Thread.Tid.Value)
-	assert.Equal(t, uint32(3), protoEvent.Context.Process.HostPid.Value)
-	assert.Equal(t, uint32(4), protoEvent.Context.Process.Thread.HostTid.Value)
-	assert.Equal(t, uint32(5), protoEvent.Context.Process.Ancestors[0].Pid.Value)
-	assert.Equal(t, uint32(6), protoEvent.Context.Process.Ancestors[0].HostPid.Value)
-	assert.Equal(t, uint32(7), protoEvent.Context.Process.RealUser.Id.Value)
+	assert.Equal(t, uint32(1), protoEvent.Workload.Process.Pid.Value)
+	assert.Equal(t, uint32(2), protoEvent.Workload.Process.Thread.Tid.Value)
+	assert.Equal(t, uint32(3), protoEvent.Workload.Process.HostPid.Value)
+	assert.Equal(t, uint32(4), protoEvent.Workload.Process.Thread.HostTid.Value)
+	assert.Equal(t, uint32(5), protoEvent.Workload.Process.Ancestors[0].Pid.Value)
+	assert.Equal(t, uint32(6), protoEvent.Workload.Process.Ancestors[0].HostPid.Value)
+	assert.Equal(t, uint32(7), protoEvent.Workload.Process.RealUser.Id.Value)
 	assert.Equal(t, pb.EventId_execve, protoEvent.Id)
-	assert.Equal(t, uint32(9), protoEvent.Context.Process.Thread.UniqueId.Value)
-	assert.Equal(t, uint32(10), protoEvent.Context.Process.UniqueId.Value)
-	assert.Equal(t, uint32(11), protoEvent.Context.Process.Ancestors[0].UniqueId.Value)
+	assert.Equal(t, uint32(9), protoEvent.Workload.Process.Thread.UniqueId.Value)
+	assert.Equal(t, uint32(10), protoEvent.Workload.Process.UniqueId.Value)
+	assert.Equal(t, uint32(11), protoEvent.Workload.Process.Ancestors[0].UniqueId.Value)
 	assert.Equal(t, "eventTest", protoEvent.Name)
 	assert.Equal(t, []string{"policyTest"}, protoEvent.Policies.Matched)
-	assert.Equal(t, "processTest", protoEvent.Context.Process.Thread.Name)
-	assert.Equal(t, "syscall", protoEvent.Context.Process.Thread.Syscall)
-	assert.Equal(t, true, protoEvent.Context.Process.Thread.Compat)
+	assert.Equal(t, "processTest", protoEvent.Workload.Process.Thread.Name)
+	assert.Equal(t, "syscall", protoEvent.Workload.Process.Thread.Syscall)
+	assert.Equal(t, true, protoEvent.Workload.Process.Thread.Compat)
 }
 
 func Test_convertEventWithStackaddresses(t *testing.T) {
@@ -75,11 +75,11 @@ func Test_convertEventWithStackaddresses(t *testing.T) {
 	}
 
 	for i := range expected {
-		assert.Equal(t, expected[i].Address, protoEvent.Context.Process.Thread.UserStackTrace.Addresses[i].Address)
+		assert.Equal(t, expected[i].Address, protoEvent.Workload.Process.Thread.UserStackTrace.Addresses[i].Address)
 	}
 }
 
-func Test_convertEventWithContainerContext(t *testing.T) {
+func Test_convertEventWithContainerWorkload(t *testing.T) {
 	t.Parallel()
 
 	traceEvent := trace.Event{
@@ -94,13 +94,13 @@ func Test_convertEventWithContainerContext(t *testing.T) {
 	protoEvent, err := convertTraceeEventToProto(traceEvent)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "containerID", protoEvent.Context.Container.Id)
-	assert.Equal(t, "containerName", protoEvent.Context.Container.Name)
-	assert.Equal(t, "imageName", protoEvent.Context.Container.Image.Name)
-	assert.Equal(t, []string{"imageDigest"}, protoEvent.Context.Container.Image.RepoDigests)
+	assert.Equal(t, "containerID", protoEvent.Workload.Container.Id)
+	assert.Equal(t, "containerName", protoEvent.Workload.Container.Name)
+	assert.Equal(t, "imageName", protoEvent.Workload.Container.Image.Name)
+	assert.Equal(t, []string{"imageDigest"}, protoEvent.Workload.Container.Image.RepoDigests)
 }
 
-func Test_convertEventWithK8sContext(t *testing.T) {
+func Test_convertEventWithK8sWorkload(t *testing.T) {
 	t.Parallel()
 
 	traceEvent := trace.Event{
@@ -114,9 +114,9 @@ func Test_convertEventWithK8sContext(t *testing.T) {
 	protoEvent, err := convertTraceeEventToProto(traceEvent)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "podName", protoEvent.Context.K8S.Pod.Name)
-	assert.Equal(t, "podNamespace", protoEvent.Context.K8S.Namespace.Name)
-	assert.Equal(t, "podUID", protoEvent.Context.K8S.Pod.Uid)
+	assert.Equal(t, "podName", protoEvent.Workload.K8S.Pod.Name)
+	assert.Equal(t, "podNamespace", protoEvent.Workload.K8S.Namespace.Name)
+	assert.Equal(t, "podUID", protoEvent.Workload.K8S.Pod.Uid)
 }
 
 func Test_convertEventWithThreat(t *testing.T) {


### PR DESCRIPTION
### 1. Explain what the PR does

0f3a94c1b **chore(grpc): bump api to latest 715b629**

```
It also updates grpc proto conversion functions to use the new api.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
