### PR TITLE
chore: pin ubuntu:latest for gh runners / trigger magic_write event

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,7 +84,7 @@ jobs:
   #
   verify-docs:
     name: Verify Documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -128,7 +128,7 @@ jobs:
   #
   verify-analyze-code:
     name: Verify and Analyze Code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -167,7 +167,7 @@ jobs:
     name: Verify Other Tools
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -198,7 +198,7 @@ jobs:
     name: Unit Tests
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -216,7 +216,7 @@ jobs:
     name: Integration Tests
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -234,7 +234,7 @@ jobs:
     name: Performance Tests
     needs:
       - verify-analyze-code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -253,7 +253,7 @@ jobs:
     #needs:
     #  - verify-signatures
     #  - verify-tools
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       matrix01: ${{ steps.set-matrix.outputs.matrix01 }}
     steps:

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1895,7 +1895,7 @@ func Test_EventFilters(t *testing.T) {
 						},
 						Spec: k8s.PolicySpec{
 							Scope: []string{
-								"comm=cat",
+								"comm=more",
 							},
 							DefaultActions: []string{"log"},
 							Rules: []k8s.Rule{
@@ -1917,7 +1917,7 @@ func Test_EventFilters(t *testing.T) {
 						},
 						Spec: k8s.PolicySpec{
 							Scope: []string{
-								"comm=cat",
+								"comm=more",
 							},
 							DefaultActions: []string{"log"},
 							Rules: []k8s.Rule{
@@ -1935,13 +1935,13 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"sh -c 'cat /etc/hostname > /tmp/hostname; cat /etc/shadow > /tmp/shadow; cat /etc/passwd > /tmp/passwd;'",
+					"sh -c 'more /etc/hostname > /tmp/hostname; more /etc/shadow > /tmp/shadow; more /etc/passwd > /tmp/passwd;'",
 					0,
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "cat", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("mw-pol-1", "mw-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/tmp/hostname")),
-						expectEvent(anyHost, "cat", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/shadow")),
-						expectEvent(anyHost, "cat", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("mw-pol-1", "mw-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/tmp/passwd")),
+						expectEvent(anyHost, "more", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("mw-pol-1", "mw-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/tmp/hostname")),
+						expectEvent(anyHost, "more", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/shadow")),
+						expectEvent(anyHost, "more", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("mw-pol-1", "mw-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/tmp/passwd")),
 					},
 					[]string{},
 				),
@@ -2004,7 +2004,7 @@ func Test_EventFilters(t *testing.T) {
 						},
 						Spec: k8s.PolicySpec{
 							Scope: []string{
-								"comm=cat",
+								"comm=more",
 							},
 							DefaultActions: []string{"log"},
 							Rules: []k8s.Rule{
@@ -2028,13 +2028,13 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"sh -c 'cat /etc/hostname > /tmp/hostname; cat /etc/shadow > /tmp/shadow; cat /etc/passwd > /tmp/passwd;'",
+					"sh -c 'more /etc/hostname > /tmp/hostname; more /etc/shadow > /tmp/shadow; more /etc/passwd > /tmp/passwd;'",
 					0,
 					1*time.Second,
 					[]trace.Event{
-						expectEvent(anyHost, "cat", testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("sfo-mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/hostname")),
-						expectEvent(anyHost, "cat", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("sfo-mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/shadow")),
-						expectEvent(anyHost, "cat", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("sfo-mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/passwd")),
+						expectEvent(anyHost, "more", testutils.CPUForTests, anyPID, 0, events.SecurityFileOpen, orPolNames("sfo-mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/hostname")),
+						expectEvent(anyHost, "more", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("sfo-mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/shadow")),
+						expectEvent(anyHost, "more", testutils.CPUForTests, anyPID, 0, events.MagicWrite, orPolNames("sfo-mw-pol-1"), orPolIDs(1), expectArg("pathname", "/tmp/passwd")),
 					},
 					[]string{},
 				),


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

9e6e4d4fd **chore(test): use more cmd to trigger magic_write event**
e442ebd73 **Revert "chore(GH): pin ubuntu (22.04) version for gh runners"**


e442ebd73 **Revert "chore(GH): pin ubuntu (22.04) version for gh runners"**

```
This reverts commit ad74ef5a637b5c6fd1830b12f58a9cb897643762.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

The GitHub runner currently uses ubuntu:latest (Ubuntu 24.04 LTS), which includes kernel 6.8. Initially, the version of the Ubuntu runner was pinned because Tracee needed to be tested with kernel 6.8.

After conducting tests on kernel 6.8 and confirming that everything worked as expected, the pinning was reverted.

The reason for pinning and later reverting the version was due to two failing integration tests. These tests relied on the command `cp /etc/netconfig /tmp/netconfig` to generate a `magic_write` event. However, starting from kernel 6.8, this command no longer triggers a `magic_write` event. Instead, the tests were updated to use the `more` command, which works as expected with kernel 6.8.
