### PR TITLE
fix: clock time detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.4
 require (
 	github.com/IBM/fluent-forward-go v0.2.2
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
+	github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61
 	github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241225084355-5b8f456dae7b
 	github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/Microsoft/hcsshim v0.12.3 h1:LS9NXqXhMoqNCplK1ApmVSfB4UnVLRDWRapB6EIl
 github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6CtY2Qg/JVQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca h1:OPbvwFFvR11c1bgOLhBq1R5Uk3hwUjHW2KfrdyJan9Y=
-github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
+github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61 h1:EdqmOm8rk/FMtYetPcceDdW27lZxXzpHZw8XpF3lG+g=
+github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61/go.mod h1:HB2DYWHuMraOB0IFcfjL8tsxN8TcFOdWKTrNqnHrTrs=
 github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72 h1:M1G3ttGcozWGfMMlD2nbdCgskGkAHSIVMsodRykOYSE=
 github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72/go.mod h1:mSYGLfhjpcLq78gjb4/XDQaY8DhfpDNAuLD0tvU2bZc=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241225084355-5b8f456dae7b h1:eTIrU0vdn49P0LhtEypnSdGgoRzLvNPAGivGHPnCBXg=


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

23d8ea16d **chore(go.mod): bump libbpfgo**
16d1e190a **fix: clock time detection**


16d1e190a **fix: clock time detection**

```
- The clock time detection was rework since the libbpfgo func
BPFHelperIsSupported changed;
- Unless it is explicitly marked as unsupported (supported=false),
it will default to BOOTTIME.
```st case the helper is not supported so the monotonic is set.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

fix: #4505 

Most of the change is located in libbpfgo, but I've inverted the order of the checking since most of the time we support boottime.

What changed and why in the libbpfgo: https://github.com/aquasecurity/libbpfgo/blob/45a155ff1a362156b5c7d1b75bc3db5f8cb5e526/libbpfgo.go#L104-L116