### PR TITLE
Bump Go to 1.24

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -15,7 +15,7 @@ runs:
       run: |
         sudo rm -f /usr/bin/go
         sudo rm -f /usr/bin/gofmt
-        curl -L -o /tmp/golang.tar.gz https://go.dev/dl/go1.22.3.linux-amd64.tar.gz
+        curl -L -o /tmp/golang.tar.gz https://go.dev/dl/go1.24.0.linux-amd64.tar.gz
         sudo tar -C /usr/local -xzf /tmp/golang.tar.gz
         sudo ln -s /usr/local/go/bin/go /usr/bin/go
         sudo ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -130,7 +130,7 @@ Vagrant.configure("2") do |config|
       USER="#{vm_user}"
       HOME="/home/#{vm_user}"
       LLVM_VERSION="14"
-      GO_VERSION="1.22.3"
+      GO_VERSION="1.24.0"
       KUBECTL_VERSION="v1.29"
       VM_TYPE="#{vm_type}"
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,8 @@
 module github.com/aquasecurity/tracee/api
 
-go 1.22.0
+go 1.24
+
+toolchain go1.24.0
 
 require (
 	google.golang.org/grpc v1.70.0

--- a/builder/Dockerfile.alpine-tracee-container
+++ b/builder/Dockerfile.alpine-tracee-container
@@ -9,7 +9,7 @@ ARG FLAVOR=tracee-ebpf-core
 # Version
 #
 
-ARG GO_VERSION=1.22.0
+ARG GO_VERSION=1.24.0
 
 
 #

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -52,7 +52,7 @@ FROM alpine-base AS go-setup
 LABEL AS=go-setup
 USER root
 
-ARG GO_VERSION=1.22.0
+ARG GO_VERSION=1.24.0
 ENV GOPATH=/go
 ENV GOROOT=/usr/local/go
 ENV GOTOOLCHAIN="auto"

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -11,7 +11,7 @@ ARG gid=1000
 # Version
 #
 
-ARG GO_VERSION=1.22.0
+ARG GO_VERSION=1.24.0
 
 # install needed environment
 

--- a/builder/Makefile.checkers
+++ b/builder/Makefile.checkers
@@ -183,11 +183,12 @@ fmt-fix: | \
 code-check: | \
 	.check_tree
 #
-	@echo "Checking Golang vet..."
-	$(GENERAL_MAKE) check-vet
-	echo "Checking Golang with StaticChecker..."
-	$(GENERAL_MAKE) -j1 check-staticcheck
-	echo "Checking Golang with errcheck..."
+	@set -e; \
+	echo "Checking Golang vet..."; \
+	$(GENERAL_MAKE) check-vet; \
+	echo "Checking Golang with StaticChecker..."; \
+	$(GENERAL_MAKE) -j1 check-staticcheck; \
+	echo "Checking Golang with errcheck..."; \
 	$(GENERAL_MAKE) -j1 check-err
 
 #

--- a/docs/contributing/building/building.md
+++ b/docs/contributing/building/building.md
@@ -13,7 +13,7 @@
 2. Building **dependencies**
 
     1. `clang` && `llvm` (14)
-    2. `golang` (1.22.3 toolchain)
+    2. `golang` (1.24.0 toolchain)
     3. `libelf` and `libelf-dev`
        (or elfutils-libelf and elfutils-libelf-devel)
     4. `zlib1g` and `zlib1g-dev`

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/aquasecurity/tracee
 
-go 1.22.0
+go 1.24
 
-toolchain go1.22.4
+toolchain go1.24.0
 
 require (
 	github.com/IBM/fluent-forward-go v0.3.0

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -41,7 +41,7 @@ func PrintEventList(includeSigs bool, wideOutput bool) {
 	}
 
 	tableRender := func(table *tablewriter.Table, title string) *tablewriter.Table {
-		fmt.Printf("\n" + title + "\n\n")
+		fmt.Print("\n" + title + "\n\n")
 		table.Render()
 		return newTable()
 	}

--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -1,8 +1,8 @@
 module github.com/aquasecurity/tracee/signatures/helpers
 
-go 1.22.0
+go 1.24
 
-toolchain go1.22.4
+toolchain go1.24.0
 
 require github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863
 

--- a/tests/e2e-install-deps.sh
+++ b/tests/e2e-install-deps.sh
@@ -214,9 +214,9 @@ install_clang_from_github() {
 
 install_golang_from_github() {
     if [[ $ARCH == x86_64 ]]; then
-        GO_URL="https://go.dev/dl/go1.22.3.linux-amd64.tar.gz"
+        GO_URL="https://go.dev/dl/go1.24.0.linux-amd64.tar.gz"
     else
-        GO_URL="https://go.dev/dl/go1.22.3.linux-arm64.tar.gz"
+        GO_URL="https://go.dev/dl/go1.24.0.linux-arm64.tar.gz"
     fi
 
     GO_FILE=$(basename $GO_URL)

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,6 +1,8 @@
 module github.com/aquasecurity/tracee/types
 
-go 1.22.0
+go 1.24
+
+toolchain go1.24.0
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
### 1. Explain what the PR does

5fd885f16 **fix(build): abort on code-check error**
dceee6286 **chore(lint): apply go vet rule**
93d2f2c9b **chore(build): bump Go to 1.24**
5a6afaba3 **chore(go): bump Go to 1.24**


5a6afaba3 **chore(go): bump Go to 1.24**

```
Upgrading to Go 1.24 brings performance improvements due to the new
Swiss Tables hash map implementation. With the same
deterministic/intensive proctree stress test, it was observed
significant reductions in CPU usage, heap memory, and object allocation.

Performance comparison:

| Metric       | Go 1.22.3 | Go 1.24.0 | Improvement |
|--------------|----------:|----------:|------------:|
| CPU avg      | 17.7%     | 13.5%     | -23.73%     |
| Heap avg     | 211MB     | 176MB     | -16.59%     |
| Heap obj avg | 1,156,562 | 730,153   | -36.86%     |

More details: https://go.dev/doc/go1.24
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
