### PR TITLE
Proctree improvements (cont)

### DIFF
--- a/docs/docs/events/builtin/extra/sched_process_exec.md
+++ b/docs/docs/events/builtin/extra/sched_process_exec.md
@@ -34,7 +34,7 @@ security, and auditing.
 12. **interp** (`const char*`): Specifies the interpreter of the binary.
 13. **stdin_type** (`umode_t`): Mode of the standard input.
 14. **stdin_path** (`char*`): Path of the standard input.
-15. **invoked_from_kernel** (`int`): Flag to determine if the process was initiated by the kernel.
+15. **invoked_from_kernel** (`bool`): Flag to determine if the process was initiated by the kernel.
 16. **env** (`const char**`): Environment variables associated with the process.
 
 ## Hooks

--- a/pkg/ebpf/controlplane/processes.go
+++ b/pkg/ebpf/controlplane/processes.go
@@ -174,7 +174,7 @@ func (ctrl *Controller) procTreeExecProcessor(args []trace.Argument) error {
 	if err != nil {
 		return err
 	}
-	execFeed.InvokedFromKernel, err = parse.ArgVal[int32](args, "invoked_from_kernel")
+	execFeed.InvokedFromKernel, err = parse.ArgVal[bool](args, "invoked_from_kernel")
 	if err != nil {
 		return err
 	}

--- a/pkg/ebpf/controlplane/processes_bench_test.go
+++ b/pkg/ebpf/controlplane/processes_bench_test.go
@@ -73,7 +73,7 @@ func Benchmark_procTreeExecProcessor(b *testing.B) {
 		{ArgMeta: trace.ArgMeta{Name: "interp"}, Value: "/lib64/ld-linux-x86-64.so.2"},
 		{ArgMeta: trace.ArgMeta{Name: "stdin_type"}, Value: uint16(1)},
 		{ArgMeta: trace.ArgMeta{Name: "stdin_path"}, Value: "/dev/null"},
-		{ArgMeta: trace.ArgMeta{Name: "invoked_from_kernel"}, Value: int32(1)},
+		{ArgMeta: trace.ArgMeta{Name: "invoked_from_kernel"}, Value: bool(true)},
 	}
 
 	b.ResetTimer()

--- a/pkg/ebpf/processor_proctree.go
+++ b/pkg/ebpf/processor_proctree.go
@@ -164,7 +164,7 @@ func (t *Tracee) procTreeExecProcessor(event *trace.Event) error {
 	if err != nil {
 		return err
 	}
-	execFeed.InvokedFromKernel, err = parse.ArgVal[int32](event.Args, "invoked_from_kernel")
+	execFeed.InvokedFromKernel, err = parse.ArgVal[bool](event.Args, "invoked_from_kernel")
 	if err != nil {
 		return err
 	}

--- a/pkg/ebpf/processor_proctree_bench_test.go
+++ b/pkg/ebpf/processor_proctree_bench_test.go
@@ -71,7 +71,7 @@ func Benchmark_procTreeExecProcessor(b *testing.B) {
 			{ArgMeta: trace.ArgMeta{Name: "interp"}, Value: "/lib64/ld-linux-x86-64.so.2"},
 			{ArgMeta: trace.ArgMeta{Name: "stdin_type"}, Value: uint16(1)},
 			{ArgMeta: trace.ArgMeta{Name: "stdin_path"}, Value: "/dev/null"},
-			{ArgMeta: trace.ArgMeta{Name: "invoked_from_kernel"}, Value: int32(1)},
+			{ArgMeta: trace.ArgMeta{Name: "invoked_from_kernel"}, Value: bool(true)},
 		},
 	}
 

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -11195,7 +11195,7 @@ var CoreEvents = map[ID]Definition{
 			{Type: "const char*", Name: "interp"},
 			{Type: "umode_t", Name: "stdin_type"},
 			{Type: "char*", Name: "stdin_path"},
-			{Type: "int", Name: "invoked_from_kernel"},
+			{Type: "bool", Name: "invoked_from_kernel"},
 			{Type: "const char*", Name: "prev_comm"},
 			{Type: "const char**", Name: "env"},
 		},
@@ -13216,7 +13216,7 @@ var CoreEvents = map[ID]Definition{
 			{Type: "const char*", Name: "interp"},
 			{Type: "umode_t", Name: "stdin_type"},
 			{Type: "char*", Name: "stdin_path"},
-			{Type: "int", Name: "invoked_from_kernel"},
+			{Type: "bool", Name: "invoked_from_kernel"},
 		},
 	},
 	SignalSchedProcessExit: {

--- a/pkg/proctree/datasource.go
+++ b/pkg/proctree/datasource.go
@@ -92,11 +92,12 @@ func (ptds *DataSource) exportProcessInfo(
 ) datasource.TimeRelevantInfo[datasource.ProcessInfo] {
 	// Pick the objects related to the process from the process tree.
 	info := process.GetInfo()
+	procHash := process.GetHash()
 	executable := process.GetExecutable()
 
 	// Walk children hashes and discover the ones alive at the query time.
 	aliveChildren := make(map[int]uint32)
-	for _, childHash := range process.GetChildren() {
+	for _, childHash := range ptds.procTree.GetChildren(procHash) {
 		child, ok := ptds.procTree.GetProcessByHash(childHash)
 		if !ok {
 			continue
@@ -109,7 +110,7 @@ func (ptds *DataSource) exportProcessInfo(
 
 	// Walk thread hashes and discover the ones alive at the query time.
 	aliveThreads := make(map[int]uint32)
-	for _, threadHash := range process.GetThreads() {
+	for _, threadHash := range ptds.procTree.GetThreads(procHash) {
 		thread, ok := ptds.procTree.GetThreadByHash(threadHash)
 		if !ok {
 			continue
@@ -126,7 +127,7 @@ func (ptds *DataSource) exportProcessInfo(
 	// Export the information as the expected datasource process structure.
 	return datasource.TimeRelevantInfo[datasource.ProcessInfo]{
 		Info: datasource.ProcessInfo{
-			EntityId: process.GetHash(),
+			EntityId: procHash,
 			// TODO: change types pkg to reduce mem footprint (Pid, NsPid, Ppid, ThreadsIds, ChildProcessesIds)
 			Pid:               int(infoFeed.Pid),
 			NsPid:             int(infoFeed.NsPid),

--- a/pkg/proctree/fileinfo.go
+++ b/pkg/proctree/fileinfo.go
@@ -12,11 +12,12 @@ import (
 // FileInfoFeed allows external packages to set/get multiple values of a task at once.
 type FileInfoFeed struct {
 	// Name      string
-	Path      string // mutable (file path)
-	Dev       uint32 // mutable (device number)
-	Ctime     uint64 // mutable (creation time)
-	Inode     uint64 // mutable (inode number)
-	InodeMode uint16 // mutable (inode mode)
+	Path      string  // mutable (file path)
+	Dev       uint32  // mutable (device number)
+	InodeMode uint16  // mutable (inode mode)
+	_         [2]byte // padding
+	Ctime     uint64  // mutable (creation time)
+	Inode     uint64  // mutable (inode number)
 }
 
 //

--- a/pkg/proctree/fileinfo_test.go
+++ b/pkg/proctree/fileinfo_test.go
@@ -1,0 +1,15 @@
+package proctree
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+// TestFileInfoFeed_PrintSizes prints the sizes of the structs used in the FileInfoFeed type.
+// Run it as DEBUG test to see the output.
+func TestFileInfoFeed_PrintSizes(t *testing.T) {
+	fileInfo := FileInfoFeed{}
+	tests.PrintStructSizes(t, os.Stdout, fileInfo)
+}

--- a/pkg/proctree/process.go
+++ b/pkg/proctree/process.go
@@ -1,7 +1,6 @@
 package proctree
 
 import (
-	"sync"
 	"sync/atomic"
 )
 
@@ -11,14 +10,10 @@ import (
 
 // Process represents a process.
 type Process struct {
-	processHash uint32              // hash of process (immutable, so no need of concurrency control)
-	parentHash  uint32              // hash of parent
-	info        *TaskInfo           // task info (immutable pointer)
-	executable  *FileInfo           // executable info (immutable pointer)
-	children    map[uint32]struct{} // hash of children
-	threads     map[uint32]struct{} // hash of threads
-	// Control fields
-	mutex *sync.RWMutex // mutex to protect the process
+	processHash uint32    // hash of process (immutable, so no need of concurrency control)
+	parentHash  uint32    // hash of parent
+	info        *TaskInfo // task info (immutable pointer)
+	executable  *FileInfo // executable info (immutable pointer)
 }
 
 // NewProcess creates a new thread with an initialized task info.
@@ -28,9 +23,6 @@ func NewProcess(hash uint32, info *TaskInfo) *Process {
 		parentHash:  0,
 		info:        info,
 		executable:  NewFileInfo(),
-		children:    make(map[uint32]struct{}),
-		threads:     make(map[uint32]struct{}),
-		mutex:       &sync.RWMutex{},
 	}
 }
 
@@ -61,66 +53,4 @@ func (p *Process) GetExecutable() *FileInfo {
 // SetParentHash sets the hash of the parent.
 func (p *Process) SetParentHash(parentHash uint32) {
 	atomic.StoreUint32(&p.parentHash, parentHash)
-}
-
-//
-// Children and Threads
-//
-
-// AddChild adds a child to the process.
-func (p *Process) AddChild(childHash uint32) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	p.children[childHash] = struct{}{}
-}
-
-// AddThread adds a thread to the process.
-func (p *Process) AddThread(threadHash uint32) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	p.threads[threadHash] = struct{}{}
-}
-
-// GetChildren returns the children of the process.
-func (p *Process) GetChildren() []uint32 {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-
-	children := make([]uint32, 0, len(p.children))
-	for child := range p.children {
-		children = append(children, child)
-	}
-
-	return children
-}
-
-// GetThreads returns the threads of the process.
-func (p *Process) GetThreads() []uint32 {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-
-	threads := make([]uint32, 0, len(p.threads))
-	for thread := range p.threads {
-		threads = append(threads, thread)
-	}
-
-	return threads
-}
-
-// DelChild deletes a child from the process.
-func (p *Process) DelChild(childHash uint32) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	delete(p.children, childHash)
-}
-
-// DelThread deletes a thread from the process.
-func (p *Process) DelThread(threadHash uint32) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	delete(p.threads, threadHash)
 }

--- a/pkg/proctree/process.go
+++ b/pkg/proctree/process.go
@@ -10,17 +10,17 @@ import (
 
 // Process represents a process.
 type Process struct {
-	processHash uint32    // hash of process (immutable, so no need of concurrency control)
-	parentHash  uint32    // hash of parent
-	info        *TaskInfo // task info (immutable pointer)
-	executable  *FileInfo // executable info (immutable pointer)
+	processHash uint32        // hash of process (immutable, so no need of concurrency control)
+	parentHash  atomic.Uint32 // hash of parent
+	info        *TaskInfo     // task info (immutable pointer)
+	executable  *FileInfo     // executable info (immutable pointer)
 }
 
 // NewProcess creates a new thread with an initialized task info.
 func NewProcess(hash uint32, info *TaskInfo) *Process {
 	return &Process{
 		processHash: hash,
-		parentHash:  0,
+		parentHash:  atomic.Uint32{},
 		info:        info,
 		executable:  NewFileInfo(),
 	}
@@ -35,7 +35,7 @@ func (p *Process) GetHash() uint32 {
 
 // GetParentHash returns the hash of the parent.
 func (p *Process) GetParentHash() uint32 {
-	return atomic.LoadUint32(&p.parentHash)
+	return p.parentHash.Load()
 }
 
 // GetInfo returns a instanced task info.
@@ -52,5 +52,5 @@ func (p *Process) GetExecutable() *FileInfo {
 
 // SetParentHash sets the hash of the parent.
 func (p *Process) SetParentHash(parentHash uint32) {
-	atomic.StoreUint32(&p.parentHash, parentHash)
+	p.parentHash.Store(parentHash)
 }

--- a/pkg/proctree/process_test.go
+++ b/pkg/proctree/process_test.go
@@ -1,0 +1,14 @@
+package proctree
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+// TestProcess_PrintSizes prints the sizes of the structs used in the Process type.
+// Run it as DEBUG test to see the output.
+func TestProcess_PrintSizes(t *testing.T) {
+	tests.PrintStructSizes(t, os.Stdout, Process{})
+}

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -16,6 +16,9 @@ import (
 
 type ForkFeed struct {
 	TimeStamp       uint64
+	ParentStartTime uint64
+	LeaderStartTime uint64
+	ChildStartTime  uint64
 	ChildHash       uint32
 	ParentHash      uint32
 	LeaderHash      uint32
@@ -23,17 +26,15 @@ type ForkFeed struct {
 	ParentNsTid     int32
 	ParentPid       int32
 	ParentNsPid     int32
-	ParentStartTime uint64
 	LeaderTid       int32
 	LeaderNsTid     int32
 	LeaderPid       int32
 	LeaderNsPid     int32
-	LeaderStartTime uint64
 	ChildTid        int32
 	ChildNsTid      int32
 	ChildPid        int32
 	ChildNsPid      int32
-	ChildStartTime  uint64
+	_               [4]byte // padding
 }
 
 func (pt *ProcessTree) setParentFeed(
@@ -202,24 +203,26 @@ func (pt *ProcessTree) FeedFromFork(feed *ForkFeed) error {
 }
 
 type ExecFeed struct {
-	TimeStamp  uint64
-	TaskHash   uint32
-	ParentHash uint32
-	LeaderHash uint32
-	CmdPath    string
-	PathName   string
-	Dev        uint32
-	Inode      uint64
-	Ctime      uint64
-	InodeMode  uint16
+	TimeStamp         uint64
+	Inode             uint64
+	Ctime             uint64
+	CmdPath           string
+	PathName          string
+	Interp            string
+	StdinPath         string
+	TaskHash          uint32
+	ParentHash        uint32
+	LeaderHash        uint32
+	Dev               uint32
+	InvokedFromKernel bool
+	_                 [3]byte // padding
+	InodeMode         uint16
+	StdinType         uint16
+
 	// InterpreterPath   string
 	// InterpreterDev    uint32
 	// InterpreterInode  uint64
 	// InterpreterCtime  uint64
-	Interp            string
-	StdinType         uint16
-	StdinPath         string
-	InvokedFromKernel int32
 }
 
 const COMM_LEN = 16
@@ -285,6 +288,7 @@ type ExitFeed struct {
 	ExitCode   int32
 	SignalCode int32
 	Group      bool
+	_          [3]byte // padding
 }
 
 // FeedFromExit feeds the process tree with an exit event.

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -154,7 +154,7 @@ func (pt *ProcessTree) FeedFromFork(feed *ForkFeed) error {
 		pt.setParentFeed(parent, feed, feedTimeStamp)
 	}
 
-	parent.AddChild(feed.LeaderHash) // add the leader as a child of the parent
+	pt.AddChildToProcess(feed.ParentHash, feed.LeaderHash) // add the leader as a child of the parent
 
 	// Update the leader process (might exist, might be the same as child if child is a process)
 
@@ -195,9 +195,9 @@ func (pt *ProcessTree) FeedFromFork(feed *ForkFeed) error {
 		pt.setThreadFeed(thread, leader, feed, feedTimeStamp)
 	}
 
-	thread.SetParentHash(feed.ParentHash) // all threads have the same parent as the thread group leader
-	thread.SetLeaderHash(feed.LeaderHash) // thread group leader is a "process" and a "thread"
-	leader.AddThread(feed.ChildHash)      // add the thread to the thread group leader
+	thread.SetParentHash(feed.ParentHash)                  // all threads have the same parent as the thread group leader
+	thread.SetLeaderHash(feed.LeaderHash)                  // thread group leader is a "process" and a "thread"
+	pt.AddThreadToProcess(feed.LeaderHash, feed.ChildHash) // add the thread to the thread group leader
 
 	return nil
 }

--- a/pkg/proctree/proctree_feed_test.go
+++ b/pkg/proctree/proctree_feed_test.go
@@ -1,0 +1,29 @@
+package proctree
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+// TestForkFeed_PrintSizes prints the sizes of the structs used in the ForkFeed type.
+// Run it as DEBUG test to see the output.
+func TestForkFeed_PrintSizes(t *testing.T) {
+	forkFeed := ForkFeed{}
+	tests.PrintStructSizes(t, os.Stdout, forkFeed)
+}
+
+// TestExecFeed_PrintSizes prints the sizes of the structs used in the ExecFeed type.
+// Run it as DEBUG test to see the output.
+func TestExecFeed_PrintSizes(t *testing.T) {
+	execFeed := ExecFeed{}
+	tests.PrintStructSizes(t, os.Stdout, execFeed)
+}
+
+// TestExitFeed_PrintSizes prints the sizes of the structs used in the ExitFeed type.
+// Run it as DEBUG test to see the output.
+func TestExitFeed_PrintSizes(t *testing.T) {
+	exitFeed := ExitFeed{}
+	tests.PrintStructSizes(t, os.Stdout, exitFeed)
+}

--- a/pkg/proctree/proctree_output.go
+++ b/pkg/proctree/proctree_output.go
@@ -23,8 +23,8 @@ func (pt *ProcessTree) String() string {
 	// getListOfChildrenPids returns a comma-separated list of children pids for a given process.
 	getListOfChildrenPids := func(process *Process) string {
 		var childrenPids []string
-		for _, childHash := range process.GetChildren() { // for each child
-			child, ok := pt.processes.Get(childHash)
+		for _, childHash := range pt.GetChildren(process.GetHash()) { // for each child
+			child, ok := pt.processesLRU.Get(childHash)
 			if !ok {
 				continue
 			}
@@ -51,8 +51,8 @@ func (pt *ProcessTree) String() string {
 	// getListOfThreadsTids returns a comma-separated list of threads tids for a given process.
 	getListOfThreadsTids := func(process *Process) string {
 		var threadsTids []string
-		for _, threadHash := range process.GetThreads() { // for each thread (if process is a thread group leader)
-			thread, ok := pt.threads.Get(threadHash)
+		for _, threadHash := range pt.GetThreads(process.GetHash()) { // for each thread (if process is a thread group leader)
+			thread, ok := pt.threadsLRU.Get(threadHash)
 			if !ok {
 				continue
 			}
@@ -107,8 +107,8 @@ func (pt *ProcessTree) String() string {
 
 	// Walk the process tree and create a table row for each process:
 
-	for _, hash := range pt.processes.Keys() { // for each process
-		process, ok := pt.processes.Get(hash)
+	for _, hash := range pt.processesLRU.Keys() { // for each process
+		process, ok := pt.processesLRU.Get(hash)
 		if !ok {
 			continue
 		}

--- a/pkg/proctree/proctree_procfs.go
+++ b/pkg/proctree/proctree_procfs.go
@@ -204,8 +204,9 @@ func dealWithProc(pt *ProcessTree, givenPid int32) error {
 	// update given process parent (if exists)
 	parent, err := getProcessByPID(pt, ppid)
 	if err == nil {
-		parent.AddChild(hash)
-		process.SetParentHash(parent.GetHash())
+		parentHash := parent.GetHash()
+		pt.AddChildToProcess(parentHash, hash)
+		process.SetParentHash(parentHash)
 	}
 
 	return nil
@@ -290,7 +291,7 @@ func dealWithThread(pt *ProcessTree, givenPid, givenTid int32) error {
 
 	leader, err := getProcessByPID(pt, tgid)
 	if err == nil {
-		leader.AddThread(hash) // threads associated with the leader (not parent)
+		pt.AddThreadToProcess(leader.GetHash(), hash) // threads associated with the leader (not parent)
 		leaderHash := leader.GetHash()
 		thread.SetLeaderHash(leaderHash) // same
 	}

--- a/pkg/proctree/taskinfo_test.go
+++ b/pkg/proctree/taskinfo_test.go
@@ -1,0 +1,15 @@
+package proctree
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+// TestTaskInfoFeed_PrintSizes prints the sizes of the structs used in the TaskInfoFeed type.
+// Run it as DEBUG test to see the output.
+func TestTaskInfoFeed_PrintSizes(t *testing.T) {
+	taskInfo := TaskInfoFeed{}
+	tests.PrintStructSizes(t, os.Stdout, taskInfo)
+}

--- a/pkg/proctree/thread.go
+++ b/pkg/proctree/thread.go
@@ -7,6 +7,7 @@ type Thread struct {
 	threadHash uint32    // hash of thread (immutable, so no need of concurrency control)
 	parentHash uint32    // hash of parent
 	leaderHash uint32    // hash of thread group leader
+	_          [4]byte   // padding
 	info       *TaskInfo // task info (immutable pointer)
 }
 

--- a/pkg/proctree/thread.go
+++ b/pkg/proctree/thread.go
@@ -4,11 +4,11 @@ import "sync/atomic"
 
 // Thread represents a thread.
 type Thread struct {
-	threadHash uint32    // hash of thread (immutable, so no need of concurrency control)
-	parentHash uint32    // hash of parent
-	leaderHash uint32    // hash of thread group leader
-	_          [4]byte   // padding
-	info       *TaskInfo // task info (immutable pointer)
+	threadHash uint32        // hash of thread (immutable, so no need of concurrency control)
+	parentHash atomic.Uint32 // hash of parent
+	leaderHash atomic.Uint32 // hash of thread group leader
+	_          [4]byte       // padding
+	info       *TaskInfo     // task info (immutable pointer)
 }
 
 // NOTE: The importance of having the thread group leader hash to each thread is the following: the
@@ -21,8 +21,8 @@ type Thread struct {
 func NewThread(hash uint32, info *TaskInfo) *Thread {
 	return &Thread{
 		threadHash: hash,
-		parentHash: 0,
-		leaderHash: 0,
+		parentHash: atomic.Uint32{},
+		leaderHash: atomic.Uint32{},
 		info:       info,
 	}
 }
@@ -36,12 +36,12 @@ func (t *Thread) GetHash() uint32 {
 
 // GetParentHash returns the hash of the parent.
 func (t *Thread) GetParentHash() uint32 {
-	return atomic.LoadUint32(&t.parentHash)
+	return t.parentHash.Load()
 }
 
 // GEtLeaderHash returns the hash of the thread group leader.
 func (t *Thread) GetLeaderHash() uint32 {
-	return atomic.LoadUint32(&t.leaderHash)
+	return t.leaderHash.Load()
 }
 
 // GetInfo returns a instanced task info.
@@ -53,10 +53,10 @@ func (t *Thread) GetInfo() *TaskInfo {
 
 // SetParentHash sets the hash of the parent.
 func (t *Thread) SetParentHash(parentHash uint32) {
-	atomic.StoreUint32(&t.parentHash, parentHash)
+	t.parentHash.Store(parentHash)
 }
 
 // SetLeaderHash sets the hash of the thread group leader.
 func (t *Thread) SetLeaderHash(leaderHash uint32) {
-	atomic.StoreUint32(&t.leaderHash, leaderHash)
+	t.leaderHash.Store(leaderHash)
 }

--- a/pkg/proctree/thread_test.go
+++ b/pkg/proctree/thread_test.go
@@ -10,6 +10,5 @@ import (
 // TestThread_PrintSizes prints the sizes of the structs used in the Thread type.
 // Run it as DEBUG test to see the output.
 func TestThread_PrintSizes(t *testing.T) {
-	thread := Thread{}
-	tests.PrintStructSizes(t, os.Stdout, thread)
+	tests.PrintStructSizes(t, os.Stdout, Thread{})
 }

--- a/pkg/proctree/thread_test.go
+++ b/pkg/proctree/thread_test.go
@@ -1,0 +1,15 @@
+package proctree
+
+import (
+	"os"
+	"testing"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
+)
+
+// TestThread_PrintSizes prints the sizes of the structs used in the Thread type.
+// Run it as DEBUG test to see the output.
+func TestThread_PrintSizes(t *testing.T) {
+	thread := Thread{}
+	tests.PrintStructSizes(t, os.Stdout, thread)
+}

--- a/pkg/utils/proc/ns_test.go
+++ b/pkg/utils/proc/ns_test.go
@@ -1,11 +1,21 @@
 package proc
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/utils/tests"
 )
+
+// TestProcNS_PrintSizes prints the sizes of the structs used in the ProcNS type.
+// Run it as DEBUG test to see the output.
+func TestTaskInfoFeed_PrintSizes(t *testing.T) {
+	procNS := ProcNS{}
+	tests.PrintStructSizes(t, os.Stdout, procNS)
+}
 
 func Test_extractNSFromLink(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Continuation of https://github.com/aquasecurity/tracee/pull/4540

Close: #4546

Ran these in `main` and `proctree-the-third` branches:

`dist/tracee --metrics --pyroscope --pprof -s tree=2609608 -e sched_process_exec,sched_process_fork,sched_process_exit --proctree source=both  --proctree disable-procfs -o none`
`dist/tracee --metrics --pyroscope --pprof -s tree=2241901 -e sched_process_exec,sched_process_fork,sched_process_exit --proctree source=both  -o none`

Stressor details:

Details
`8 threads with 1_000_000 ops each` running on:

cpu: AMD Ryzen 9 7950X 16-Core Processor
MemTotal: 64923992 kB (64GB)

### procfs disabled

```
| Metric       | main              | proctree-the-third | % Diff (main vs. work)  |
|--------------|-------------------|--------------------|-------------------------|
| malloc avg   | 1,667,695         | 1,622,511          | -2.7%                   |
| heap avg     | 103MB             | 85MB               | -17.5%                  |
| heap obj avg | 752,513           | 685,354            | -8.9%                   |
```

### procfs enabled

```
| Metric       | main.             | proctree-the-third | % Diff (main vs. work)  |
|--------------|-------------------|--------------------|-------------------------|
| malloc avg   | 2,097,349         | 2,015,099          | -3.9%                   |
| heap avg     | 189MB             | 136MB              | -28.0%                  |
| heap obj avg | 1,265,703         | 1,151,860          | -9.0%                   |
```


### 1. Explain what the PR does

1150c947b **chore(proctree): use atomic types**
989290eff **perf(proctree): centralize child and thread Maps**
ecba8294d **perf(proctree)!: rearrange struct fields**


989290eff **perf(proctree): centralize child and thread Maps**

```
Previously, each Process maintained its own maps for children and
threads, leading to significant overhead in the process tree. This
commit moves those maps into the ProcessTree, which now centrally
manages the children and threads for every process.

Additionally, this change allows us to simplify the Process struct by
removing the dedicated mutex that was solely used for protecting the
individual maps.
```

ecba8294d **perf(proctree)!: rearrange struct fields**

```
Mind the padding and the alignment of the fields to avoid wasting
memory.

BREAKING CHANGE: invoked_from_kernel, sched_process_exec event arg, is
now a bool.
```



### 2. Explain how to test it


### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
