### PR TITLE
fix(build): fix build checkers for goimports

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -81,7 +81,7 @@ runs:
       shell: bash
     - name: Install goimports-reviser
       run: |
-        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@v3.6.5
+        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/incu6us/goimports-reviser/v3@v3.8.2
         sudo cp $HOME/go/bin/goimports-reviser /usr/bin/
       shell: bash
     - name: Install errcheck

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -71,7 +71,7 @@ RUN TARGETARCH=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') &&
 
 # install Go tools
 RUN go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 && \
-    go install github.com/incu6us/goimports-reviser/v3@latest && \
+    go install github.com/incu6us/goimports-reviser/v3@v3.8.2 && \
     go install github.com/mgechev/revive@e33fb87 && \
     go install github.com/kisielk/errcheck@latest
 

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -89,7 +89,7 @@ RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
 # install goimports-reviser
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
-    go install github.com/incu6us/goimports-reviser/v3@v3.6.5 && \
+    go install github.com/incu6us/goimports-reviser/v3@v3.8.2 && \
     cp $HOME/go/bin/goimports-reviser /usr/bin/
 
 # install revive

--- a/builder/Makefile.checkers
+++ b/builder/Makefile.checkers
@@ -81,6 +81,7 @@ C_FILES_TO_BE_CHECKED = $(shell find ./pkg/ebpf/c/ -regextype posix-extended -re
 
 CMD_GOIMPORTS_COMPANY_PREFIXES ?= "github.com/aquasecurity"
 CMD_GOIMPORTS_PROJECT ?= "github.com/aquasecurity/tracee"
+CMD_GOIMPORTS_OUTPUT_FILE ?= "/tmp/check-goimports-fmt"
 
 .PHONY: fmt-check
 fmt-check: | \
@@ -101,29 +102,25 @@ fmt-check: | \
 	rm -f /tmp/check-c-fmt
 #
 	echo "Checking golang files imports formatting..."
-	rm -f /tmp/check-goimports-fmt
-	# need to iterate due to this issue https://github.com/incu6us/goimports-reviser/issues/93
-	for file in `$(CMD_FIND) . -type f -name '*.go'`; do \
-		$(CMD_GOIMPORTS) \
-			-output stdout \
-			-list-diff \
-			-company-prefixes $(CMD_GOIMPORTS_COMPANY_PREFIXES) \
-			-project-name $(CMD_GOIMPORTS_PROJECT) \
-			$$file >> /tmp/check-goimports-fmt 2>&1; \
-	done
-	goimportsamount=$$(cat /tmp/check-goimports-fmt | wc -l)
+	rm -f $(CMD_GOIMPORTS_OUTPUT_FILE)
+	$(CMD_GOIMPORTS) \
+		-output stdout \
+		-list-diff \
+		-company-prefixes $(CMD_GOIMPORTS_COMPANY_PREFIXES) \
+		-project-name $(CMD_GOIMPORTS_PROJECT) \
+		./... 2>/dev/null > $(CMD_GOIMPORTS_OUTPUT_FILE)
+	goimportsamount=$$(grep -cve '^\s*$$' $(CMD_GOIMPORTS_OUTPUT_FILE))
 	if [[ $$goimportsamount -ne 0 ]]; then
 		errors=1
 	fi
 	if [[ $$errors -ne 0 ]]; then
-		cat /tmp/check-goimports-fmt
+		cat $(CMD_GOIMPORTS_OUTPUT_FILE)
 		echo
 		echo "Please fix formatting errors in the files above!"
 		echo "Use: $(MAKE) fmt-fix target".
 		echo
 		exit 1
 	fi
-	rm -f /tmp/check-goimports-fmt
 #
 	echo "Checking golang files formatting..."
 	$(CMD_GOFMT) -l -s -d . | tee /tmp/check-go-fmt
@@ -169,10 +166,9 @@ fmt-fix: | \
 #
 	echo "Fixing golang files imports formatting..."
 	$(CMD_GOIMPORTS) \
-		-list-diff \
 		-company-prefixes $(CMD_GOIMPORTS_COMPANY_PREFIXES) \
 		-project-name $(CMD_GOIMPORTS_PROJECT) \
-		./...
+		./... 2>/dev/null
 #
 	echo "Fixing golang files formatting..."
 	$(CMD_GOFMT) -l -s -d . > /tmp/patch.$$


### PR DESCRIPTION
Close: #4416 

### 1. Explain what the PR does

9b8d817ee **fix(build): fix build checkers for goimports**

```
It also align goimports version to v3.8.2 in different environments.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
