### PR TITLE
chore(GH): pin ubuntu (22.04) version for gh runners

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,7 +84,7 @@ jobs:
   #
   verify-docs:
     name: Verify Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -128,7 +128,7 @@ jobs:
   #
   verify-analyze-code:
     name: Verify and Analyze Code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -167,7 +167,7 @@ jobs:
     name: Verify Signatures
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -188,7 +188,7 @@ jobs:
     name: Verify Other Tools
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -219,7 +219,7 @@ jobs:
     name: Unit Tests
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -237,7 +237,7 @@ jobs:
     name: Integration Tests
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -255,7 +255,7 @@ jobs:
     name: Performance Tests
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -274,7 +274,7 @@ jobs:
     #needs:
     #  - verify-signatures
     #  - verify-tools
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix01: ${{ steps.set-matrix.outputs.matrix01 }}
     steps:


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

8c14f78d4 **chore(GH): pin ubuntu (22.04) version for gh runners**

```
Currently, ubuntu:latest uses Ubuntu version 24.04, which includes
kernel 6.8. Since Tracee needs to be tested with kernel 6.8, it is
better to pin the version of the Ubuntu runners.

After testing Tracee with kernel 6.8 and confirming that everything
works correctly, this commit can be reverted.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
