### PR TITLE
feat(helpers): reapply: unparsed flag helpers

### DIFF
--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -5,3 +5,9 @@ go 1.22.0
 toolchain go1.22.4
 
 require github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863
+
+require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+)

--- a/signatures/helpers/go.sum
+++ b/signatures/helpers/go.sum
@@ -1,10 +1,10 @@
 github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863 h1:domVTTQICTuCvX+ZW5EjvdUBz8EH7FedBj5lRqwpgf4=
 github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863/go.mod h1:Jwh9OOuiMHXDoGQY12N9ls5YB+j1FlRcXvFMvh1CmIU=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -3,15 +3,16 @@ package helpers
 import (
 	"fmt"
 	"strings"
+	"syscall"
 
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
 // IsFileWrite returns whether the passed file permissions string contains
 // o_wronly or o_rdwr
-func IsFileWrite(flags string) bool {
-	flagsLow := strings.ToLower(flags)
-	if strings.Contains(flagsLow, "o_wronly") || strings.Contains(flagsLow, "o_rdwr") {
+func IsFileWrite(flags int) bool {
+	accessMode := uint64(flags) & syscall.O_ACCMODE
+	if accessMode == syscall.O_WRONLY || accessMode == syscall.O_RDWR {
 		return true
 	}
 	return false
@@ -19,9 +20,9 @@ func IsFileWrite(flags string) bool {
 
 // IsFileRead returns whether the passed file permissions string contains
 // o_rdonly or o_rdwr
-func IsFileRead(flags string) bool {
-	flagsLow := strings.ToLower(flags)
-	if strings.Contains(flagsLow, "o_rdonly") || strings.Contains(flagsLow, "o_rdwr") {
+func IsFileRead(flags int) bool {
+	accessMode := uint64(flags) & syscall.O_ACCMODE
+	if accessMode == syscall.O_RDONLY || accessMode == syscall.O_RDWR {
 		return true
 	}
 	return false


### PR DESCRIPTION
This is part of #4541 to make possible to merge #4544.

### 1. Explain what the PR does

ed62bef6a **feat(helpers): unparsed flag helpers**

```
flag helpers previously took a string argument to test against possible
flag configurations. New implementation takes the integer form and
makes the test with the bit flag directly.

It makes use of syscall package to get constants for the flags instead
of Tracee's parsers package.

Co-authored-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it


### 3. Other comments

