### PR TITLE
fix(metrics): ignore bpf submit stats & gracefully stop tracee

### DIFF
--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -340,7 +340,12 @@ func (p tableEventPrinter) Print(event trace.Event) {
 func (p tableEventPrinter) Epilogue(stats metrics.Stats) {
 	fmt.Println()
 	fmt.Fprintf(p.out, "End of events stream\n")
-	fmt.Fprintf(p.out, "Stats: %+v\n", stats)
+
+	jsonStats, err := stats.MarshalJSON()
+	if err != nil {
+		logger.Errorw("Error marshaling stats to json", "error", err)
+	}
+	fmt.Fprintf(p.out, "%s\n", string(jsonStats))
 }
 
 func (p tableEventPrinter) Close() {

--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -1,6 +1,7 @@
 package counter
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -12,8 +13,8 @@ type Counter struct {
 	value uint64
 }
 
-func NewCounter(initialValue uint64) Counter {
-	return Counter{value: initialValue}
+func NewCounter(initialValue uint64) *Counter {
+	return &Counter{value: initialValue}
 }
 
 // Increment
@@ -92,6 +93,12 @@ func (c *Counter) Get() uint64 {
 	return atomic.LoadUint64(&c.value)
 }
 
+// Stringer and JSON Marshaler interfaces
+
 func (c *Counter) Format(f fmt.State, r rune) {
 	f.Write([]byte(strconv.FormatUint(c.Get(), 10)))
+}
+
+func (c *Counter) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.Get())
 }

--- a/pkg/events/ftrace.go
+++ b/pkg/events/ftrace.go
@@ -60,7 +60,7 @@ func GetFtraceBaseEvent() *trace.Event {
 
 // FtraceHookEvent check for ftrace hooks periodically and reports them.
 // It wakes up every random time to check if there was a change in the hooks.
-func FtraceHookEvent(eventsCounter counter.Counter, out chan *trace.Event, baseEvent *trace.Event, selfLoadedProgs map[string]int) {
+func FtraceHookEvent(eventsCounter *counter.Counter, out chan *trace.Event, baseEvent *trace.Event, selfLoadedProgs map[string]int) {
 	if reportedFtraceHooks == nil { // Failed allocating cache - no point in running
 		return
 	}
@@ -129,7 +129,7 @@ func initFtraceArgs(fields []trace.ArgMeta) []trace.Argument {
 }
 
 // checkFtraceHooks checks for ftrace hooks
-func checkFtraceHooks(eventsCounter counter.Counter, out chan *trace.Event, baseEvent *trace.Event, ftraceDef *Definition, selfLoadedProgs map[string]int) error {
+func checkFtraceHooks(eventsCounter *counter.Counter, out chan *trace.Event, baseEvent *trace.Event, ftraceDef *Definition, selfLoadedProgs map[string]int) error {
 	ftraceHooksBytes, err := getFtraceHooksData()
 	if err != nil {
 		return err

--- a/pkg/events/trigger/context.go
+++ b/pkg/events/trigger/context.go
@@ -23,7 +23,7 @@ type Context interface {
 type context struct {
 	store   map[uint64]trace.Event
 	mutex   *sync.Mutex
-	counter counter.Counter
+	counter *counter.Counter
 }
 
 // NewContext creates a new context store.

--- a/pkg/metrics/event_collector.go
+++ b/pkg/metrics/event_collector.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"encoding/json"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/aquasecurity/tracee/pkg/counter"
@@ -71,4 +73,10 @@ func (ec *EventCollector) Log() {
 	// Log the counts
 	keyVals = append(keyVals, "total", total.Get())
 	logger.Infow(description, keyVals...)
+}
+
+// JSON marshaler interface
+
+func (ec *EventCollector) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ec.Total())
 }

--- a/tests/testutils/tracee.go
+++ b/tests/testutils/tracee.go
@@ -16,13 +16,13 @@ import (
 const (
 	readinessPollTime           = 200 * time.Millisecond
 	httpRequestTimeout          = 1 * time.Second
-	TraceeDefaultStartupTimeout = 10 * time.Second
+	TraceeDefaultStartupTimeout = 15 * time.Second
 )
 
 var (
 	TraceeBinary   = "../../dist/tracee"
 	TraceeHostname = "localhost"
-	TraceePort     = 3366
+	TraceePort     = 3369
 )
 
 type TraceeStatus int
@@ -51,6 +51,10 @@ func NewRunningTracee(givenCtx context.Context, cmdLine string) *RunningTracee {
 	// Add healthz flag if not present (required for readiness check)
 	if !strings.Contains(cmdLine, "--healthz") {
 		cmdLine = fmt.Sprintf("--healthz %s", cmdLine)
+	}
+
+	if !strings.Contains(cmdLine, "--http-listen-addr") {
+		cmdLine = fmt.Sprintf("--http-listen-addr=:%d %s", TraceePort, cmdLine)
 	}
 
 	cmdLine = fmt.Sprintf("%s %s", TraceeBinary, cmdLine)


### PR DESCRIPTION
Close: #4485 
Close: #4486 
Close: #4487
Close: #4593

@ShohamBit if some somehow still happen after 0abfcabf6, please reopen the respective one.

### 1. Explain what the PR does

0abfcabf6 **fix(perftests): make Tracee stop gracefully**
c2d41507c **fix(metrics): ignore bpf submit stats when METRICS=0**


c2d41507c **fix(metrics): ignore bpf submit stats when METRICS=0**

```
This also:

- Prints Stats as json.
- Pass Counter as pointer instead of value.
```

### 2. Explain how to test it

Stats output:

##### METRICS=0

`{"Stats":{"EventCount":122,"EventsFiltered":0,"NetCapCount":0,"BPFLogsCount":0,"ErrorCount":0,"LostEvCount":0,"LostWrCount":0,"LostNtCapCount":0,"LostBPFLogsCount":0}}`

##### METRICS=1

`{"Stats":{"EventCount":122,"EventsFiltered":0,"NetCapCount":0,"BPFLogsCount":0,"ErrorCount":0,"LostEvCount":0,"LostWrCount":0,"LostNtCapCount":0,"LostBPFLogsCount":0,"BPFPerfEventSubmitAttemptsCount":2188,"BPFPerfEventSubmitFailuresCount":0}}`

### 3. Other comments
