### PR TITLE
feat: reapply: remove default usage of parse-arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61
 	github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72
-	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241225084355-5b8f456dae7b
+	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250123101549-f57a1ebab93a
 	github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155
 	github.com/containerd/containerd v1.7.25
 	github.com/docker/docker v26.1.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61
 github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61/go.mod h1:HB2DYWHuMraOB0IFcfjL8tsxN8TcFOdWKTrNqnHrTrs=
 github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72 h1:M1G3ttGcozWGfMMlD2nbdCgskGkAHSIVMsodRykOYSE=
 github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72/go.mod h1:mSYGLfhjpcLq78gjb4/XDQaY8DhfpDNAuLD0tvU2bZc=
-github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241225084355-5b8f456dae7b h1:eTIrU0vdn49P0LhtEypnSdGgoRzLvNPAGivGHPnCBXg=
-github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20241225084355-5b8f456dae7b/go.mod h1:DL+Q2DxyS7dpJGt4NVj26XbPiE2bjRK4vwqrmImr6Go=
+github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250123101549-f57a1ebab93a h1:xCyaZJpgUgtpjKgrjQffKAjhz9jw3c0niMwtre2gh/E=
+github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250123101549-f57a1ebab93a/go.mod h1:ea2x/5u4oOKJiuZsbPaa9WJlldZehprNsCTNhjeWYrs=
 github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155 h1:SOcc74U3FXyGJFfSV1QvI0I8VmXBHneq2y9suAdqmT4=
 github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155/go.mod h1:qG8nK8fjdHLTWAlTqDjCdxBuBUge2PyK5SHX/tfrxfY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -82,28 +82,16 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 			// arguments parsing) can affect engine stage.
 			eventCopy := *event
 
-			// if t.config.Output.ParseArguments {
-			// 	// shallow clone the event arguments before parsing them (new slice is created),
-			// 	// to keep the eventCopy with raw arguments.
-			// 	eventCopy.Args = slices.Clone(event.Args)
-
-			// 	err := t.parseArguments(event)
-			// 	if err != nil {
-			// 		t.handleError(err)
-			// 		return
-			// 	}
-			// }
-
-			// This is a workaround to keep working with parsed arguments in the engine stage.
-			// Once fully migrated, this should be reverted to the commented code above
-			eventCopy.Args = slices.Clone(event.Args)
-			err := t.parseArguments(&eventCopy)
-			if err != nil {
-				t.handleError(err)
-				return
-			}
 			if t.config.Output.ParseArguments {
-				event.Args = slices.Clone(eventCopy.Args)
+				// shallow clone the event arguments before parsing them (new slice is created),
+				// to keep the eventCopy with raw arguments.
+				eventCopy.Args = slices.Clone(event.Args)
+
+				err := t.parseArguments(event)
+				if err != nil {
+					t.handleError(err)
+					return
+				}
 			}
 
 			// pass the event to the sink stage, if the event is also marked as emit

--- a/pkg/signatures/benchmark/signature/golang/code_injection.go
+++ b/pkg/signatures/benchmark/signature/golang/code_injection.go
@@ -65,11 +65,11 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	}
 	switch ee.EventName {
 	case "open", "openat":
-		flags, err := helpers.GetTraceeArgumentByName(ee, "flags", helpers.GetArgOps{DefaultArgs: false})
+		flags, err := helpers.GetTraceeIntArgumentByName(ee, "flags")
 		if err != nil {
 			return fmt.Errorf("%v %#v", err, ee)
 		}
-		if helpers.IsFileWrite(flags.Value.(string)) {
+		if helpers.IsFileWrite(flags) {
 			pathname, err := helpers.GetTraceeArgumentByName(ee, "pathname", helpers.GetArgOps{DefaultArgs: false})
 			if err != nil {
 				return err

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,12 +12,12 @@ import (
 
 type AntiDebuggingPtraceme struct {
 	cb            detect.SignatureHandler
-	ptraceTraceMe string
+	ptraceTraceMe int
 }
 
 func (sig *AntiDebuggingPtraceme) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptraceTraceMe = "PTRACE_TRACEME"
+	sig.ptraceTraceMe = int(parsers.PTRACE_TRACEME.Value())
 	return nil
 }
 
@@ -52,7 +53,7 @@ func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/anti_debugging_ptraceme_test.go
+++ b/signatures/golang/anti_debugging_ptraceme_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_TRACEME"),
+							Value: interface{}(int64(parsers.PTRACE_TRACEME.Value())),
 						},
 					},
 				},
@@ -44,7 +45,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_TRACEME"),
+								Value: interface{}(int64(parsers.PTRACE_TRACEME.Value())),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +77,7 @@ func TestAntiDebuggingPtraceme(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: interface{}(int64(parsers.PTRACE_PEEKTEXT.Value())),
 						},
 					},
 				},

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -57,7 +57,7 @@ func (sig *AslrInspection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/aslr_inspection_test.go
+++ b/signatures/golang/aslr_inspection_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestAslrInspection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -94,7 +95,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},
@@ -111,7 +112,7 @@ func TestAslrInspection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -59,7 +59,7 @@ func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) erro
 		}
 		basename := path.Base(pathname)
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_notify_on_release_modification_test.go
+++ b/signatures/golang/cgroup_notify_on_release_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestCgroupNotifyOnReleaseModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -56,7 +56,7 @@ func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/cgroup_release_agent_modification_test.go
+++ b/signatures/golang/cgroup_release_agent_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 							},
 						},
 					}.ToProtocol(),
