### PR TITLE
[v0.22.6] chore(go.mod): bump api to latest 6968a8b

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/IBM/fluent-forward-go v0.2.2
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20250117141734-5eb6fe431140
-	github.com/aquasecurity/tracee/api v0.0.0-20240910204947-35a9e259821a
+	github.com/aquasecurity/tracee/api v0.0.0-20241209124740-6968a8b5477c
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee
 	github.com/aquasecurity/tracee/types v0.0.0-20241011005226-27f2cbdf6bd7
 	github.com/containerd/containerd v1.7.17

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVb
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20250117141734-5eb6fe431140 h1:5dR75+C8hqo6PCErThbZvvkZ1DZYJzprv3DHnUVnEP0=
 github.com/aquasecurity/libbpfgo v0.7.0-libbpf-1.4.0.20250117141734-5eb6fe431140/go.mod h1:UpO6kTehEgAGGKR2twztBxvzjTiLiV/cb2xmlYb+TfE=
-github.com/aquasecurity/tracee/api v0.0.0-20240910204947-35a9e259821a h1:J+Kfx5Ju7084mov6cgqxf74x2bH5kH9bIqHlAtmwhvM=
-github.com/aquasecurity/tracee/api v0.0.0-20240910204947-35a9e259821a/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
+github.com/aquasecurity/tracee/api v0.0.0-20241209124740-6968a8b5477c h1:zg95SvPU2E3a7FpW0cl6kyfMdLaLWBPl5fwQVtkuo4Y=
+github.com/aquasecurity/tracee/api v0.0.0-20241209124740-6968a8b5477c/go.mod h1:Gn6xVkaBkVe1pOQ0++uuHl+lMMClv0TPY8mCQ6j88aA=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee h1:1KJy6Z2bSpmKQVPShU7hhbXgGVOgMwvzf9rjoWMTYEg=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20240607205742-90c301111aee/go.mod h1:SX08YRCsPFh8CvCvzkV8FSn1sqWAarNVEJq9RSZoF/8=
 github.com/aquasecurity/tracee/types v0.0.0-20241011005226-27f2cbdf6bd7 h1:6s4t+6UK7kMn2iTsPPooit4k5T22nmFcIguLRkWvmzk=


### PR DESCRIPTION
### 1. Explain what the PR does

15c5730dc **chore(go.mod): bump api to latest 6968a8b**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
