### PR TITLE
chore: add kernel 6.8 and 6.10 in matrix images

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -302,6 +302,10 @@ jobs:
               ["Mantic 6.5 aarch64"]="0387f77c4820c98db aarch64"
               ["Mantic 6.6 x86_64"]="05b5ac8f6c43b3ca5 x86_64"
               ["Mantic 6.6 aarch64"]="05c9d6cd9343f0a43 aarch64"
+              ["Noble 6.8 x86_64"]="0cc63426ae75d47c8 x86_64"
+              ["Noble 6.8 aarch64"]="0f5260685b3ec2293 aarch64"
+              ["Noble 6.10 x86_64"]="0ae23eabda70efc60 x86_64"
+              ["Noble 6.10 aarch64"]="01ce0f71400b5ff38 aarch64"
               # expand as needed
           )
           for num in 01; do


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

d4524045e **chore: add kernel 6.8 and 6.10 in matrix images**

```
- Add kernel 6.8 and 6.10, both for x86_64 and aarch64;
- Both kernels are based on Ubuntu 24.04 LTS (codename Noble).
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