@@ -141,7 +142,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_RDONLY)),
 						},
 					},
 				},
@@ -164,7 +165,7 @@ func TestCgroupReleaseAgentModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: interface{}(buildFlagArgValue(parsers.O_WRONLY)),
 						},
 					},
 				},

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -58,7 +58,7 @@ func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/core_pattern_modification_test.go
+++ b/signatures/golang/core_pattern_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestCorePatternModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestCorePatternModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -59,7 +59,7 @@ func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/default_loader_modification_test.go
+++ b/signatures/golang/default_loader_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -141,7 +142,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -164,7 +165,7 @@ func TestDefaultLoaderModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -61,7 +61,7 @@ func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/docker_abuse_test.go
+++ b/signatures/golang/docker_abuse_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +31,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +53,7 @@ func TestDockerAbuse(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -140,7 +141,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -164,7 +165,7 @@ func TestDockerAbuse(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -11,12 +11,12 @@ import (
 
 type DynamicCodeLoading struct {
 	cb        detect.SignatureHandler
-	alertText string
+	alertType trace.MemProtAlert
 }
 
 func (sig *DynamicCodeLoading) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.alertText = "Protection changed from W to E!"
+	sig.alertType = trace.ProtAlertMprotectWXToX
 	return nil
 }
 
@@ -52,12 +52,13 @@ func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "mem_prot_alert":
-		alert, err := helpers.GetTraceeStringArgumentByName(eventObj, "alert")
+		alert, err := helpers.GetTraceeUintArgumentByName(eventObj, "alert")
 		if err != nil {
 			return err
 		}
+		memProtAlert := trace.MemProtAlert(alert)
 
-		if alert == sig.alertText {
+		if memProtAlert == sig.alertType {
 			metadata, err := sig.GetMetadata()
 			if err != nil {
 				return err

--- a/signatures/golang/dynamic_code_loading_test.go
+++ b/signatures/golang/dynamic_code_loading_test.go
@@ -29,7 +29,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed from W to E!"),
+							Value: uint32(trace.ProtAlertMprotectWXToX),
 						},
 					},
 				},
@@ -44,7 +44,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "alert",
 								},
-								Value: interface{}("Protection changed from W to E!"),
+								Value: uint32(trace.ProtAlertMprotectWXToX),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +76,7 @@ func TestDynamicCodeLoading(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "alert",
 							},
-							Value: interface{}("Protection changed to Executable!"),
+							Value: uint32(trace.ProtAlertMmapWX),
 						},
 					},
 				},

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -70,7 +70,7 @@ func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/k8s_service_account_token_test.go
+++ b/signatures/golang/k8s_service_account_token_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +31,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +53,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -91,7 +92,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -115,7 +116,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -139,7 +140,7 @@ func TestK8SServiceAccountToken(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -65,7 +65,7 @@ func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) erro
 			}
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/kubernetes_certificate_theft_attempt_test.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -30,7 +31,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -52,7 +53,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -138,7 +139,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -162,7 +163,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -186,7 +187,7 @@ func TestKubernetesCertificateTheftAttempt(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -85,7 +85,7 @@ func (sig *LdPreload) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ld_preload_test.go
+++ b/signatures/golang/ld_preload_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestLdPreload(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -194,7 +195,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -217,7 +218,7 @@ func TestLdPreload(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -58,7 +58,7 @@ func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_kcore_read_test.go
+++ b/signatures/golang/proc_kcore_read_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestProcKcoreRead(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -94,7 +95,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestProcKcoreRead(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -61,7 +61,7 @@ func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_access_test.go
+++ b/signatures/golang/proc_mem_access_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestProcMemAccess(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +112,7 @@ func TestProcMemAccess(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -61,7 +61,7 @@ func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/proc_mem_code_injection_test.go
+++ b/signatures/golang/proc_mem_code_injection_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +112,7 @@ func TestProcMemCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -11,14 +12,14 @@ import (
 
 type PtraceCodeInjection struct {
 	cb             detect.SignatureHandler
-	ptracePokeText string
-	ptracePokeData string
+	ptracePokeText int
+	ptracePokeData int
 }
 
 func (sig *PtraceCodeInjection) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-	sig.ptracePokeText = "PTRACE_POKETEXT"
-	sig.ptracePokeData = "PTRACE_POKEDATA"
+	sig.ptracePokeText = int(parsers.PTRACE_POKETEXT.Value())
+	sig.ptracePokeData = int(parsers.PTRACE_POKEDATA.Value())
 	return nil
 }
 
@@ -54,7 +55,7 @@ func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "ptrace":
-		requestArg, err := helpers.GetTraceeStringArgumentByName(eventObj, "request")
+		requestArg, err := helpers.GetTraceeIntArgumentByName(eventObj, "request")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/ptrace_code_injection_test.go
+++ b/signatures/golang/ptrace_code_injection_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKETEXT"),
+							Value: int32(parsers.PTRACE_POKETEXT.Value()),
 						},
 					},
 				},
@@ -44,7 +45,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKETEXT"),
+								Value: int32(parsers.PTRACE_POKETEXT.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -76,7 +77,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_POKEDATA"),
+							Value: int32(parsers.PTRACE_POKEDATA.Value()),
 						},
 					},
 				},
@@ -91,7 +92,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "request",
 								},
-								Value: interface{}("PTRACE_POKEDATA"),
+								Value: int32(parsers.PTRACE_POKEDATA.Value()),
 							},
 						},
 					}.ToProtocol(),
