### PR TITLE
Fix ProcessTree rogue entries

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -273,10 +273,10 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 			evt.ContextFlags = flags
 			evt.Syscall = syscall
 			evt.Metadata = nil
-			// compute hashes using kernel start times as-is, to be consistent with signals
-			evt.ThreadEntityId = utils.HashTaskID(eCtx.HostTid, eCtx.StartTime)
-			evt.ProcessEntityId = utils.HashTaskID(eCtx.HostPid, eCtx.LeaderStartTime)
-			evt.ParentEntityId = utils.HashTaskID(eCtx.HostPpid, eCtx.ParentStartTime)
+			// compute hashes using normalized times
+			evt.ThreadEntityId = utils.HashTaskID(eCtx.HostTid, uint64(evt.ThreadStartTime))
+			evt.ProcessEntityId = utils.HashTaskID(eCtx.HostPid, traceetime.BootToEpochNS(eCtx.LeaderStartTime))
+			evt.ParentEntityId = utils.HashTaskID(eCtx.HostPpid, traceetime.BootToEpochNS(eCtx.ParentStartTime))
 
 			// If there aren't any policies that need filtering in userland, tracee **may** skip
 			// this event, as long as there aren't any derivatives or signatures that depend on it.

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -97,7 +97,7 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 
 		// sanity checks
 
