### PR TITLE
fix(ebpf): treat sched_process_exit corner case

### DIFF
--- a/pkg/ebpf/c/vmlinux_missing.h
+++ b/pkg/ebpf/c/vmlinux_missing.h
@@ -48,7 +48,8 @@
 
 #define ICMPV6_ECHO_REQUEST 128
 
-#define PF_KTHREAD 0x00200000 /* I am a kernel thread */
+#define PF_SIGNALED 0x00000400 /* Killed by a signal */
+#define PF_KTHREAD  0x00200000 /* I am a kernel thread */
 
 #define TASK_COMM_LEN 16
 

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -221,10 +221,9 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 				id := events.ID(eCtx.Syscall)
 				syscallDef := events.Core.GetDefinitionByID(id)
 				if syscallDef.NotValid() {
-					// This should never fail, as the translation used in eBPF relies on the same event definitions
 					commStr := string(eCtx.Comm[:bytes.IndexByte(eCtx.Comm[:], 0)])
 					utsNameStr := string(eCtx.UtsName[:bytes.IndexByte(eCtx.UtsName[:], 0)])
-					logger.Errorw(
+					logger.Debugw(
 						fmt.Sprintf("Event %s with an invalid syscall id %d", evtName, id),
 						"Comm", commStr,
 						"UtsName", utsNameStr,


### PR DESCRIPTION
Close: #4558

### 1. Explain what the PR does

cccaf7f83 **fix(ebpf): treat sched_process_exit corner cases**

```
The sched_process_exit event may be triggered by a standard exit, such
as a syscall, or by alternative kernel paths, making it unsafe to assume
that it is always associated with a syscall exit.

do_exit and do_exit_group, while typically invoked by the exit and
exit_group syscalls, can also be reached through internal kernel
mechanisms such as signal handling. A concrete example of this occurs
when a syscall returns, enters signal handling, and subsequently calls
do_exit after get_signal. Both get_signal and do_exit involve
tracepoints.

A real execution flow illustrating this scenario in the kernel is as
follows:

entry_SYSCALL_64
  ├── do_syscall_64
  ├── syscall_exit_to_user_mode
  ├── __syscall_exit_to_user_mode_work
  ├── exit_to_user_mode_prepare
  ├── exit_to_user_mode_loop
  ├── arch_do_signal_or_restart
  ├── get_signal  (has signal_deliver tracepoint)
  ├── do_group_exit
  └── do_exit  (has sched_process_exit tracepoint)
```

### 2. Explain how to test it

Run this before on main to get sporadic errors as negative syscall numbers (triggered by signals):

`INSTTESTS="WRITABLE_DATA_SOURCE" ./tests/e2e-inst-test.sh`

After that, test this PR by running the same command above and make sure that there's no error since `sched_process_exit` will just submit `NO_SYSCALL` in such cases.

### 3. Other comments

