### PR TITLE
refactor(containers): split cgroup to container map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250225170549-3d4b390e091b
 	github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782
 	github.com/containerd/containerd v1.7.26
-	github.com/docker/docker v27.5.1+incompatible
+	github.com/docker/docker v28.0.0+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/google/gopacket v1.1.19
 	github.com/grafana/pyroscope-go v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v27.5.1+incompatible h1:4PYU5dnBYqRQi0294d1FBECqT9ECWeQAIfE8q4YnPY8=
-github.com/docker/docker v27.5.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.0.0+incompatible h1:Olh0KS820sJ7nPsBKChVhk5pzqcwDR15fumfAd/p9hM=
+github.com/docker/docker v28.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=

--- a/pkg/containers/path_resolver.go
+++ b/pkg/containers/path_resolver.go
@@ -69,9 +69,8 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 		if len(entries) == 0 {
 			return "", errfmt.Errorf("empty directory")
 		}
-		if err == nil {
-			return fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath), nil
-		}
+
+		return fmt.Sprintf("%s%s", procRootPath, mountNSAbsolutePath), nil
 	}
 
 	return "", ErrContainerFSUnreachable

--- a/pkg/containers/runtime/docker.go
+++ b/pkg/containers/runtime/docker.go
@@ -61,7 +61,7 @@ func (e *dockerEnricher) Get(ctx context.Context, containerId string) (Container
 
 	// attempt to get image name from registry (image from config usually has tag as sha/no tag at all)
 	imageId := container.Image
-	image, _, err := e.client.ImageInspectWithRaw(ctx, imageId)
+	image, err := e.client.ImageInspect(ctx, imageId)
 	if err != nil {
 		// if we can't fetch the image or image has no name, return the metadata with the image found in config
 		return metadata, nil

--- a/pkg/containers/runtime/runtime.go
+++ b/pkg/containers/runtime/runtime.go
@@ -4,21 +4,6 @@ import (
 	"context"
 )
 
-type ContainerMetadata struct {
-	ContainerId string
-	Name        string
-	Image       string
-	ImageDigest string
-	Pod         PodMetadata
-}
-
-type PodMetadata struct {
-	Name      string
-	Namespace string
-	UID       string
-	Sandbox   bool
-}
-
 // These labels are injected by kubelet on container creation, we can use them to gather additional data in a k8s context
 const (
 	PodNameLabel                 = "io.kubernetes.pod.name"
@@ -30,8 +15,20 @@ const (
 	ContainerTypeCrioAnnotation  = "io.kubernetes.cri-o.ContainerType"
 )
 
+type EnrichResult struct {
+	/* CONTAINER RESULTS */
+	ContName    string
+	Image       string
+	ImageDigest string
+	/* POD RESULTS */
+	PodName   string
+	Namespace string
+	UID       string
+	Sandbox   bool
+}
+
 type ContainerEnricher interface {
-	Get(ctx context.Context, containerId string) (ContainerMetadata, error)
+	Get(ctx context.Context, containerId string) (EnrichResult, error)
 }
 
 // Represents the internal ID of a container runtime

--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -57,7 +57,9 @@ func (t *Tracee) handleFileCaptures(ctx context.Context) {
 				continue
 			}
 
-			containerId := t.containers.GetCgroupInfo(meta.CgroupID).Container.ContainerId
+			cgroup, _ := t.containers.GetCgroupInfo(meta.CgroupID)
+
+			containerId := cgroup.ContainerId
 			if containerId == "" {
 				containerId = "host"
 			}

--- a/pkg/ebpf/controlplane/cgroups.go
+++ b/pkg/ebpf/controlplane/cgroups.go
@@ -26,11 +26,11 @@ func (ctrl *Controller) processCgroupMkdir(args []trace.Argument) error {
 	if err != nil {
 		return errfmt.Errorf("error parsing cgroup_mkdir signal args: %v", err)
 	}
-	info, err := ctrl.cgroupManager.CgroupMkdir(cgroupId, path, hId)
+	info, _, err := ctrl.cgroupManager.CgroupMkdir(cgroupId, path, hId)
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
-	if info.Container.ContainerId == "" && !info.Dead {
+	if info.ContainerId == "" && !info.Dead {
 		// If cgroupId is from a regular cgroup directory, and not a container related directory
 		// (from known runtimes), it should be removed from the containers bpf map.
 		err := capabilities.GetInstance().EBPF(

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -28,7 +28,7 @@ type Controller struct {
 	bpfModule      *libbpfgo.Module
 	signalBuffer   *libbpfgo.PerfBuffer
 	signalPool     *sync.Pool
-	cgroupManager  *containers.Containers
+	cgroupManager  *containers.Manager
 	processTree    *proctree.ProcessTree
 	enrichDisabled bool
 }
@@ -36,7 +36,7 @@ type Controller struct {
 // NewController creates a new controller.
 func NewController(
 	bpfModule *libbpfgo.Module,
-	cgroupManager *containers.Containers,
+	cgroupManager *containers.Manager,
 	enrichDisabled bool,
 	procTree *proctree.ProcessTree,
 ) (*Controller, error) {

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -198,7 +198,7 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 				stackAddresses = t.getStackAddresses(eCtx.StackID)
 			}
 
-			containerInfo := t.containers.GetCgroupInfo(eCtx.CgroupID).Container
+			_, containerInfo := t.containers.GetCgroupInfo(eCtx.CgroupID)
 			containerData := trace.Container{
 				ID:          containerInfo.ContainerId,
 				ImageName:   containerInfo.Image,

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -103,7 +103,7 @@ type Tracee struct {
 	lostBPFLogChannel   chan uint64 // channel for lost bpf logs
 	// Containers
 	cgroups           *cgroup.Cgroups
-	containers        *containers.Containers
+	containers        *containers.Manager
 	contPathResolver  *containers.ContainerPathResolver
 	contSymbolsLoader *sharedobjs.ContainersSymbolsLoader
 	// Control Plane

--- a/pkg/events/derive/container_remove.go
+++ b/pkg/events/derive/container_remove.go
@@ -10,11 +10,11 @@ import (
 
 // ContainerRemove receives a containers.Containers object as a closure argument to track it's containers.
 // If it receives a cgroup_rmdir event, it can derive a container_remove event from it.
-func ContainerRemove(cts *containers.Containers) DeriveFunction {
+func ContainerRemove(cts *containers.Manager) DeriveFunction {
 	return deriveSingleEvent(events.ContainerRemove, deriveContainerRemoveArgs(cts))
 }
 
-func deriveContainerRemoveArgs(cts *containers.Containers) deriveArgsFunction {
+func deriveContainerRemoveArgs(cts *containers.Manager) deriveArgsFunction {
 	return func(event trace.Event) ([]interface{}, error) {
 		// if cgroup_id is from non default hid (v1 case), the cgroup info query will fail, so we skip
 		if check, err := isCgroupEventInHid(&event, cts); !check {
@@ -24,8 +24,8 @@ func deriveContainerRemoveArgs(cts *containers.Containers) deriveArgsFunction {
 		if err != nil {
 			return nil, errfmt.WrapError(err)
 		}
-		if info := cts.GetCgroupInfo(cgroupId); info.Container.ContainerId != "" {
-			return []interface{}{info.Runtime.String(), info.Container.ContainerId}, nil
+		if _, container := cts.GetCgroupInfo(cgroupId); container.ContainerId != "" {
+			return []interface{}{container.Runtime.String(), container.ContainerId}, nil
 		}
 		return nil, nil
 	}

--- a/pkg/events/usermode.go
+++ b/pkg/events/usermode.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/aquasecurity/tracee/pkg/containers"
-	"github.com/aquasecurity/tracee/pkg/containers/runtime"
 	"github.com/aquasecurity/tracee/pkg/logger"
 	traceeversion "github.com/aquasecurity/tracee/pkg/version"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -114,17 +113,17 @@ func fetchInitNamespaces() map[string]uint32 {
 }
 
 // ExistingContainersEvents returns a list of events for each existing container
-func ExistingContainersEvents(cts *containers.Containers, enrichDisabled bool) []trace.Event {
+func ExistingContainersEvents(cts *containers.Manager, enrichDisabled bool) []trace.Event {
 	var events []trace.Event
 
 	def := Core.GetDefinitionByID(ExistingContainer)
-	existingContainers := cts.GetContainers()
-	for id, info := range existingContainers {
+	existingContainers := cts.GetLiveContainers()
+	for id, container := range existingContainers {
 		cgroupId := uint64(id)
-		cRuntime := info.Runtime.String()
-		containerId := info.Container.ContainerId
-		ctime := info.Ctime.UnixNano()
-		container := runtime.ContainerMetadata{}
+		cRuntime := container.Runtime.String()
+		containerId := container.ContainerId
+		ctime := container.CreatedAt.UnixNano()
+		container := containers.Container{}
 		if !enrichDisabled {
 			container, _ = cts.EnrichCgroupInfo(cgroupId)
 		}

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -671,7 +671,7 @@ func populateProcInfoMap(bpfModule *bpf.Module, binEqualities map[filters.NSBina
 // updateProcTree indicates whether the process tree map should be updated or not.
 func (ps *policies) updateBPF(
 	bpfModule *bpf.Module,
-	cts *containers.Containers,
+	cts *containers.Manager,
 	rules map[events.ID]*eventFlags,
 	eventsFields map[events.ID][]bufferdecoder.ArgType,
 	createNewMaps bool,

--- a/pkg/policy/equality.go
+++ b/pkg/policy/equality.go
@@ -163,7 +163,7 @@ func updateAffixEqualities[T comparable](
 // updating the provided filtersEqualities struct.
 func (ps *policies) computeFilterEqualities(
 	fEqs *filtersEqualities,
-	cts *containers.Containers,
+	cts *containers.Manager,
 ) error {
 	for _, p := range ps.allFromMap() {
 		policyID := uint(p.ID)

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -592,7 +592,7 @@ func (m *Manager) LookupByName(name string) (*Policy, error) {
 
 func (m *Manager) UpdateBPF(
 	bpfModule *bpf.Module,
-	cts *containers.Containers,
+	cts *containers.Manager,
 	eventsFields map[events.ID][]bufferdecoder.ArgType,
 	createNewMaps bool,
 	updateProcTree bool,


### PR DESCRIPTION
### 1. Explain what the PR does

7e600b6d1 **refactor(containers): split cgroup to container map**

```
Some general refactors to the containers package.
Containers and cgroup data is split up so that querying and maintaining
container data can managed "offline", without a cgroup fs backend.
```

### 2. Explain how to test it

Nothing breaks

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
