### PR TITLE
fix empty arguments resolution

### DIFF
--- a/pkg/events/parse_args_helpers.go
+++ b/pkg/events/parse_args_helpers.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"strconv"
+
 	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -16,7 +18,7 @@ func parseSocketDomainArgument(arg *trace.Argument, domain uint64) {
 	arg.Type = "string"
 	socketDomainArgument, err := parsers.ParseSocketDomainArgument(domain)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(domain, 10)
 		return
 	}
 	arg.Value = socketDomainArgument.String()
@@ -26,7 +28,7 @@ func parseSocketType(arg *trace.Argument, typ uint64) {
 	arg.Type = "string"
 	socketTypeArgument, err := parsers.ParseSocketType(typ)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(typ, 10)
 		return
 	}
 	arg.Value = socketTypeArgument.String()
@@ -36,7 +38,7 @@ func parseInodeMode(arg *trace.Argument, mode uint64) {
 	arg.Type = "string"
 	inodeModeArgument, err := parsers.ParseInodeMode(mode)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(mode, 10)
 		return
 	}
 	arg.Value = inodeModeArgument.String()
@@ -46,7 +48,7 @@ func parseBPFProgType(arg *trace.Argument, progType uint64) {
 	arg.Type = "string"
 	bpfProgTypeArgument, err := parsers.ParseBPFProgType(progType)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(progType, 10)
 		return
 	}
 	arg.Value = bpfProgTypeArgument.String()
@@ -56,7 +58,7 @@ func parseCapability(arg *trace.Argument, capability uint64) {
 	arg.Type = "string"
 	capabilityFlagArgument, err := parsers.ParseCapability(capability)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(capability, 10)
 		return
 	}
 	arg.Value = capabilityFlagArgument.String()
@@ -74,12 +76,13 @@ func parseSyscall(arg *trace.Argument, id int32) {
 	// NOTE: This might cause data races in the future if the map is modified.
 	// One solution to keep better CPU time is to segregate the map into two maps:
 	// one for proper core (read-only) events and another for the dynamic events.
+	arg.Type = "string"
 	def, ok := CoreEvents[ID(id)]
 	if !ok || !def.IsSyscall() {
+		arg.Value = strconv.FormatInt(int64(id), 10)
 		return
 	}
 
-	arg.Type = "string"
 	arg.Value = def.GetName()
 }
 
@@ -87,7 +90,7 @@ func parsePtraceRequestArgument(arg *trace.Argument, req uint64) {
 	arg.Type = "string"
 	ptraceRequestArgument, err := parsers.ParsePtraceRequestArgument(req)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(req, 10)
 		return
 	}
 	arg.Value = ptraceRequestArgument.String()
@@ -97,7 +100,7 @@ func parsePrctlOption(arg *trace.Argument, opt uint64) {
 	arg.Type = "string"
 	prctlOptionArgument, err := parsers.ParsePrctlOption(opt)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(opt, 10)
 		return
 	}
 	arg.Value = prctlOptionArgument.String()
@@ -105,19 +108,19 @@ func parsePrctlOption(arg *trace.Argument, opt uint64) {
 
 func parseSocketcallCall(arg *trace.Argument, call uint64) {
 	arg.Type = "string"
-	socketcallArgument, err := parsers.ParseSocketcallCall(call)
+	socketCallArgument, err := parsers.ParseSocketcallCall(call)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(call, 10)
 		return
 	}
-	arg.Value = socketcallArgument.String()
+	arg.Value = socketCallArgument.String()
 }
 
 func parseAccessMode(arg *trace.Argument, mode uint64) {
 	arg.Type = "string"
 	accessModeArgument, err := parsers.ParseAccessMode(mode)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(mode, 10)
 		return
 	}
 	arg.Value = accessModeArgument.String()
@@ -127,7 +130,7 @@ func parseExecFlag(arg *trace.Argument, flags uint64) {
 	arg.Type = "string"
 	execFlagArgument, err := parsers.ParseExecFlag(flags)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(flags, 10)
 		return
 	}
 	arg.Value = execFlagArgument.String()
