### PR TITLE
fix(man): missing rebuild

### DIFF
--- a/docs/man/scope.1
+++ b/docs/man/scope.1
@@ -57,7 +57,7 @@ if starting with `*'.
 .PP
 NOTE: Expressions containing `*' token must be escaped!
 .PP
-you can learn more about the wildcard in the \f[CR]event\f[R] section
+you can learn more about the wildcard in the \f[CR]event\f[R] section.
 .SS BOOLEAN OPERATOR (PREPENDED)
 `!'
 .PP


### PR DESCRIPTION
### 1. Explain what the PR does

526c4eec5 **fix(man): missing rebuild**

```
Somehow the lack of a rebuild step passed unnoticed by CI. This change
is the result of `make -f builder/Makefile.man man-run`.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
