### PR TITLE
feat: extend string data filtering to LSM related events

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -11,6 +11,10 @@ runs:
         sudo apt-get install -y zlib1g-dev libelf-dev libzstd-dev
         sudo apt-get install -y software-properties-common
       shell: bash
+    - name: Install Packages for tests
+      run: |
+        sudo apt-get install -y inotify-tools bpftrace
+      shell: bash
     - name: Install Golang
       run: |
         sudo rm -f /usr/bin/go

--- a/Makefile
+++ b/Makefile
@@ -839,6 +839,7 @@ test-integration: \
 		-v \
 		-p 1 \
 		-count=1 \
+		-timeout=20m \
 		./tests/integration/... \
 
 .PHONY: test-upstream-libbpfgo

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -387,6 +387,9 @@ int syscall__execve_enter(void *ctx)
             &p.event->args_buf, (const char *const *) sys->args.args[2] /*envp*/, 2);
     }
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -417,6 +420,9 @@ int syscall__execve_exit(void *ctx)
             &p.event->args_buf, (const char *const *) sys->args.args[2] /*envp*/, 2);
     }
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, sys->ret);
 }
 
@@ -446,6 +452,9 @@ int syscall__execveat_enter(void *ctx)
             &p.event->args_buf, (const char *const *) sys->args.args[3] /*envp*/, 3);
     }
     save_to_submit_buf(&p.event->args_buf, (void *) &sys->args.args[4] /*flags*/, sizeof(int), 4);
+
+    if (!evaluate_data_filters(&p, 1))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }
@@ -478,6 +487,9 @@ int syscall__execveat_exit(void *ctx)
             &p.event->args_buf, (const char *const *) sys->args.args[3] /*envp*/, 3);
     }
     save_to_submit_buf(&p.event->args_buf, (void *) &sys->args.args[4] /*flags*/, sizeof(int), 4);
+
+    if (!evaluate_data_filters(&p, 1))
+        return 0;
 
     return events_perf_submit(&p, sys->ret);
 }
@@ -1711,6 +1723,9 @@ int BPF_KPROBE(trace_call_usermodehelper)
     save_str_arr_to_buf(&p.event->args_buf, (const char *const *) envp, 2);
     save_to_submit_buf(&p.event->args_buf, (void *) &wait, sizeof(int), 3);
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -2269,6 +2284,9 @@ int BPF_KPROBE(trace_security_bprm_check)
     if (p.config->options & OPT_EXEC_ENV)
         save_str_arr_to_buf(&p.event->args_buf, envp, 4);
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -2435,6 +2453,9 @@ int BPF_KPROBE(trace_security_sb_mount)
     save_str_to_buf(&p.event->args_buf, (void *) type, 2);
     save_to_submit_buf(&p.event->args_buf, &flags, sizeof(unsigned long), 3);
 
+    if (!evaluate_data_filters(&p, 1))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -2468,6 +2489,9 @@ int BPF_KPROBE(trace_security_inode_unlink)
     save_to_submit_buf(&p.event->args_buf, &unlinked_file_id.inode, sizeof(unsigned long), 1);
     save_to_submit_buf(&p.event->args_buf, &unlinked_file_id.device, sizeof(dev_t), 2);
     save_to_submit_buf(&p.event->args_buf, &unlinked_file_id.ctime, sizeof(u64), 3);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }
@@ -2667,6 +2691,9 @@ int BPF_KPROBE(trace_security_inode_symlink)
 
     save_str_to_buf(&p.event->args_buf, dentry_path, 0);
     save_str_to_buf(&p.event->args_buf, (void *) old_name, 1);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }
@@ -3684,6 +3711,12 @@ int BPF_KPROBE(trace_ret_do_mmap)
     save_to_submit_buf(&p.event->args_buf, &addr, sizeof(void *), 0);
     if (file != NULL) {
         save_str_to_buf(&p.event->args_buf, file_path, 1);
+
+        // TODO: move this logic to the end after
+        // fully implement data filter
+        if (!evaluate_data_filters(&p, 1))
+            return 0;
+
         save_to_submit_buf(&p.event->args_buf, &flags, sizeof(unsigned int), 2);
         save_to_submit_buf(&p.event->args_buf, &s_dev, sizeof(dev_t), 3);
         save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 4);
