### PR TITLE
fix(ebpf): correct value of exit and signal code for sched_process_exit

### DIFF
--- a/pkg/ebpf/c/common/task.h
+++ b/pkg/ebpf/c/common/task.h
@@ -28,7 +28,7 @@ statfunc u64 get_task_start_time(struct task_struct *task);
 statfunc u32 get_task_host_pid(struct task_struct *task);
 statfunc u32 get_task_host_tgid(struct task_struct *task);
 statfunc struct task_struct *get_parent_task(struct task_struct *task);
-statfunc u32 get_task_exit_code(struct task_struct *task);
+statfunc int get_task_exit_code(struct task_struct *task);
 statfunc int get_task_parent_flags(struct task_struct *task);
 statfunc const struct cred *get_task_real_cred(struct task_struct *task);
 
@@ -195,7 +195,7 @@ statfunc struct task_struct *get_leader_task(struct task_struct *task)
     return BPF_CORE_READ(task, group_leader);
 }
 
-statfunc u32 get_task_exit_code(struct task_struct *task)
+statfunc int get_task_exit_code(struct task_struct *task)
 {
     return BPF_CORE_READ(task, exit_code);
 }

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -1547,7 +1547,6 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
     if (!policies_matched(p.event))
         return 0;
 
-    long exit_code = get_task_exit_code(p.event->task);
     bool group_dead = false;
     struct task_struct *task = p.event->task;
     struct signal_struct *signal = BPF_CORE_READ(task, signal);
@@ -1559,8 +1558,16 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
         group_dead = true;
     }
 
-    save_to_submit_buf(&p.event->args_buf, (void *) &exit_code, sizeof(long), 0);
-    save_to_submit_buf(&p.event->args_buf, (void *) &group_dead, sizeof(bool), 1);
+    // extract exit code and signal values
+    int exit_code = get_task_exit_code(p.event->task);
+    int exit_code_real = exit_code >> 8;
+
+    save_to_submit_buf(&p.event->args_buf, (void *) &exit_code_real, sizeof(int), 0);
+    if (task_flags & PF_SIGNALED) {
+        int signal_code = exit_code & 0xFF;
+        save_to_submit_buf(&p.event->args_buf, (void *) &signal_code, sizeof(int), 1);
+    }
+    save_to_submit_buf(&p.event->args_buf, (void *) &group_dead, sizeof(bool), 2);
 
     events_perf_submit(&p, 0);
 
@@ -7155,10 +7162,17 @@ int sched_process_exit_signal(struct bpf_raw_tracepoint_args *ctx)
     if (live.counter == 0)
         group_dead = true;
 
-    long exit_code = get_task_exit_code(task);
+    // extract exit code and signal values
+    int task_flags = get_task_flags(task);
+    int exit_code = get_task_exit_code(task);
+    int exit_code_real = exit_code >> 8;
 
-    save_to_submit_buf(&signal->args_buf, (void *) &exit_code, sizeof(long), 4);
-    save_to_submit_buf(&signal->args_buf, (void *) &group_dead, sizeof(bool), 5);
+    save_to_submit_buf(&signal->args_buf, (void *) &exit_code_real, sizeof(int), 4);
+    if (task_flags & PF_SIGNALED) {
+        int signal_code = exit_code & 0xFF;
+        save_to_submit_buf(&signal->args_buf, (void *) &signal_code, sizeof(int), 5);
+    }
+    save_to_submit_buf(&signal->args_buf, (void *) &group_dead, sizeof(bool), 6);
 
     signal_perf_submit(ctx, signal);
 

