### PR TITLE
Fix: `net_tcp_connect` event

### DIFF
--- a/pkg/events/derive/net_tcp.go
+++ b/pkg/events/derive/net_tcp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/events/parse"
+	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	"github.com/aquasecurity/tracee/types/trace"
 )
@@ -58,11 +59,11 @@ func pickIpAndPort(event trace.Event, fieldName string) (string, int, error) {
 	// e.g: sockaddr: map[sa_family:AF_INET sin_addr:10.10.11.2 sin_port:1234]
 
 	// Check if socket is a TCP socket.
-	sType, err := parse.ArgVal[string](event.Args, "type")
+	sType, err := parse.ArgVal[int32](event.Args, "type")
 	if err != nil {
 		return "", 0, errfmt.WrapError(err)
 	}
-	if sType != "SOCK_STREAM" {
+	if sType != int32(parsers.SOCK_STREAM.Value()) {
 		return "", 0, nil
 	}
 


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

The code attempted to cast "type" as a string, which caused issues when the actual value was of a different type. So this PR changes the type to int32, aligning it with parsers.SOCK_STREAM.Value(), and adds an integration test.

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

8845c70a1 **test: add test for event net_tcp_connect**
3ff256021 **fix: type parsing net_tcp_connect**

3ff256021 **fix: type parsing net_tcp_connect**

```
The code attempted to cast "type" as a string, which caused issues
when the actual value was of a different type. So this commit changes
the type to int32, aligning it with parsers.SOCK_STREAM.Value().
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->
cmd:
```
nc -zv localhost 7777
```
Tracee:
```
sudo ./dist/tracee -e net_tcp_connect
TIME             UID    COMM             PID     TID     RET              EVENT                     ARGS
16:12:03:441124  1000   nc               2561853 2561853 0                net_tcp_connect           dst: 127.0.0.1, dst_port: 7777, dst_dns: []
```
### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

fix #4568 

Thansk @oshaked1 to report this issue.