@@ -3726,6 +3759,9 @@ int BPF_KPROBE(trace_security_mmap_file)
         save_to_submit_buf(&p.event->args_buf, &s_dev, sizeof(dev_t), 2);
         save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 3);
         save_to_submit_buf(&p.event->args_buf, &ctime, sizeof(u64), 4);
+
+        if (!evaluate_data_filters(&p, 0))
+            return 0;
 
         events_perf_submit(&p, 0);
     }
@@ -3794,6 +3830,9 @@ int BPF_KPROBE(trace_security_file_mprotect)
             int pkey = get_syscall_arg4(p.event->task, task_regs, false);
             save_to_submit_buf(&p.event->args_buf, &pkey, sizeof(int), 6);
         }
+
+        if (!evaluate_data_filters(&p, 0))
+            return 0;
 
         events_perf_submit(&p, 0);
     }
@@ -4037,6 +4076,9 @@ int BPF_KPROBE(trace_security_bpf_map)
     // 2nd argument == map_name (const char *)
     save_str_to_buf(&p.event->args_buf, (void *) __builtin_preserve_access_index(&map->name), 1);
 
+    if (!evaluate_data_filters(&p, 1))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -4091,6 +4133,9 @@ int BPF_KPROBE(trace_security_bpf_prog)
     save_u64_arr_to_buf(&p.event->args_buf, (const u64 *) val.helpers, 4, 2);
     save_to_submit_buf(&p.event->args_buf, &prog_id, sizeof(u32), 3);
     save_to_submit_buf(&p.event->args_buf, &is_load, sizeof(bool), 4);
+
+    if (!evaluate_data_filters(&p, 1))
+        return 0;
 
     events_perf_submit(&p, 0);
 
@@ -4233,6 +4278,9 @@ int BPF_KPROBE(trace_security_kernel_read_file)
     save_to_submit_buf(&p.event->args_buf, &type_id, sizeof(int), 3);
     save_to_submit_buf(&p.event->args_buf, &ctime, sizeof(u64), 4);
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -4257,6 +4305,10 @@ int BPF_KPROBE(trace_security_kernel_post_read_file)
         save_str_to_buf(&p.event->args_buf, file_path, 0);
         save_to_submit_buf(&p.event->args_buf, &size, sizeof(loff_t), 1);
         save_to_submit_buf(&p.event->args_buf, &type_id, sizeof(int), 2);
+
+        if (!evaluate_data_filters(&p, 0))
+            return 0;
+
         events_perf_submit(&p, 0);
     }
 
@@ -4304,6 +4356,9 @@ int BPF_KPROBE(trace_security_inode_mknod)
     save_str_to_buf(&p.event->args_buf, dentry_path, 0);
     save_to_submit_buf(&p.event->args_buf, &mode, sizeof(unsigned short), 1);
     save_to_submit_buf(&p.event->args_buf, &dev, sizeof(dev_t), 2);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }
@@ -4547,6 +4602,10 @@ int tracepoint__module__module_load(struct bpf_raw_tracepoint_args *ctx)
     save_str_to_buf(&p.event->args_buf, (void *) version, 1);
     save_str_to_buf(&p.event->args_buf, (void *) srcversion, 2);
 
+    if (p.event->context.syscall == SYSCALL_FINIT_MODULE)
+        if (!evaluate_data_filters(&p, 3))
+            return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -4655,6 +4714,10 @@ int BPF_KPROBE(trace_load_elf_phdrs)
     save_str_to_buf(&p.event->args_buf, (void *) elf_pathname, 0);
     save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.device, sizeof(dev_t), 1);
     save_to_submit_buf(&p.event->args_buf, &proc_info->interpreter.id.inode, sizeof(unsigned long), 2);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     events_perf_submit(&p, 0);
 
     return 0;
@@ -4761,6 +4824,9 @@ int BPF_KPROBE(trace_security_inode_rename)
     save_str_to_buf(&p.event->args_buf, old_dentry_path, 0);
     void *new_dentry_path = get_dentry_path_str(new_dentry);
     save_str_to_buf(&p.event->args_buf, new_dentry_path, 1);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }
@@ -4900,6 +4966,9 @@ statfunc int common_utimes(struct pt_regs *ctx)
     save_to_submit_buf(&p.event->args_buf, &atime, sizeof(u64), 3);
     save_to_submit_buf(&p.event->args_buf, &mtime, sizeof(u64), 4);
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -4936,6 +5005,9 @@ int BPF_KPROBE(trace_do_truncate)
     save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 1);
     save_to_submit_buf(&p.event->args_buf, &dev, sizeof(dev_t), 2);
     save_to_submit_buf(&p.event->args_buf, &length, sizeof(u64), 3);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }
@@ -5127,6 +5199,9 @@ int BPF_KPROBE(trace_ret_inotify_find_inode)
     save_to_submit_buf(&p.event->args_buf, &inode_nr, sizeof(unsigned long), 1);
     save_to_submit_buf(&p.event->args_buf, &dev, sizeof(dev_t), 2);
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -5281,6 +5356,9 @@ int BPF_KPROBE(trace_security_path_notify)
     save_to_submit_buf(&p.event->args_buf, &mask, sizeof(u64), 3);
     save_to_submit_buf(&p.event->args_buf, &obj_type, sizeof(unsigned int), 4);
 
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
+
     return events_perf_submit(&p, 0);
 }
 
@@ -5383,6 +5461,9 @@ int BPF_KPROBE(trace_chmod_common)
 
     save_str_to_buf(&p.event->args_buf, file_path, 0);
     save_to_submit_buf(&p.event->args_buf, &mode, sizeof(umode_t), 1);
+
+    if (!evaluate_data_filters(&p, 0))
+        return 0;
 
     return events_perf_submit(&p, 0);
 }

--- a/pkg/filters/data.go
+++ b/pkg/filters/data.go
@@ -72,7 +72,7 @@ func NewDataFilter() *DataFilter {
 	}
 }
 
-// list of events and field names allowed to have in-kernel filter
+// list of events and field names (and index) allowed to have in-kernel filter
 var allowedKernelField = map[events.ID]string{
 	// LSM hooks
 	events.SecurityBprmCheck:           "pathname",  // 0

--- a/tests/integration/scripts/exec_sec_chk.sh
+++ b/tests/integration/scripts/exec_sec_chk.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# Execute ls to trigger shared_object_loaded, security_file_mprotect
+# and security_bprm_check events.
+
+# shared_object_loaded (libc.so.6) – The dynamic linker loads libc.so.6, as
+# ls is dynamically linked and requires it for execution.
+# security_file_mprotect (/usr/bin/bash) – Memory protections for bash are
+# temporarily changed (PROT_READ).
+# security_bprm_check (/usr/bin/ls) – Bash executes ls -l, triggering an
+# execution check via security_bprm_check.
+
+ls -l

--- a/tests/integration/scripts/inotify_file.sh
+++ b/tests/integration/scripts/inotify_file.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+exit_err() {
+    echo -n "ERROR: "
+    echo "$@"
+    exit 1
+}
+
+# inotify-tools should be installed
+
+# Create the file
+touch /tmp/inotify_file
+
+# Run inotifywait for 5 seconds only
+timeout 5 inotifywait -m /tmp/inotify_file || exit 0

--- a/tests/integration/scripts/load_ebpf_prog_map.sh
+++ b/tests/integration/scripts/load_ebpf_prog_map.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+exit_err() {
+    echo -n "ERROR: "
+    echo "$@"
+    exit 1
+}
+
+# bpftrace should be installed
+
+# Run bpftrace command
+timeout 5 bpftrace -e '
+tracepoint:syscalls:sys_enter_execve {
+    @my_fixed_map = count();
+}' || exit 0

--- a/tests/integration/scripts/load_module_security_checks.sh
+++ b/tests/integration/scripts/load_module_security_checks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/bash -e
+
+exit_err() {
+    echo -n "ERROR: "
+    echo "$@"
+    exit 1
+}
+
+# Build and load module
+dir="scripts/module"
+cd $dir || exit_err "could not cd to $dir"
+make && ./load.sh || exit_err "could not load module"
+
+# Sleep a bit to allow module to load
+sleep 5
+lsmod | grep linux_module || exit_err "module not loaded"
+
+# Unload module after 10 seconds
+nohup sleep 10 > /dev/null 2>&1 && ./unload.sh &

--- a/tests/integration/scripts/module/Makefile
+++ b/tests/integration/scripts/module/Makefile
@@ -1,0 +1,10 @@
+obj-m := linux_module.o
+
+KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+PWD := $(shell pwd)
+
+all:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) clean