--- a/pkg/ebpf/controlplane/processes.go
+++ b/pkg/ebpf/controlplane/processes.go
@@ -219,7 +219,11 @@ func (ctrl *Controller) procTreeExitProcessor(args []trace.Argument) error {
 	// }
 
 	// // Exit logic arguments
-	// exitFeed.ExitCode, err = parse.ArgVal[int64](args, "exit_code")
+	// exitFeed.ExitCode, err = parse.ArgVal[int32](args, "exit_code")
+	// if err != nil {
+	// 	return err
+	// }
+	// exitFeed.SignalCode, err = parse.ArgVal[int32](args, "signal_code")
 	// if err != nil {
 	// 	return err
 	// }

--- a/pkg/ebpf/controlplane/processes_bench_test.go
+++ b/pkg/ebpf/controlplane/processes_bench_test.go
@@ -98,7 +98,8 @@ func Benchmark_procTreeExitProcessor(b *testing.B) {
 		{ArgMeta: trace.ArgMeta{Name: "task_hash"}, Value: uint32(1)},
 		{ArgMeta: trace.ArgMeta{Name: "parent_hash"}, Value: uint32(1)},
 		{ArgMeta: trace.ArgMeta{Name: "leader_hash"}, Value: uint32(1)},
-		{ArgMeta: trace.ArgMeta{Name: "exit_code"}, Value: int64(1)},
+		{ArgMeta: trace.ArgMeta{Name: "exit_code"}, Value: int32(1)},
+		{ArgMeta: trace.ArgMeta{Name: "signal_code"}, Value: int32(1)},
 		{ArgMeta: trace.ArgMeta{Name: "process_group_exit"}, Value: true},
 	}
 

--- a/pkg/ebpf/processor_proctree.go
+++ b/pkg/ebpf/processor_proctree.go
@@ -197,7 +197,7 @@ func (t *Tracee) procTreeExitProcessor(event *trace.Event) error {
 	defer t.processTree.PutExitFeedInPool(exitFeed)
 
 	// // Exit logic arguments
-	// exitFeed.ExitCode, err = parse.ArgVal[int64](event.Args, "exit_code")
+	// exitFeed.ExitCode, err = parse.ArgVal[int32](event.Args, "exit_code")
 	// if err != nil {
 	// 	return err
 	// }

--- a/pkg/ebpf/processor_proctree_bench_test.go
+++ b/pkg/ebpf/processor_proctree_bench_test.go
@@ -94,7 +94,8 @@ func Benchmark_procTreeExitProcessor(b *testing.B) {
 
 	event := &trace.Event{
 		Args: []trace.Argument{
-			{ArgMeta: trace.ArgMeta{Name: "exit_code"}, Value: int64(1)},
+			{ArgMeta: trace.ArgMeta{Name: "exit_code"}, Value: int32(1)},
+			{ArgMeta: trace.ArgMeta{Name: "signal_code"}, Value: int32(1)},
 			{ArgMeta: trace.ArgMeta{Name: "process_group_exit"}, Value: true},
 		},
 	}

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11213,7 +11213,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		sets: []string{"proc", "proc_life"},
 		fields: []trace.ArgMeta{
-			{Type: "long", Name: "exit_code"},
+			{Type: "int", Name: "exit_code"},
+			{Type: "int", Name: "signal_code"},
 			// The field value represents that all threads exited at the event time.
 			// Multiple exits of threads of the same process group at the same time could result that all threads exit
 			// events would have 'true' value in this field altogether.
@@ -13234,7 +13235,8 @@ var CoreEvents = map[ID]Definition{
 			{Type: "u32", Name: "task_hash"},
 			{Type: "u32", Name: "parent_hash"},
 			{Type: "u32", Name: "leader_hash"},
-			{Type: "long", Name: "exit_code"},
+			{Type: "int", Name: "exit_code"},
+			{Type: "int", Name: "signal_code"},
 			{Type: "bool", Name: "process_group_exit"},
 		},
 	},

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -281,7 +281,8 @@ type ExitFeed struct {
 	TaskHash   uint32
 	ParentHash uint32
 	LeaderHash uint32
-	ExitCode   int64
+	ExitCode   int32
+	SignalCode int32
 	Group      bool
 }
 

--- a/pkg/server/grpc/event_data_test.go
+++ b/pkg/server/grpc/event_data_test.go
@@ -87,7 +87,7 @@ func Test_getEventData(t *testing.T) {
 			args: []trace.Argument{
 				{
 					ArgMeta: trace.ArgMeta{
-						Name: "exit_code",
+						Name: "newmask",
 						Type: "long",
 					},
 					Value: int64(1000),
@@ -95,7 +95,7 @@ func Test_getEventData(t *testing.T) {
 			},
 			expected: []*pb.EventValue{
 				{
-					Name: "exit_code",
+					Name: "newmask",
 					Value: &pb.EventValue_Int64{
 						Int64: 1000,
 					},


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

a13d497a4 **fix: get exit code and signal values**

```
When a process exits normally via exit(n), the exit code is
stored in the upper byte (exit_code << 8). The lower byte is
used for signal information if the process was terminated by
a signal.

Also, align the type of exit_code used at struct task_struct.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

Use the following code to trigger:
```
gcc -o trigger trigger.c
```
```c
#include <unistd.h>
#include <stdlib.h>
#include <stdio.h>
#include <sys/types.h>
#include <sys/wait.h>
#include <signal.h>

int main() {
    printf("Forking process...\n");
    pid_t pid = fork();
    
    if (pid == 0) {
        printf("Child process running, PID: %d\n", getpid());
        sleep(10);
        printf("Child process exiting normally\n");
        exit(1);
    } else if (pid > 0) {
        // Parent process
        sleep(1);
        printf("Parent sending SIGKILL to child PID: %d\n", pid);
        kill(pid, SIGKILL);
        wait(NULL);
    } else {
        perror("fork");
        return 1;
    }

    exit(77);
}
```

Tracee before this PR:
```
sudo ./dist/tracee -e sched_process_exit -s comm=trigger
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
12:08:14:542122  1000   trigger          3133042 3133042 0                sched_process_exit        exit_code: 9, process_group_exit: true
12:08:14:542306  1000   trigger          3133041 3133041 0                sched_process_exit        exit_code: 19712, process_group_exit: true
```

Tracee after this PR:
```
sudo ./dist/tracee -e sched_process_exit -s comm=trigger
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
12:09:52:080566  1000   trigger          3137039 3137039 0                sched_process_exit        exit_code: 1, signal_code: 9, process_group_exit: true
12:09:52:081407  1000   trigger          3137038 3137038 0                sched_process_exit        exit_code: 77, signal_code: 0, process_group_exit: true
```

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
