### PR TITLE
Procfs improvements

### DIFF
--- a/pkg/changelog/changelog_test.go
+++ b/pkg/changelog/changelog_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/aquasecurity/tracee/pkg/utils"
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
 )
 
 func getTimeFromSec(second int) time.Time {
@@ -189,16 +189,16 @@ func TestChangelog_StructType(t *testing.T) {
 // Run it as DEBUG test to see the output.
 func TestChangelog_PrintSizes(t *testing.T) {
 	changelog1 := NewChangelog[int](1)
-	utils.PrintStructSizes(os.Stdout, changelog1)
+	tests.PrintStructSizes(t, os.Stdout, changelog1)
 
 	entry1 := entry[int]{}
-	utils.PrintStructSizes(os.Stdout, entry1)
+	tests.PrintStructSizes(t, os.Stdout, entry1)
 
 	//
 
 	changelog2 := NewChangelog[string](1)
-	utils.PrintStructSizes(os.Stdout, changelog2)
+	tests.PrintStructSizes(t, os.Stdout, changelog2)
 
 	entry2 := entry[string]{}
-	utils.PrintStructSizes(os.Stdout, entry2)
+	tests.PrintStructSizes(t, os.Stdout, entry2)
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -289,7 +289,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 
 	// Initialize buckets cache
 
-	var mntNSProcs map[int]int
+	var mntNSProcs map[uint32]int32 // map[mntns]pid
 
 	if t.config.MaxPidsCache == 0 {
 		t.config.MaxPidsCache = 5 // TODO: configure this ? never set, default = 5
@@ -307,7 +307,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	)
 	if err == nil {
 		for mountNS, pid := range mntNSProcs {
-			t.pidsInMntns.AddBucketItem(uint32(mountNS), uint32(pid))
+			t.pidsInMntns.AddBucketItem(mountNS, uint32(pid))
 		}
 	} else {
 		logger.Debugw("Initializing buckets cache", "error", errfmt.WrapError(err))

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -27,18 +27,15 @@ type BinaryFilter struct {
 var _ utils.Cloner[*BinaryFilter] = &BinaryFilter{}
 
 func getHostMntNS() (uint32, error) {
-	var ns int
+	var ns uint32
 	var err error
 
 	ns, err = proc.GetProcNS(1, "mnt")
 	if err != nil {
 		return 0, errfmt.WrapError(err)
 	}
-	if ns < 0 || ns > math.MaxUint32 {
-		return 0, errfmt.Errorf("invalid mnt namespace %d", ns)
-	}
 
-	return uint32(ns), nil
+	return ns, nil
 }
 
 func NewBinaryFilter() *BinaryFilter {
@@ -84,11 +81,11 @@ func (f *BinaryFilter) Parse(operatorAndValues string) error {
 				}
 				bin.MntNS = hostMntNS
 			} else {
-				mntNS, err := strconv.Atoi(mntAndPath[0])
+				mntNS, err := strconv.ParseUint(mntAndPath[0], 10, 32)
 				if err != nil {
 					return InvalidValue(val)
 				}
-				if mntNS < 0 || mntNS > math.MaxUint32 {
+				if mntNS > math.MaxUint32 {
 					return InvalidValue(val)
 				}
 				bin.MntNS = uint32(mntNS)

--- a/pkg/proctree/datasource.go
+++ b/pkg/proctree/datasource.go
@@ -103,7 +103,7 @@ func (ptds *DataSource) exportProcessInfo(
 		}
 		childInfo := child.GetInfo()
 		if childInfo.IsAliveAt(queryTime) {
-			aliveChildren[childInfo.GetPid()] = childHash
+			aliveChildren[int(childInfo.GetPid())] = childHash // TODO: change types pkg to reduce mem footprint
 		}
 	}
 
@@ -116,7 +116,7 @@ func (ptds *DataSource) exportProcessInfo(
 		}
 		threadInfo := thread.GetInfo()
 		if threadInfo.IsAliveAt(queryTime) {
-			aliveThreads[threadInfo.GetTid()] = threadHash
+			aliveThreads[int(threadInfo.GetTid())] = threadHash // TODO: change types pkg to reduce mem footprint
 		}
 	}
 
@@ -126,10 +126,11 @@ func (ptds *DataSource) exportProcessInfo(
 	// Export the information as the expected datasource process structure.
 	return datasource.TimeRelevantInfo[datasource.ProcessInfo]{
 		Info: datasource.ProcessInfo{
-			EntityId:          process.GetHash(),
-			Pid:               infoFeed.Pid,
-			NsPid:             infoFeed.NsPid,
-			Ppid:              infoFeed.PPid,
+			EntityId: process.GetHash(),
+			// TODO: change types pkg to reduce mem footprint (Pid, NsPid, Ppid, ThreadsIds, ChildProcessesIds)
+			Pid:               int(infoFeed.Pid),
+			NsPid:             int(infoFeed.NsPid),
+			Ppid:              int(infoFeed.PPid),
 			ContainerId:       "",         // TODO: Add
 			Cmd:               []string{}, // TODO: Add
 			ExecutionBinary:   exportFileInfo(executable, queryTime),
@@ -156,12 +157,13 @@ func (ptds *DataSource) exportThreadInfo(
 	// Export the information as the expected datasource thread structure.
 	return datasource.TimeRelevantInfo[datasource.ThreadInfo]{
 		Info: datasource.ThreadInfo{
-			EntityId:  thread.GetHash(),
-			Tid:       infoFeed.Tid,
-			NsTid:     infoFeed.NsTid,
-			Pid:       infoFeed.Pid,
-			UserId:    infoFeed.Uid,
-			GroupId:   infoFeed.Gid,
+			EntityId: thread.GetHash(),
+			// TODO: change types pkg to reduce mem footprint (Tid, NsTid, Pid, UserId, GroupId)
+			Tid:       int(infoFeed.Tid),
+			NsTid:     int(infoFeed.NsTid),
+			Pid:       int(infoFeed.Pid),
+			UserId:    int(infoFeed.Uid),
+			GroupId:   int(infoFeed.Gid),
 			StartTime: info.GetStartTime(),
 			ExitTime:  info.GetExitTime(),
 			Name:      infoFeed.Name,
@@ -217,11 +219,12 @@ func exportFileInfo(fileInfo *FileInfo, queryTime time.Time) datasource.FileInfo
 
 	// Export the information as the expected datasource file structure.
 	return datasource.FileInfo{
-		Path:   fileInfoFeed.Path,
-		Hash:   "", // TODO: Add
-		Inode:  fileInfoFeed.Inode,
-		Device: fileInfoFeed.Dev,
+		Path: fileInfoFeed.Path,
+		Hash: "", // TODO: Add
+		// TODO: change types pkg to reduce mem footprint (Inode, Device, Mode)
+		Inode:  int(fileInfoFeed.Inode),
+		Device: int(fileInfoFeed.Dev),
 		Ctime:  time.Unix(0, int64(fileInfoFeed.Ctime)),
-		Mode:   fileInfoFeed.InodeMode,
+		Mode:   int(fileInfoFeed.InodeMode),
 	}
 }

--- a/pkg/proctree/fileinfo.go
+++ b/pkg/proctree/fileinfo.go
@@ -1,6 +1,7 @@
 package proctree
 
 import (
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -12,10 +13,10 @@ import (
 type FileInfoFeed struct {
 	// Name      string
 	Path      string // mutable (file path)
-	Dev       int    // mutable (device number)
-	Ctime     int    // mutable (creation time)
-	Inode     int    // mutable (inode number)
-	InodeMode int    // mutable (inode mode)
+	Dev       uint32 // mutable (device number)
+	Ctime     uint64 // mutable (creation time)
+	Inode     uint64 // mutable (inode number)
+	InodeMode uint16 // mutable (inode mode)
 }
 
 //
@@ -88,16 +89,16 @@ func (fi *FileInfo) setFeedAt(feed *FileInfoFeed, targetTime time.Time) {
 		}
 		atFeed.Path = filePath
 	}
-	if feed.Dev >= 0 {
+	if feed.Dev != math.MaxUint32 {
 		atFeed.Dev = feed.Dev
 	}
-	if feed.Ctime >= 0 {
+	if feed.Ctime != math.MaxUint64 {
 		atFeed.Ctime = feed.Ctime
 	}
-	if feed.Inode >= 0 {
+	if feed.Inode != math.MaxUint64 {
 		atFeed.Inode = feed.Inode
 	}
-	if feed.InodeMode >= 0 {
+	if feed.InodeMode != math.MaxUint16 {
 		atFeed.InodeMode = feed.InodeMode
 	}
 
@@ -145,7 +146,7 @@ func (fi *FileInfo) GetPathAt(targetTime time.Time) string {
 }
 
 // GetDev returns the device number of the file.
-func (fi *FileInfo) GetDev() int {
+func (fi *FileInfo) GetDev() uint32 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -153,7 +154,7 @@ func (fi *FileInfo) GetDev() int {
 }
 
 // GetDevAt returns the device number of the file at the given time.
-func (fi *FileInfo) GetDevAt(targetTime time.Time) int {
+func (fi *FileInfo) GetDevAt(targetTime time.Time) uint32 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -161,7 +162,7 @@ func (fi *FileInfo) GetDevAt(targetTime time.Time) int {
 }
 
 // GetCtime returns the creation time of the file.
-func (fi *FileInfo) GetCtime() int {
+func (fi *FileInfo) GetCtime() uint64 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -169,7 +170,7 @@ func (fi *FileInfo) GetCtime() int {
 }
 
 // GetCtimeAt returns the creation time of the file at the given time.
-func (fi *FileInfo) GetCtimeAt(targetTime time.Time) int {
+func (fi *FileInfo) GetCtimeAt(targetTime time.Time) uint64 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -177,7 +178,7 @@ func (fi *FileInfo) GetCtimeAt(targetTime time.Time) int {
 }
 
 // GetInode returns the inode number of the file.
-func (fi *FileInfo) GetInode() int {
+func (fi *FileInfo) GetInode() uint64 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -185,7 +186,7 @@ func (fi *FileInfo) GetInode() int {
 }
 
 // GetInodeAt returns the inode number of the file at the given time.
-func (fi *FileInfo) GetInodeAt(targetTime time.Time) int {
+func (fi *FileInfo) GetInodeAt(targetTime time.Time) uint64 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -193,7 +194,7 @@ func (fi *FileInfo) GetInodeAt(targetTime time.Time) int {
 }
 
 // GetInodeMode returns the inode mode of the file.
-func (fi *FileInfo) GetInodeMode() int {
+func (fi *FileInfo) GetInodeMode() uint16 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 
@@ -201,7 +202,7 @@ func (fi *FileInfo) GetInodeMode() int {
 }
 
 // GetInodeModeAt returns the inode mode of the file at the given time.
-func (fi *FileInfo) GetInodeModeAt(targetTime time.Time) int {
+func (fi *FileInfo) GetInodeModeAt(targetTime time.Time) uint16 {
 	fi.mutex.RLock()
 	defer fi.mutex.RUnlock()
 

--- a/pkg/proctree/proctree.go
+++ b/pkg/proctree/proctree.go
@@ -74,7 +74,7 @@ type ProcTreeConfig struct {
 type ProcessTree struct {
 	processes   *lru.Cache[uint32, *Process] // hash -> process
 	threads     *lru.Cache[uint32, *Thread]  // hash -> threads
-	procfsChan  chan int                     // channel of pids to read from procfs
+	procfsChan  chan int32                   // channel of pids to read from procfs
 	procfsOnce  *sync.Once                   // busy loop debug message throttling
 	ctx         context.Context              // context for the process tree
 	procfsQuery bool

--- a/pkg/proctree/proctree_output.go
+++ b/pkg/proctree/proctree_output.go
@@ -124,9 +124,9 @@ func (pt *ProcessTree) String() string {
 		}
 		hashStr := fmt.Sprintf("%v", process.GetHash())
 		startTime := fmt.Sprintf("%v", process.GetInfo().GetStartTimeNS())
-		tid := stringify(processFeed.Tid)
-		pid := stringify(processFeed.Pid)
-		ppid := stringify(processFeed.PPid)
+		tid := stringify(int(processFeed.Tid))
+		pid := stringify(int(processFeed.Pid))
+		ppid := stringify(int(processFeed.PPid))
 		date := process.GetInfo().GetStartTime().Format("2006-01-02 15:04:05")
 
 		// add the row to the table

--- a/pkg/proctree/proctree_procfs.go
+++ b/pkg/proctree/proctree_procfs.go
@@ -318,7 +318,7 @@ func dealWithProcFsEntry(pt *ProcessTree, givenPid int) error {
 		return err
 	}
 
-	taskPath := fmt.Sprintf("/proc/%v/task", givenPid)
+	taskPath := proc.GetTaskPath(givenPid)
 	taskDirs, err := os.ReadDir(taskPath)
 	if err != nil {
 		return err

--- a/pkg/proctree/taskinfo.go
+++ b/pkg/proctree/taskinfo.go
@@ -1,6 +1,7 @@
 package proctree
 
 import (
+	"math"
 	"sync"
 	"time"
 
@@ -11,14 +12,14 @@ import (
 // TaskInfoFeed allows external packages to set/get multiple values of a task at once.
 type TaskInfoFeed struct {
 	Name        string // mutable (process name can be changed)
-	Tid         int    // immutable
-	Pid         int    // immutable
-	PPid        int    // mutable (process can be reparented)
-	NsTid       int    // immutable
-	NsPid       int    // immutable
-	NsPPid      int    // mutable (process can be reparented)
-	Uid         int    // mutable (process uid can be changed)
-	Gid         int    // mutable (process gid can be changed)
+	Tid         int32  // immutable
+	Pid         int32  // immutable
+	PPid        int32  // mutable (process can be reparented)
+	NsTid       int32  // immutable
+	NsPid       int32  // immutable
+	NsPPid      int32  // mutable (process can be reparented)
+	Uid         uint32 // mutable (process uid can be changed)
+	Gid         uint32 // mutable (process gid can be changed)
 	StartTimeNS uint64 // immutable (this is a duration, in ns, since boot)
 	ExitTimeNS  uint64 // immutable (this is a duration, in ns, since boot)
 }
@@ -91,10 +92,10 @@ func (ti *TaskInfo) SetFeedAt(feed *TaskInfoFeed, targetTime time.Time) {
 	if feed.NsPid >= 0 {
 		atFeed.NsPPid = feed.NsPPid
 	}
-	if feed.Uid >= 0 {
+	if feed.Uid != math.MaxUint32 {
 		atFeed.Uid = feed.Uid
 	}
-	if feed.Gid >= 0 {
+	if feed.Gid != math.MaxUint32 {
 		atFeed.Gid = feed.Gid
 	}
 	if feed.StartTimeNS != 0 {
@@ -184,7 +185,7 @@ func (ti *TaskInfo) GetNameAt(targetTime time.Time) string {
 }
 
 // GetTid returns the tid of the task.
-func (ti *TaskInfo) GetTid() int {
+func (ti *TaskInfo) GetTid() int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -192,7 +193,7 @@ func (ti *TaskInfo) GetTid() int {
 }
 
 // GetPid returns the pid of the task.
-func (ti *TaskInfo) GetPid() int {
+func (ti *TaskInfo) GetPid() int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -200,7 +201,7 @@ func (ti *TaskInfo) GetPid() int {
 }
 
 // GetNsTid returns the nsTid of the task.
-func (ti *TaskInfo) GetNsTid() int {
+func (ti *TaskInfo) GetNsTid() int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -208,7 +209,7 @@ func (ti *TaskInfo) GetNsTid() int {
 }
 
 // GetNsPid returns the nsPid of the task.
-func (ti *TaskInfo) GetNsPid() int {
+func (ti *TaskInfo) GetNsPid() int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -216,7 +217,7 @@ func (ti *TaskInfo) GetNsPid() int {
 }
 
 // GetPPid returns the ppid of the task.
-func (ti *TaskInfo) GetPPid() int {
+func (ti *TaskInfo) GetPPid() int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -224,7 +225,7 @@ func (ti *TaskInfo) GetPPid() int {
 }
 
 // GetPPidAt returns the ppid of the task at the given time.
-func (ti *TaskInfo) GetPPidAt(targetTime time.Time) int {
+func (ti *TaskInfo) GetPPidAt(targetTime time.Time) int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -232,7 +233,7 @@ func (ti *TaskInfo) GetPPidAt(targetTime time.Time) int {
 }
 
 // GetNsPPid returns the nsPPid of the task.
-func (ti *TaskInfo) GetNsPPid() int {
+func (ti *TaskInfo) GetNsPPid() int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -240,7 +241,7 @@ func (ti *TaskInfo) GetNsPPid() int {
 }
 
 // GetNsPPidAt returns the nsPPid of the task at the given time.
-func (ti *TaskInfo) GetNsPPidAt(targetTime time.Time) int {
+func (ti *TaskInfo) GetNsPPidAt(targetTime time.Time) int32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -248,7 +249,7 @@ func (ti *TaskInfo) GetNsPPidAt(targetTime time.Time) int {
 }
 
 // GetUid returns the uid of the task.
-func (ti *TaskInfo) GetUid() int {
+func (ti *TaskInfo) GetUid() uint32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -256,7 +257,7 @@ func (ti *TaskInfo) GetUid() int {
 }
 
 // GetUidAt returns the uid of the task at the given time.
-func (ti *TaskInfo) GetUidAt(targetTime time.Time) int {
+func (ti *TaskInfo) GetUidAt(targetTime time.Time) uint32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -264,7 +265,7 @@ func (ti *TaskInfo) GetUidAt(targetTime time.Time) int {
 }
 
 // GetGid returns the gid of the task.
-func (ti *TaskInfo) GetGid() int {
+func (ti *TaskInfo) GetGid() uint32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 
@@ -272,7 +273,7 @@ func (ti *TaskInfo) GetGid() int {
 }
 
 // GetGidAt returns the gid of the task at the given time.
-func (ti *TaskInfo) GetGidAt(targetTime time.Time) int {
+func (ti *TaskInfo) GetGidAt(targetTime time.Time) uint32 {
 	ti.mutex.RLock()
 	defer ti.mutex.RUnlock()
 

--- a/pkg/utils/proc/exe.go
+++ b/pkg/utils/proc/exe.go
@@ -1,7 +1,6 @@
 package proc
 
 import (
-	"fmt"
 	"os"
 	"strconv"
 
@@ -11,8 +10,9 @@ import (
 
 // GetProcNS returns the namespace ID of a given namespace and process.
 // To do so, it requires access to the /proc file system of the host, and CAP_SYS_PTRACE capability.
-func GetProcBinary(pid uint) (string, error) {
-	binPath, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+func GetProcBinary(pid int) (string, error) {
+	exePath := GetProcExePath(pid)
+	binPath, err := os.Readlink(exePath)
 	if err != nil {
 		return "", errfmt.Errorf("could not read exe file: %v", err)
 	}
@@ -37,12 +37,12 @@ func GetAllBinaryProcs() (map[string][]uint32, error) {
 	}
 	binProcs := map[string][]uint32{}
 	for _, proc := range procs {
-		procUint, _ := strconv.ParseUint(proc, 10, 32)
-		bin, _ := GetProcBinary(uint(procUint))
+		procInt, _ := strconv.ParseInt(proc, 10, 32)
+		bin, _ := GetProcBinary(int(procInt))
 		if _, ok := binProcs[bin]; !ok {
 			binProcs[bin] = []uint32{}
 		}
-		binProcs[bin] = append(binProcs[bin], uint32(procUint))
+		binProcs[bin] = append(binProcs[bin], uint32(procInt))
 	}
 
 	return binProcs, nil

--- a/pkg/utils/proc/formatters.go
+++ b/pkg/utils/proc/formatters.go
@@ -4,28 +4,28 @@ import "strconv"
 
 // GetTaskPath returns the path to the task directory of a process given its PID.
 // The path is in the form /proc/<pid>/task.
-func GetTaskPath(pid int) string {
+func GetTaskPath(pid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	return "/proc/" + pidStr + "/task"
 }
 
 // GetStatPath returns the path to the stat file of a process given its PID.
 // The path is in the form /proc/<pid>/stat.
-func GetStatPath(pid int) string {
+func GetStatPath(pid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	return "/proc/" + pidStr + "/stat"
 }
 
 // GetStatusPath returns the path to the status file of a process given its PID.
 // The path is in the form /proc/<pid>/status.
-func GetStatusPath(pid int) string {
+func GetStatusPath(pid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	return "/proc/" + pidStr + "/status"
 }
 
 // GetTaskStatPath returns the path to the stat file of a thread given its PID and TID.
 // The path is in the form /proc/<pid>/task/<tid>/stat.
-func GetTaskStatPath(pid, tid int) string {
+func GetTaskStatPath(pid, tid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	tidStr := strconv.FormatInt(int64(tid), 10)
 	return "/proc/" + pidStr + "/task/" + tidStr + "/stat"
@@ -33,7 +33,7 @@ func GetTaskStatPath(pid, tid int) string {
 
 // GetTaskStatusPath returns the path to the status file of a thread given its PID and TID.
 // The path is in the form /proc/<pid>/task/<tid>/status.
-func GetTaskStatusPath(pid, tid int) string {
+func GetTaskStatusPath(pid, tid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	tidStr := strconv.FormatInt(int64(tid), 10)
 	return "/proc/" + pidStr + "/task/" + tidStr + "/status"
@@ -41,20 +41,20 @@ func GetTaskStatusPath(pid, tid int) string {
 
 // GetProcExePath returns the path to the executable of a process given its PID.
 // The path is in the form /proc/<pid>/exe.
-func GetProcExePath(pid int) string {
+func GetProcExePath(pid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	return "/proc/" + pidStr + "/exe"
 }
 
 // GetProcNSDirPath returns the path to the directory containing the namespaces of a process given its PID.
 // The path is in the form /proc/<pid>/ns.
-func GetProcNSDirPath(pid int) string {
+func GetProcNSDirPath(pid int32) string {
 	pidStr := strconv.FormatInt(int64(pid), 10)
 	return "/proc/" + pidStr + "/ns"
 }
 
 // GetProcNSPath returns the path to a specific namespace of a process given its PID and the namespace name.
 // The path is in the form /proc/<pid>/ns/<nsName>.
-func GetProcNSPath(pid int, nsName string) string {
+func GetProcNSPath(pid int32, nsName string) string {
 	return GetProcNSDirPath(pid) + "/" + nsName
 }

--- a/pkg/utils/proc/formatters.go
+++ b/pkg/utils/proc/formatters.go
@@ -1,0 +1,60 @@
+package proc
+
+import "strconv"
+
+// GetTaskPath returns the path to the task directory of a process given its PID.
+// The path is in the form /proc/<pid>/task.
+func GetTaskPath(pid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	return "/proc/" + pidStr + "/task"
+}
+
+// GetStatPath returns the path to the stat file of a process given its PID.
+// The path is in the form /proc/<pid>/stat.
+func GetStatPath(pid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	return "/proc/" + pidStr + "/stat"
+}
+
+// GetStatusPath returns the path to the status file of a process given its PID.
+// The path is in the form /proc/<pid>/status.
+func GetStatusPath(pid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	return "/proc/" + pidStr + "/status"
+}
+
+// GetTaskStatPath returns the path to the stat file of a thread given its PID and TID.
+// The path is in the form /proc/<pid>/task/<tid>/stat.
+func GetTaskStatPath(pid, tid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	tidStr := strconv.FormatInt(int64(tid), 10)
+	return "/proc/" + pidStr + "/task/" + tidStr + "/stat"
+}
+
+// GetTaskStatusPath returns the path to the status file of a thread given its PID and TID.
+// The path is in the form /proc/<pid>/task/<tid>/status.
+func GetTaskStatusPath(pid, tid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	tidStr := strconv.FormatInt(int64(tid), 10)
+	return "/proc/" + pidStr + "/task/" + tidStr + "/status"
+}
+
+// GetProcExePath returns the path to the executable of a process given its PID.
+// The path is in the form /proc/<pid>/exe.
+func GetProcExePath(pid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	return "/proc/" + pidStr + "/exe"
+}
+
+// GetProcNSDirPath returns the path to the directory containing the namespaces of a process given its PID.
+// The path is in the form /proc/<pid>/ns.
+func GetProcNSDirPath(pid int) string {
+	pidStr := strconv.FormatInt(int64(pid), 10)
+	return "/proc/" + pidStr + "/ns"
+}
+
+// GetProcNSPath returns the path to a specific namespace of a process given its PID and the namespace name.
+// The path is in the form /proc/<pid>/ns/<nsName>.
+func GetProcNSPath(pid int, nsName string) string {
+	return GetProcNSDirPath(pid) + "/" + nsName
+}

--- a/pkg/utils/proc/ns.go
+++ b/pkg/utils/proc/ns.go
@@ -35,17 +35,18 @@ func GetMountNSFirstProcesses() (map[int]int, error) {
 	mountNSTimeMap := make(map[int]pidTimestamp)
 	// Iterate over each pid
 	for _, entry := range entries {
-		pid, err := strconv.ParseUint(entry, 10, 32)
+		pid, err := ParseInt32(entry)
 		if err != nil {
 			continue
 		}
-		procNS, err := GetAllProcNS(uint(pid))
+
+		procNS, err := GetAllProcNS(pid)
 		if err != nil {
 			logger.Debugw("Failed in fetching process mount namespace", "pid", pid, "error", err.Error())
 			continue
 		}
 
-		processStartTime, err := GetProcessStartTime(uint(pid))
+		processStartTime, err := GetProcessStartTime(pid)
 		if err != nil {
 			logger.Debugw("Failed in fetching process start time", "pid", pid, "error", err.Error())
 			continue
@@ -69,8 +70,8 @@ func GetMountNSFirstProcesses() (map[int]int, error) {
 }
 
 // GetProcessStartTime return the start time of the process using the procfs
-func GetProcessStartTime(pid uint) (int, error) {
-	statPath := GetStatPath(int(pid))
+func GetProcessStartTime(pid int32) (int, error) {
+	statPath := GetStatPath(pid)
 	stat, err := os.ReadFile(statPath)
 	if err != nil {
 		return 0, errfmt.WrapError(err)
@@ -111,8 +112,8 @@ type ProcNS struct {
 
 // GetAllProcNS return all the namespaces of a given process.
 // To do so, it requires access to the /proc file system of the host, and CAP_SYS_PTRACE capability.
-func GetAllProcNS(pid uint) (*ProcNS, error) {
-	nsDirPath := GetProcNSDirPath(int(pid))
+func GetAllProcNS(pid int32) (*ProcNS, error) {
+	nsDirPath := GetProcNSDirPath(pid)
 	nsDir, err := os.Open(nsDirPath)
 	if err != nil {
 		return nil, errfmt.Errorf("could not open ns dir: %v", err)
@@ -169,8 +170,8 @@ func GetAllProcNS(pid uint) (*ProcNS, error) {
 
 // GetProcNS returns the namespace ID of a given namespace and process.
 // To do so, it requires access to the /proc file system of the host, and CAP_SYS_PTRACE capability.
-func GetProcNS(pid uint, nsName string) (int, error) {
-	nsPath := GetProcNSPath(int(pid), nsName)
+func GetProcNS(pid int32, nsName string) (int, error) {
+	nsPath := GetProcNSPath(pid, nsName)
 	nsLink, err := os.Readlink(nsPath)
 	if err != nil {
 		return 0, errfmt.Errorf("could not read ns file: %v", err)

--- a/pkg/utils/proc/ns.go
+++ b/pkg/utils/proc/ns.go
@@ -151,12 +151,17 @@ func GetMountNSFirstProcesses() (map[uint32]int32, error) { // map[mountNS]pid
 			continue
 		}
 
-		procStat, err := NewProcStat(pid)
-		processStartTime := procStat.GetStartTime()
+		procStat, err := NewProcStatFields(
+			pid,
+			[]StatField{
+				StatStartTime,
+			},
+		)
 		if err != nil {
 			logger.Debugw("Failed in fetching process start time", "pid", pid, "error", err.Error())
 			continue
 		}
+		processStartTime := procStat.GetStartTime()
 
 		currentNSProcess, ok := mountNSTimeMap[procNS.Mnt]
 		if ok {

--- a/pkg/utils/proc/ns.go
+++ b/pkg/utils/proc/ns.go
@@ -1,113 +1,26 @@
 package proc
 
 import (
-	"bytes"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/logger"
 )
 
-// GetMountNSFirstProcesses return mapping between mount NS to its first process
-// (aka, the process with the oldest start time in the mount NS)
-func GetMountNSFirstProcesses() (map[int]int, error) {
-	procDir, err := os.Open("/proc")
-	if err != nil {
-		return nil, errfmt.Errorf("could not open proc dir: %v", err)
-	}
-	defer func() {
-		if err := procDir.Close(); err != nil {
-			logger.Errorw("Closing file", "error", err)
-		}
-	}()
-
-	entries, err := procDir.Readdirnames(-1)
-	if err != nil {
-		return nil, errfmt.Errorf("could not read proc dir: %v", err)
-	}
-
-	type pidTimestamp struct {
-		pid       uint
-		timestamp int
-	}
-	mountNSTimeMap := make(map[int]pidTimestamp)
-	// Iterate over each pid
-	for _, entry := range entries {
-		pid, err := ParseInt32(entry)
-		if err != nil {
-			continue
-		}
-
-		procNS, err := GetAllProcNS(pid)
-		if err != nil {
-			logger.Debugw("Failed in fetching process mount namespace", "pid", pid, "error", err.Error())
-			continue
-		}
-
-		processStartTime, err := GetProcessStartTime(pid)
-		if err != nil {
-			logger.Debugw("Failed in fetching process start time", "pid", pid, "error", err.Error())
-			continue
-		}
-
-		currentNSProcess, ok := mountNSTimeMap[procNS.Mnt]
-		if ok {
-			// If executed after current save process, it can't be the first process
-			if processStartTime >= currentNSProcess.timestamp {
-				continue
-			}
-		}
-		mountNSTimeMap[procNS.Mnt] = pidTimestamp{timestamp: processStartTime, pid: uint(pid)}
-	}
-
-	mountNSToFirstProcess := make(map[int]int)
-	for mountNS, p := range mountNSTimeMap {
-		mountNSToFirstProcess[mountNS] = int(p.pid)
-	}
-	return mountNSToFirstProcess, nil
-}
-
-// GetProcessStartTime return the start time of the process using the procfs
-func GetProcessStartTime(pid int32) (int, error) {
-	statPath := GetStatPath(pid)
-	stat, err := os.ReadFile(statPath)
-	if err != nil {
-		return 0, errfmt.WrapError(err)
-	}
-	// see https://man7.org/linux/man-pages/man5/proc.5.html for how to read /proc/pid/stat
-	startTimeOffset := 22 // Offset start at 1
-	commOffset := 2
-	// We want to remove the comm from the string, because it can contain a space which will change the offsets after split
-	splitByComm := bytes.SplitN(stat, []byte{')', ' '}, 2)
-	if len(splitByComm) != 2 {
-		return 0, errfmt.Errorf("error in parsing /proc/<pid>/stat format - comm name is not surrounded by parentheses as expected")
-	}
-	newStartTimeOffset := startTimeOffset - commOffset
-	splitStat := bytes.SplitN(splitByComm[1], []byte{' '}, newStartTimeOffset+1)
-	if len(splitStat) != newStartTimeOffset+1 {
-		return 0, errfmt.Errorf("error in parsing /proc/<pid>/stat format - only %d values found inside", len(splitStat))
-	}
-	startTime, err := strconv.Atoi(string(splitStat[newStartTimeOffset-1]))
-	if err != nil {
-		return 0, errfmt.WrapError(err)
-	}
-
-	return startTime, nil
-}
-
+// https://elixir.bootlin.com/linux/v6.13/source/include/linux/ns_common.h#L12
+// struct ns_common inum member is unsigned int
 type ProcNS struct {
-	Cgroup          int
-	Ipc             int
-	Mnt             int
-	Net             int
-	Pid             int
-	PidForChildren  int
-	Time            int
-	TimeForChildren int
-	User            int
-	Uts             int
+	Cgroup          uint32
+	Ipc             uint32
+	Mnt             uint32
+	Net             uint32
+	Pid             uint32
+	PidForChildren  uint32
+	Time            uint32
+	TimeForChildren uint32
+	User            uint32
+	Uts             uint32
 }
 
 // GetAllProcNS return all the namespaces of a given process.
@@ -130,68 +43,138 @@ func GetAllProcNS(pid int32) (*ProcNS, error) {
 	}
 
 	var procNS ProcNS
+
+	// namespace mapping to avoid branching and reduce function size
+	nsMap := map[string]*uint32{
+		"cgroup":            &procNS.Cgroup,
+		"ipc":               &procNS.Ipc,
+		"mnt":               &procNS.Mnt,
+		"net":               &procNS.Net,
+		"pid":               &procNS.Pid,
+		"pid_for_children":  &procNS.PidForChildren,
+		"time":              &procNS.Time,
+		"time_for_children": &procNS.TimeForChildren,
+		"user":              &procNS.User,
+		"uts":               &procNS.Uts,
+	}
+
 	for _, entry := range entries {
 		entryNSPath := nsDirPath + "/" + entry // /proc/<pid>/ns/<entry>
 		nsLink, err := os.Readlink(entryNSPath)
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
+
 		ns, err := extractNSFromLink(nsLink)
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
-		switch entry {
-		case "cgroup":
-			procNS.Cgroup = ns
-		case "ipc":
-			procNS.Ipc = ns
-		case "mnt":
-			procNS.Mnt = ns
-		case "net":
-			procNS.Net = ns
-		case "pid":
-			procNS.Pid = ns
-		case "pid_for_children":
-			procNS.PidForChildren = ns
-		case "time":
-			procNS.Time = ns
-		case "time_for_children":
-			procNS.TimeForChildren = ns
-		case "user":
-			procNS.User = ns
-		case "uts":
-			procNS.Uts = ns
-		default:
+
+		nsPtr, ok := nsMap[entry]
+		if !ok {
 			return nil, errfmt.Errorf("encountered unexpected namespace file - %s", entry)
 		}
+
+		*nsPtr = ns
 	}
+
 	return &procNS, nil
 }
 
 // GetProcNS returns the namespace ID of a given namespace and process.
 // To do so, it requires access to the /proc file system of the host, and CAP_SYS_PTRACE capability.
-func GetProcNS(pid int32, nsName string) (int, error) {
+func GetProcNS(pid int32, nsName string) (uint32, error) {
 	nsPath := GetProcNSPath(pid, nsName)
 	nsLink, err := os.Readlink(nsPath)
 	if err != nil {
 		return 0, errfmt.Errorf("could not read ns file: %v", err)
 	}
+
 	ns, err := extractNSFromLink(nsLink)
 	if err != nil {
 		return 0, errfmt.Errorf("could not extract ns id: %v", err)
 	}
+
 	return ns, nil
 }
 
-func extractNSFromLink(link string) (int, error) {
-	nsLinkSplitted := strings.SplitN(link, ":[", 2)
-	if len(nsLinkSplitted) != 2 {
+func extractNSFromLink(link string) (uint32, error) {
+	startIdx := strings.IndexByte(link, '[')
+	if startIdx == -1 {
 		return 0, errfmt.Errorf("link format is not supported")
 	}
-	nsString := strings.TrimSuffix(nsLinkSplitted[1], "]")
-	ns, err := strconv.Atoi(nsString)
+
+	// assume that the namespace ID is the content between the first '[' and the last ']'
+	nsString := link[startIdx+1 : len(link)-1]
+	ns, err := ParseUint32(nsString)
 	if err != nil {
-		return 0, errfmt.WrapError(err)
+		return 0, errfmt.Errorf("invalid namespace ID %s: %v", nsString, err)
 	}
+
 	return ns, nil
+}
+
+// GetMountNSFirstProcesses return mapping between mount NS to its first process
+// (aka, the process with the oldest start time in the mount NS)
+func GetMountNSFirstProcesses() (map[uint32]int32, error) { // map[mountNS]pid
+	procDir, err := os.Open("/proc")
+	if err != nil {
+		return nil, errfmt.Errorf("could not open proc dir: %v", err)
+	}
+	defer func() {
+		if err := procDir.Close(); err != nil {
+			logger.Errorw("Closing file", "error", err)
+		}
+	}()
+
+	entries, err := procDir.Readdirnames(-1)
+	if err != nil {
+		return nil, errfmt.Errorf("could not read proc dir: %v", err)
+	}
+
+	type pidTimestamp struct {
+		pid       int32
+		timestamp uint64
+	}
+	mountNSTimeMap := make(map[uint32]pidTimestamp)
+
+	// Iterate over each pid
+	for _, entry := range entries {
+		pid, err := ParseInt32(entry)
+		if err != nil {
+			continue
+		}
+
+		procNS, err := GetAllProcNS(pid)
+		if err != nil {
+			logger.Debugw("Failed in fetching process mount namespace", "pid", pid, "error", err.Error())
+			continue
+		}
+
+		procStat, err := NewProcStat(pid)
+		processStartTime := procStat.GetStartTime()
+		if err != nil {
+			logger.Debugw("Failed in fetching process start time", "pid", pid, "error", err.Error())
+			continue
+		}
+
+		currentNSProcess, ok := mountNSTimeMap[procNS.Mnt]
+		if ok {
+			// If executed after current save process, it can't be the first process
+			if processStartTime >= currentNSProcess.timestamp {
+				continue
+			}
+		}
+		mountNSTimeMap[procNS.Mnt] = pidTimestamp{
+			timestamp: processStartTime,
+			pid:       pid,
+		}
+	}
+
+	mountNSToFirstProcess := make(map[uint32]int32)
+	for mountNS, p := range mountNSTimeMap {
+		mountNSToFirstProcess[mountNS] = p.pid
+	}
+
+	return mountNSToFirstProcess, nil
 }

--- a/pkg/utils/proc/ns_bench_test.go
+++ b/pkg/utils/proc/ns_bench_test.go
@@ -1,0 +1,9 @@
+package proc
+
+import "testing"
+
+func BenchmarkGetAllProcNS(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		GetAllProcNS(1)
+	}
+}

--- a/pkg/utils/proc/ns_test.go
+++ b/pkg/utils/proc/ns_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractNSFromLink(t *testing.T) {
+func Test_extractNSFromLink(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
 		name          string
 		link          string
-		expectedNS    int
+		expectedNS    uint32
 		expectedError bool
 	}{
 		{

--- a/pkg/utils/proc/parsers.go
+++ b/pkg/utils/proc/parsers.go
@@ -19,6 +19,11 @@ func ParseInt64(value string) (int64, error) {
 	return strconv.ParseInt(value, 10, 64)
 }
 
+func ParseUint32(value string) (uint32, error) {
+	val, err := strconv.ParseUint(value, 10, 32)
+	return uint32(val), err
+}
+
 func ParseUint64(value string) (uint64, error) {
 	return strconv.ParseUint(value, 10, 64)
 }

--- a/pkg/utils/proc/parsers.go
+++ b/pkg/utils/proc/parsers.go
@@ -2,7 +2,6 @@ package proc
 
 import (
 	"strconv"
-	"strings"
 )
 
 //
@@ -22,8 +21,4 @@ func ParseInt64(value string) (int64, error) {
 
 func ParseUint64(value string) (uint64, error) {
 	return strconv.ParseUint(value, 10, 64)
-}
-
-func parseString(value string) string {
-	return strings.Clone(value) // clone it to avoid memory leak
 }

--- a/pkg/utils/proc/parsers.go
+++ b/pkg/utils/proc/parsers.go
@@ -14,9 +14,12 @@ func parseInt(value string) int {
 	return val
 }
 
-func parseUint64(value string) uint64 {
-	val, _ := strconv.ParseUint(value, 10, 64)
-	return val
+func ParseInt64(value string) (int64, error) {
+	return strconv.ParseInt(value, 10, 64)
+}
+
+func ParseUint64(value string) (uint64, error) {
+	return strconv.ParseUint(value, 10, 64)
 }
 
 func parseString(value string) string {

--- a/pkg/utils/proc/parsers.go
+++ b/pkg/utils/proc/parsers.go
@@ -7,11 +7,13 @@ import (
 
 //
 // proc status/stat fields type parsers
+// TODO: move to a more appropriate package (e.g. pkg/utils/parsers.go)
+// TODO: consider using them in argument parsing
 //
 
-func parseInt(value string) int {
-	val, _ := strconv.Atoi(value)
-	return val
+func ParseInt32(value string) (int32, error) {
+	val, err := strconv.ParseInt(value, 10, 32)
+	return int32(val), err
 }
 
 func ParseInt64(value string) (int64, error) {

--- a/pkg/utils/proc/readfile.go
+++ b/pkg/utils/proc/readfile.go
@@ -1,0 +1,41 @@
+package proc
+
+import (
+	"io"
+	"os"
+)
+
+// ReadFile reads the content of a file and returns it as a byte slice.
+// This function is specifically optimized for reading small files in the /proc directory,
+// where the file size reported by the stat syscall is often 0.
+// It reads the file in chunks, dynamically growing the buffer as needed to ensure all
+// content is retrieved efficiently.
+func ReadFile(filePath string, initialBufferSize int) ([]byte, error) {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	data := make([]byte, 0, initialBufferSize)
+
+	// read file in chunks
+	for {
+		n, err := file.Read(data[len(data):cap(data)])
+		data = data[:len(data)+n]
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+
+			return data, err
+		}
+
+		if len(data) >= cap(data) {
+			d := append(data[:cap(data)], 0)
+			data = d[:len(data)]
+		}
+	}
+}

--- a/pkg/utils/proc/readfile_bench_test.go
+++ b/pkg/utils/proc/readfile_bench_test.go
@@ -1,0 +1,100 @@
+package proc
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+func BenchmarkReadFile(b *testing.B) {
+	tmpFiles := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "Empty File",
+			content: "",
+		},
+		{
+			name:    "Small File",
+			content: "Hello, world!",
+		},
+		{
+			name:    "Exact Buffer Size",
+			content: string(bytes.Repeat([]byte("A"), StatReadFileInitialBufferSize)),
+		},
+		//
+		// This test is disabled because the temporary file is not an actual /proc file.
+		// As a result, os.ReadFile uses the file size retrieved by the stat syscall,
+		// which ensures it is always more optimal than ReadFile in this scenario.
+		//
+		// {
+		// 	name:    "Larger Than Buffer Size",
+		// 	content: string(bytes.Repeat([]byte("B"), 2*StatReadFileInitialBufferSize)),
+		// },
+	}
+
+	for _, tt := range tmpFiles {
+		b.Run("ProcFSReadFile/"+tt.name, func(b *testing.B) {
+			tempFile := tests.CreateTempFile(b, tt.content)
+			defer os.Remove(tempFile.Name())
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ReadFile(tempFile.Name(), StatReadFileInitialBufferSize)
+				if err != nil {
+					b.Fatalf("ReadFile failed: %v", err)
+				}
+			}
+		})
+
+		b.Run("OsReadFile/"+tt.name, func(b *testing.B) {
+			tempFile := tests.CreateTempFile(b, tt.content)
+			defer os.Remove(tempFile.Name())
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := os.ReadFile(tempFile.Name())
+				if err != nil {
+					b.Fatalf("os.ReadFile failed: %v", err)
+				}
+			}
+		})
+	}
+
+	// The benchmark for /proc file below is not fully deterministic
+	// due to the dynamic nature of their content. However, they still
+	// allow for a meaningful comparison of the performance between
+	// ReadFile and os.ReadFile, assuming the file content (size)
+	// remains relatively stable during the test.
+
+	statFile := "/proc/self/stat"
+
+	b.Run("ProcFSReadFile_"+statFile, func(b *testing.B) {
+		tempFile := tests.CreateTempFile(b, statFile)
+		defer os.Remove(tempFile.Name())
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := ReadFile(tempFile.Name(), StatReadFileInitialBufferSize)
+			if err != nil {
+				b.Fatalf("ReadFile failed: %v", err)
+			}
+		}
+	})
+
+	b.Run("OsReadFile_"+statFile, func(b *testing.B) {
+		tempFile := tests.CreateTempFile(b, statFile)
+		defer os.Remove(tempFile.Name())
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := os.ReadFile(tempFile.Name())
+			if err != nil {
+				b.Fatalf("os.ReadFile failed: %v", err)
+			}
+		}
+	})
+}

--- a/pkg/utils/proc/readfile_test.go
+++ b/pkg/utils/proc/readfile_test.go
@@ -1,0 +1,67 @@
+package proc
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+func TestReadFile(t *testing.T) {
+	tt := []struct {
+		name           string
+		content        string
+		expectedOutput string
+		expectedErr    error
+	}{
+		{
+			name:           "Empty File",
+			content:        "",
+			expectedOutput: "",
+			expectedErr:    nil,
+		},
+		{
+			name:           "Small File",
+			content:        "Hello, world!",
+			expectedOutput: "Hello, world!",
+			expectedErr:    nil,
+		},
+		{
+			name:           "Exact Buffer Size",
+			content:        string(bytes.Repeat([]byte("A"), 512)),
+			expectedOutput: string(bytes.Repeat([]byte("A"), 512)),
+			expectedErr:    nil,
+		},
+		{
+			name:           "Larger Than Buffer Size",
+			content:        string(bytes.Repeat([]byte("B"), 1024)),
+			expectedOutput: string(bytes.Repeat([]byte("B"), 1024)),
+			expectedErr:    nil,
+		},
+		{
+			name:           "Multibyte Characters",
+			content:        "こんにちは世界",
+			expectedOutput: "こんにちは世界",
+			expectedErr:    nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			tempFile := tests.CreateTempFile(t, tc.content)
+			defer os.Remove(tempFile.Name())
+
+			// test
+			output, err := ReadFile(tempFile.Name(), 512)
+
+			// verify
+			if !bytes.Equal(output, []byte(tc.expectedOutput)) {
+				t.Errorf("Expected output %q, got %q", tc.expectedOutput, string(output))
+			}
+			if err != tc.expectedErr {
+				t.Errorf("Expected error %v, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}

--- a/pkg/utils/proc/stat.go
+++ b/pkg/utils/proc/stat.go
@@ -67,7 +67,8 @@ import (
 // ExitCode            int    // the thread's exit_code in the form reported by the waitpid system call
 
 const (
-	StatNumFields = 52
+	StatNumFields                 = 52
+	StatReadFileInitialBufferSize = 256 // greater than average size calculated from 10k stat files
 )
 
 // ProcStat represents the minimal required fields of the /proc stat file.
@@ -96,7 +97,7 @@ func NewProcStat(pid int) (*ProcStat, error) {
 }
 
 func newProcStat(filePath string) (*ProcStat, error) {
-	statBytes, err := os.ReadFile(filePath)
+	statBytes, err := ReadFile(filePath, StatReadFileInitialBufferSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/proc/stat.go
+++ b/pkg/utils/proc/stat.go
@@ -85,14 +85,14 @@ var procStatValueParserArray = [StatNumFields]procStatValueParser{
 
 // NewThreadProcStat reads the /proc/<pid>/task/<tid>/stat file and parses it into a ProcStat struct.
 func NewThreadProcStat(pid, tid int) (*ProcStat, error) {
-	filepath := fmt.Sprintf("/proc/%v/task/%v/stat", pid, tid)
-	return newProcStat(filepath)
+	taskStatPath := GetTaskStatPath(pid, tid)
+	return newProcStat(taskStatPath)
 }
 
 // NewProcStat reads the /proc/<pid>/stat file and parses it into a ProcStat struct.
 func NewProcStat(pid int) (*ProcStat, error) {
-	filePath := fmt.Sprintf("/proc/%v/stat", pid)
-	return newProcStat(filePath)
+	statPath := GetStatPath(pid)
+	return newProcStat(statPath)
 }
 
 func newProcStat(filePath string) (*ProcStat, error) {

--- a/pkg/utils/proc/stat.go
+++ b/pkg/utils/proc/stat.go
@@ -103,13 +103,13 @@ var procStatValueParserArray = [StatMaxNumFields]procStatValueParser{
 }
 
 // NewThreadProcStat reads the /proc/<pid>/task/<tid>/stat file and parses it into a ProcStat struct.
-func NewThreadProcStat(pid, tid int) (*ProcStat, error) {
+func NewThreadProcStat(pid, tid int32) (*ProcStat, error) {
 	taskStatPath := GetTaskStatPath(pid, tid)
 	return newProcStat(taskStatPath)
 }
 
 // NewProcStat reads the /proc/<pid>/stat file and parses it into a ProcStat struct.
-func NewProcStat(pid int) (*ProcStat, error) {
+func NewProcStat(pid int32) (*ProcStat, error) {
 	statPath := GetStatPath(pid)
 	return newProcStat(statPath)
 }

--- a/pkg/utils/proc/stat_bench_test.go
+++ b/pkg/utils/proc/stat_bench_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Benchmark_newProcStat(b *testing.B) {
-	file := tests.CreateTempFile(b, content)
+	file := tests.CreateTempFile(b, statContent)
 	defer os.Remove(file.Name())
 
 	b.ResetTimer()

--- a/pkg/utils/proc/stat_bench_test.go
+++ b/pkg/utils/proc/stat_bench_test.go
@@ -7,49 +7,12 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils/tests"
 )
 
-func createMockStatFile() (string, error) {
-	dirPath := "/tmp/tracee-test"
-	filePath, err := tests.GenerateTimestampFileName(dirPath, "stat")
-	if err != nil {
-		return "", err
-	}
-
-	err = os.MkdirAll(dirPath, 0755)
-	if err != nil {
-		return "", err
-	}
-
-	file, err := os.Create(filePath)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	content := "3529367 (Isolated (((Web))) Co) S 3437358 3433422 3433422 0 -1 4194560 " +
-		"50679 0 0 0 566 643 0 0 20 0 29 0 46236871 2609160192 33222 " +
-		"18446744073709551615 94165013317536 94165014109840 140730010890672 " +
-		"0 0 0 0 16846850 1082134264 0 0 0 17 29 0 0 0 0 0 94165014122560 " +
-		"94165014122664 94165887094784 140730010895394 140730010895699 " +
-		"140730010895699 140730010898399 0\n"
-
-	_, err = file.WriteString(content)
-	if err != nil {
-		return "", err
-	}
-
-	return filePath, nil
-}
-
 func Benchmark_newProcStat(b *testing.B) {
-	filePath, err := createMockStatFile()
-	if err != nil {
-		os.Remove(filePath)
-		b.Fatalf("Failed to create mock stat file: %v", err)
-	}
-	defer os.Remove(filePath)
+	file := tests.CreateTempFile(b, content)
+	defer os.Remove(file.Name())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = newProcStat(filePath)
+		_, _ = newProcStat(file.Name())
 	}
 }

--- a/pkg/utils/proc/stat_bench_test.go
+++ b/pkg/utils/proc/stat_bench_test.go
@@ -13,6 +13,6 @@ func Benchmark_newProcStat(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = newProcStat(file.Name())
+		_, _ = newProcStat(file.Name(), statDefaultFields)
 	}
 }

--- a/pkg/utils/proc/stat_test.go
+++ b/pkg/utils/proc/stat_test.go
@@ -15,6 +15,13 @@ const (
 	maxProcStatLength = 8
 )
 
+// TestProcStat_PrintSizes prints the sizes of the structs used in the ProcStat type.
+// Run it as DEBUG test to see the output.
+func TestProcStat_PrintSizes(t *testing.T) {
+	procStat := ProcStat{}
+	tests.PrintStructSizes(t, os.Stdout, procStat)
+}
+
 func TestProcStatSize(t *testing.T) {
 	t.Parallel()
 
@@ -45,14 +52,14 @@ func TestProcStatSize(t *testing.T) {
 	}
 }
 
-var content = "3529367 (Isolated (((Web))) Co) S 3437358 3433422 3433422 0 -1 4194560 " +
+var statContent = "3529367 (Isolated (((Web))) Co) S 3437358 3433422 3433422 0 -1 4194560 " +
 	"50679 0 0 0 566 643 0 0 20 0 29 0 46236871 2609160192 33222 " +
 	"18446744073709551615 94165013317536 94165014109840 140730010890672 " +
 	"0 0 0 0 16846850 1082134264 0 0 0 17 29 0 0 0 0 0 94165014122560 " +
 	"94165014122664 94165887094784 140730010895394 140730010895699 " +
-	"140730010895699 140730010898399 0\n"
+	"140730010895699 140730010898399 -1\n"
 
-func TestProcStatParsing(t *testing.T) {
+func Test_newProcStat(t *testing.T) {
 	t.Parallel()
 
 	tt := []struct {
@@ -71,12 +78,12 @@ func TestProcStatParsing(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			file := tests.CreateTempFile(t, content)
+			file := tests.CreateTempFile(t, statContent)
 			defer os.Remove(file.Name())
 
 			result, err := newProcStat(file.Name())
 			if err != nil {
-				t.Fatalf("Error parsing the proc stat: %v", err)
+				t.Fatalf("Error creating new ProcStat: %v", err)
 			}
 
 			if !cmp.Equal(*result, tc.expected, cmp.AllowUnexported(ProcStat{})) {

--- a/pkg/utils/proc/stat_test.go
+++ b/pkg/utils/proc/stat_test.go
@@ -81,7 +81,7 @@ func Test_newProcStat(t *testing.T) {
 			file := tests.CreateTempFile(t, statContent)
 			defer os.Remove(file.Name())
 
-			result, err := newProcStat(file.Name())
+			result, err := newProcStat(file.Name(), statDefaultFields)
 			if err != nil {
 				t.Fatalf("Error creating new ProcStat: %v", err)
 			}

--- a/pkg/utils/proc/status.go
+++ b/pkg/utils/proc/status.go
@@ -47,12 +47,12 @@ import (
 // ProcStatus represents the minimal required fields of the /proc status file.
 type ProcStatus struct {
 	name   string // up to 64 chars: https://elixir.bootlin.com/linux/v6.11.4/source/fs/proc/array.c#L99
-	tgid   int
-	pid    int
-	pPid   int
-	nstgid int
-	nspid  int
-	nspgid int
+	tgid   int32
+	pid    int32
+	pPid   int32
+	nstgid int32
+	nspid  int32
+	nspgid int32
 }
 
 type procStatusValueParser func(value string, s *ProcStatus)
@@ -70,13 +70,13 @@ var procStatusValueParserMap = map[string]procStatusValueParser{ // key: status 
 }
 
 // NewThreadProcStatus reads the /proc/<pid>/task/<tid>/status file and parses it into a ProcStatus struct.
-func NewThreadProcStatus(pid, tid int) (*ProcStatus, error) {
+func NewThreadProcStatus(pid, tid int32) (*ProcStatus, error) {
 	taskStatusPath := GetTaskStatusPath(pid, tid)
 	return newProcStatus(taskStatusPath)
 }
 
 // NewProcStatus reads the /proc/<pid>/status file and parses it into a ProcStatus struct.
-func NewProcStatus(pid int) (*ProcStatus, error) {
+func NewProcStatus(pid int32) (*ProcStatus, error) {
 	statusPath := GetStatusPath(pid)
 	return newProcStatus(statusPath)
 }
@@ -130,27 +130,27 @@ func parseName(value string, s *ProcStatus) {
 }
 
 func parseTgid(value string, s *ProcStatus) {
-	s.tgid = parseInt(value)
+	s.tgid, _ = ParseInt32(value)
 }
 
 func parsePid(value string, s *ProcStatus) {
-	s.pid = parseInt(value)
+	s.pid, _ = ParseInt32(value)
 }
 
 func parsePPid(value string, s *ProcStatus) {
-	s.pPid = parseInt(value)
+	s.pPid, _ = ParseInt32(value)
 }
 
 func parseNsTgid(value string, s *ProcStatus) {
-	s.nstgid = parseInt(value)
+	s.nstgid, _ = ParseInt32(value)
 }
 
 func parseNsPid(value string, s *ProcStatus) {
-	s.nspid = parseInt(value)
+	s.nspid, _ = ParseInt32(value)
 }
 
 func parseNsPgid(value string, s *ProcStatus) {
-	s.nspgid = parseInt(value)
+	s.nspgid, _ = ParseInt32(value)
 }
 
 //
@@ -163,31 +163,31 @@ func (s *ProcStatus) GetName() string {
 }
 
 // GetPid returns the process ID.
-func (s *ProcStatus) GetPid() int {
+func (s *ProcStatus) GetPid() int32 {
 	return s.pid
 }
 
 // GetTgid returns the thread group ID.
-func (s *ProcStatus) GetTgid() int {
+func (s *ProcStatus) GetTgid() int32 {
 	return s.tgid
 }
 
 // GetPPid returns the parent process ID.
-func (s *ProcStatus) GetPPid() int {
+func (s *ProcStatus) GetPPid() int32 {
 	return s.pPid
 }
 
 // GetNsPid returns process ID in the namespace of the process.
-func (s *ProcStatus) GetNsPid() int {
+func (s *ProcStatus) GetNsPid() int32 {
 	return s.nspid
 }
 
 // GetNsTgid returns thread group ID in the namespace of the process.
-func (s *ProcStatus) GetNsTgid() int {
+func (s *ProcStatus) GetNsTgid() int32 {
 	return s.nstgid
 }
 
 // GetNsPPid returns process group ID in the namespace of the process.
-func (s *ProcStatus) GetNsPPid() int {
+func (s *ProcStatus) GetNsPPid() int32 {
 	return s.nspgid
 }

--- a/pkg/utils/proc/status.go
+++ b/pkg/utils/proc/status.go
@@ -1,52 +1,133 @@
 package proc
 
 import (
-	"bufio"
 	"bytes"
-	"os"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 //
 // ProcStatus
-// https://elixir.bootlin.com/linux/v6.11.4/source/fs/proc/array.c#L439
+// https://elixir.bootlin.com/linux/v6.13/source/fs/proc/array.c#L444
+// https://man7.org/linux/man-pages/man5/proc_pid_status.5.html
 //
 
-// Most common fields from /proc/<pid>/[task/<tid>/]status file:
-//
-// Name           string   // Name of the process
-// State          string   // State of the process
-// Tgid           int      // Thread group ID
-// Ngid           int      // NUMA group ID (if available)
-// Pid            int      // Process ID
-// PPid           int      // Parent Process ID
-// TracerPid      int      // PID of process tracing this process
-// Uid            [4]int   // Real, effective, saved set, and filesystem UIDs
-// Gid            [4]int   // Real, effective, saved set, and filesystem GIDs
-// FDSize         int      // Number of file descriptor slots currently allocated
-// Groups         []int    // Supplementary group list
-// NStgid         int      // Thread group ID in the namespace of the process
-// NSpid          int      // Process ID in the namespace of the process
-// NSpgid         int      // Process group ID in the namespace of the process
-// NSsid          int      // Session ID in the namespace of the process
-// VmPeak         int64    // Peak virtual memory size
-// VmSize         int64    // Total program size
-// VmLck          int64    // Locked memory size
-// VmPin          int64    // Pinned memory size (guaranteed never to be swapped out)
-// VmHWM          int64    // Peak resident set size ("high water mark")
-// VmRSS          int64    // Resident set size
-// VmData         int64    // Size of data
-// VmStk          int64    // Size of stack
-// VmExe          int64    // Size of text segments
-// VmLib          int64    // Shared library code size
-// VmPTE          int64    // Page table entries size
-// VmSwap         int64    // Swap size
-// Threads        int      // Number of threads in process
-//
-// ...
+type StatusField byte
+
+// Fields from /proc/<pid>/[task/<tid>/]status file:
+const (
+	//                        // parse type  // fmt  // kernel C type            // description
+	//                        // ----------  // ---  // ----------------------   // ----------------------------------------------------------------------
+	Name StatusField = iota // string         %s      char[64]                 // Name of the process
+	// if umask >= 0
+	Umask //                     int32          %#04o   int                      // Process umask, expressed in octal with a leading zero
+	// endif umask >= 0
+	//
+	State     //                 byte           %c      char                     // State of the process (leftmost char of the field)
+	Tgid      //                 uint64         %llu    pid_t (int)              // Thread group ID
+	Ngid      //                 uint64         %llu    pid_t (int)              // NUMA group ID (if available)
+	Pid       //                 uint64         %llu    pid_t (int)              // Process ID
+	PPid      //                 uint64         %llu    pid_t (int)              // Parent Process ID
+	TracerPid //                 uint64         %llu    pid_t (int)              // PID of process tracing this process
+	Uid
+	// (separator is '\t')
+	// UidReal                   uint64         %llu    uid_t (unsigned int)     // Real UID
+	// UidEffective              uint64         %llu    uid_t (unsigned int)     // Effective UID
+	// UidSaved                  uint64         %llu    uid_t (unsigned int)     // Saved set UID
+	// UidFS                     uint64         %llu    uid_t (unsigned int)     // Filesystem UID
+	Gid
+	// (separator is '\t')
+	// GidReal                   uint64         %llu    gid_t (unsigned int)     // Real GID
+	// GidEffective              uint64         %llu    gid_t (unsigned int)     // Effective GID
+	// GidSaved                  uint64         %llu    gid_t (unsigned int)     // Saved set GID
+	// GidFS                     uint64         %llu    gid_t (unsigned int)     // Filesystem GID
+	FDSize //                    uint64         %llu    unsigned int             // Number of file descriptor slots currently allocated
+	Groups //                    []uint64       %llu    gid_t (unsigned int)     // Supplementary group list (separator is ' ')
+	//
+	// #ifdef CONFIG_PID_NS
+	NStgid  //                   []uint64       %llu    pid_t (int)              // Thread group ID in each of the PID namespaces of which pid is a member
+	NSpid   //                   []uint64       %llu    pid_t (int)              // Thread ID in each of the PID namespaces of which pid is a member
+	NSpgid  //                   []uint64       %llu    pid_t (int)              // Process group ID in each of the PID namespaces of which pid is a member
+	NSsid   //                   []uint64       %llu    pid_t (int)              // Namespace session ID in each of the PID namespaces of which pid is a member
+	Kthread //                   bool           %c      char                     // Is the process a kernel thread? (0 = no, 1 = yes)
+	// #endif // CONFIG_PID_NS
+	//
+	// if mm != NULL
+	VmPeak       //              uint64         %8llu   unsigned long            // Peak virtual memory size (kB)
+	VmSize       //              uint64         %8llu   unsigned long            // Total program size (kB)
+	VmLck        //              uint64         %8llu   unsigned long            // Locked memory size (kB)
+	VmPin        //              uint64         %8llu   s64                      // Pinned memory size (guaranteed never to be swapped out) (kB)
+	VmHWM        //              uint64         %8llu   unsigned long            // Peak resident set size ("high water mark") (kB)
+	VmRSS        //              uint64         %8llu   unsigned long            // Resident set size (kB)
+	RssAnon      //              uint64         %8llu   unsigned long            // Size of resident anonymous memory (kB)
+	RssFile      //              uint64         %8llu   unsigned long            // Size of resident file mappings (kB)
+	RssShmem     //              uint64         %8llu   unsigned long            // Size of shared memory resident (kB)
+	VmData       //              uint64         %8llu   unsigned long            // Size of data segment (kB)
+	VmStk        //              uint64         %8llu   unsigned long            // Size of stack segment (kB)
+	VmExe        //              uint64         %8llu   unsigned long            // Size of text segment (kB)
+	VmLib        //              uint64         %8llu   unsigned long            // Shared library code size (kB)
+	VmPTE        //              uint64         %8llu   unsigned long            // Page table entries size (kB)
+	VmSwap       //              uint64         %8llu   unsigned long            // Swap size (kB)
+	HugetlbPages //              uint64         %8lu    long                     // Size of hugetlb memory portions (kB)
+	// endif mm != NULL
+	//
+	CoreDumping //               bool           %llu    int                      // Is the process dumping core? (0 = no, 1 = yes)
+	THPEnabled  //               bool           %d      bool                     // Is transparent huge pages enabled? (0 = no, 1 = yes)
+	UntagMask   //               uint64         %#lx    unsigned long            // Untag mask
+	Threads     //               uint64         %llu    int                      // Number of threads in process containing this thread
+	SigQ
+	// (separator is '/')
+	// SigQ                      uint64         %llu    unsigned int             // Number of signals queued for the thread
+	// SigQLimit                 uint64         %llu    unsigned long            // Resource limit on number of signals that can be queued
+	SigPnd //                    uint64         %016llx sigset_t (unsigned long) // Mask of signals pending for the thread
+	ShdPnd //                    uint64         %016llx sigset_t (unsigned long) // Mask of signals that thread is sharing
+	SigBlk //                    uint64         %016llx sigset_t (unsigned long) // Mask of signals being blocked
+	SigIgn //                    uint64         %016llx sigset_t (unsigned long) // Mask of signals being ignored
+	SigCgt //                    uint64         %016llx sigset_t (unsigned long) // Mask of signals being caught
+	//
+	CapInh     //                uint64         %016llx cap_user_header_t (u64)  // Mask of inheritable capabilities
+	CapPrm     //                uint64         %016llx cap_user_header_t (u64)  // Mask of permitted capabilities
+	CapEff     //                uint64         %016llx cap_user_header_t (u64)  // Mask of effective capabilities
+	CapBnd     //                uint64         %016llx cap_user_header_t (u64)  // Mask of capabilities bounding set
+	CapAmb     //                uint64         %016llx cap_user_header_t (u64)  // Ambient capability set
+	NoNewPrivs //                bool           %d      bool                     // Was the process started with no new privileges? (0 = no, 1 = yes)
+	//
+	// #ifdef CONFIG_SECCOMP
+	Seccomp //                   uint64         %llu    int                      // Seccomp mode of the process
+	// #endif // CONFIG_SECCOMP
+	//
+	// #ifdef CONFIG_SECCOMP_FILTER
+	Seccomp_filters //           uint64         %llu    int                      // Number of seccomp filters attached to the process
+	// #endif // CONFIG_SECCOMP_FILTER
+	//
+	SpeculationStoreBypass    // string         %s      char *                   // Speculation flaw mitigation state
+	SpeculationIndirectBranch // string         %s      char *                   // Speculation indirect branch mitigation state
+	//
+	CpusAllowed     //           uint64         %016llx unsigned long            // Mask of CPUs on which this process may run
+	CpusAllowedList //           string         %s      char *                   // Same as previous, but in "list format" (e.g. "0-3,5,7")
+	//
+	MemsAllowed     //           uint64         %016llx unsigned long            // Mask of memory nodes allowed to this process
+	MemsAllowedList //           string         %s      char *                   // Same as previous, but in "list format" (e.g. "0-3,5,7")
+	//
+	VoluntaryCtxtSwitches    //  uint64         %llu    unsigned long            // Number of voluntary context switches
+	NonVoluntaryCtxtSwitches //  uint64         %llu    unsigned long            // Number of involuntary context switches
+	//
+	// #ifdef CONFIG_X86_USER_SHADOW_STACK
+	x86ThreadFeatures       //   string         %s      char *                   // x86 Thread features
+	x86ThreadFeaturesLocked //   string         %s      char *                   // x86 Thread features locked
+	// #endif // CONFIG_X86_USER_SHADOW_STACK
+	//
+)
+
+const (
+	StatusLastField                 = x86ThreadFeaturesLocked
+	StatusMaxNumFields              = StatusLastField + 1
+	StatusReadFileInitialBufferSize = 1480 // greater than average size (~1290) calculated from ~700 status files
+)
 
 // ProcStatus represents the minimal required fields of the /proc status file.
 type ProcStatus struct {
-	name   string // up to 64 chars: https://elixir.bootlin.com/linux/v6.11.4/source/fs/proc/array.c#L99
+	name   string // up to 64 chars: https://elixir.bootlin.com/linux/v6.13/source/fs/proc/array.c#L101
 	tgid   int32
 	pid    int32
 	pPid   int32
@@ -55,18 +136,20 @@ type ProcStatus struct {
 	nspgid int32
 }
 
-type procStatusValueParser func(value string, s *ProcStatus)
+type procStatusParser struct {
+	fieldName []byte
+	parse     func(value []byte, s *ProcStatus)
+}
 
-// procStatusValueParserMap maps the keys in the status file to their respective value parsers.
-// If a key is not present in the map, it is ignored on parsing.
-var procStatusValueParserMap = map[string]procStatusValueParser{ // key: status file key, value: parser function
-	"Name":   parseName,
-	"Tgid":   parseTgid,
-	"Pid":    parsePid,
-	"PPid":   parsePPid,
-	"NStgid": parseNsTgid,
-	"NSpid":  parseNsPid,
-	"NSpgid": parseNsPgid,
+// procStatusValueParserArray maps the indexes of the status lines (fields) to their respective value parsers.
+var procStatusValueParserArray = [StatusMaxNumFields]procStatusParser{
+	Name:   {fieldName: []byte("Name"), parse: parseName},
+	Tgid:   {fieldName: []byte("Tgid"), parse: parseTgid},
+	Pid:    {fieldName: []byte("Pid"), parse: parsePid},
+	PPid:   {fieldName: []byte("PPid"), parse: parsePPid},
+	NStgid: {fieldName: []byte("NStgid"), parse: parseNsTgid},
+	NSpid:  {fieldName: []byte("NSpid"), parse: parseNsPid},
+	NSpgid: {fieldName: []byte("NSpgid"), parse: parseNsPgid},
 }
 
 // NewThreadProcStatus reads the /proc/<pid>/task/<tid>/status file and parses it into a ProcStatus struct.
@@ -82,75 +165,115 @@ func NewProcStatus(pid int32) (*ProcStatus, error) {
 }
 
 func newProcStatus(filePath string) (*ProcStatus, error) {
-	file, err := os.Open(filePath)
+	statusBytes, err := ReadFile(filePath, StatusReadFileInitialBufferSize)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		_ = file.Close()
-	}()
 
-	status := &ProcStatus{}
-	remainingFields := len(procStatusValueParserMap)
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		parts := bytes.SplitN(line, []byte(":"), 2)
-		if len(parts) < 2 {
-			continue
-		}
-		key := parts[0]
-		value := bytes.TrimSpace(parts[1])
-
-		parseValue, ok := procStatusValueParserMap[string(key)]
-		if !ok {
-			// unknown key or not required, see procStatusValueParserMap and ProcStatus struct
-			continue
-		}
-
-		parseValue(string(value), status)
-		remainingFields--
-		if remainingFields == 0 {
-			break
-		}
+	// Fields to parse from the status file.
+	// Even though a subset, they must be in the correct order.
+	fields := []StatusField{
+		Name,
+		Tgid,
+		Pid,
+		PPid,
+		NStgid,
+		NSpid,
+		NSpgid,
 	}
 
-	if err := scanner.Err(); err != nil {
+	status := &ProcStatus{}
+	err = status.parse(statusBytes, fields)
+	if err != nil {
 		return nil, err
 	}
 
 	return status, nil
 }
 
+// parse parses the status file for the required fields filling the ProcStatus struct.
+// fields can be a subset but must always be ordered as in the StatusField enum.
+func (s *ProcStatus) parse(statusBytes []byte, fields []StatusField) error {
+	if len(statusBytes) == 0 {
+		return errfmt.Errorf("empty status file")
+	}
+	if len(fields) == 0 {
+		return errfmt.Errorf("none status fields specified")
+	}
+
+	fieldsNeeded := len(fields)
+
+	// single-pass parsing of the status file
+	pos := 0
+	for pos < len(statusBytes) && fieldsNeeded > 0 {
+		// find end of the current line
+		end := bytes.IndexByte(statusBytes[pos:], '\n')
+		if end == -1 {
+			end = len(statusBytes)
+		} else {
+			end += pos
+		}
+
+		line := statusBytes[pos:end]
+		field := fields[len(fields)-fieldsNeeded]
+		parser := procStatusValueParserArray[field]
+
+		if !bytes.HasPrefix(line, parser.fieldName) {
+			pos = end + 1 // move to the beginning of the next line
+			continue
+		}
+
+		// field found, parse the value
+
+		// find the first non-space/tab character after the colon
+		valueStart := len(parser.fieldName) + 1
+		for i := valueStart; i < len(line); i++ {
+			if line[i] != ' ' && line[i] != '\t' {
+				valueStart = i
+				break
+			}
+		}
+
+		value := line[valueStart:]
+		parser.parse(value, s)
+		fieldsNeeded--
+	}
+
+	if fieldsNeeded > 0 {
+		return errfmt.Errorf("failed to parse all required fields from status file")
+	}
+
+	return nil
+}
+
 // status fields parsers
 
-func parseName(value string, s *ProcStatus) {
-	s.name = parseString(value)
+func parseName(value []byte, s *ProcStatus) {
+	s.name = string(value)
 }
 
-func parseTgid(value string, s *ProcStatus) {
-	s.tgid, _ = ParseInt32(value)
+func parseTgid(value []byte, s *ProcStatus) {
+	s.tgid, _ = ParseInt32(string(value))
 }
 
-func parsePid(value string, s *ProcStatus) {
-	s.pid, _ = ParseInt32(value)
+func parsePid(value []byte, s *ProcStatus) {
+	s.pid, _ = ParseInt32(string(value))
 }
 
-func parsePPid(value string, s *ProcStatus) {
-	s.pPid, _ = ParseInt32(value)
+func parsePPid(value []byte, s *ProcStatus) {
+	s.pPid, _ = ParseInt32(string(value))
 }
 
-func parseNsTgid(value string, s *ProcStatus) {
-	s.nstgid, _ = ParseInt32(value)
+func parseNsTgid(value []byte, s *ProcStatus) {
+	s.nstgid, _ = ParseInt32(string(value))
 }
 
-func parseNsPid(value string, s *ProcStatus) {
-	s.nspid, _ = ParseInt32(value)
+func parseNsPid(value []byte, s *ProcStatus) {
+	s.nspid, _ = ParseInt32(string(value))
 }
 
-func parseNsPgid(value string, s *ProcStatus) {
-	s.nspgid, _ = ParseInt32(value)
+func parseNsPgid(value []byte, s *ProcStatus) {
+	s.nspgid, _ = ParseInt32(string(value))
 }
 
 //

--- a/pkg/utils/proc/status.go
+++ b/pkg/utils/proc/status.go
@@ -3,7 +3,6 @@ package proc
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"os"
 )
 
@@ -72,14 +71,14 @@ var procStatusValueParserMap = map[string]procStatusValueParser{ // key: status 
 
 // NewThreadProcStatus reads the /proc/<pid>/task/<tid>/status file and parses it into a ProcStatus struct.
 func NewThreadProcStatus(pid, tid int) (*ProcStatus, error) {
-	filePath := fmt.Sprintf("/proc/%v/task/%v/status", pid, tid)
-	return newProcStatus(filePath)
+	taskStatusPath := GetTaskStatusPath(pid, tid)
+	return newProcStatus(taskStatusPath)
 }
 
 // NewProcStatus reads the /proc/<pid>/status file and parses it into a ProcStatus struct.
 func NewProcStatus(pid int) (*ProcStatus, error) {
-	filePath := fmt.Sprintf("/proc/%v/status", pid)
-	return newProcStatus(filePath)
+	statusPath := GetStatusPath(pid)
+	return newProcStatus(statusPath)
 }
 
 func newProcStatus(filePath string) (*ProcStatus, error) {

--- a/pkg/utils/proc/status_bench_test.go
+++ b/pkg/utils/proc/status_bench_test.go
@@ -13,6 +13,6 @@ func Benchmark_newProcStatus(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = newProcStatus(file.Name())
+		_, _ = newProcStatus(file.Name(), statusDefaultFields)
 	}
 }

--- a/pkg/utils/proc/status_bench_test.go
+++ b/pkg/utils/proc/status_bench_test.go
@@ -7,106 +7,12 @@ import (
 	"github.com/aquasecurity/tracee/pkg/utils/tests"
 )
 
-func createMockStatusFile() (string, error) {
-	dirPath := "/tmp/tracee-test"
-	filePath, err := tests.GenerateTimestampFileName(dirPath, "status")
-	if err != nil {
-		return "", err
-	}
-
-	err = os.MkdirAll(dirPath, 0755)
-	if err != nil {
-		return "", err
-	}
-
-	file, err := os.Create(filePath)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
-	content := `
-Name:   Utility Process
-Umask:  0022
-State:  R (running)
-Tgid:   216447
-Ngid:   0
-Pid:    216447
-PPid:   3994523
-TracerPid:      0
-Uid:    1000    1000    1000    1000
-Gid:    1000    1000    1000    1000
-FDSize: 128
-Groups: 3 90 98 108 955 959 986 991 998 1000 
-NStgid: 216447
-NSpid:  216447
-NSpgid: 216447
-NSsid:  3994523
-Kthread:        0
-VmPeak:    10392 kB
-VmSize:    10356 kB
-VmLck:         0 kB
-VmPin:         0 kB
-VmHWM:      6400 kB
-VmRSS:      6400 kB
-RssAnon:            1536 kB
-RssFile:            4864 kB
-RssShmem:              0 kB
-VmData:     1384 kB
-VmStk:       136 kB
-VmExe:      2860 kB
-VmLib:      2372 kB
-VmPTE:        64 kB
-VmSwap:        0 kB
-HugetlbPages:          0 kB
-CoreDumping:    0
-THP_enabled:    1
-untag_mask:     0xffffffffffffffff
-Threads:        1
-SigQ:   0/253444
-SigPnd: 0000000000000000
-ShdPnd: 0000000000000000
-SigBlk: 0000000000000000
-SigIgn: 0000000000001000
-SigCgt: 0000000000000440
-CapInh: 0000000000000000
-CapPrm: 0000000000000000
-CapEff: 0000000000000000
-CapBnd: 000001ffffffffff
-CapAmb: 0000000000000000
-NoNewPrivs:     0
-Seccomp:        0
-Seccomp_filters:        0
-Speculation_Store_Bypass:       thread vulnerable
-SpeculationIndirectBranch:      conditional enabled
-Cpus_allowed:   ffffffff
-Cpus_allowed_list:      0-31
-Mems_allowed:   00000001
-Mems_allowed_list:      0
-voluntary_ctxt_switches:        1
-nonvoluntary_ctxt_switches:     0
-x86_Thread_features:
-x86_Thread_features_locked:
-`
-
-	_, err = file.WriteString(content)
-	if err != nil {
-		return "", err
-	}
-
-	return filePath, nil
-}
-
 func Benchmark_newProcStatus(b *testing.B) {
-	filePath, err := createMockStatusFile()
-	if err != nil {
-		os.Remove(filePath)
-		b.Fatalf("Failed to create mock status file: %v", err)
-	}
-	defer os.Remove(filePath)
+	file := tests.CreateTempFile(b, statusContent)
+	defer os.Remove(file.Name())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = newProcStatus(filePath)
+		_, _ = newProcStatus(file.Name())
 	}
 }

--- a/pkg/utils/proc/status_test.go
+++ b/pkg/utils/proc/status_test.go
@@ -1,16 +1,19 @@
 package proc
 
 import (
+	"os"
 	"testing"
 	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
 )
 
 const (
 	// ensure that the test will fail if the ProcStatus struct size changes
 	maxProcStatusNameLength = 64 // https://elixir.bootlin.com/linux/v6.11.4/source/fs/proc/array.c#L99
-	maxProcStatusLength     = 128
+	maxProcStatusLength     = 104
 )
 
 func TestProcStatusSize(t *testing.T) {
@@ -24,12 +27,12 @@ func TestProcStatusSize(t *testing.T) {
 		{
 			name:         "Empty string",
 			input:        ProcStatus{name: ""},
-			expectedSize: 64, // 64 bytes struct = 48 bytes (6 * int) + 16 bytes (string = 8 bytes pointer + 8 bytes length)
+			expectedSize: 40, // 40 bytes struct = [24 bytes (6 * int32)] + [16 bytes (string = 8 bytes pointer + 8 bytes length)]
 		},
 		{
 			name:         "String with 64 characters (max length)",
 			input:        ProcStatus{name: string(make([]byte, maxProcStatusNameLength))},
-			expectedSize: maxProcStatusLength, // 128 bytes struct = 48 bytes (6 * int) + 16 bytes (string = 8 bytes pointer + 8 bytes length) + 64 bytes (string content)
+			expectedSize: maxProcStatusLength, // 104 bytes struct = [24 bytes (6 * int32)] + [16 bytes (string = 8 bytes pointer + 8 bytes length)] + [64 bytes (string content)]
 		},
 	}
 
@@ -44,6 +47,13 @@ func TestProcStatusSize(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProcStatus_PrintSizes prints the sizes of the structs used in the ProcStatus type.
+// Run it as DEBUG test to see the output.
+func TestProcStatus_PrintSizes(t *testing.T) {
+	procStatus := ProcStatus{}
+	tests.PrintStructSizes(t, os.Stdout, procStatus)
 }
 
 func TestProcStatusParsing(t *testing.T) {

--- a/pkg/utils/proc/status_test.go
+++ b/pkg/utils/proc/status_test.go
@@ -148,7 +148,7 @@ func Test_newProcStatus(t *testing.T) {
 			file := tests.CreateTempFile(t, statusContent)
 			defer os.Remove(file.Name())
 
-			result, err := newProcStatus(file.Name())
+			result, err := newProcStatus(file.Name(), statusDefaultFields)
 			if err != nil {
 				t.Fatalf("Error parsing the proc status: %v", err)
 			}

--- a/pkg/utils/tests/helpers.go
+++ b/pkg/utils/tests/helpers.go
@@ -2,7 +2,11 @@ package tests
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
+	"reflect"
+	"testing"
 	"time"
 )
 
@@ -11,4 +15,67 @@ func GenerateTimestampFileName(dir string, filenamePrefix string) (string, error
 	fullPath := filepath.Join(dir, fmt.Sprintf("%s_%s", filenamePrefix, timestamp))
 
 	return fullPath, nil
+}
+
+// PrintStructSizes prints the size of a struct and the size of its fields
+func PrintStructSizes(tb testing.TB, w io.Writer, structure interface{}) {
+	tb.Helper()
+
+	typ := reflect.TypeOf(structure)
+
+	// if the type is a pointer to a struct, dereference it
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	if typ.Kind() != reflect.Struct {
+		fmt.Fprintf(w, "Type %s is not a struct\n", typ.Kind())
+		return
+	}
+
+	totalSize := typ.Size()
+	expectedSize := uintptr(0)
+	fieldsInfo := "["
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		fieldSize := field.Type.Size()
+		fieldOffset := field.Offset
+		fieldsInfo += fmt.Sprintf(
+			"%s:%s %d bytes (offset=%d), ",
+			field.Name, field.Type.String(), fieldSize, fieldOffset,
+		)
+		expectedSize += fieldSize
+	}
+
+	padding := totalSize - expectedSize
+	paddingInfo := ""
+	if padding > 0 {
+		paddingInfo = "(has padding)"
+	}
+
+	// remove trailing comma and space
+	if len(fieldsInfo) > 2 {
+		fieldsInfo = fieldsInfo[:len(fieldsInfo)-2]
+	}
+	fieldsInfo += "]"
+
+	fmt.Fprintf(w, "%s: %d bytes %s %s\n", typ.Name(), totalSize, fieldsInfo, paddingInfo)
+}
+
+func CreateTempFile(tb testing.TB, content string) *os.File {
+	tb.Helper()
+
+	file, err := os.CreateTemp("", "test_temp_file_*.txt")
+	if err != nil {
+		tb.Fatalf("Failed to create temp file: %v", err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		tb.Fatalf("Failed to write to temp file: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		tb.Fatalf("Failed to close temp file: %v", err)
+	}
+
+	return file
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,10 +1,7 @@
 package utils
 
 import (
-	"fmt"
-	"io"
 	"math/rand"
-	"reflect"
 	"time"
 )
 
@@ -65,48 +62,4 @@ func ReverseString(s string) string {
 		bytes[n-i-1] = s[i]
 	}
 	return string(bytes)
-}
-
-// PrintStructSizes prints the size of a struct and the size of its fields
-func PrintStructSizes(w io.Writer, structure interface{}) {
-	typ := reflect.TypeOf(structure)
-
-	// if the type is a pointer to a struct, dereference it
-	if typ.Kind() == reflect.Ptr {
-		typ = typ.Elem()
-	}
-
-	if typ.Kind() != reflect.Struct {
-		fmt.Fprintf(w, "Type %s is not a struct\n", typ.Kind())
-		return
-	}
-
-	totalSize := typ.Size()
-	expectedSize := uintptr(0)
-	fieldsInfo := "["
-
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		fieldSize := field.Type.Size()
-		fieldOffset := field.Offset
-		fieldsInfo += fmt.Sprintf(
-			"%s:%s %d bytes (offset=%d), ",
-			field.Name, field.Type.String(), fieldSize, fieldOffset,
-		)
-		expectedSize += fieldSize
-	}
-
-	padding := totalSize - expectedSize
-	paddingInfo := ""
-	if padding > 0 {
-		paddingInfo = "(has padding)"
-	}
-
-	// remove trailing comma and space
-	if len(fieldsInfo) > 2 {
-		fieldsInfo = fieldsInfo[:len(fieldsInfo)-2]
-	}
-	fieldsInfo += "]"
-
-	fmt.Fprintf(w, "%s: %d bytes %s %s\n", typ.Name(), totalSize, fieldsInfo, paddingInfo)
 }

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -244,11 +244,12 @@ func assureIsRoot(t *testing.T) {
 }
 
 func getProcNS(nsName string) string {
-	pid := syscall.Getpid()
-	nsID, err := uproc.GetProcNS(uint(pid), nsName)
+	pidInt := syscall.Getpid()
+	pid := int32(pidInt)
+	nsID, err := uproc.GetProcNS(pid, nsName)
 	if err != nil {
 		panic(err)
 	}
 
-	return strconv.Itoa(nsID)
+	return strconv.FormatUint(uint64(nsID), 10)
 }


### PR DESCRIPTION
Ran these in `main` and `procfs-work` branches:

`dist/tracee --metrics --pyroscope --pprof -s tree=2609608 -e sched_process_exec,sched_process_fork,sched_process_exit --proctree source=both  --proctree disable-procfs -o none`
`dist/tracee --metrics --pyroscope --pprof -s tree=2241901 -e sched_process_exec,sched_process_fork,sched_process_exit --proctree source=both  -o none`

Stressor details:

Details
`8 threads with 1_000_000 ops each` running on:

cpu: AMD Ryzen 9 7950X 16-Core Processor
MemTotal: 64923992 kB (64GB)

```
| Metric        | NO procfs (%) | WITH procfs  (%) |
|---------------|--------------:|-----------------:|
| CPU avg       | -2.65%        | -28.46%          |
| Malloc avg    | -1.56%        | -22.60%          |
| Heap avg      | -1.94%        | +5.65%           |
| Heap obj avg  | -0.52%        | +1.82%           |
```

**NOTE:** You may notice that the `WITH procfs` Heap values ​​have increased - it is a side effect of the CPU time improvement in the proc package. Since the process termination window has been reduced (from feed request to proc file reading), more child processes have been added to the Process still living in LRU.

Close: #4547 

### 1. Explain what the PR does

c5be62d6e **perf(proctree): remove stat call**
d474eeb0d **chore: introduce builders with specific fields**
c7178632a **perf(proc): improve ns**
8fc7eb389 **perf(proc): improve status file parsing**
7471ae27b **perf(proctree/proc): align fields to real size**
764ba4abd **perf(proc): improve stat file parsing**
2afe59496 **perf(proc): introduce ReadFile for /proc**
d6818c109 **perf(proc): use formatters for procfs file paths**


c5be62d6e **perf(proctree): remove stat call**

```
Calling stat on /proc/<pid> would only increase the window for
process termination between the stat call and the read of the file.

This also replaces fmt.Sprintf with string concatenation and
strconv.FormatInt for better performance.
```

d474eeb0d **chore: introduce builders with specific fields**

```
- NewProcStatFields()
- NewThreadStatFields()
- NewProcStatusFields()
- NewThreadStatusFields()
```

c7178632a **perf(proc): improve ns**

```
Reduce ProcNS memory footprint by using the right member type sizes -
namespace id is an uint32, since it is the inode number in
struct ns_common.

This change also improves the performance of GetAllProcNS(), GetProcNS()
and GetMountNSFirstProcesses().
```

8fc7eb389 **perf(proc): improve status file parsing**

```
Remove the use of library functions to parse the status file and instead
parse it manually (on the fly) to reduce the number of allocations and
improve performance.
```

7471ae27b **perf(proctree/proc): align fields to real size**

```
Propagate values based on its real size which in most cases is smaller
than int (64-bit). This change reduces the memory footprint or at least
the stress on the stack/heap.
```

764ba4abd **perf(proc): improve stat file parsing**

```
Remove the use of library functions to parse the stat file and instead
parse it manually (on the fly) to reduce the number of allocations and
improve performance.

chore(proc): align parsing of stat field with the formats size

This also align parsing sizes with the formats to avoid wrong parsing
of the stat file. The internal fields are represented aligned with the
actual kernel fields to avoid any confusion (signed/unsigned).
```

2afe59496 **perf(proc): introduce ReadFile for /proc**

```
`os.ReadFile` is not efficient for reading files in `/proc` because it
attempts to determine the file size before reading. This step is
unnecessary for `/proc` files, as they are virtual files with sizes
that are often reported as unknown or `0`.

`proc.ReadFile` is a new function designed specifically for reading
files in `/proc`. It reads directly into a buffer and is more efficient
than `os.ReadFile` because it allows tuning the initial buffer size to
better suit the characteristics of `/proc` files.

Running tool: /home/gg/.goenv/versions/1.22.4/bin/go test -benchmem
-run=^$ -tags ebpf -bench ^BenchmarkReadFile$
github.com/aquasecurity/tracee/pkg/utils/proc -benchtime=10000000x

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/utils/proc
cpu: AMD Ryzen 9 7950X 16-Core Processor
BenchmarkReadFile/ProcFSReadFile/Empty_File-32        10000000  3525 ns/op  408 B/op  4 allocs/op
BenchmarkReadFile/OsReadFile/Empty_File-32            10000000  4070 ns/op  872 B/op  5 allocs/op
BenchmarkReadFile/ProcFSReadFile/Small_File-32        10000000  3961 ns/op  408 B/op  4 allocs/op
BenchmarkReadFile/OsReadFile/Small_File-32            10000000  4538 ns/op  872 B/op  5 allocs/op
BenchmarkReadFile/ProcFSReadFile/Exact_Buffer_Size-32 10000000  4229 ns/op  920 B/op  5 allocs/op
BenchmarkReadFile/OsReadFile/Exact_Buffer_Size-32     10000000  4523 ns/op  872 B/op  5 allocs/op
BenchmarkReadFile/ProcFSReadFile_/proc/self/stat-32   10000000  4043 ns/op  408 B/op  4 allocs/op
BenchmarkReadFile/OsReadFile_/proc/self/stat-32       10000000  4585 ns/op  872 B/op  5 allocs/op
PASS
ok  	github.com/aquasecurity/tracee/pkg/utils/proc	334.751s
```

d6818c109 **perf(proc): use formatters for procfs file paths**

```
Since the type of the converted primitive is already known, formatter
helpers should be used to construct procfs file paths instead of relying
on `fmt.Sprintf`. Using `fmt.Sprintf` is relatively costly due to its
internal formatting logic, which is unnecessary for simple path
construction.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
