### PR TITLE
fix(ebpf): adjust inode struct to kernel v6.11

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -658,7 +658,8 @@ struct inode {
     umode_t i_mode;
     struct super_block *i_sb;
     long unsigned int i_ino;
-    struct timespec64 __i_ctime;
+    time64_t i_ctime_sec;
+    u32 i_ctime_nsec;
     loff_t i_size;
     struct file_operations *i_fop;
 };

--- a/pkg/ebpf/c/vmlinux_flavors.h
+++ b/pkg/ebpf/c/vmlinux_flavors.h
@@ -100,6 +100,11 @@ struct inode___older_v66 {
     struct timespec64 i_ctime;
 };
 
+// kernel >= v6.11 inode i_ctime field change
+struct inode___older_v611 {
+    struct timespec64 __i_ctime;
+};
+
 ///////////////////
 
 #pragma clang attribute pop


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

b54f498f4 **fix(ebpf): adjust inode struct to kernel v6.11**

```
- Add support for three different ranges of kernel versions.
- For kernel 6.11 and newer, struct inode uses the fields
i_ctime_sec and i_ctime_nsec for time.
- For kernels 6.6 to 6.10, struct inode uses __i_ctime.
- For kernels 6.5 and older, struct inode uses i_ctime.
- Align struct inode to the kernel 6.11 structure and mock
the inode struct for kernels older than 6.11.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
Thank you, @agalauner-r7, for providing such a detailed issue report and proposing various solutions to address this issue.

fix: #4391