@@ -137,7 +140,7 @@ func parseOpenFlagArgument(arg *trace.Argument, flags uint64) {
 	arg.Type = "string"
 	openFlagArgument, err := parsers.ParseOpenFlagArgument(flags)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(flags, 10)
 		return
 	}
 	arg.Value = openFlagArgument.String()
@@ -147,7 +150,7 @@ func parseCloneFlags(arg *trace.Argument, flags uint64) {
 	arg.Type = "string"
 	cloneFlagArgument, err := parsers.ParseCloneFlags(flags)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(flags, 10)
 		return
 	}
 	arg.Value = cloneFlagArgument.String()
@@ -157,7 +160,7 @@ func parseBPFCmd(arg *trace.Argument, cmd uint64) {
 	arg.Type = "string"
 	bpfCommandArgument, err := parsers.ParseBPFCmd(cmd)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(cmd, 10)
 		return
 	}
 	arg.Value = bpfCommandArgument.String()
@@ -167,7 +170,7 @@ func parseSocketLevel(arg *trace.Argument, level uint64) {
 	arg.Type = "string"
 	socketLevelArgument, err := parsers.ParseSocketLevel(level)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(level, 10)
 		return
 	}
 	arg.Value = socketLevelArgument.String()
@@ -185,7 +188,7 @@ func parseGetSocketOption(arg *trace.Argument, opt uint64, evtID ID) {
 	if err == nil {
 		arg.Value = optionNameArgument.String()
 	} else {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(opt, 10)
 	}
 }
 
