### PR TITLE
[v0.22.6] clock time fix and libbpf/libbpfgo bumps

### DIFF
--- a/deploy/helm/tracee/Chart.yaml
+++ b/deploy/helm/tracee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tracee
 description: Linux Runtime Security and Forensics using eBPF
-home: https://aquasecurity.github.io/tracee/v0.22.5/
+home: https://aquasecurity.github.io/tracee/v0.22.6/
 sources:
   - https://github.com/aquasecurity/tracee
 
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.22.5"
+version: "0.22.6"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.22.5"
+appVersion: "0.22.6"

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: tracee
   labels:
-    helm.sh/chart: tracee-0.22.5
+    helm.sh/chart: tracee-0.22.6
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.22.5"
+    app.kubernetes.io/version: "0.22.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: tracee/templates/serviceaccount.yaml
@@ -17,10 +17,10 @@ kind: ServiceAccount
 metadata:
   name: tracee-operator
   labels:
-    helm.sh/chart: tracee-0.22.5
+    helm.sh/chart: tracee-0.22.6
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.22.5"
+    app.kubernetes.io/version: "0.22.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: tracee/templates/tracee-config.yaml
@@ -29,10 +29,10 @@ kind: ConfigMap
 metadata:
   name: tracee-config
   labels:
-    helm.sh/chart: tracee-0.22.5
+    helm.sh/chart: tracee-0.22.6
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.22.5"
+    app.kubernetes.io/version: "0.22.6"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |-
@@ -117,10 +117,10 @@ kind: DaemonSet
 metadata:
   name: tracee
   labels:
-    helm.sh/chart: tracee-0.22.5
+    helm.sh/chart: tracee-0.22.6
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.22.5"
+    app.kubernetes.io/version: "0.22.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: tracee
-          image: "docker.io/aquasec/tracee:0.22.5"
+          image: "docker.io/aquasec/tracee:0.22.6"
           imagePullPolicy: IfNotPresent
           command:
             - /tracee/tracee
@@ -217,10 +217,10 @@ kind: Deployment
 metadata:
   name: tracee-operator
   labels:
-    helm.sh/chart: tracee-0.22.5
+    helm.sh/chart: tracee-0.22.6
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.22.5"
+    app.kubernetes.io/version: "0.22.6"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -237,7 +237,7 @@ spec:
         {}
       containers:
       - name: tracee-operator
-        image: "docker.io/aquasec/tracee:0.22.5"
+        image: "docker.io/aquasec/tracee:0.22.6"
         imagePullPolicy: IfNotPresent
         command:
           - /tracee/tracee-operator

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ toolchain go1.22.4
 require (
 	github.com/IBM/fluent-forward-go v0.2.2
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca
-	github.com/aquasecurity/tracee/api v0.0.0-20241209124740-6968a8b5477c
+	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20250117141734-5eb6fe431140
+	github.com/aquasecurity/tracee/api v0.0.0-20240910204947-35a9e259821a
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee
 	github.com/aquasecurity/tracee/types v0.0.0-20241011005226-27f2cbdf6bd7
 	github.com/containerd/containerd v1.7.17

--- a/go.sum
+++ b/go.sum
@@ -404,10 +404,10 @@ github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdII
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca h1:OPbvwFFvR11c1bgOLhBq1R5Uk3hwUjHW2KfrdyJan9Y=
-github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20240729111821-61d531acf4ca/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
-github.com/aquasecurity/tracee/api v0.0.0-20241209124740-6968a8b5477c h1:zg95SvPU2E3a7FpW0cl6kyfMdLaLWBPl5fwQVtkuo4Y=
-github.com/aquasecurity/tracee/api v0.0.0-20241209124740-6968a8b5477c/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
+github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20250117141734-5eb6fe431140 h1:5dR75+C8hqo6PCErThbZvvkZ1DZYJzprv3DHnUVnEP0=
+github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20250117141734-5eb6fe431140/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
+github.com/aquasecurity/tracee/api v0.0.0-20240910204947-35a9e259821a h1:J+Kfx5Ju7084mov6cgqxf74x2bH5kH9bIqHlAtmwhvM=
+github.com/aquasecurity/tracee/api v0.0.0-20240910204947-35a9e259821a/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee h1:1KJy6Z2bSpmKQVPShU7hhbXgGVOgMwvzf9rjoWMTYEg=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee/go.mod h1:SX08YRCsPFh8CvCvzkV8FSn1sqWAarNVEJq9RSZoF/8=
 github.com/aquasecurity/tracee/types v0.0.0-20241011005226-27f2cbdf6bd7 h1:6s4t+6UK7kMn2iTsPPooit4k5T22nmFcIguLRkWvmzk=

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -3,14 +3,12 @@ package ebpf
 import (
 	gocontext "context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"unsafe"
 
 	"kernel.org/pub/linux/libs/security/libcap/cap"
@@ -527,17 +525,24 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	usedClockID := traceetime.CLOCK_BOOTTIME
 	err = capabilities.GetInstance().EBPF(
 		func() error {
+			// Since this code is running with sufficient capabilities, we can safely trust the result of `BPFHelperIsSupported`.
+			// If the helper is reported as supported (`supported == true`), it is assumed to be reliable for use.
+			// If `supported == false`, it indicates that the helper for getting BOOTTIME is not available.
+			// The `innerErr` provides information about errors that occurred during the check, regardless of whether `supported`
+			// is true or false.
+			// For a full explanation of the caveats and behavior, refer to:
+			// https://github.com/aquasecurity/libbpfgo/blob/eb576c71ece75930a693b8b0687c5d052a5dbd56/libbpfgo.go#L99-L119
 			supported, innerErr := bpf.BPFHelperIsSupported(bpf.BPFProgTypeKprobe, bpf.BPFFuncKtimeGetBootNs)
 
-			// only report if operation not permitted
-			if errors.Is(innerErr, syscall.EPERM) {
-				return innerErr
-			}
-
-			// If BPFFuncKtimeGetBootNs is not available, eBPF will generate events based on monotonic time.
+			// Use CLOCK_MONOTONIC only when the helper is explicitly unsupported
 			if !supported {
 				usedClockID = traceetime.CLOCK_MONOTONIC
 			}
+
+			if innerErr != nil {
+				logger.Debugw("Detect clock timing", "warn", innerErr)
+			}
+
 			return nil
 		})
 	if err != nil {


### PR DESCRIPTION
### 1. Explain what the PR does

8b58a2cf5 **chore(k8s): prepare v0.22.6 release**

```
commit: ffab7a0 (main), cherry-pick
```

10616e3d9 **chore: bump 3rdparty/libbpf to v1.5.0 (#4530)**

```
| Metric          | Difference (%)       |
|-----------------|----------------------|
| CPU Avg (%)     | -0.34%  (negligible) |
| Heap Avg (MB)   |  0.00%               |

commit: 409b3cc (main), cherry-pick
```

19ba04216 **fix: clock time detection**

```
* chore(go.mod): bump libbpfgo

commit: aeca328 (main), backport

[backport]
  - point go.mod to libbpfgo branch with the helper fix

* fix: clock time detection

- The clock time detection was rework since the libbpfgo func
BPFHelperIsSupported changed;
- Unless it is explicitly marked as unsupported (supported=false),
it will default to BOOTTIME.

commit: f5cb740 (main), cherry-pick
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
