### PR TITLE
Fix clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,6 @@ AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-PenaltyReturnTypeOnItsOwnLine: 1000000
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 AttributeMacros:
@@ -83,14 +82,6 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments: true
 SortIncludes: false
@@ -118,7 +109,7 @@ SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
 BitFieldColonSpacing: Both
 Standard: Latest
-TabWidth: 8
+TabWidth: 4
 UseCRLF: false
 UseTab: Never
 WhitespaceSensitiveMacros:
@@ -127,5 +118,14 @@ WhitespaceSensitiveMacros:
   - BOOST_PP_STRINGIZE
   - NS_SWIFT_NAME
   - CF_SWIFT_NAME
-...
+
+# Penalties
+# This decides what order things should be done if a line is too long
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 10
+PenaltyExcessCharacter: 100
+PenaltyReturnTypeOnItsOwnLine: 60
 

--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -609,8 +609,8 @@ statfunc int events_perf_submit(program_data_t *p, long ret)
         }
     }
 
-    u32 size = sizeof(event_context_t) + sizeof(u8) +
-               p->event->args_buf.offset; // context + argnum + arg buffer size
+    // context + argnum + arg buffer size
+    u32 size = sizeof(event_context_t) + sizeof(u8) + p->event->args_buf.offset;
 
     // inline bounds check to force compiler to use the register of size
     asm volatile("if %[size] < %[max_size] goto +1;\n"
@@ -636,8 +636,8 @@ statfunc int events_perf_submit(program_data_t *p, long ret)
 
 statfunc int signal_perf_submit(void *ctx, controlplane_signal_t *sig)
 {
-    u32 size =
-        sizeof(u32) + sizeof(u8) + sig->args_buf.offset; // signal id + argnum + arg buffer size
+    // signal id + argnum + arg buffer size
+    u32 size = sizeof(u32) + sizeof(u8) + sig->args_buf.offset;
 
     // inline bounds check to force compiler to use the register of size
     asm volatile("if %[size] < %[max_size] goto +1;\n"

--- a/pkg/ebpf/c/common/filtering.h
+++ b/pkg/ebpf/c/common/filtering.h
@@ -358,8 +358,8 @@ statfunc u64 match_data_filters(program_data_t *p, u8 index)
     u64 explicit_enable_policies = 0;
     u64 default_enable_policies = 0;
     // Determine policies that do not use any type of string filter (exact, prefix, suffix)
-    u64 mask_no_str_filter_policies =
-        ~str_filter->exact_enabled & ~str_filter->prefix_enabled & ~str_filter->suffix_enabled;
+    u64 mask_no_str_filter_policies = ~str_filter->exact_enabled & ~str_filter->prefix_enabled &
+                                      ~str_filter->suffix_enabled;
     void *filter_map = NULL;
 
     // event ID

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -937,11 +937,10 @@ statfunc int find_modules_from_module_kset_list(program_data_t *p)
 
 #pragma unroll
     for (int i = 0; i < MAX_NUM_MODULES; i++) {
-        if (BPF_CORE_READ(n, name) ==
-            NULL) { // Without this the list seems infinite. Also, using pos
-                    // here seems incorrect as it starts from a weird member
+        // Without this the list seems infinite.
+        // Also, using pos here seems incorrect as it starts from a weird member.
+        if (BPF_CORE_READ(n, name) == NULL)
             return 0;
-        }
 
         struct module_kobject *mod_kobj =
             (struct module_kobject *) container_of(n, struct module_kobject, kobj);
@@ -1033,8 +1032,8 @@ int lkm_seeker_modtree_loop(struct pt_regs *ctx)
                     break;
                 }
 
-                /* We have visited the node and its left subtree.
-                Now, it's right subtree's turn */
+                // We have visited the node and its left subtree.
+                // Now, it's right subtree's turn.
                 curr = BPF_CORE_READ(curr, rb_right);
             }
         }
@@ -1220,9 +1219,9 @@ int uprobe_lkm_seeker_submitter(struct pt_regs *ctx)
     if (p.config->tracee_pid != trigger_pid)
         return 0;
 
-    u32 flags =
-        ((u32) received_flags) | HIDDEN_MODULE; // Convert to 32bit and turn on the bit that will
-                                                // cause it to be sent as an event to the user
+    // Convert to 32bit and turn on the bit that will cause it to be sent as an
+    // event to the user.
+    u32 flags = ((u32) received_flags) | HIDDEN_MODULE;
     lkm_seeker_send_to_userspace((struct module *) mod_address, &flags, &p);
 
     return 0;
@@ -1287,8 +1286,9 @@ int lkm_seeker_kset_tail(struct pt_regs *ctx)
     if (ret < 0) {
         tracee_log(ctx, BPF_LOG_LVL_WARN, BPF_LOG_ID_HID_KER_MOD, ret);
         u32 flags = HISTORY_SCAN_FINISHED;
-        lkm_seeker_send_to_userspace(
-            (struct module *) HISTORY_SCAN_FAILURE, &flags, &p); // Report failure of history scan
+
+        // Report failure of history scan
+        lkm_seeker_send_to_userspace((struct module *) HISTORY_SCAN_FAILURE, &flags, &p);
         return -1;
     }
 
@@ -1362,8 +1362,8 @@ int lkm_seeker_new_mod_only_tail(struct pt_regs *ctx)
         return -1;
     }
 
