### PR TITLE
feat(ksymbols): reimplement ksymbols

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -586,8 +586,11 @@ statfunc void update_thread_stack(void *ctx, task_info_t *task_info, struct task
     #error Unsupported architecture
 #endif
 
-    // Find VMA which contains the SP
-    struct vm_area_struct *vma = find_vma(ctx, task, thread_sp);
+    // Find VMA which contains the SP.
+    // We subtract 1 fromt the SP because it may be just past the end of the VMA (top of the stack).
+    // For example: stack VMA mapped at 0x1000 with size 0x1000,
+    // SP is set to 0x2000 (which is not part of the VMA whose address range is 0x1000-0x1fff).
+    struct vm_area_struct *vma = find_vma(ctx, task, thread_sp - 1);
     if (unlikely(vma == NULL))
         return;
 

--- a/pkg/ebpf/event_parameters.go
+++ b/pkg/ebpf/event_parameters.go
@@ -131,7 +131,7 @@ func registerSyscallChecker(t *Tracee, eventParams []map[string]filters.Filter[*
 			if err := probeGroup.AddProbe(handle, probe); err != nil {
 				return errfmt.WrapError(err)
 			}
-			if err := probeGroup.Attach(handle, t.kernelSymbols); err != nil {
+			if err := probeGroup.Attach(handle, t.getKernelSymbols()); err != nil {
 				// Report attachment errors but don't fail, because it may be a syscall that doesn't exist on this system
 				logger.Warnw("Failed to attach syscall checker kprobe", "syscall", syscall.name, "error", err)
 				continue

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"slices"
 	"strconv"
 	"sync"
@@ -221,7 +222,7 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 					syscall = events.Core.GetDefinitionByID(id).GetName()
 				} else {
 					// This should never fail, as the translation used in eBPF relies on the same event definitions
-					logger.Errorw("No syscall event with id %d", id)
+					logger.Errorw(fmt.Sprintf("No syscall event with id %d", id))
 				}
 			}
 

--- a/pkg/ebpf/hooked_syscall_table.go
+++ b/pkg/ebpf/hooked_syscall_table.go
@@ -160,11 +160,11 @@ func (t *Tracee) getSyscallNameByKerVer(restrictions []events.KernelRestrictions
 // populateExpectedSyscallTableArray fills the expected values of the syscall table
 func (t *Tracee) populateExpectedSyscallTableArray(tableMap *bpf.BPFMap) error {
 	// Get address to the function that defines the not implemented sys call
-	niSyscallSymbol, err := t.kernelSymbols.GetSymbolByOwnerAndName("system", events.SyscallPrefix+"ni_syscall")
+	niSyscallSymbol, err := t.getKernelSymbols().GetSymbolByOwnerAndName("system", events.SyscallPrefix+"ni_syscall")
 	if err != nil {
 		e := err
 		// RHEL 8.x uses sys_ni_syscall instead of __arch_ni_syscall
-		niSyscallSymbol, err = t.kernelSymbols.GetSymbolByOwnerAndName("system", "sys_ni_syscall")
+		niSyscallSymbol, err = t.getKernelSymbols().GetSymbolByOwnerAndName("system", "sys_ni_syscall")
 		if err != nil {
 			logger.Debugw("hooked_syscall: syscall symbol not found", "name", "sys_ni_syscall")
 			return e
@@ -188,7 +188,7 @@ func (t *Tracee) populateExpectedSyscallTableArray(tableMap *bpf.BPFMap) error {
 			continue
 		}
 
-		kernelSymbol, err := t.kernelSymbols.GetSymbolByOwnerAndName("system", events.SyscallPrefix+syscallName)
+		kernelSymbol, err := t.getKernelSymbols().GetSymbolByOwnerAndName("system", events.SyscallPrefix+syscallName)
 		if err != nil {
 			logger.Warnw(fmt.Sprintf("hooked_syscall: Unable to locate syscall symbol... permanently skipping hook check for syscall ID %d", index))
 			zero := 0

--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -45,7 +45,7 @@ func (t *Tracee) UpdateKallsyms() error {
 	// For every ksymbol required by tracee ...
 	for _, required := range allReqSymbols {
 		// ... get the symbol address from the kallsyms file ...
-		symbol, err := t.kernelSymbols.GetSymbolByOwnerAndName(globalSymbolOwner, required)
+		symbol, err := t.getKernelSymbols().GetSymbolByOwnerAndName(globalSymbolOwner, required)
 		if err != nil {
 			logger.Debugw("failed to get symbol", "symbol", required, "error", err)
 			continue

--- a/pkg/ebpf/probes/trace.go
+++ b/pkg/ebpf/probes/trace.go
@@ -111,7 +111,7 @@ func (p *TraceProbe) attach(module *bpf.Module, args ...interface{}) error {
 		var err error
 		var link *bpf.BPFLink
 		var attachFunc func(uint64) (*bpf.BPFLink, error)
-		var syms []environment.KernelSymbol
+		var syms []*environment.KernelSymbol
 		// https://github.com/aquasecurity/tracee/issues/3653#issuecomment-1832642225
 		//
 		// After commit b022f0c7e404 ('tracing/kprobes: Return EADDRNOTAVAIL

--- a/pkg/events/derive/hooked_seq_ops.go
+++ b/pkg/events/derive/hooked_seq_ops.go
@@ -4,7 +4,6 @@ import (
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
-	"github.com/aquasecurity/tracee/pkg/utils"
 	"github.com/aquasecurity/tracee/pkg/utils/environment"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -43,7 +42,7 @@ func deriveHookedSeqOpsArgs(kernelSymbols *environment.KernelSymbolTable) derive
 			if addr == 0 {
 				continue
 			}
-			hookingFunction := utils.ParseSymbol(addr, kernelSymbols)
+			hookingFunction := kernelSymbols.GetPotentiallyHiddenSymbolByAddr(addr)[0]
 			seqOpsStruct := NetSeqOps[i/4]
 			seqOpsFunc := NetSeqOpsFuncs[i%4]
 			hookedSeqOps[seqOpsStruct+"_"+seqOpsFunc] =

--- a/pkg/events/derive/hooked_syscall.go
+++ b/pkg/events/derive/hooked_syscall.go
@@ -28,19 +28,19 @@ func InitHookedSyscall() error {
 }
 
 func DetectHookedSyscall(kernelSymbols *environment.KernelSymbolTable) DeriveFunction {
-	return deriveSingleEvent(events.HookedSyscall, deriveDetectHookedSyscallArgs(kernelSymbols))
+	return deriveMultipleEvents(events.HookedSyscall, deriveDetectHookedSyscallArgs(kernelSymbols))
 }
 
-func deriveDetectHookedSyscallArgs(kernelSymbols *environment.KernelSymbolTable) deriveArgsFunction {
-	return func(event trace.Event) ([]interface{}, error) {
+func deriveDetectHookedSyscallArgs(kernelSymbols *environment.KernelSymbolTable) multiDeriveArgsFunction {
+	return func(event trace.Event) ([][]interface{}, []error) {
 		syscallId, err := parse.ArgVal[int32](event.Args, "syscall_id")
 		if err != nil {
-			return nil, errfmt.Errorf("error parsing syscall_id arg: %v", err)
+			return nil, []error{errfmt.Errorf("error parsing syscall_id arg: %v", err)}
 		}
 
 		address, err := parse.ArgVal[uint64](event.Args, "syscall_address")
 		if err != nil {
-			return nil, errfmt.Errorf("error parsing syscall_address arg: %v", err)
+			return nil, []error{errfmt.Errorf("error parsing syscall_address arg: %v", err)}
 		}
 
 		alreadyReportedAddress, found := reportedHookedSyscalls.Get(syscallId)
@@ -50,18 +50,20 @@ func deriveDetectHookedSyscallArgs(kernelSymbols *environment.KernelSymbolTable)
 
 		reportedHookedSyscalls.Add(syscallId, address) // Upsert
 
-		hookedFuncName := ""
-		hookedOwner := ""
-		hookedFuncSymbol, err := kernelSymbols.GetSymbolByAddr(address)
-		if err == nil {
-			hookedFuncName = hookedFuncSymbol[0].Name
-			hookedOwner = hookedFuncSymbol[0].Owner
-		}
-
 		syscallName := convertToSyscallName(syscallId)
 		hexAddress := fmt.Sprintf("%x", address)
 
-		return []interface{}{syscallName, hexAddress, hookedFuncName, hookedOwner}, nil
+		hookedFuncSymbols, err := kernelSymbols.GetSymbolByAddr(address)
+		if err != nil {
+			return [][]interface{}{{syscallName, hexAddress, "", ""}}, nil
+		}
+
+		events := make([][]interface{}, 0)
+		for _, symbol := range hookedFuncSymbols {
+			events = append(events, []interface{}{syscallName, hexAddress, symbol.Name, symbol.Owner})
+		}
+
+		return events, nil
 	}
 }
 

--- a/pkg/utils/environment/kernel_symbols_test.go
+++ b/pkg/utils/environment/kernel_symbols_test.go
@@ -2,32 +2,30 @@ package environment
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
-// TestParseLine tests the parseKallsymsLine function.
-func TestParseKallsymsLine(t *testing.T) {
-	testCases := []struct {
-		line     []string
-		expected *KernelSymbol
-	}{
-		{[]string{"00000000", "t", "my_symbol", "[my_owner]"}, &KernelSymbol{Name: "my_symbol", Type: "t", Address: 0, Owner: "my_owner"}},
-		{[]string{"00000001", "T", "another_symbol"}, &KernelSymbol{Name: "another_symbol", Type: "T", Address: 1, Owner: "system"}},
-		{[]string{"invalid_address", "T", "invalid_symbol"}, nil},
-		{[]string{"00000002", "T"}, nil},
-	}
+type symbolInfo struct {
+	name    string
+	address uint64
+	owner   string
+}
 
-	for _, tc := range testCases {
-		result := parseKallsymsLine(tc.line)
-		if !reflect.DeepEqual(result, tc.expected) {
-			t.Errorf("parseKallsymsLine(%v) = %v; want %v", tc.line, result, tc.expected)
-		}
+func symbolToSymbolInfo(symbol *KernelSymbol) *symbolInfo {
+	if symbol == nil {
+		return nil
+	}
+	return &symbolInfo{
+		name:    symbol.Name,
+		address: symbol.Address,
+		owner:   symbol.Owner,
 	}
 }
 
 // TestNewKernelSymbolTable tests the NewKernelSymbolTable function.
 func TestNewKernelSymbolTable(t *testing.T) {
-	kst, err := NewKernelSymbolTable()
+	kst, err := NewKernelSymbolTable(true, false)
 	if err != nil {
 		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
 	}
@@ -36,26 +34,56 @@ func TestNewKernelSymbolTable(t *testing.T) {
 		t.Fatalf("NewKernelSymbolTable() returned nil")
 	}
 
-	// Check if the onlyRequired flag is set correctly
-	if kst.onlyRequired {
-		t.Errorf("onlyRequired flag should be false by default")
+	// Check if symbols is initialized
+	if kst.symbols == nil {
+		t.Errorf("KernelSymbolTable is not initialized correctly")
+	}
+}
+
+func getTheOnlySymbol(t *testing.T, kst *KernelSymbolTable) *KernelSymbol {
+	i := 0
+	var foundSymbol *KernelSymbol
+	kst.ForEachSymbol(func(symbol *KernelSymbol) {
+		i++
+		foundSymbol = symbol
+	})
+	if i > 1 {
+		t.Errorf("multiple symbols found")
+	}
+	return foundSymbol
+}
+
+// TestUpdate tests the kallsyms parsing logic.
+func TestUpdate(t *testing.T) {
+	testCases := []struct {
+		buf      string
+		expected *symbolInfo
+	}{
+		{"ffffffff00000001	t	my_symbol	[my_owner]", &symbolInfo{name: "my_symbol", address: 0xffffffff00000001, owner: "my_owner"}},
+		{"ffffffff00000002	T	another_symbol", &symbolInfo{name: "another_symbol", address: 0xffffffff00000002, owner: "system"}},
+		{"invalid_address	T	invalid_symbol", nil},
+		{"ffffffff00000003	T", nil},
 	}
 
-	// Check if maps are initialized
-	if kst.symbols == nil || kst.addrs == nil || kst.symByName == nil || kst.symByAddr == nil {
-		t.Errorf("KernelSymbolTable maps are not initialized correctly")
+	for _, tc := range testCases {
+		kst, err := NewKernelSymbolTableFromReader(strings.NewReader(tc.buf), false, false)
+		if err != nil {
+			t.Fatalf("NewKernelSymbolTableFromReader() failed: %v", err)
+		}
+		symbol := getTheOnlySymbol(t, kst)
+		result := symbolToSymbolInfo(symbol)
+		if !reflect.DeepEqual(result, tc.expected) {
+			t.Errorf("update(%v) = %v; want %v", tc.buf, result, tc.expected)
+		}
 	}
 }
 
 // TestGetSymbolByName tests the GetSymbolByName function.
 func TestGetSymbolByName(t *testing.T) {
-	kst, err := NewKernelSymbolTable()
+	buf := "ffffffff00000001	t	test_symbol	test_owner"
+	kst, err := NewKernelSymbolTableFromReader(strings.NewReader(buf), false, false)
 	if err != nil {
-		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
-	}
-
-	kst.symbols["test_symbol"] = []*KernelSymbol{
-		{Name: "test_symbol", Type: "t", Address: 0, Owner: "test_owner"},
+		t.Fatalf("NewKernelSymbolTableFromReader() failed: %v", err)
 	}
 
 	symbols, err := kst.GetSymbolByName("test_symbol")
@@ -67,24 +95,47 @@ func TestGetSymbolByName(t *testing.T) {
 		t.Errorf("Expected 1 symbol, got %d", len(symbols))
 	}
 
-	expectedSymbol := KernelSymbol{Name: "test_symbol", Type: "t", Address: 0, Owner: "test_owner"}
-	if !reflect.DeepEqual(symbols[0], expectedSymbol) {
-		t.Errorf("GetSymbolByName() = %v; want %v", symbols[0], expectedSymbol)
+	expected := &symbolInfo{name: "test_symbol", address: 0xffffffff00000001, owner: "test_owner"}
+	result := symbolToSymbolInfo(symbols[0])
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetSymbolByName() = %v; want %v", result, expected)
+	}
+}
+
+// TestGetSymbolByOwnerAndName tests the GetSymbolByOwnerAndName function.
+func TestGetSymbolByOwnerAndName(t *testing.T) {
+	buf := `ffffffff00000001	t	test_symbol	test_owner1
+ffffffff00000002	t	test_symbol	test_owner2`
+	kst, err := NewKernelSymbolTableFromReader(strings.NewReader(buf), false, false)
+	if err != nil {
+		t.Fatalf("NewKernelSymbolTableFromReader() failed: %v", err)
+	}
+
+	symbols, err := kst.GetSymbolByOwnerAndName("test_owner1", "test_symbol")
+	if err != nil {
+		t.Fatalf("GetSymbolByName() failed: %v", err)
+	}
+
+	if len(symbols) != 1 {
+		t.Errorf("Expected 1 symbol, got %d", len(symbols))
+	}
+
+	expected := &symbolInfo{name: "test_symbol", address: 0xffffffff00000001, owner: "test_owner1"}
+	result := symbolToSymbolInfo(symbols[0])
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetSymbolByOwnerAndName() = %v; want %v", result, expected)
 	}
 }
 
 // TestGetSymbolByAddr tests the GetSymbolByAddr function.
 func TestGetSymbolByAddr(t *testing.T) {
-	kst, err := NewKernelSymbolTable()
+	buf := "ffffffff00001234	t	test_symbol	test_owner"
+	kst, err := NewKernelSymbolTableFromReader(strings.NewReader(buf), false, false)
 	if err != nil {
-		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+		t.Fatalf("NewKernelSymbolTableFromReader() failed: %v", err)
 	}
 
-	kst.addrs[0x1234] = []*KernelSymbol{
-		{Name: "test_symbol", Type: "t", Address: 0x1234, Owner: "test_owner"},
-	}
-
-	symbols, err := kst.GetSymbolByAddr(0x1234)
+	symbols, err := kst.GetSymbolByAddr(0xffffffff00001234)
 	if err != nil {
 		t.Fatalf("GetSymbolByAddr() failed: %v", err)
 	}
@@ -93,84 +144,30 @@ func TestGetSymbolByAddr(t *testing.T) {
 		t.Errorf("Expected 1 symbol, got %d", len(symbols))
 	}
 
-	expectedSymbol := KernelSymbol{Name: "test_symbol", Type: "t", Address: 0x1234, Owner: "test_owner"}
-	if !reflect.DeepEqual(symbols[0], expectedSymbol) {
-		t.Errorf("GetSymbolByAddr() = %v; want %v", symbols[0], expectedSymbol)
+	expected := &symbolInfo{name: "test_symbol", address: 0xffffffff00001234, owner: "test_owner"}
+	result := symbolToSymbolInfo(symbols[0])
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetSymbolByAddr() = %v; want %v", result, expected)
 	}
 }
 
-// TestRefresh tests the Refresh function.
-func TestRefresh(t *testing.T) {
-	// Creating a mock KernelSymbolTable with required symbols to test Refresh
-	kst, err := NewKernelSymbolTable(WithRequiredSymbols([]string{"_stext", "_etext"}))
+// TestGetPotentiallyHiddenSymbolByAddr tests the GetPotentiallyHiddenSymbolByAddr function.
+func TestGetPotentiallyHiddenSymbolByAddr(t *testing.T) {
+	buf := "ffffffff00000001	t	test_symbol	test_owner"
+	kst, err := NewKernelSymbolTableFromReader(strings.NewReader(buf), false, false)
 	if err != nil {
-		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
+		t.Fatalf("NewKernelSymbolTableFromReader() failed: %v", err)
 	}
 
-	// Simulate the presence of these symbols
-	kst.symbols["_stext"] = []*KernelSymbol{{Name: "_stext", Type: "T", Address: 0x1000, Owner: "system"}}
-	kst.symbols["_etext"] = []*KernelSymbol{{Name: "_etext", Type: "T", Address: 0x2000, Owner: "system"}}
+	symbols := kst.GetPotentiallyHiddenSymbolByAddr(0xffffffff00000002)
 
-	// Call Refresh to update the symbol table
-	if err := kst.Refresh(); err != nil {
-		t.Fatalf("Refresh() failed: %v", err)
+	if len(symbols) != 1 {
+		t.Errorf("Expected 1 symbol, got %d", len(symbols))
 	}
 
-	// Check if symbols were added correctly
-	symbolsToTest := []string{"_stext", "_etext"}
-	for _, symbol := range symbolsToTest {
-		if syms, err := kst.GetSymbolByName(symbol); err != nil || len(syms) == 0 {
-			t.Errorf("Expected to find symbol %s, but it was not found", symbol)
-		}
-	}
-}
-
-// TestTextSegmentContains tests the TextSegmentContains function.
-func TestTextSegmentContains(t *testing.T) {
-	// Creating a mock KernelSymbolTable with text segment addresses
-	kst, err := NewKernelSymbolTable()
-	if err != nil {
-		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
-	}
-
-	kst.symByName[nameAndOwner{"_stext", "system"}] = []*KernelSymbol{{Name: "_stext", Type: "T", Address: 0x1000, Owner: "system"}}
-	kst.symByName[nameAndOwner{"_etext", "system"}] = []*KernelSymbol{{Name: "_etext", Type: "T", Address: 0x2000, Owner: "system"}}
-
-	tests := []struct {
-		addr     uint64
-		expected bool
-	}{
-		{0x1000, true},
-		{0x1500, true},
-		{0x2000, false},
-		{0x0999, false},
-	}
-
-	for _, tt := range tests {
-		result, err := kst.TextSegmentContains(tt.addr)
-		if err != nil {
-			t.Errorf("TextSegmentContains(%v) failed: %v", tt.addr, err)
-		}
-		if result != tt.expected {
-			t.Errorf("TextSegmentContains(%v) = %v; want %v", tt.addr, result, tt.expected)
-		}
-	}
-}
-
-// Helper function to test required symbols or addresses.
-func TestValidateOrAddRequired(t *testing.T) {
-	kst, err := NewKernelSymbolTable(WithRequiredSymbols([]string{"test_symbol"}))
-	if err != nil {
-		t.Fatalf("NewKernelSymbolTable() failed: %v", err)
-	}
-
-	kst.requiredSyms["test_symbol"] = struct{}{}
-
-	if err := kst.validateOrAddRequiredSym("test_symbol"); err != nil {
-		t.Errorf("validateOrAddRequiredSym() failed: %v", err)
-	}
-
-	if err := kst.validateOrAddRequiredAddr(0x1234); err != nil {
-		t.Errorf("validateOrAddRequiredAddr() failed: %v", err)
+	expected := &symbolInfo{name: "", address: 0xffffffff00000002, owner: "hidden"}
+	result := symbolToSymbolInfo(symbols[0])
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("GetSymbolByAddr() = %v; want %v", result, expected)
 	}
 }

--- a/pkg/utils/symbol_table.go
+++ b/pkg/utils/symbol_table.go
@@ -1,0 +1,209 @@
+package utils
+
+import (
+	"errors"
+	"sort"
+	"sync"
+)
+
+// The Symbol interface defines what is needed from a symbol implementation in
+// order to facilitate the lookup functionalities provided by SymbolTable.
+// Implementations of Symbol can hold various types of information relevant to
+// the type of symbol they represent.
+type Symbol[T any] interface {
+	// Name returns the symbol's name
+	Name() string
+	// Address returns the base address of the symbol
+	Address() uint64
+	// Contains returns whether a given address belongs to the symbol's
+	// address range, which is defined by the symbol's implementation
+	Contains(address uint64) bool
+	Cloner[T]
+}
+
+// SymbolTable is used to hold information about symbols (mapping from symbolic
+// names used in code to their address) in a certain executable.
+// It can be used to hold symbols from an ELF binary, or symbols of the entire
+// kernel and its modules.
+// It provides functions to lookup symbols by address and name.
+type SymbolTable[T Symbol[T]] struct {
+	mu sync.RWMutex
+	// All symbols sorted by their address in descending order,
+	// for quick binary searches by address.
+	sortedSymbols []*T
+	// If lazyNameLookup is true, the symbolsByName map
+	// will be populated only when a failed lookup occurs.
+	symbolsByName  map[string][]*T
+	lazyNameLookup bool
+}
+
+var ErrSymbolNotFound = errors.New("symbol not found")
+
+// Creates a new SymbolTable. If lazyNameLookup is true, the mapping from
+// name to symbol will be populated only when a failed lookup occurs.
+// This reduces memory footprint at the cost of the time it takes to lookup
+// a symbol name for the first time.
+func NewSymbolTable[T Symbol[T]](lazyNameLookup bool) *SymbolTable[T] {
+	return &SymbolTable[T]{
+		sortedSymbols:  make([]*T, 0),
+		symbolsByName:  make(map[string][]*T),
+		lazyNameLookup: lazyNameLookup,
+	}
+}
+
+// Adds a slice of symbols to the symbol table.
+func (st *SymbolTable[T]) AddSymbols(symbols []*T) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	// Add the new symbols to the sorted slice (which now becomes unsorted).
+	// Allocate the slice with the needed capacity to avoid overallocation.
+	oldSymbols := st.sortedSymbols
+	newLen := len(oldSymbols) + len(symbols)
+	st.sortedSymbols = make([]*T, 0, newLen)
+	st.sortedSymbols = append(st.sortedSymbols, oldSymbols...)
+	st.sortedSymbols = append(st.sortedSymbols, symbols...)
+
+	// If lazyNameLookup is false, we update the name to symbol mapping for
+	// each new symbol
+	if !st.lazyNameLookup {
+		for _, symbol := range symbols {
+			name := (*symbol).Name()
+			if symbols, found := st.symbolsByName[name]; found {
+				st.symbolsByName[name] = append(symbols, symbol)
+			} else {
+				st.symbolsByName[name] = []*T{symbol}
+			}
+		}
+	}
+
+	// Sort the symbols slice by address in descending order
+	sort.Slice(st.sortedSymbols,
+		func(i, j int) bool {
+			return (*st.sortedSymbols[i]).Address() > (*st.sortedSymbols[j]).Address()
+		})
+}
+
+// Lookup a symbol in the table by its name.
+// Because there may be multiple symbols with the same name, a slice of all
+// matching symbols is returned.
+func (st *SymbolTable[T]) LookupByName(name string) ([]*T, error) {
+	st.mu.RLock()
+	// We call RUnlock manually and not using defer because we may need to upgrade to a write lock later
+
+	// Lookup the name in the name to symbol mapping
+	if symbols, found := st.symbolsByName[name]; found {
+		st.mu.RUnlock()
+		return symbols, nil
+	}
+
+	// Lazy name lookup is disabled, the lookup failed
+	if !st.lazyNameLookup {
+		st.mu.RUnlock()
+		return nil, ErrSymbolNotFound
+	}
+
+	// Lazy name lookup is enabled, perform a linear search to find the requested name
+	symbols := []*T{}
+	for _, symbol := range st.sortedSymbols {
+		if (*symbol).Name() == name {
+			symbols = append(symbols, symbol)
+		}
+	}
+
+	if len(symbols) > 0 {
+		// We found symbols with this name, update the mapping
+		st.mu.RUnlock()
+		st.mu.Lock()
+		defer st.mu.Unlock()
+		st.symbolsByName[name] = symbols
+		return symbols, nil
+	}
+
+	st.mu.RUnlock()
+	return nil, ErrSymbolNotFound
+}
+
+// Lookup a symbol in the table by its exact address.
+// Because there may be multiple symbols at the same address, a slice of all
+// matching symbols is returned.
+func (st *SymbolTable[T]) LookupByAddressExact(address uint64) ([]*T, error) {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+
+	// Find the first symbol at an address smaller than or equal to the requested address
+	idx := sort.Search(len(st.sortedSymbols),
+		func(i int) bool {
+			return address >= (*st.sortedSymbols[i]).Address()
+		})
+
+	// Not found or not exact match
+	if idx == len(st.sortedSymbols) || (*st.sortedSymbols[idx]).Address() != address {
+		return nil, ErrSymbolNotFound
+	}
+
+	// The search result is the first symbol with the requested address,
+	// find any additional symbols with the same address.
+	syms := []*T{st.sortedSymbols[idx]}
+	for i := idx + 1; i < len(st.sortedSymbols); i++ {
+		if (*st.sortedSymbols[i]).Address() != address {
+			break
+		}
+		syms = append(syms, st.sortedSymbols[i])
+	}
+
+	return syms, nil
+}
+
+// Find the symbol which contains the given address.
+// If multiple symbols at different addresses contain the requested address,
+// the symbol with the highest address will be returned.
+// If multiple symbols at the same address contain the requested address,
+// one of them will be returned, but there is no guarantee which one.
+// This function assumes that symbols don't overlap in a way that a symbol with
+// a smaller address contains the requested address while a symbol with a larger
+// address (but still smaller that requested) doesn't contain it.
+// For example, the following situation is assumed to be impossible:
+//
+//	        Requested Address
+//	                 |
+//	                 |
+//	 +---------------+--+
+//	 |Symbol 1       |  |
+//	 +---------------+--+
+//	    +--------+   |
+//	    |Symbol 2|   |
+//	    +--------+   v
+//	<---------------------->
+//
+// Smaller            Larger
+// Address            Address
+//
+// If the above situation happens, no symbol will be returned.
+func (st *SymbolTable[T]) LookupByAddressContains(address uint64) (*T, error) {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+
+	// Find the first symbol at an address smaller than or equal to the requested address
+	idx := sort.Search(len(st.sortedSymbols),
+		func(i int) bool {
+			return address >= (*st.sortedSymbols[i]).Address()
+		})
+
+	// Not found or the symbol doesn't contain this address
+	if idx == len(st.sortedSymbols) || !(*st.sortedSymbols[idx]).Contains(address) {
+		return nil, ErrSymbolNotFound
+	}
+
+	return st.sortedSymbols[idx], nil
+}
+
+func (st *SymbolTable[T]) ForEachSymbol(callback func(symbol *T)) {
+	st.mu.RLock()
+	defer st.mu.RUnlock()
+
+	for i := range len(st.sortedSymbols) {
+		sym := (*st.sortedSymbols[i]).Clone()
+		callback(&sym)
+	}
+}

--- a/pkg/utils/symbol_table_test.go
+++ b/pkg/utils/symbol_table_test.go
@@ -1,0 +1,344 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testSymbol struct {
+	name string
+	addr uint64
+	size uint64
+}
+
+func (s testSymbol) Name() string {
+	return s.name
+}
+
+func (s testSymbol) Address() uint64 {
+	return s.addr
+}
+
+func (s testSymbol) Contains(address uint64) bool {
+	return s.addr <= address && s.addr+s.size > address
+}
+
+func (s testSymbol) Clone() testSymbol {
+	return testSymbol{
+		name: s.name,
+		addr: s.addr,
+		size: s.size,
+	}
+}
+
+// TestNewSymbolTable tests the NewSymbolTable function.
+func TestNewSymbolTable(t *testing.T) {
+	st := NewSymbolTable[testSymbol](true)
+	if st == nil {
+		t.Fatalf("NewSymbolTable() returned nil")
+	}
+
+	if !st.lazyNameLookup {
+		t.Errorf("lazyNameLookup was not set to true")
+	}
+
+	if st.sortedSymbols == nil || st.symbolsByName == nil {
+		t.Errorf("data structures are nil")
+	}
+}
+
+// TestAddSymbols tests the AddSymbols function
+func TestAddSymbols(t *testing.T) {
+	testCases := []struct {
+		symbols       []*testSymbol
+		expectedOrder []int
+	}{
+		{[]*testSymbol{
+			{name: "symbol1", addr: 1, size: 1},
+			{name: "symbol2", addr: 1, size: 1},
+		}, []int{0, 1}},
+		{[]*testSymbol{
+			{name: "symbol1", addr: 2, size: 1},
+			{name: "symbol2", addr: 1, size: 1},
+		}, []int{0, 1}},
+		{[]*testSymbol{
+			{name: "symbol1", addr: 1, size: 1},
+			{name: "symbol2", addr: 2, size: 1},
+		}, []int{1, 0}},
+	}
+
+	for _, tc := range testCases {
+		st := NewSymbolTable[testSymbol](false)
+		st.AddSymbols(tc.symbols)
+
+		if len(st.sortedSymbols) != len(tc.symbols) {
+			t.Errorf("len(st.sortedSymbol) = %d, want %d", len(st.sortedSymbols), len(tc.symbols))
+			continue
+		}
+
+		for i := range st.sortedSymbols {
+			if !reflect.DeepEqual(*st.sortedSymbols[i], *tc.symbols[tc.expectedOrder[i]]) {
+				t.Errorf("AddSymbols(%v) = symbol %d: %v; want %v", tc.symbols, i, st.sortedSymbols[i], tc.symbols[tc.expectedOrder[i]])
+			}
+		}
+	}
+}
+
+// TestLookupByName tests the LookupByName function
+func TestLookupByName(t *testing.T) {
+	testCases := []struct {
+		symbols           []*testSymbol
+		lookupName        string
+		expectLookupError bool
+		expected          []testSymbol
+	}{
+		{
+			[]*testSymbol{{name: "symbol1", addr: 1, size: 1}},
+			"symbol1",
+			false,
+			[]testSymbol{{name: "symbol1", addr: 1, size: 1}},
+		},
+		{
+			[]*testSymbol{},
+			"symbol2",
+			true,
+			[]testSymbol{},
+		},
+		{
+			[]*testSymbol{{name: "symbol3", addr: 1, size: 1}},
+			"symbol4",
+			true,
+			[]testSymbol{},
+		},
+		{
+			[]*testSymbol{{name: "symbol5", addr: 1, size: 1}, {name: "symbol6", addr: 2, size: 2}},
+			"symbol6",
+			false,
+			[]testSymbol{{name: "symbol6", addr: 2, size: 2}},
+		},
+		{
+			[]*testSymbol{{name: "symbol7", addr: 1, size: 1}, {name: "symbol7", addr: 2, size: 2}},
+			"symbol7",
+			false,
+			[]testSymbol{{name: "symbol7", addr: 1, size: 1}, {name: "symbol7", addr: 2, size: 2}},
+		},
+	}
+
+	for _, tc := range testCases {
+		st := NewSymbolTable[testSymbol](false)
+		st.AddSymbols(tc.symbols)
+		result, err := st.LookupByName(tc.lookupName)
+		if !tc.expectLookupError && err != nil {
+			t.Errorf("LookupByName(%s) failed: %v", tc.lookupName, err)
+			continue
+		} else if tc.expectLookupError {
+			if err == nil {
+				t.Errorf("LookupByName(%s) expected to fail but didn't", tc.lookupName)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(copySliceOfPointersToSliceOfStructs(result), tc.expected) {
+			t.Errorf("LookupByName(%s) = %v, expected %v", tc.lookupName, copySliceOfPointersToSliceOfStructs(result), tc.expected)
+		}
+	}
+}
+
+// TestLazyNameLookup tests the lazy name lookup functionality
+func TestLazyNameLookup(t *testing.T) {
+	testCases := []struct {
+		symbols          []*testSymbol
+		lazyNameLookup   bool
+		lookups          []string
+		expectedMappings []int
+	}{
+		{
+			[]*testSymbol{{name: "symbol", addr: 1, size: 1}},
+			false,
+			[]string{},
+			[]int{0},
+		},
+		{
+			[]*testSymbol{{name: "symbol", addr: 1, size: 1}},
+			true,
+			[]string{},
+			[]int{},
+		},
+		{
+			[]*testSymbol{{name: "symbol1", addr: 1, size: 1}, {name: "symbol2", addr: 2, size: 1}},
+			true,
+			[]string{"symbol1", "symbol2"},
+			[]int{0, 1},
+		},
+		{
+			[]*testSymbol{{name: "symbol1", addr: 1, size: 1}, {name: "symbol2", addr: 2, size: 1}},
+			true,
+			[]string{"symbol2"},
+			[]int{1},
+		},
+	}
+
+testLoop:
+	for _, tc := range testCases {
+		st := NewSymbolTable[testSymbol](tc.lazyNameLookup)
+		st.AddSymbols(tc.symbols)
+		if tc.lazyNameLookup {
+			if len(st.symbolsByName) != 0 {
+				t.Errorf("len(st.symbolsByName) = %d, expected 0", len(st.symbolsByName))
+				continue
+			}
+		} else {
+			if len(st.symbolsByName) != len(tc.symbols) {
+				t.Errorf("len(st.symbolsByName) = %d, expected %d", len(st.symbolsByName), len(tc.symbols))
+				continue
+			}
+		}
+		for _, lookupName := range tc.lookups {
+			_, err := st.LookupByName(lookupName)
+			if err != nil {
+				t.Errorf("LookupByName(%s) failed: %v", lookupName, err)
+				continue testLoop
+			}
+		}
+		for i := range tc.expectedMappings {
+			if !reflect.DeepEqual(*(st.symbolsByName[tc.symbols[tc.expectedMappings[i]].name][0]), *tc.symbols[tc.expectedMappings[i]]) {
+				t.Errorf("st.symbolsByName[\"%s\"] = %v, expected %v", tc.symbols[tc.expectedMappings[i]].name, *(st.symbolsByName[tc.symbols[tc.expectedMappings[i]].name][0]), *tc.symbols[tc.expectedMappings[i]])
+				continue
+			}
+		}
+	}
+}
+
+// TestLookupByAddressExact tests the LookupByAddressExact function
+func TestLookupByAddressExact(t *testing.T) {
+	testCases := []struct {
+		symbols           []*testSymbol
+		lookupAddr        uint64
+		expectLookupError bool
+		expected          []testSymbol
+	}{
+		{
+			[]*testSymbol{{name: "symbol1", addr: 1, size: 1}},
+			1,
+			false,
+			[]testSymbol{{name: "symbol1", addr: 1, size: 1}},
+		},
+		{
+			[]*testSymbol{},
+			2,
+			true,
+			[]testSymbol{},
+		},
+		{
+			[]*testSymbol{{name: "symbol3", addr: 3, size: 1}},
+			4,
+			true,
+			[]testSymbol{},
+		},
+		{
+			[]*testSymbol{{name: "symbol5", addr: 5, size: 1}, {name: "symbol6", addr: 6, size: 2}},
+			6,
+			false,
+			[]testSymbol{{name: "symbol6", addr: 6, size: 2}},
+		},
+		{
+			[]*testSymbol{{name: "symbol7", addr: 7, size: 1}, {name: "symbol8", addr: 7, size: 2}},
+			7,
+			false,
+			[]testSymbol{{name: "symbol7", addr: 7, size: 1}, {name: "symbol8", addr: 7, size: 2}},
+		},
+	}
+
+	for _, tc := range testCases {
+		st := NewSymbolTable[testSymbol](false)
+		st.AddSymbols(tc.symbols)
+		result, err := st.LookupByAddressExact(tc.lookupAddr)
+		if !tc.expectLookupError && err != nil {
+			t.Errorf("LookupByAddressExact(%d) failed: %v", tc.lookupAddr, err)
+			continue
+		} else if tc.expectLookupError && err == nil {
+			t.Errorf("LookupByAddressExact(%d) expected to fail but didn't", tc.lookupAddr)
+			continue
+		}
+		if !reflect.DeepEqual(copySliceOfPointersToSliceOfStructs(result), tc.expected) {
+			t.Errorf("LookupByAddressExact(%d) = %v, expected %v", tc.lookupAddr, copySliceOfPointersToSliceOfStructs(result), tc.expected)
+		}
+	}
+}
+
+// TestLookupByAddressContains tests the LookupByAddressContains function
+func TestLookupByAddressContains(t *testing.T) {
+	testCases := []struct {
+		symbols    []*testSymbol
+		lookupAddr uint64
+		expected   *testSymbol
+	}{
+		{
+			[]*testSymbol{},
+			1,
+			nil,
+		},
+		{
+			[]*testSymbol{{name: "symbol1", addr: 2, size: 2}},
+			2,
+			&testSymbol{name: "symbol1", addr: 2, size: 2},
+		},
+		{
+			[]*testSymbol{{name: "symbol2", addr: 3, size: 2}},
+			4,
+			&testSymbol{name: "symbol2", addr: 3, size: 2},
+		},
+		{
+			[]*testSymbol{{name: "symbol3", addr: 4, size: 2}},
+			6,
+			nil,
+		},
+		{
+			[]*testSymbol{{name: "symbol4", addr: 10, size: 2}},
+			8,
+			nil,
+		},
+		{
+			[]*testSymbol{{name: "symbol5", addr: 11, size: 2}},
+			14,
+			nil,
+		},
+		{
+			[]*testSymbol{{name: "symbol6", addr: 15, size: 5}, {name: "symbol7", addr: 17, size: 3}},
+			18,
+			&testSymbol{name: "symbol7", addr: 17, size: 3},
+		},
+		{ // this is a special case assumed to be impossible in practice, see the docstring of LookupByAddressContains()
+			[]*testSymbol{{name: "symbol8", addr: 20, size: 5}, {name: "symbol9", addr: 21, size: 2}},
+			23,
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		st := NewSymbolTable[testSymbol](false)
+		st.AddSymbols(tc.symbols)
+		result, err := st.LookupByAddressContains(tc.lookupAddr)
+		if tc.expected != nil && err != nil {
+			t.Errorf("LookupByAddressContains(%d) failed: %v", tc.lookupAddr, err)
+			continue
+		}
+		if tc.expected == nil {
+			if err == nil {
+				t.Errorf("LookupByAddressContains(%d) expected to fail, but returned %v", tc.lookupAddr, *result)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(*result, *tc.expected) {
+			t.Errorf("LookupByAddressContains(%d) = %v, expected %v", tc.lookupAddr, *result, *tc.expected)
+		}
+	}
+}
+
+// copySliceOfPointersToSliceOfStructs converts a slice of pointers to a slice of structs.
+func copySliceOfPointersToSliceOfStructs(s []*testSymbol) []testSymbol {
+	ret := make([]testSymbol, len(s))
+	for i, v := range s {
+		ret[i] = *v
+	}
+	return ret
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,10 +5,7 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
-	"strings"
 	"time"
-
-	"github.com/aquasecurity/tracee/pkg/utils/environment"
 )
 
 // Cloner is a generic interface for objects that can clone themselves.
@@ -23,23 +20,6 @@ type Iterator[T any] interface {
 
 	// Next returns the next element in the iteration.
 	Next() T
-}
-
-func ParseSymbol(address uint64, table *environment.KernelSymbolTable) environment.KernelSymbol {
-	var hookingFunction environment.KernelSymbol
-
-	symbols, err := table.GetSymbolByAddr(address)
-	if err != nil {
-		hookingFunction = environment.KernelSymbol{}
-		hookingFunction.Owner = "hidden"
-	} else {
-		hookingFunction = symbols[0]
-	}
-
-	hookingFunction.Owner = strings.TrimPrefix(hookingFunction.Owner, "[")
-	hookingFunction.Owner = strings.TrimSuffix(hookingFunction.Owner, "]")
-
-	return hookingFunction
 }
 
 func HasBit(n uint64, offset uint) bool {


### PR DESCRIPTION
### 1. Explain what the PR does

The previous ksymbols implementation used a lazy lookup method, where only symbols marked as required ahead of time were stored. Trying to lookup a symbol that was not stored resulted in `/proc/kallsyms` being read and parsed in its entirety.
While most symbols being looked up were registered as required ahead of time, some weren't (in particular symbols needed for kprobe attachment) which incurred significant overhead when tracee is being initialized.

This new implementation stores all symbols, or if a `requiredDataSymbolsOnly` flag is used when creating the symbol table (used by default), only non-data symbols are stored (and required data symbols must be registered before updating). Some additional memory usage optimizations are included, for example encoding symbol owners as an index into a list of owner names, and also lazy symbol name lookups where the map of symbol name to symbol is populated only for symbols that were looked up once.

From measurements I performed, the extra memory consumption is around 21MB (from ~159MB to ~180MB when running tracee with no arguments on my machine).

Under the hood, this ksymbols implementation uses a generic symbol table implementation that can be used by future code for managing executable file symbols.

A significant advantage gained by storing all non-data symbols is the ability to lookup a function symbol that contains a given code address, a feature that I plan to use in the future.

This PR closes #4463 and renders #4325 irrelevant (because `/proc/kallsyms` reads no-longer happen "spontaneously").