### PR TITLE
fix(events): fix incorrect handling of event parameters

### DIFF
--- a/pkg/ebpf/event_parameters.go
+++ b/pkg/ebpf/event_parameters.go
@@ -40,11 +40,13 @@ func (t *Tracee) handleEventParameters() error {
 		eventParams := make([]map[string]filters.Filter[*filters.StringFilter], 0)
 		for iterator := t.policyManager.CreateAllIterator(); iterator.HasNext(); {
 			policy := iterator.Next()
-			policyParams := policy.Rules[eventID].DataFilter.GetFieldFilters()
-			if len(policyParams) == 0 {
-				continue
+			if rule, ok := policy.Rules[eventID]; ok {
+				policyParams := rule.DataFilter.GetFieldFilters()
+				if len(policyParams) == 0 {
+					continue
+				}
+				eventParams = append(eventParams, policyParams)
 			}
-			eventParams = append(eventParams, policyParams)
 		}
 		if len(eventParams) == 0 {
 			// No parameters for this event


### PR DESCRIPTION
If an event that uses parameters is enabled but not present in all policies, a nil access occurs and tracee panics. This fix makes sure the event is present in each policy before accessing its parameters.