@@ -123,7 +124,7 @@ func TestPtraceCodeInjection(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "request",
 							},
-							Value: interface{}("PTRACE_PEEKTEXT"),
+							Value: int32(parsers.PTRACE_PEEKTEXT.Value()),
 						},
 					},
 				},

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -65,7 +65,7 @@ func (sig *RcdModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/rcd_modification_test.go
+++ b/signatures/golang/rcd_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +110,7 @@ func TestRcdModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -288,7 +289,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -311,7 +312,7 @@ func TestRcdModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -57,7 +57,7 @@ func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sched_debug_recon_test.go
+++ b/signatures/golang/sched_debug_recon_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestSchedDebugRecon(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_RDONLY"),
+								Value: buildFlagArgValue(parsers.O_RDONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -111,7 +112,7 @@ func TestSchedDebugRecon(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -65,7 +65,7 @@ func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/scheduled_task_modification_test.go
+++ b/signatures/golang/scheduled_task_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -29,7 +30,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -50,7 +51,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -88,7 +89,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -109,7 +110,7 @@ func TestScheduledTaskModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 							{
 								ArgMeta: trace.ArgMeta{
@@ -288,7 +289,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{
@@ -311,7 +312,7 @@ func TestScheduledTaskModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 						{
 							ArgMeta: trace.ArgMeta{

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -59,7 +59,7 @@ func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 	switch eventObj.EventName {
 	case "security_file_open":
 
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/sudoers_modification_test.go
+++ b/signatures/golang/sudoers_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -115,7 +116,7 @@ func TestSudoersModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -247,7 +248,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -270,7 +271,7 @@ func TestSudoersModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -52,7 +52,7 @@ func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) err
 
 	switch eventObj.EventName {
 	case "security_file_open":
-		flags, err := helpers.GetTraceeStringArgumentByName(eventObj, "flags")
+		flags, err := helpers.GetTraceeIntArgumentByName(eventObj, "flags")
 		if err != nil {
 			return err
 		}

--- a/signatures/golang/system_request_key_config_modification_test.go
+++ b/signatures/golang/system_request_key_config_modification_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/signaturestest"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -35,7 +36,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},
@@ -56,7 +57,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 								ArgMeta: trace.ArgMeta{
 									Name: "flags",
 								},
-								Value: interface{}("O_WRONLY"),
+								Value: buildFlagArgValue(parsers.O_WRONLY),
 							},
 						},
 					}.ToProtocol(),
@@ -94,7 +95,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_RDONLY"),
+							Value: buildFlagArgValue(parsers.O_RDONLY),
 						},
 					},
 				},
@@ -117,7 +118,7 @@ func TestSystemRequestKeyConfigModification(t *testing.T) {
 							ArgMeta: trace.ArgMeta{
 								Name: "flags",
 							},
-							Value: interface{}("O_WRONLY"),
+							Value: buildFlagArgValue(parsers.O_WRONLY),
 						},
 					},
 				},

--- a/signatures/golang/test_helpers.go
+++ b/signatures/golang/test_helpers.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/aquasecurity/tracee/pkg/events/parsers"
+
+func buildFlagArgValue(flags ...parsers.SystemFunctionArgument) int32 {
+	var res int32
+	for _, flagVal := range flags {
+		res = res | int32(flagVal.Value())
+	}
+	return res
+}

--- a/tests/e2e-inst-signatures/e2e-bpf_attach.go
+++ b/tests/e2e-inst-signatures/e2e-bpf_attach.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -48,14 +49,14 @@ func (sig *e2eBpfAttach) OnEvent(event protocol.Event) error {
 			return err
 		}
 
-		attachType, err := helpers.GetTraceeStringArgumentByName(eventObj, "attach_type")
+		attachType, err := helpers.GetTraceeIntArgumentByName(eventObj, "attach_type")
 		if err != nil {
 			return err
 		}
 
 		// check expected values from test for detection
 
-		if symbolName != "security_file_open" || attachType != "kprobe" {
+		if symbolName != "security_file_open" || attachType != int(parsers.BPFProgTypeKprobe) {
 			return nil
 		}
 

--- a/tests/e2e-inst-signatures/e2e-stack_pivot.go
+++ b/tests/e2e-inst-signatures/e2e-stack_pivot.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -45,7 +46,7 @@ func (sig *e2eStackPivot) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "stack_pivot":
-		syscall, err := helpers.ArgVal[string](eventObj.Args, "syscall")
+		syscall, err := helpers.ArgVal[int32](eventObj.Args, "syscall")
 		if err != nil {
 			return err
 		}
@@ -55,7 +56,7 @@ func (sig *e2eStackPivot) OnEvent(event protocol.Event) error {
 		}
 
 		// Make sure this is the exact event we're looking for
-		if eventObj.ProcessName == "stack_pivot" && syscall == "exit_group" && vmaType == "heap" {
+		if eventObj.ProcessName == "stack_pivot" && syscall == int32(events.ExitGroup) && vmaType == "heap" {
 			// Make sure there was no false positive
 			if !sig.falsePositive {
 				m, _ := sig.GetMetadata()

--- a/tests/e2e-inst-signatures/e2e-suspicious_syscall_source.go
+++ b/tests/e2e-inst-signatures/e2e-suspicious_syscall_source.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -48,7 +49,7 @@ func (sig *e2eSuspiciousSyscallSource) OnEvent(event protocol.Event) error {
 
 	switch eventObj.EventName {
 	case "suspicious_syscall_source":
-		syscall, err := helpers.ArgVal[string](eventObj.Args, "syscall")
+		syscall, err := helpers.ArgVal[int32](eventObj.Args, "syscall")
 		if err != nil {
 			return err
 		}
@@ -59,7 +60,7 @@ func (sig *e2eSuspiciousSyscallSource) OnEvent(event protocol.Event) error {
 
 		// check expected values from test for detection
 
-		if syscall != "exit" {
+		if syscall != int32(events.Exit) {
 			return nil
 		}
 


### PR DESCRIPTION
Close: #4541

This reverts #4331 back.

### 1. Explain what the PR does

c922aaa60 **Reapply "feat(sigs): refactor to use nonparsed arguments"**
f680998bc **Revert "Add workaround: Revert to using raw ... argument values in engine stage".**
1f00c689d **chore(deps): bump signatures/helpers to f57a1ebab9**


c922aaa60 **Reapply "feat(sigs): refactor to use nonparsed arguments"**

```
This reverts commit b46a2b6bde588825877ea45ec690a7dc871fe73c.
```

f680998bc **Revert "Add workaround: Revert to using raw ... argument values in engine stage".**

```
This reverts commit a481d11d2ad3eda1ea9c5a187a8574e0c46e9e33.
```

### 2. Explain how to test it


### 3. Other comments