@@ -193,7 +196,7 @@ func parseFsNotifyObjType(arg *trace.Argument, objType uint64) {
 	arg.Type = "string"
 	fsNotifyObjTypeArgument, err := parsers.ParseFsNotifyObjType(objType)
 	if err != nil {
-		arg.Value = ""
+		arg.Value = strconv.FormatUint(objType, 10)
 		return
 	}
 	arg.Value = fsNotifyObjTypeArgument.String()
@@ -206,6 +209,7 @@ func parseBpfHelpersUsage(arg *trace.Argument, helpersList []uint64) {
 			// helper number <i> is used. get its name from libbpfgo
 			bpfHelper, err := parsers.ParseBPFFunc(uint64(i))
 			if err != nil {
+				usedHelpers = append(usedHelpers, strconv.FormatInt(int64(i), 10))
 				continue
 			}
 			usedHelpers = append(usedHelpers, bpfHelper.String())
@@ -235,9 +239,8 @@ func parseBpfAttachType(arg *trace.Argument, attachType int32) {
 	case 5:
 		attTypeName = "uretprobe"
 	default:
-		arg.Value = ""
+		attTypeName = strconv.FormatInt(int64(attachType), 10)
 		logger.Errorw("Unknown attach_type got from bpf_attach event")
-		return
 	}
 
 	arg.Value = attTypeName

--- a/pkg/events/parse_args_helpers_test.go
+++ b/pkg/events/parse_args_helpers_test.go
@@ -1,0 +1,1385 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+func TestParseArgsHelpers(t *testing.T) {
+	t.Parallel()
+	TestParseMMapProt(t)
+	TestParseSocketDomainArgument(t)
+	TestParseSocketType(t)
+	TestParseInodeMode(t)
+	TestParseBPFProgType(t)
+	TestParseCapability(t)
+	TestParseMemProtAlert(t)
+	TestParseSyscall(t)
+	TestParsePtraceRequestArgument(t)
+	TestParsePrctlOption(t)
+	TestParseSocketcallCall(t)
+	TestParseAccessMode(t)
+	TestParseExecFlag(t)
+	TestParseOpenFlagArgument(t)
+	TestParseCloneFlags(t)
+	TestParseBPFCmd(t)
+	TestParseSocketLevel(t)
+	TestParseGetSocketOption(t)
+	TestParseFsNotifyObjType(t)
+	TestParseBpfHelpersUsage(t)
+	TestParseBpfAttachType(t)
+}
+func TestParseMMapProt(t *testing.T) {
+	// No need to add other test cases because there isn't a case where parseMMapProt fail
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{{
+		name: "normal flow",
+		args: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{
+					Name: "prot",
+					Type: "int",
+				},
+				Value: parsers.PROT_READ.Value(),
+			},
+		},
+		expectedArgs: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{
+					Name: "prot",
+					Type: "string",
+				},
+				Value: "PROT_READ",
+			},
+		},
+	},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseMMapProt(GetArg(event, "prot"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseSocketDomainArgument(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "domain",
+						Type: "int",
+					},
+					Value: parsers.AF_INET.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "domain",
+						Type: "string",
+					},
+					Value: "AF_INET",
+				},
+			},
+		},
+		{
+			name: "invalid domain",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "domain",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "domain",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseSocketDomainArgument(GetArg(event, "domain"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseSocketType(t *testing.T) {
+	testCases := []struct {
+		eventId      int
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name:    "normal flow",
+			eventId: int(Socket),
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "int",
+					},
+					Value: int32(parsers.SOCK_STREAM.Value()),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "string",
+					},
+					Value: "SOCK_STREAM",
+				},
+			},
+		},
+		{
+			name:    "invalid type",
+			eventId: int(Socket),
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "int",
+					},
+					Value: int32(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				EventID: testCase.eventId,
+				Args:    testCase.args,
+			}
+			err := ParseArgs(event)
+			require.NoError(t, err)
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseInodeMode(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "mode",
+						Type: "int",
+					},
+					Value: parsers.S_IFSOCK.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "mode",
+						Type: "string",
+					},
+					Value: "S_IFSOCK",
+				},
+			},
+		},
+		{
+			name: "invalid mode",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "mode",
+						Type: "int",
+					},
+					Value: uint64(0),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "mode",
+						Type: "string",
+					},
+					Value: "",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseInodeMode(GetArg(event, "mode"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseBPFProgType(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "int",
+					},
+					Value: parsers.BPFProgTypeUnspec.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "string",
+					},
+					Value: "BPF_PROG_TYPE_UNSPEC",
+				},
+			},
+		},
+		{
+			name: "invalid type",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "type",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseBPFProgType(GetArg(event, "type"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseCapability(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "capability",
+						Type: "int",
+					},
+					Value: parsers.CAP_CHOWN.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "capability",
+						Type: "string",
+					},
+					Value: "CAP_CHOWN",
+				},
+			},
+		},
+		{
+			name: "invalid capability",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "capability",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "capability",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseCapability(GetArg(event, "capability"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseMemProtAlert(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "alert",
+						Type: "int",
+					},
+					Value: uint32(trace.ProtAlertMmapWX),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "alert",
+						Type: "string",
+					},
+					Value: "Mmaped region with W+E permissions!",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseMemProtAlert(GetArg(event, "alert"), testCase.args[0].Value.(uint32))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseSyscall(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "id",
+						Type: "int",
+					},
+					Value: int32(Ptrace),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "id",
+						Type: "string",
+					},
+					Value: "ptrace",
+				},
+			},
+		},
+		{
+			name: "invalid syscall",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "id",
+						Type: "int",
+					},
+					Value: int32(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "id",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseSyscall(GetArg(event, "id"), testCase.args[0].Value.(int32))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParsePtraceRequestArgument(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "req",
+						Type: "int",
+					},
+					Value: parsers.PTRACE_PEEKTEXT.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "req",
+						Type: "string",
+					},
+					Value: "PTRACE_PEEKTEXT",
+				},
+			},
+		},
+		{
+			name: "invalid req",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "req",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "req",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parsePtraceRequestArgument(GetArg(event, "req"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParsePrctlOption(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "opt",
+						Type: "int",
+					},
+					Value: parsers.PR_SET_NO_NEW_PRIVS.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "opt",
+						Type: "string",
+					},
+					Value: "PR_SET_NO_NEW_PRIVS",
+				},
+			},
+		},
+		{
+			name: "invalid opt",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "opt",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "opt",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parsePrctlOption(GetArg(event, "opt"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseSocketcallCall(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "call",
+						Type: "int",
+					},
+					Value: parsers.SYS_SOCKET.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "call",
+						Type: "string",
+					},
+					Value: "SYS_SOCKET",
+				},
+			},
+		},
+		{
+			name: "invalid call",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "call",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "call",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseSocketcallCall(GetArg(event, "call"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseAccessMode(t *testing.T) {
+	testcase := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		// TODO: remove comment when tracee handles an empty flag, will be fixed in #4279
+		// {
+		// 	name: "normal flow",
+		// 	args: []trace.Argument{
+		// 		{
+		// 			ArgMeta: trace.ArgMeta{
+		// 				Name: "mode",
+		// 				Type: "int",
+		// 			},
+		// 			Value: parsers.F_OK.Value(),
+		// 		},
+		// 	},
+		// 	expectedArgs: []trace.Argument{
+		// 		{
+		// 			ArgMeta: trace.ArgMeta{
+		// 				Name: "mode",
+		// 				Type: "string",
+		// 			},
+		// 			Value: "F_OK",
+		// 		},
+		// 	},
+		// },
+		{
+			name: "multiple flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "mode",
+						Type: "int",
+					},
+					Value: parsers.X_OK.Value() | parsers.R_OK.Value() | parsers.W_OK.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "mode",
+						Type: "string",
+					},
+					Value: "R_OK|W_OK|X_OK",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testcase {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseAccessMode(GetArg(event, "mode"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseExecFlag(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "int",
+					},
+					Value: parsers.AT_SYMLINK_NOFOLLOW.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "string",
+					},
+					Value: "AT_SYMLINK_NOFOLLOW",
+				},
+			},
+		},
+		{
+			name: "invalid flags",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "int",
+					},
+					Value: uint64(100),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "string",
+					},
+					Value: "100",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseExecFlag(GetArg(event, "flags"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseOpenFlagArgument(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		// TODO: remove comment when tracee handles an empty flag, will be fixed in #4279
+		// {
+		// 	name: "normal flow",
+		// 	args: []trace.Argument{
+		// 		{
+		// 			ArgMeta: trace.ArgMeta{
+		// 				Name: "flags",
+		// 				Type: "int",
+		// 			},
+		// 			Value: parsers.O_RDONLY.Value(),
+		// 		},
+		// 	},
+		// 	expectedArgs: []trace.Argument{
+		// 		{
+		// 			ArgMeta: trace.ArgMeta{
+		// 				Name: "flags",
+		// 				Type: "string",
+		// 			},
+		// 			Value: "O_RDONLY",
+		// 		},
+		// 	},
+		// },
+		{
+			name: "multiple flags",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "int",
+					},
+					Value: parsers.O_RDWR.Value() | parsers.O_CREAT.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "string",
+					},
+					Value: "O_RDWR|O_CREAT",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseOpenFlagArgument(GetArg(event, "flags"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseCloneFlags(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "int",
+					},
+					Value: parsers.CLONE_VM.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "string",
+					},
+					Value: "CLONE_VM",
+				},
+			},
+		},
+		{
+			name: "multiple flags",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "int",
+					},
+					Value: parsers.CLONE_VM.Value() | parsers.CLONE_FS.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "string",
+					},
+					Value: "CLONE_VM|CLONE_FS",
+				},
+			},
+		},
+		{
+			name: "zero flags",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "int",
+					},
+					Value: uint64(0),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "flags",
+						Type: "string",
+					},
+					Value: "",
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseCloneFlags(GetArg(event, "flags"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseBPFCmd(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "cmd",
+						Type: "int",
+					},
+					Value: parsers.BPF_PROG_LOAD.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "cmd",
+						Type: "string",
+					},
+					Value: "BPF_PROG_LOAD",
+				},
+			},
+		},
+		{
+			name: "invalid cmd",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "cmd",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "cmd",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseBPFCmd(GetArg(event, "cmd"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseSocketLevel(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "level",
+						Type: "int",
+					},
+					Value: parsers.SOL_SOCKET.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "level",
+						Type: "string",
+					},
+					Value: "SOL_SOCKET",
+				},
+			},
+		},
+		{
+			name: "invalid level",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "level",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "level",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseSocketLevel(GetArg(event, "level"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseGetSocketOption(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "optname",
+						Type: "int",
+					},
+					Value: parsers.SO_LOCK_FILTER.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "optname",
+						Type: "string",
+					},
+					Value: "SO_LOCK_FILTER",
+				},
+			},
+		},
+		{
+			name: "invalid flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "optname",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "optname",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseGetSocketOption(GetArg(event, "optname"), testCase.args[0].Value.(uint64), Getsockopt)
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseFsNotifyObjType(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "objType",
+						Type: "int",
+					},
+					Value: parsers.FSNOTIFY_OBJ_TYPE_INODE.Value(),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "objType",
+						Type: "string",
+					},
+					Value: "FSNOTIFY_OBJ_TYPE_INODE",
+				},
+			},
+		},
+		{
+			name: "invalid objType",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "objType",
+						Type: "int",
+					},
+					Value: uint64(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "objType",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseFsNotifyObjType(GetArg(event, "objType"), testCase.args[0].Value.(uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseBpfHelpersUsage(t *testing.T) {
+	var emptyValue []string
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "helpersList",
+						Type: "int",
+					},
+					Value: []uint64{1, 2, 3},
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "helpersList",
+						Type: "const char**",
+					},
+					Value: []string{"unspec", "xdp_adjust_tail", "sk_cgroup_id", "sk_ancestor_cgroup_id"},
+				},
+			},
+		},
+		{
+			name: "invalid helpersList",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "helpersList",
+						Type: "int",
+					},
+					Value: []uint64{0},
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "helpersList",
+						Type: "const char**",
+					},
+					Value: emptyValue,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseBpfHelpersUsage(GetArg(event, "helpersList"), testCase.args[0].Value.([]uint64))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}
+func TestParseBpfAttachType(t *testing.T) {
+	testCases := []struct {
+		name         string
+		args         []trace.Argument
+		expectedArgs []trace.Argument
+	}{
+		{
+			name: "normal flow",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "attachType",
+						Type: "int",
+					},
+					Value: int32(0),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "attachType",
+						Type: "string",
+					},
+					Value: "raw_tracepoint",
+				},
+			},
+		},
+		{
+			name: "invalid attachType",
+			args: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "attachType",
+						Type: "int",
+					},
+					Value: int32(12345),
+				},
+			},
+			expectedArgs: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "attachType",
+						Type: "string",
+					},
+					Value: "12345",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			event := &trace.Event{
+				Args: testCase.args,
+			}
+			parseBpfAttachType(GetArg(event, "attachType"), testCase.args[0].Value.(int32))
+			for _, expArg := range testCase.expectedArgs {
+				arg := GetArg(event, expArg.Name)
+				assert.Equal(t, expArg, *arg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does
- fix issue #3892 
- fix the empty result of failed parse helper argument
- add test to parse_args_helper.go

`make check-pr`:

1cbdc3d1dc **tests: add argument parsers tests**
69d55cbe77 **fix: empty arguments resolution**


69d55cbe77 **fix: empty arguments resolution**

```
When tracee tries to resolve a numeric argument to a string (e.g. cmd value of
bpf syscall), if the resolution fails, the event field will contain an empty
string.

Return the raw value as a string in case of a failed resolution.
```
### 2. Explain how to test it

In order to test you can run the test in the file with this command 
``` bash
GOOS=linux CC=clang GOARCH=amd64 CGO_CFLAGS="-I/tracee/dist/libbpf -I/tracee/3rdparty/libbpf/include/uapi" CGO_LDFLAGS="-L/tracee/dist/libbpf/obj -lbpf" \
go test \
	-tags ebpf \
        -v \
        -short \
	-race \
	-coverprofile=coverage.txt \
	./pkg/events -run TestParseArgsHelpers
```

- this will run the test functions for parse_args_helpers.go file
-  you can  change `TestParseArgsHelpers` to a function name like: `TestParseBPFCmd` to test a more specific 
### 3. Other comments

Resolves #3892 