--- a/tests/integration/scripts/module/linux_module.c
+++ b/tests/integration/scripts/module/linux_module.c
@@ -1,0 +1,18 @@
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Tester");
+MODULE_DESCRIPTION("Module for triggering security_kernel_read_file/security_kernel_post_read_file");
+
+static int __init mod_init(void) {
+    printk(KERN_INFO "Module loaded.\n");
+    return 0;
+}
+
+static void __exit mod_exit(void) {
+    printk(KERN_INFO "Module unloaded.\n");
+}
+
+module_init(mod_init);
+module_exit(mod_exit);

--- a/tests/integration/scripts/module/load.sh
+++ b/tests/integration/scripts/module/load.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mod="linux_module"
+
+if [[ $UID -ne 0 ]]; then
+    echo must be root
+    exit 1
+fi
+
+sudo lsmod | grep -q $mod && {
+    echo module already loaded
+    exit 0
+}
+
+
+insmod $mod.ko

--- a/tests/integration/scripts/module/unload.sh
+++ b/tests/integration/scripts/module/unload.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mod="linux_module"
+
+if [[ $UID -ne 0 ]]; then
+    echo must be root
+    exit 1
+fi
+
+rmmod $mod


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

1591fd007 **chore: install deps**
3eae8ff25 **fix: increase timeout for go test**
8e8ec5fa5 **test: external triggers for integration**
6e2f4f1be **feat(ebpf): extend string data filtering for LSM events**
5a22b3658 **feat: allow different field names**


3eae8ff25 **fix: increase timeout for go test**

```
- Since we have added integration tests and the default Go test
timeout is 10 minutes, we need to increase it otherwise it get panic.
```

8e8ec5fa5 **test: external triggers for integration**

```
- Add external scripts to be triggered in order to test data filter
related to events that uses LSM.
```

6e2f4f1be **feat(ebpf): extend string data filtering for LSM events**

```
- Only for LSM related events.
```

5a22b3658 **feat: allow different field names**

```
- Allow any field name in the in-kernel string filter.
- Currently, only one string-type field name is supported.
- Future support for multiple field names is planned.
- Start with LSM related events.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

This PR focuses only on LSM hooks and the related tests. Some tests were added to the integration test suite with external C program triggers.

part of #4432 

Event | String Name | Trigger
-- | -- | --
✅ security_bprm_check | `pathname` | `5`
✅ security_file_open | `pathname` | `1` (already present)
✅ security_inode_unlink | `pathname` | `3`
✅ security_sb_mount | `path` | `6`
✅ security_bpf_map | `map_name` | `9`
✅ security_kernel_read_file | `pathname` | `4`
✅ security_inode_mknod | `file_name` | `7`
✅ security_kernel_post_read_file | `pathname` | `4`
✅ security_inode_symlink | `linkpath` | `3`
✅ security_mmap_file | `pathname` | `2` (already present)
✅ security_file_mprotect | `pathname` | `5`
✅ security_inode_rename | `old_path` | `3`
✅ security_bpf_prog | `name` | `9`
✅ security_path_notify | `pathname` | `8`
✅ shared_object_loaded | `pathname` | `5`

Trigger | Name
-- | -- 
1 | `comm: event: data: trace event security_file_open set in multiple policies using multiple filter types`
2 | `comm: event: data: trace event security_mmap_file using multiple filter types`
3 | `event: data: trace event security_inode_symlink, security_inode_rename and security_inode_unlink using data filter`
4 | `event: data: trace event security_kernel_read_file and security_kernel_post_read_file using data filter`
5 | `comm: event: data: trace event shared_object_loaded, security_file_mprotect and security_bprm_check using data filter`
6 | `event: data: trace event security_sb_mount using data filter`
7 | `event: data: trace event security_inode_mknod using data filter`
8 | `event: data: trace event security_path_notify using data filter`
9 | `event: data: trace event security_bpf_prog and security_bpf_map using data filter`