-		payloadArg := events.GetArg(event, "payload")
+		payloadArg := events.GetArg(event.Args, "payload")
 		if payloadArg == nil {
 			logger.Debugw("Network capture: no payload packet")
 			return

--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -85,21 +85,23 @@ func (t *Tracee) registerEventProcessors() {
 	// Processors registered when proctree source "events" is enabled.
 	switch t.config.ProcTree.Source {
 	case proctree.SourceEvents, proctree.SourceBoth:
+		t.RegisterEventProcessor(events.SchedProcessFork, t.procTreeForkProcessor)
+		t.RegisterEventProcessor(events.SchedProcessExec, t.procTreeExecProcessor)
+		t.RegisterEventProcessor(events.SchedProcessExit, t.procTreeExitProcessor)
+
 		// Event Timestamps Normalization
 		//
-		// Convert all time relate args to nanoseconds since epoch.
-		// NOTE: Make sure to convert time related args (of your event) in here, so that
-		// any later code has access to normalized time arguments.
+		// Convert all time-related arguments to nanoseconds since the epoch.
+		// NOTE: Ensure that all time-related arguments for your event are
+		// converted here, so subsequent code works with normalized time values.
+		// Exception: ProcessTree hashes rely on non-normalized timestamps,
+		// so this conversion must occur AFTER the procTreeXXX processors.
 		t.RegisterEventProcessor(events.SchedProcessFork, t.normalizeTimeArg(
 			"start_time",
 			"parent_start_time",
 			"parent_process_start_time",
 			"leader_start_time",
 		))
-
-		t.RegisterEventProcessor(events.SchedProcessFork, t.procTreeForkProcessor)
-		t.RegisterEventProcessor(events.SchedProcessExec, t.procTreeExecProcessor)
-		t.RegisterEventProcessor(events.SchedProcessExit, t.procTreeExitProcessor)
 	}
 	// Processors enriching process tree with regular pipeline events.
 	if t.config.ProcTree.Source != proctree.SourceNone {

--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -85,23 +85,21 @@ func (t *Tracee) registerEventProcessors() {
 	// Processors registered when proctree source "events" is enabled.
 	switch t.config.ProcTree.Source {
 	case proctree.SourceEvents, proctree.SourceBoth:
-		t.RegisterEventProcessor(events.SchedProcessFork, t.procTreeForkProcessor)
-		t.RegisterEventProcessor(events.SchedProcessExec, t.procTreeExecProcessor)
-		t.RegisterEventProcessor(events.SchedProcessExit, t.procTreeExitProcessor)
-
 		// Event Timestamps Normalization
 		//
 		// Convert all time-related arguments to nanoseconds since the epoch.
 		// NOTE: Ensure that all time-related arguments for your event are
 		// converted here, so subsequent code works with normalized time values.
-		// Exception: ProcessTree hashes rely on non-normalized timestamps,
-		// so this conversion must occur AFTER the procTreeXXX processors.
 		t.RegisterEventProcessor(events.SchedProcessFork, t.normalizeTimeArg(
 			"start_time",
 			"parent_start_time",
 			"parent_process_start_time",
 			"leader_start_time",
 		))
+
+		t.RegisterEventProcessor(events.SchedProcessFork, t.procTreeForkProcessor)
+		t.RegisterEventProcessor(events.SchedProcessExec, t.procTreeExecProcessor)
+		t.RegisterEventProcessor(events.SchedProcessExit, t.procTreeExitProcessor)
 	}
 	// Processors enriching process tree with regular pipeline events.
 	if t.config.ProcTree.Source != proctree.SourceNone {

--- a/pkg/ebpf/processor_proctree.go
+++ b/pkg/ebpf/processor_proctree.go
@@ -174,10 +174,17 @@ func (t *Tracee) procTreeExecProcessor(event *trace.Event) error {
 		return err
 	}
 
-	execFeed.TimeStamp = uint64(event.Timestamp)
-	execFeed.TaskHash = utils.HashTaskID(uint32(event.HostThreadID), uint64(event.ThreadStartTime))
-	execFeed.ParentHash = 0 // regular pipeline does not have parent hash
-	execFeed.LeaderHash = 0 // regular pipeline does not have leader hash
+	execFeed.TimeStamp = uint64(event.Timestamp)       // already normalized at decode stage
+	execFeed.StartTime = uint64(event.ThreadStartTime) // already normalized at decode stage
+	execFeed.TaskHash = event.ThreadEntityId           // already computed at decode stage
+	execFeed.ParentHash = event.ParentEntityId         // already computed at decode stage
+	execFeed.LeaderHash = event.ProcessEntityId        // already computed at decode stage
+	execFeed.Pid = int32(event.ProcessID)
+	execFeed.Tid = int32(event.ThreadID)
+	execFeed.PPid = int32(event.ParentProcessID)
+	execFeed.HostPid = int32(event.HostProcessID)
+	execFeed.HostTid = int32(event.HostThreadID)
+	execFeed.HostPPid = int32(event.HostParentProcessID)
 
 	return t.processTree.FeedFromExec(execFeed)
 }

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -13195,10 +13195,15 @@ var CoreEvents = map[ID]Definition{
 		},
 		sets: []string{"signal"},
 		fields: []trace.ArgMeta{
+			// time
 			{Type: "u64", Name: "timestamp"},
-			{Type: "u32", Name: "task_hash"},
-			{Type: "u32", Name: "parent_hash"},
-			{Type: "u32", Name: "leader_hash"},
+			{Type: "u64", Name: "task_start_time"},
+			{Type: "u64", Name: "parent_start_time"},
+			{Type: "u64", Name: "leader_start_time"},
+			// pid
+			{Type: "int", Name: "task_pid"},
+			{Type: "int", Name: "parent_pid"},
+			{Type: "int", Name: "leader_pid"},
 			// command
 			{Type: "const char*", Name: "cmdpath"},
 			{Type: "const char*", Name: "pathname"},
@@ -13232,9 +13237,8 @@ var CoreEvents = map[ID]Definition{
 		sets: []string{"signal"},
 		fields: []trace.ArgMeta{
 			{Type: "u64", Name: "timestamp"},
-			{Type: "u32", Name: "task_hash"},
-			{Type: "u32", Name: "parent_hash"},
-			{Type: "u32", Name: "leader_hash"},
+			{Type: "u64", Name: "task_start_time"},
+			{Type: "int", Name: "task_pid"},
 			{Type: "int", Name: "exit_code"},
 			{Type: "int", Name: "signal_code"},
 			{Type: "bool", Name: "process_group_exit"},

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -82,7 +82,7 @@ func strToLower(given string) string {
 
 // parsePayloadArg returns the packet payload from the event.
 func parsePayloadArg(event *trace.Event) ([]byte, error) {
-	payloadArg := events.GetArg(event, "payload")
+	payloadArg := events.GetArg(event.Args, "payload")
 	if payloadArg == nil {
 		return nil, noPayloadError()
 	}

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events/parsers"
+	traceetime "github.com/aquasecurity/tracee/pkg/time"
 	"github.com/aquasecurity/tracee/types/trace"
 )
 
@@ -26,221 +27,221 @@ func ParseArgs(event *trace.Event) error {
 	evtID := ID(event.EventID)
 	switch evtID {
 	case MemProtAlert:
-		if alertArg := GetArg(event, "alert"); alertArg != nil {
+		if alertArg := GetArg(event.Args, "alert"); alertArg != nil {
 			if alert, isUint32 := alertArg.Value.(uint32); isUint32 {
 				parseMemProtAlert(alertArg, alert)
 			}
 		}
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := GetArg(event.Args, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				parseMMapProt(protArg, uint64(prot))
 			}
 		}
-		if prevProtArg := GetArg(event, "prev_prot"); prevProtArg != nil {
+		if prevProtArg := GetArg(event.Args, "prev_prot"); prevProtArg != nil {
 			if prevProt, isInt32 := prevProtArg.Value.(int32); isInt32 {
 				parseMMapProt(prevProtArg, uint64(prevProt))
 			}
 		}
 	case SysEnter, SysExit:
-		if syscallArg := GetArg(event, "syscall"); syscallArg != nil {
+		if syscallArg := GetArg(event.Args, "syscall"); syscallArg != nil {
 			if id, isInt32 := syscallArg.Value.(int32); isInt32 {
 				parseSyscall(syscallArg, id)
 			}
 		}
 	case CapCapable:
-		if capArg := GetArg(event, "cap"); capArg != nil {
+		if capArg := GetArg(event.Args, "cap"); capArg != nil {
 			if capability, isInt32 := capArg.Value.(int32); isInt32 {
 				parseCapability(capArg, uint64(capability))
 			}
 		}
 	case SecurityMmapFile, DoMmap:
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := GetArg(event.Args, "prot"); protArg != nil {
 			if prot, isUint64 := protArg.Value.(uint64); isUint64 {
 				parseMMapProt(protArg, prot)
 			}
 		}
 	case Mmap, Mprotect, PkeyMprotect:
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := GetArg(event.Args, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				parseMMapProt(protArg, uint64(prot))
 			}
 		}
 	case SecurityFileMprotect:
-		if protArg := GetArg(event, "prot"); protArg != nil {
+		if protArg := GetArg(event.Args, "prot"); protArg != nil {
 			if prot, isInt32 := protArg.Value.(int32); isInt32 {
 				parseMMapProt(protArg, uint64(prot))
 			}
 		}
-		if prevProtArg := GetArg(event, "prev_prot"); prevProtArg != nil {
+		if prevProtArg := GetArg(event.Args, "prev_prot"); prevProtArg != nil {
 			if prevProt, isInt32 := prevProtArg.Value.(int32); isInt32 {
 				parseMMapProt(prevProtArg, uint64(prevProt))
 			}
 		}
 	case Ptrace:
-		if reqArg := GetArg(event, "request"); reqArg != nil {
+		if reqArg := GetArg(event.Args, "request"); reqArg != nil {
 			if req, isInt64 := reqArg.Value.(int64); isInt64 {
 				parsePtraceRequestArgument(reqArg, uint64(req))
 			}
 		}
 	case Prctl:
-		if optArg := GetArg(event, "option"); optArg != nil {
+		if optArg := GetArg(event.Args, "option"); optArg != nil {
 			if option, isInt32 := optArg.Value.(int32); isInt32 {
 				parsePrctlOption(optArg, uint64(option))
 			}
 		}
 	case Socketcall:
-		if callArg := GetArg(event, "call"); callArg != nil {
+		if callArg := GetArg(event.Args, "call"); callArg != nil {
 			if call, isInt32 := callArg.Value.(int32); isInt32 {
 				parseSocketcallCall(callArg, uint64(call))
 			}
 		}
 	case Socket:
-		if domArg := GetArg(event, "domain"); domArg != nil {
+		if domArg := GetArg(event.Args, "domain"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				parseSocketDomainArgument(domArg, uint64(dom))
 			}
 		}
-		if typeArg := GetArg(event, "type"); typeArg != nil {
+		if typeArg := GetArg(event.Args, "type"); typeArg != nil {
 			if typ, isInt32 := typeArg.Value.(int32); isInt32 {
 				parseSocketType(typeArg, uint64(typ))
 			}
 		}
 	case SecuritySocketCreate, SecuritySocketConnect:
-		if domArg := GetArg(event, "family"); domArg != nil {
+		if domArg := GetArg(event.Args, "family"); domArg != nil {
 			if dom, isInt32 := domArg.Value.(int32); isInt32 {
 				parseSocketDomainArgument(domArg, uint64(dom))
 			}
 		}
-		if typeArg := GetArg(event, "type"); typeArg != nil {
+		if typeArg := GetArg(event.Args, "type"); typeArg != nil {
 			if typ, isInt32 := typeArg.Value.(int32); isInt32 {
 				parseSocketType(typeArg, uint64(typ))
 			}
 		}
 	case Access:
-		if modeArg := GetArg(event, "mode"); modeArg != nil {
+		if modeArg := GetArg(event.Args, "mode"); modeArg != nil {
 			if mode, isInt32 := modeArg.Value.(int32); isInt32 {
 				parseAccessMode(modeArg, uint64(mode))
 			}
 		}
 	case Faccessat:
-		if modeArg := GetArg(event, "mode"); modeArg != nil {
+		if modeArg := GetArg(event.Args, "mode"); modeArg != nil {
 			if mode, isInt32 := modeArg.Value.(int32); isInt32 {
 				parseAccessMode(modeArg, uint64(mode))
 			}
 		}
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := GetArg(event.Args, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				parseFaccessatFlag(flagsArg, uint64(flags))
 			}
 		}
 	case Execveat:
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := GetArg(event.Args, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				parseExecveatFlag(flagsArg, uint64(flags))
 			}
 		}
 	case Open, Openat, SecurityFileOpen:
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := GetArg(event.Args, "flags"); flagsArg != nil {
 			if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 				parseOpenFlagArgument(flagsArg, uint64(flags))
 			}
 		}
 	case Mknod, Mknodat, SecurityInodeMknod, Chmod, Fchmod, Fchmodat, ChmodCommon:
-		if modeArg := GetArg(event, "mode"); modeArg != nil {
+		if modeArg := GetArg(event.Args, "mode"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				parseInodeMode(modeArg, uint64(mode))
 			}
 		}
 		if evtID == Fchmodat {
-			if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+			if flagsArg := GetArg(event.Args, "flags"); flagsArg != nil {
 				if flags, isInt32 := flagsArg.Value.(int32); isInt32 {
 					parseFchmodatFlag(flagsArg, uint64(flags))
 				}
 			}
 		}
 	case Clone:
-		if flagsArg := GetArg(event, "flags"); flagsArg != nil {
+		if flagsArg := GetArg(event.Args, "flags"); flagsArg != nil {
 			if flags, isUint64 := flagsArg.Value.(uint64); isUint64 {
 				parseCloneFlags(flagsArg, flags)
 			}
 		}
 	case Bpf, SecurityBPF:
-		if cmdArg := GetArg(event, "cmd"); cmdArg != nil {
+		if cmdArg := GetArg(event.Args, "cmd"); cmdArg != nil {
 			if cmd, isInt32 := cmdArg.Value.(int32); isInt32 {
 				parseBPFCmd(cmdArg, uint64(cmd))
 			}
 		}
 	case SecurityKernelReadFile, SecurityPostReadFile:
-		if typeArg := GetArg(event, "type"); typeArg != nil {
+		if typeArg := GetArg(event.Args, "type"); typeArg != nil {
 			if readFileId, isInt32 := typeArg.Value.(trace.KernelReadType); isInt32 {
 				typeArg.Type = "string"
 				typeArg.Value = readFileId.String()
 			}
 		}
 	case SchedProcessExec:
-		if modeArg := GetArg(event, "stdin_type"); modeArg != nil {
+		if modeArg := GetArg(event.Args, "stdin_type"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				parseInodeMode(modeArg, uint64(mode))
 			}
 		}
 	case DirtyPipeSplice:
-		if modeArg := GetArg(event, "in_file_type"); modeArg != nil {
+		if modeArg := GetArg(event.Args, "in_file_type"); modeArg != nil {
 			if mode, isUint16 := modeArg.Value.(uint16); isUint16 {
 				parseInodeMode(modeArg, uint64(mode))
 			}
 		}
 	case SecuritySocketSetsockopt, Setsockopt, Getsockopt:
-		if levelArg := GetArg(event, "level"); levelArg != nil {
+		if levelArg := GetArg(event.Args, "level"); levelArg != nil {
 			if level, isInt := levelArg.Value.(int32); isInt {
 				parseSocketLevel(levelArg, uint64(level))
 			}
 		}
-		if optionNameArg := GetArg(event, "optname"); optionNameArg != nil {
+		if optionNameArg := GetArg(event.Args, "optname"); optionNameArg != nil {
 			if opt, isInt := optionNameArg.Value.(int32); isInt {
 				parseGetSocketOption(optionNameArg, uint64(opt), ID(event.EventID))
 			}
 		}
 	case BpfAttach:
-		if progTypeArg := GetArg(event, "prog_type"); progTypeArg != nil {
+		if progTypeArg := GetArg(event.Args, "prog_type"); progTypeArg != nil {
 			if progType, isInt := progTypeArg.Value.(int32); isInt {
 				parseBPFProgType(progTypeArg, uint64(progType))
 			}
 		}
-		if helpersArg := GetArg(event, "prog_helpers"); helpersArg != nil {
+		if helpersArg := GetArg(event.Args, "prog_helpers"); helpersArg != nil {
 			if helpersList, isUintSlice := helpersArg.Value.([]uint64); isUintSlice {
 				parseBpfHelpersUsage(helpersArg, helpersList)
 			}
 		}
-		if attachTypeArg := GetArg(event, "attach_type"); attachTypeArg != nil {
+		if attachTypeArg := GetArg(event.Args, "attach_type"); attachTypeArg != nil {
 			if attachType, isInt := attachTypeArg.Value.(int32); isInt {
 				parseBpfAttachType(attachTypeArg, attachType)
 			}
 		}
 	case SecurityBpfProg:
-		if progTypeArg := GetArg(event, "type"); progTypeArg != nil {
+		if progTypeArg := GetArg(event.Args, "type"); progTypeArg != nil {
 			if progType, isInt := progTypeArg.Value.(int32); isInt {
 				parseBPFProgType(progTypeArg, uint64(progType))
 			}
 		}
-		if helpersArg := GetArg(event, "helpers"); helpersArg != nil {
+		if helpersArg := GetArg(event.Args, "helpers"); helpersArg != nil {
 			if helpersList, isUintSlice := helpersArg.Value.([]uint64); isUintSlice {
 				parseBpfHelpersUsage(helpersArg, helpersList)
 			}
 		}
 	case SecurityPathNotify:
-		if maskArg := GetArg(event, "mask"); maskArg != nil {
+		if maskArg := GetArg(event.Args, "mask"); maskArg != nil {
 			if mask, isUint64 := maskArg.Value.(uint64); isUint64 {
 				maskArg.Type = "string"
 				maskArg.Value = parsers.ParseFsNotifyMask(mask).String()
 			}
 		}
-		if objTypeArg := GetArg(event, "obj_type"); objTypeArg != nil {
+		if objTypeArg := GetArg(event.Args, "obj_type"); objTypeArg != nil {
 			if objType, isUint := objTypeArg.Value.(uint32); isUint {
 				parseFsNotifyObjType(objTypeArg, uint64(objType))
 			}
 		}
 	case SuspiciousSyscallSource, StackPivot:
-		if vmaFlagsArg := GetArg(event, "vma_flags"); vmaFlagsArg != nil {
+		if vmaFlagsArg := GetArg(event.Args, "vma_flags"); vmaFlagsArg != nil {
 			if flags, isUint64 := vmaFlagsArg.Value.(uint64); isUint64 {
 				vmaFlagsArg.Type = "string"
 				vmaFlagsArg.Value = parsers.ParseVmFlags(flags).String()
@@ -252,7 +253,7 @@ func ParseArgs(event *trace.Event) error {
 }
 
 func ParseArgsFDs(event *trace.Event, origTimestamp uint64, fdArgPathMap *bpf.BPFMap) error {
-	if fdArg := GetArg(event, "fd"); fdArg != nil {
+	if fdArg := GetArg(event.Args, "fd"); fdArg != nil {
 		if fd, isInt32 := fdArg.Value.(int32); isInt32 {
 			ts := origTimestamp
 			bs, err := fdArgPathMap.GetValue(unsafe.Pointer(&ts))
@@ -265,7 +266,7 @@ func ParseArgsFDs(event *trace.Event, origTimestamp uint64, fdArgPathMap *bpf.BP
 		}
 	}
 
-	if dirfdArg := GetArg(event, "dirfd"); dirfdArg != nil {
+	if dirfdArg := GetArg(event.Args, "dirfd"); dirfdArg != nil {
 		if dirfd, isInt32 := dirfdArg.Value.(int32); isInt32 {
 			parseDirfdAt(dirfdArg, uint64(dirfd))
 		}
@@ -274,21 +275,47 @@ func ParseArgsFDs(event *trace.Event, origTimestamp uint64, fdArgPathMap *bpf.BP
 	return nil
 }
 
-func GetArg(event *trace.Event, argName string) *trace.Argument {
-	for i := range event.Args {
-		if event.Args[i].Name == argName {
-			return &event.Args[i]
+func GetArg(args []trace.Argument, argName string) *trace.Argument {
+	for i := range args {
+		if args[i].Name == argName {
+			return &args[i]
 		}
 	}
+
 	return nil
 }
 
 func SetArgValue(event *trace.Event, argName string, value any) error {
-	arg := GetArg(event, argName)
+	arg := GetArg(event.Args, argName)
 	if arg == nil {
 		return fmt.Errorf("event %s has no argument named %s", event.EventName, argName)
 	}
 	arg.Value = value
+	return nil
+}
+
+// NormalizeTimeArgs normalizes the time arguments of an event, converting them to
+// nanoseconds since the epoch.
+func NormalizeTimeArgs(args []trace.Argument, timeArgNames []string) error {
+	for i := range timeArgNames {
+		arg := GetArg(args, timeArgNames[i])
+		if arg == nil {
+			return errfmt.Errorf("couldn't find argument %s", timeArgNames[i])
+		}
+		if arg.Value == nil {
+			continue
+		}
+
+		argTime, ok := arg.Value.(uint64)
+		if !ok {
+			return errfmt.Errorf("argument %s is not uint64, it is %T",
+				timeArgNames[i],
+				arg.Value,
+			)
+		}
+		arg.Value = traceetime.BootToEpochNS(argTime)
+	}
+
 	return nil
 }
 

--- a/pkg/events/parse_args_helpers_test.go
+++ b/pkg/events/parse_args_helpers_test.go
@@ -70,9 +70,9 @@ func TestParseMMapProt(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseMMapProt(GetArg(event, "prot"), testCase.args[0].Value.(uint64))
+			parseMMapProt(GetArg(event.Args, "prot"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -135,9 +135,9 @@ func TestParseSocketDomainArgument(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseSocketDomainArgument(GetArg(event, "domain"), testCase.args[0].Value.(uint64))
+			parseSocketDomainArgument(GetArg(event.Args, "domain"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -207,7 +207,7 @@ func TestParseSocketType(t *testing.T) {
 			err := ParseArgs(event)
 			require.NoError(t, err)
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -268,9 +268,9 @@ func TestParseInodeMode(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseInodeMode(GetArg(event, "mode"), testCase.args[0].Value.(uint64))
+			parseInodeMode(GetArg(event.Args, "mode"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -333,9 +333,9 @@ func TestParseBPFProgType(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseBPFProgType(GetArg(event, "type"), testCase.args[0].Value.(uint64))
+			parseBPFProgType(GetArg(event.Args, "type"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -398,9 +398,9 @@ func TestParseCapability(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseCapability(GetArg(event, "capability"), testCase.args[0].Value.(uint64))
+			parseCapability(GetArg(event.Args, "capability"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -442,9 +442,9 @@ func TestParseMemProtAlert(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseMemProtAlert(GetArg(event, "alert"), testCase.args[0].Value.(uint32))
+			parseMemProtAlert(GetArg(event.Args, "alert"), testCase.args[0].Value.(uint32))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -507,9 +507,9 @@ func TestParseSyscall(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseSyscall(GetArg(event, "id"), testCase.args[0].Value.(int32))
+			parseSyscall(GetArg(event.Args, "id"), testCase.args[0].Value.(int32))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -572,9 +572,9 @@ func TestParsePtraceRequestArgument(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parsePtraceRequestArgument(GetArg(event, "req"), testCase.args[0].Value.(uint64))
+			parsePtraceRequestArgument(GetArg(event.Args, "req"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -637,9 +637,9 @@ func TestParsePrctlOption(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parsePrctlOption(GetArg(event, "opt"), testCase.args[0].Value.(uint64))
+			parsePrctlOption(GetArg(event.Args, "opt"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -702,9 +702,9 @@ func TestParseSocketcallCall(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseSocketcallCall(GetArg(event, "call"), testCase.args[0].Value.(uint64))
+			parseSocketcallCall(GetArg(event.Args, "call"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -768,9 +768,9 @@ func TestParseAccessMode(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseAccessMode(GetArg(event, "mode"), testCase.args[0].Value.(uint64))
+			parseAccessMode(GetArg(event.Args, "mode"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -833,9 +833,9 @@ func TestParseExecveatFlag(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseExecveatFlag(GetArg(event, "flags"), testCase.args[0].Value.(uint64))
+			parseExecveatFlag(GetArg(event.Args, "flags"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -899,9 +899,9 @@ func TestParseOpenFlagArgument(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseOpenFlagArgument(GetArg(event, "flags"), testCase.args[0].Value.(uint64))
+			parseOpenFlagArgument(GetArg(event.Args, "flags"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -984,9 +984,9 @@ func TestParseCloneFlags(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseCloneFlags(GetArg(event, "flags"), testCase.args[0].Value.(uint64))
+			parseCloneFlags(GetArg(event.Args, "flags"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -1049,9 +1049,9 @@ func TestParseBPFCmd(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseBPFCmd(GetArg(event, "cmd"), testCase.args[0].Value.(uint64))
+			parseBPFCmd(GetArg(event.Args, "cmd"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -1114,9 +1114,9 @@ func TestParseSocketLevel(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseSocketLevel(GetArg(event, "level"), testCase.args[0].Value.(uint64))
+			parseSocketLevel(GetArg(event.Args, "level"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -1179,9 +1179,9 @@ func TestParseGetSocketOption(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseGetSocketOption(GetArg(event, "optname"), testCase.args[0].Value.(uint64), Getsockopt)
+			parseGetSocketOption(GetArg(event.Args, "optname"), testCase.args[0].Value.(uint64), Getsockopt)
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -1244,9 +1244,9 @@ func TestParseFsNotifyObjType(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseFsNotifyObjType(GetArg(event, "objType"), testCase.args[0].Value.(uint64))
+			parseFsNotifyObjType(GetArg(event.Args, "objType"), testCase.args[0].Value.(uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -1310,9 +1310,9 @@ func TestParseBpfHelpersUsage(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseBpfHelpersUsage(GetArg(event, "helpersList"), testCase.args[0].Value.([]uint64))
+			parseBpfHelpersUsage(GetArg(event.Args, "helpersList"), testCase.args[0].Value.([]uint64))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})
@@ -1375,9 +1375,9 @@ func TestParseBpfAttachType(t *testing.T) {
 			event := &trace.Event{
 				Args: testCase.args,
 			}
-			parseBpfAttachType(GetArg(event, "attachType"), testCase.args[0].Value.(int32))
+			parseBpfAttachType(GetArg(event.Args, "attachType"), testCase.args[0].Value.(int32))
 			for _, expArg := range testCase.expectedArgs {
-				arg := GetArg(event, expArg.Name)
+				arg := GetArg(event.Args, expArg.Name)
 				assert.Equal(t, expArg, *arg)
 			}
 		})

--- a/pkg/events/parse_args_test.go
+++ b/pkg/events/parse_args_test.go
@@ -78,7 +78,7 @@ func TestParseArgs(t *testing.T) {
 				err := ParseArgs(&event)
 				require.NoError(t, err)
 				for _, expArg := range testCase.expectedArgs {
-					arg := GetArg(&event, expArg.Name)
+					arg := GetArg(event.Args, expArg.Name)
 					assert.Equal(t, expArg, *arg)
 				}
 			})
@@ -185,7 +185,7 @@ func TestParseArgs(t *testing.T) {
 				err := ParseArgs(&event)
 				require.NoError(t, err)
 				for _, expArg := range testCase.expectedArgs {
-					arg := GetArg(&event, expArg.Name)
+					arg := GetArg(event.Args, expArg.Name)
 					assert.Equal(t, expArg, *arg)
 				}
 			})
@@ -271,7 +271,7 @@ func TestParseArgs(t *testing.T) {
 				err := ParseArgs(event)
 				require.NoError(t, err)
 				for _, expArg := range testCase.expectedArgs {
-					arg := GetArg(event, expArg.Name)
+					arg := GetArg(event.Args, expArg.Name)
 					assert.Equal(t, expArg, *arg)
 				}
 			})

--- a/pkg/proctree/proctree.go
+++ b/pkg/proctree/proctree.go
@@ -129,7 +129,7 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig) (*ProcessTree, e
 	}
 
 	var err error
-	procEvited := 0
+	procEvicted := 0
 	thrEvicted := 0
 
 	// Create caches for processes.
@@ -138,7 +138,7 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig) (*ProcessTree, e
 		func(key uint32, value *Process) {
 			procTree.EvictThreads(key)
 			procTree.EvictChildren(key)
-			procEvited++
+			procEvicted++
 		},
 	)
 	if err != nil {
@@ -168,14 +168,14 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig) (*ProcessTree, e
 			case <-ctx.Done():
 				return
 			case <-ticker15s.C:
-				if procEvited != 0 || thrEvicted != 0 {
+				if procEvicted != 0 || thrEvicted != 0 {
 					logger.Debugw("proctree cache stats",
-						"processes evicted", procEvited,
+						"processes evicted", procEvicted,
 						"total processes", procTree.processesLRU.Len(),
 						"threads evicted", thrEvicted,
 						"total threads", procTree.threadsLRU.Len(),
 					)
-					procEvited = 0
+					procEvicted = 0
 					thrEvicted = 0
 				}
 

--- a/pkg/proctree/proctree.go
+++ b/pkg/proctree/proctree.go
@@ -178,6 +178,9 @@ func NewProcessTree(ctx context.Context, config ProcTreeConfig) (*ProcessTree, e
 					procEvited = 0
 					thrEvicted = 0
 				}
+
+				// For debugging purposes, print the entire process tree.
+				// fmt.Println(procTree.String())
 			case <-ticker1m.C:
 				logger.Debugw("proctree cache stats",
 					"total processes", procTree.processesLRU.Len(),

--- a/pkg/proctree/proctree_feed.go
+++ b/pkg/proctree/proctree_feed.go
@@ -306,8 +306,6 @@ func (pt *ProcessTree) FeedFromExec(feed *ExecFeed) error {
 type ExitFeed struct {
 	TimeStamp  uint64
 	TaskHash   uint32
-	ParentHash uint32
-	LeaderHash uint32
 	ExitCode   int32
 	SignalCode int32
 	Group      bool

--- a/pkg/proctree/proctree_output.go
+++ b/pkg/proctree/proctree_output.go
@@ -85,7 +85,7 @@ func (pt *ProcessTree) String() string {
 	// Use tablewriter to print the tree in a table
 	newTable := func() *tablewriter.Table {
 		table := tablewriter.NewWriter(buffer)
-		table.SetHeader([]string{"Ppid", "Tid", "Pid", "StartTime", "Hash", "Date", "CMD", "Children", "Threads"})
+		table.SetHeader([]string{"Ppid", "Tid", "Pid", "StartTime", "ExitTime", "Hash", "Date", "CMD", "Children", "Threads"})
 		table.SetAutoWrapText(false)
 		table.SetRowLine(false)
 		table.SetAutoFormatHeaders(true)
@@ -112,9 +112,9 @@ func (pt *ProcessTree) String() string {
 		if !ok {
 			continue
 		}
-		if !process.GetInfo().IsAlive() { // only running processes
-			continue
-		}
+		// if !process.GetInfo().IsAlive() { // only running processes
+		// 	continue
+		// }
 
 		// create a row for the table
 		processFeed := process.GetInfo().GetFeed()
@@ -123,7 +123,8 @@ func (pt *ProcessTree) String() string {
 			execName = execName[:20] + "..."
 		}
 		hashStr := fmt.Sprintf("%v", process.GetHash())
-		startTime := fmt.Sprintf("%v", process.GetInfo().GetStartTimeNS())
+		startTimeStr := fmt.Sprintf("%v", process.GetInfo().GetStartTimeNS())
+		exitTimeStr := fmt.Sprintf("%v", process.GetInfo().GetExitTimeNS())
 		tid := stringify(int(processFeed.Tid))
 		pid := stringify(int(processFeed.Pid))
 		ppid := stringify(int(processFeed.PPid))
@@ -133,7 +134,8 @@ func (pt *ProcessTree) String() string {
 		unsortedRows = append(unsortedRows,
 			[]string{
 				ppid, tid, pid,
-				startTime, hashStr,
+				startTimeStr, exitTimeStr,
+				hashStr,
 				date, execName,
 				getListOfChildrenPids(process),
 				getListOfThreadsTids(process),

--- a/pkg/proctree/proctree_procfs.go
+++ b/pkg/proctree/proctree_procfs.go
@@ -149,10 +149,10 @@ func dealWithProc(pt *ProcessTree, givenPid int32) error {
 
 	// sanity checks
 	switch givenPid {
-	case 0, 1: // PID 0 and 1 are special
+	case 0, 1, 2: // PIDs 0, 1 and 2 are special
 	default:
 		if name == "" || pid == 0 || tgid == 0 || ppid == 0 {
-			return errfmt.Errorf("invalid process")
+			return errfmt.Errorf("invalid process - status: %v, stat: %v", status, stat)
 		}
 	}
 
@@ -167,7 +167,7 @@ func dealWithProc(pt *ProcessTree, givenPid int32) error {
 
 	// check if the process info was already set (proctree might miss ppid and name)
 	switch givenPid {
-	case 0, 1: // PID 0 and 1 are special
+	case 0, 1: // PIDs 0 and 1 are special
 	default:
 		if procInfo.GetName() != "" && procInfo.GetPPid() != 0 {
 			return nil
@@ -245,7 +245,7 @@ func dealWithThread(pt *ProcessTree, givenPid, givenTid int32) error {
 
 	// sanity checks
 	if name == "" || pid == 0 || tgid == 0 || ppid == 0 {
-		return errfmt.Errorf("invalid thread")
+		return errfmt.Errorf("invalid thread - status: %v, stat: %v", status, stat)
 	}
 
 	// thread start time (monotonic boot)

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -237,7 +237,7 @@ for TEST in $TESTS; do
 
     # Make sure we exit tracee before checking output and log files
 
-    pid_tracee=$(pidof tracee | cut -d' ' -f1)
+    pid_tracee=$(pgrep -x tracee | xargs)
     kill -SIGINT "$pid_tracee"
     sleep $TRACEE_SHUTDOWN_TIMEOUT
     kill -SIGKILL "$pid_tracee" >/dev/null 2>&1


### PR DESCRIPTION
Close: #4580
Close: #3878

### 1. Explain what the PR does

f2e413059 **chore(proctree): mov hash computation to userspace**
5d943de68 **chore(proctree): add debug comment**
71bb922af **fix(proctree): exec event already brings data**
0ed6a1a3a **fix(proctree): treat kthread as special case**
fa4bc3283 **fix(proctree): time normalization momentum**
0e9065f8f **fix(tests): kill only tracee (-x exact match)**
ab4e18441 **chore(proctree): add exittime to debug**


71bb922af **fix(proctree): exec event already brings data**

```
Populate Process TaskInfo with data from sched_process_exec event.
Without it, the ProcessTree when set as source=events will contain
entries with no relevant data.
```

0ed6a1a3a **fix(proctree): treat kthread as special case**

```
kthread was being added only as parent, so its taskinfo was not being
updated.
```

fa4bc3283 **fix(proctree): time normalization momentum**

```
ProcessTree was populated with rogue entries because time normalization
was not performed at the correct moment, leading to a mismatch between
hashes from signals and those from events.
```

### 2. Explain how to test it

Uncomment https://github.com/aquasecurity/tracee/pull/4582/files#diff-72195925b110a2e9579f4bd9491d18052a9fb1875d2b3757987cfdfc288a1cffR183 and run tracee with `--proctree source=both`, `--proctree source=events`, `--proctree source=signals` for checking the current state of the ProcessTree. One might also wanna run `INSTTESTS="PROCTREE_DATA_SOURCE" ./tests/e2e-inst-test.sh` changing the source type inside that script before.

One won't see anymore:

- Rogue entries (hashes without pid, tid or ppid)
- Different hashes for the same pid, tid and ppid
- pid 2 as a rogue entry

### 3. Other comments