-    struct module *mod =
-        (struct module *) start_scan_time; // Use the module address field as the start_scan_time
+    // Use the module address field as the start_scan_time
+    struct module *mod = (struct module *) start_scan_time;
     u32 flags = NEW_MOD;
     lkm_seeker_send_to_userspace(mod, &flags, &p);
 
@@ -2737,8 +2737,8 @@ int BPF_KPROBE(trace_security_socket_connect)
             break;
         case SYSCALL_SOCKETCALL:
             arr_addr = (void *) get_syscall_arg2(p.event->task, task_regs, false);
-            bpf_probe_read_user(
-                &sockfd, sizeof(int), arr_addr); // fd is the first entry in the array
+            // fd is the first entry in the array
+            bpf_probe_read_user(&sockfd, sizeof(int), arr_addr);
             stsb(args_buf, &sockfd, sizeof(int), 0);
             break;
     }
@@ -3195,12 +3195,8 @@ statfunc bool
 filter_file_write_capture(program_data_t *p, struct file *file, io_data_t io_data, off_t start_pos)
 {
     return filter_file_path(p->ctx, &file_write_path_filter, file) ||
-           filter_file_type(p->ctx,
-                            &file_type_filter,
-                            CAPTURE_WRITE_TYPE_FILTER_IDX,
-                            file,
-                            io_data,
-                            start_pos) ||
+           filter_file_type(
+               p->ctx, &file_type_filter, CAPTURE_WRITE_TYPE_FILTER_IDX, file, io_data, start_pos) ||
            filter_file_fd(p->ctx, &file_type_filter, CAPTURE_WRITE_TYPE_FILTER_IDX, file);
 }
 

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -232,10 +232,10 @@ typedef struct {
 typedef struct task_info {
     task_context_t context;
     syscall_data_t syscall_data;
-    bool syscall_traced; // indicates that syscall_data is valid
-    u8 container_state;  // the state of the container the task resides in
-    address_range_t
-        stack; // stack area, only relevant for tasks that aren't group leaders (threads)
+    bool syscall_traced;   // indicates that syscall_data is valid
+    u8 container_state;    // the state of the container the task resides in
+    address_range_t stack; // stack area, only relevant for tasks that aren't
+                           // group leaders (threads)
 } task_info_t;
 
 typedef struct file_id {


### PR DESCRIPTION
### 1. Explain what the PR does

12a7e77bb **chore(ebpf): format apply based on the latest fix**
d3fc3e14e **fix: remove duplicate entry in .clang-format**


d3fc3e14e **fix: remove duplicate entry in .clang-format**

```
PenaltyReturnTypeOnItsOwnLine was duplicated in the .clang-format file.
It was crashing the clangd server.

Since the value of PenaltyReturnTypeOnItsOwnLine was being wrongly
interpreted, this opportunistically changes the other Penalty* values.
```

### 2. Explain how to test it



### 3. Other comments
