### PR TITLE
Bpf inner maps

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1126,13 +1126,7 @@ func (t *Tracee) populateBPFMaps() error {
 
 // populateFilterMaps populates the eBPF maps with the given policies
 func (t *Tracee) populateFilterMaps(updateProcTree bool) error {
-	polCfg, err := t.policyManager.UpdateBPF(
-		t.bpfModule,
-		t.containers,
-		t.eventsFieldTypes,
-		true,
-		updateProcTree,
-	)
+	polCfg, err := t.policyManager.UpdateBPF(t.bpfModule, t.containers, t.eventsFieldTypes)
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
@@ -1271,13 +1265,6 @@ func (t *Tracee) initBPF() error {
 	// collector to free the BPF object
 	t.config.BPFObjBytes = nil
 
-	// Populate eBPF maps with initial data
-
-	err = t.populateBPFMaps()
-	if err != nil {
-		return errfmt.WrapError(err)
-	}
-
 	// Initialize Control Plane
 
 	t.controlPlane, err = controlplane.NewController(
@@ -1290,8 +1277,9 @@ func (t *Tracee) initBPF() error {
 		return errfmt.WrapError(err)
 	}
 
-	// returned PoliciesConfig is not used here, therefore it's discarded
-	_, err = t.policyManager.UpdateBPF(t.bpfModule, t.containers, t.eventsFieldTypes, false, true)
+	// Populate eBPF maps with initial data
+
+	err = t.populateBPFMaps()
 	if err != nil {
 		return errfmt.WrapError(err)
 	}

--- a/pkg/policy/policies.go
+++ b/pkg/policy/policies.go
@@ -1,8 +1,6 @@
 package policy
 
 import (
-	bpf "github.com/aquasecurity/libbpfgo"
-
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/filters"
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -20,11 +18,10 @@ var AlwaysSubmit = events.EventState{
 }
 
 type policies struct {
-	bpfInnerMaps      map[string]*bpf.BPFMapLow // BPF inner maps
-	policiesArray     [PolicyMax]*Policy        // underlying policies array for fast access of empty slots
-	policiesMapByID   map[int]*Policy           // all policies map by ID
-	policiesMapByName map[string]*Policy        // all policies map by name
-	policiesList      []*Policy                 // all policies list
+	policiesArray     [PolicyMax]*Policy // underlying policies array for fast access of empty slots
+	policiesMapByID   map[int]*Policy    // all policies map by ID
+	policiesMapByName map[string]*Policy // all policies map by name
+	policiesList      []*Policy          // all policies list
 
 	// computed values
 
@@ -41,7 +38,6 @@ type policies struct {
 
 func NewPolicies() *policies {
 	return &policies{
-		bpfInnerMaps:            map[string]*bpf.BPFMapLow{},
 		policiesArray:           [PolicyMax]*Policy{},
 		policiesMapByID:         map[int]*Policy{},
 		policiesMapByName:       map[string]*Policy{},

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -590,15 +590,9 @@ func (m *Manager) LookupByName(name string) (*Policy, error) {
 	return m.ps.lookupByName(name)
 }
 
-func (m *Manager) UpdateBPF(
-	bpfModule *bpf.Module,
-	cts *containers.Containers,
-	eventsFields map[events.ID][]bufferdecoder.ArgType,
-	createNewMaps bool,
-	updateProcTree bool,
-) (*PoliciesConfig, error) {
+func (m *Manager) UpdateBPF(bpfModule *bpf.Module, cts *containers.Containers, eventsFields map[events.ID][]bufferdecoder.ArgType) (*PoliciesConfig, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	return m.ps.updateBPF(bpfModule, cts, m.rules, eventsFields, createNewMaps, updateProcTree)
+	return m.ps.updateBPF(bpfModule, cts, m.rules, eventsFields)
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

Refactor: Remove redundant policyManager.UpdateBPF call in initBPF
The `policyManager.UpdateBPF` function was being called twice during Tracee initialization. This change removes the redundant call in `initBPF`, simplifying the initialization logic.
The unnecessary `updateProcTree` and `createNewMaps` parameters were also removed from  `policyManager.UpdateBPF`. New maps are now always created implicitly, simplifying the map update process.

Refactor: Move bpfInnerMaps to local scope in updateBPF
Remove bpfInnerMaps from the policies struct as it was only used within the updateBPF function and make it a local variable within updateBPF.
This change improves code organization by keeping BPF-related logic separate from policies logic, reflecting a clearer structure in the codebase.


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
