### PR TITLE
Bump lint tools versions

### DIFF
--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -71,7 +71,7 @@ runs:
       shell: bash
     - name: Install revive
       run: |
-        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/mgechev/revive@e33fb87
+        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/mgechev/revive@v1.7.0
         sudo cp $HOME/go/bin/revive /usr/bin/
       shell: bash
     - name: Install goimports-reviser

--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -66,7 +66,7 @@ runs:
       shell: bash
     - name: Install staticchecker
       run: |
-        GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@2023.1.7
+        GOROOT=/usr/local/go GOPATH=$HOME/go go install honnef.co/go/tools/cmd/staticcheck@2025.1
         sudo cp $HOME/go/bin/staticcheck /usr/bin/
       shell: bash
     - name: Install revive

--- a/.github/actions/build-dependencies/action.yaml
+++ b/.github/actions/build-dependencies/action.yaml
@@ -81,7 +81,7 @@ runs:
       shell: bash
     - name: Install errcheck
       run: |
-        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/kisielk/errcheck@v1.7.0
+        GOROOT=/usr/local/go GOPATH=$HOME/go go install github.com/kisielk/errcheck@v1.9.0
         sudo cp $HOME/go/bin/errcheck /usr/bin/
       shell: bash
     - name: Install docker

--- a/.revive.toml
+++ b/.revive.toml
@@ -82,6 +82,8 @@ enableAllRules = true
     Disabled = false
 [rule.indent-error-flow]
     Disabled = false
+[rule.max-control-nesting]
+    arguments = [15]
 [rule.imports-blacklist]
     Disabled = true
 [rule.import-shadowing]

--- a/.revive.toml
+++ b/.revive.toml
@@ -95,7 +95,7 @@ enableAllRules = true
 [rule.modifies-parameter]
     Disabled = false
 [rule.modifies-value-receiver]
-    Disabled = true
+    Disabled = false
 [rule.nested-structs]
     Disabled = true
 [rule.optimize-operands-order]

--- a/.revive.toml
+++ b/.revive.toml
@@ -150,3 +150,5 @@ enableAllRules = true
     Disabled = false
 [rule.waitgroup-by-value]
     Disabled = false
+[rule.use-errors-new]
+    Disabled = false

--- a/.revive.toml
+++ b/.revive.toml
@@ -9,7 +9,7 @@ enableAllRules = true
 [rule.add-constant]
     Disabled = true
 [rule.argument-limit]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.atomic]
     Disabled = false
 [rule.bare-return]
@@ -23,13 +23,13 @@ enableAllRules = true
 [rule.call-to-gc]
     Disabled = false
 [rule.confusing-naming]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.comment-spacings]
     Disabled = false
 [rule.confusing-results]
-    Disabled = true
+    Disabled = false
 [rule.cognitive-complexity]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.constant-logical-expr]
     Disabled = false
 [rule.context-as-argument]
@@ -37,11 +37,11 @@ enableAllRules = true
 [rule.context-keys-type]
     Disabled = false
 [rule.cyclomatic]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.datarace]
     Disabled = false
 [rule.deep-exit]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.defer]
     Disabled = false
 [rule.dot-imports]
@@ -69,9 +69,10 @@ enableAllRules = true
 [rule.flag-parameter]
     Disabled = true
 [rule.function-result-limit]
-    Disabled = true
+    Disabled = false
+    arguments = [3]
 [rule.function-length]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.get-return]
     Disabled = false
 [rule.identical-branches]
@@ -84,20 +85,20 @@ enableAllRules = true
     Disabled = false
 [rule.max-control-nesting]
     arguments = [15]
-[rule.imports-blacklist]
-    Disabled = true
 [rule.import-shadowing]
     Disabled = false
 [rule.line-length-limit]
     Disabled = true # TODO: set max length to 100 max
+    arguments = [100]
 [rule.max-public-structs]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
+    arguments = [5]
 [rule.modifies-parameter]
     Disabled = false
 [rule.modifies-value-receiver]
     Disabled = false
 [rule.nested-structs]
-    Disabled = true
+    Disabled = false
 [rule.optimize-operands-order]
     Disabled = false
 [rule.package-comments]
@@ -111,11 +112,18 @@ enableAllRules = true
 [rule.receiver-naming]
     Disabled = false
 [rule.redefines-builtin-id]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.string-of-int]
-    Disabled = true
+    Disabled = false
 [rule.struct-tag]
-    Disabled = true # TODO: interesting to check
+    Disabled = false
+    arguments = ["json,inline"]
+[rule.redundant-import-alias]
+    Disabled = false
+[rule.redundant-build-tag]
+    Disabled = false
+[rule.redundant-test-main-exit]
+    Disabled = false
 [rule.string-format]
     Disabled = true # TODO: interesting to check
 [rule.superfluous-else]
@@ -139,13 +147,13 @@ enableAllRules = true
 [rule.unhandled-error]
     Disabled = true # TODO: already being done by errcheck (change ?)
 [rule.unnecessary-stmt]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.unreachable-code]
     Disabled = false
 [rule.unused-parameter]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.unused-receiver]
-    Disabled = true
+    Disabled = true # TODO: consider enabling this
 [rule.use-any]
     Disabled = true # TODO: should we rename interface{} to any ?
 [rule.useless-break]

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -68,7 +68,7 @@ RUN TARGETARCH=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') &&
 RUN go install honnef.co/go/tools/cmd/staticcheck@2025.1 && \
     go install github.com/incu6us/goimports-reviser/v3@v3.8.2 && \
     go install github.com/mgechev/revive@v1.7.0 && \
-    go install github.com/kisielk/errcheck@latest
+    go install github.com/kisielk/errcheck@v1.9.0
 
 #
 # user-setup: configure user environment and permissions

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -67,7 +67,7 @@ RUN TARGETARCH=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') &&
 # install Go tools
 RUN go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 && \
     go install github.com/incu6us/goimports-reviser/v3@v3.8.2 && \
-    go install github.com/mgechev/revive@e33fb87 && \
+    go install github.com/mgechev/revive@v1.7.0 && \
     go install github.com/kisielk/errcheck@latest
 
 #

--- a/builder/Dockerfile.alpine-tracee-make
+++ b/builder/Dockerfile.alpine-tracee-make
@@ -65,7 +65,7 @@ RUN TARGETARCH=$(uname -m | sed 's:x86_64:amd64:g' | sed 's:aarch64:arm64:g') &&
     rm go${GO_VERSION}.linux-${TARGETARCH}.tar.gz
 
 # install Go tools
-RUN go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 && \
+RUN go install honnef.co/go/tools/cmd/staticcheck@2025.1 && \
     go install github.com/incu6us/goimports-reviser/v3@v3.8.2 && \
     go install github.com/mgechev/revive@v1.7.0 && \
     go install github.com/kisielk/errcheck@latest

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -89,7 +89,7 @@ RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
 # install revive
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
-    go install github.com/mgechev/revive@e33fb87 && \
+    go install github.com/mgechev/revive@v1.7.0 && \
     cp $HOME/go/bin/revive /usr/bin/
 
 # install errcheck

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -95,7 +95,7 @@ RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
 # install errcheck
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
-    go install github.com/kisielk/errcheck@v1.7.0 && \
+    go install github.com/kisielk/errcheck@v1.9.0 && \
     cp $HOME/go/bin/errcheck /usr/bin/
 
 USER tracee

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -77,7 +77,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 # install staticcheck
 
 RUN GOROOT=/usr/local/go GOPATH=$HOME/go \
-    go install honnef.co/go/tools/cmd/staticcheck@2023.1.7 && \
+    go install honnef.co/go/tools/cmd/staticcheck@2025.1 && \
     cp $HOME/go/bin/staticcheck /usr/bin/
 
 # install goimports-reviser

--- a/cmd/tracee-bench/main.go
+++ b/cmd/tracee-bench/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -74,7 +75,7 @@ func main() {
 			address := ctx.String(prometheusAddressFlag)
 
 			if address == "" {
-				return fmt.Errorf("prometheus address required for tracee-er")
+				return errors.New("prometheus address required for tracee-er")
 			}
 
 			client, err := api.NewClient(api.Config{

--- a/cmd/tracee-gptdocs/main.go
+++ b/cmd/tracee-gptdocs/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"log"
 	"os"
 	"os/signal"
@@ -55,15 +55,15 @@ func main() {
 
 			key := c.String(openAIKey)
 			if key == "" {
-				return fmt.Errorf("you should provide an OpenAI API key")
+				return errors.New("you should provide an OpenAI API key")
 			}
 			temp := c.Float64(temperature)
 			if temp < 0.0 || temp > 2.0 {
-				return fmt.Errorf("temperature should be between 0.0 and 2.0")
+				return errors.New("temperature should be between 0.0 and 2.0")
 			}
 			token := c.Int(maxTokens)
 			if token < 0 || token > 4096 {
-				return fmt.Errorf("max tokens should be between 0 and 4096")
+				return errors.New("max tokens should be between 0 and 4096")
 			}
 			events := c.StringSlice(givenEvents)
 

--- a/docs/docs/advanced/data-sources/builtin/containers.md
+++ b/docs/docs/advanced/data-sources/builtin/containers.md
@@ -42,7 +42,7 @@ func (sig *e2eContainersDataSource) Init(ctx detect.SignatureContext) error {
     sig.cb = ctx.Callback
     containersData, ok := ctx.GetDataSource("tracee", "containers")
     if !ok {
-        return fmt.Errorf("containers data source not registered")
+        return errors.New("containers data source not registered")
     }
     sig.containersData = containersData
     return nil
@@ -59,14 +59,14 @@ Given the following example:
 func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
     eventObj, ok := event.Payload.(trace.Event)
     if !ok {
-        return fmt.Errorf("failed to cast event's payload")
+        return errors.New("failed to cast event's payload")
     }
 
     switch eventObj.EventName {
     case "sched_process_exec":
         containerId := eventObj.Container.ID
         if containerId == "" {
-            return fmt.Errorf("received non container event")
+            return errors.New("received non container event")
         }
 
         container, err := sig.containersData.Get(containerId)
@@ -76,7 +76,7 @@ func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
 
         containerImage, ok := container["container_image"].(string)
         if !ok {
-            return fmt.Errorf("failed to obtain the container image name")
+            return errors.New("failed to obtain the container image name")
         }
 
         m, _ := sig.GetMetadata()

--- a/docs/docs/advanced/data-sources/builtin/dns.md
+++ b/docs/docs/advanced/data-sources/builtin/dns.md
@@ -64,7 +64,7 @@ func (sig *e2eDnsDataSource) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
 	dnsData, ok := ctx.GetDataSource("tracee", "dns")
 	if !ok {
-		return fmt.Errorf("dns data source not registered")
+		return errors.New("dns data source not registered")
 	}
 	if dnsData.Version() > 1 {
 		return fmt.Errorf("dns data source version not supported, please update this signature")
@@ -84,7 +84,7 @@ Given the following example:
 func (sig *e2eDnsDataSource) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {
@@ -100,18 +100,18 @@ func (sig *e2eDnsDataSource) OnEvent(event protocol.Event) error {
 
 		ipResults, ok := dns["ip_addresses"].([]string)
 		if !ok {
-			return fmt.Errorf("failed to extract ip results")
+			return errors.New("failed to extract ip results")
 		}
 		if len(ipResults) < 1 {
-			return fmt.Errorf("ip results were empty")
+			return errors.New("ip results were empty")
 		}
 
 		dnsResults, ok := dns["dns_queries"].([]string)
 		if !ok {
-			return fmt.Errorf("failed to extract dns results")
+			return errors.New("failed to extract dns results")
 		}
 		if len(dnsResults) < 1 {
-			return fmt.Errorf("dns results were empty")
+			return errors.New("dns results were empty")
 		}
 		if dnsResults[0] != "google.com" {
 			return fmt.Errorf("bad dns query: %s", dnsResults[0])

--- a/docs/docs/advanced/data-sources/builtin/process-tree.md
+++ b/docs/docs/advanced/data-sources/builtin/process-tree.md
@@ -107,7 +107,7 @@ func (sig *e2eProcessTreeDataSource) Init(ctx detect.SignatureContext) error {
 
     processTreeDataSource, ok := ctx.GetDataSource("tracee", "process_tree")
     if !ok {
-        return fmt.Errorf("data source tracee/process_tree is not registered")
+        return errors.New("data source tracee/process_tree is not registered")
     }
 
     sig.processTreeDS = processTreeDataSource
@@ -129,7 +129,7 @@ Before explaining each request type and how to use them, consider the following 
 func (sig *e2eProcessTreeDataSource) OnEvent(event protocol.Event) error {
     eventObj, ok := event.Payload.(trace.Event)
     if !ok {
-        return fmt.Errorf("failed to cast event's payload")
+        return errors.New("failed to cast event's payload")
     }
 
     switch eventObj.EventName {
@@ -174,22 +174,22 @@ func (sig *e2eProcessTreeDataSource) checkProcess(eventObj *trace.Event) error {
             Time:     time.Unix(0, int64(eventObj.Timestamp)),
         })
     if err != nil {
-        return fmt.Errorf(debug("could not find process"))
+        return errors.New(debug("could not find process"))
     }
     processInfo, ok := procQueryAnswer["process_info"].(datasource.ProcessInfo)
     if !ok {
-        return fmt.Errorf(debug("could not extract info"))
+        return errors.New(debug("could not extract info"))
     }
 
     // Compare PID, NS PID and PPID
     if processInfo.Pid != eventObj.HostProcessID {
-        return fmt.Errorf(debug("no match for pid"))
+        return errors.New(debug("no match for pid"))
     }
     if processInfo.NsPid != eventObj.ProcessID {
-        return fmt.Errorf(debug("no match for ns pid"))
+        return errors.New(debug("no match for ns pid"))
     }
     if processInfo.Ppid != eventObj.HostParentProcessID {
-        return fmt.Errorf(debug("no match for ppid"))
+        return errors.New(debug("no match for ppid"))
     }
 
     // Check if the process lists itself in the list of its threads
@@ -201,7 +201,7 @@ func (sig *e2eProcessTreeDataSource) checkProcess(eventObj *trace.Event) error {
         }
     }
     if !threadExist {
-        return fmt.Errorf(debug("process not listed as thread"))
+        return errors.New(debug("process not listed as thread"))
     }
 ```
 
@@ -226,22 +226,22 @@ func (sig *e2eProcessTreeDataSource) checkThread(eventObj *trace.Event) error {
         },
     )
     if err != nil {
-        return fmt.Errorf(debug("could not find thread"))
+        return errors.New(debug("could not find thread"))
     }
     threadInfo, ok := threadQueryAnswer["thread_info"].(datasource.ThreadInfo)
     if !ok {
-        return fmt.Errorf(debug("could not extract info"))
+        return errors.New(debug("could not extract info"))
     }
 
     // Compare TID, NS TID and PID
     if threadInfo.Tid != eventObj.HostThreadID {
-        return fmt.Errorf(debug("no match for tid"))
+        return errors.New(debug("no match for tid"))
     }
     if threadInfo.NsTid != eventObj.ThreadID {
-        return fmt.Errorf(debug("no match for ns tid"))
+        return errors.New(debug("no match for ns tid"))
     }
     if threadInfo.Pid != eventObj.HostProcessID {
-        return fmt.Errorf(debug("no match for pid"))
+        return errors.New(debug("no match for pid"))
     }
 
     return nil
@@ -267,11 +267,11 @@ func (sig *e2eProcessTreeDataSource) checkLineage(eventObj *trace.Event) error {
         },
     )
     if err != nil {
-        return fmt.Errorf(debug("could not find lineage"))
+        return errors.New(debug("could not find lineage"))
     }
     lineageInfo, ok := lineageQueryAnswer["process_lineage"].(datasource.ProcessLineage)
     if !ok {
-        return fmt.Errorf("failed to extract ProcessLineage from data")
+        return errors.New("failed to extract ProcessLineage from data")
     }
 
     compareMaps := func(map1, map2 map[int]uint32) bool {

--- a/docs/docs/advanced/data-sources/overview.md
+++ b/docs/docs/advanced/data-sources/overview.md
@@ -43,7 +43,7 @@ func (sig *mySig) Init(ctx detect.SignatureContext) error {
     ...
     containersData, ok := ctx.GetDataSource("tracee", "containers")
  if !ok {
-  return fmt.Errorf("containers data source not registered")
+  return errors.New("containers data source not registered")
  }
     if containersData.Version() > 1 {
   return fmt.Errorf("containers data source version not supported, please update this signature")

--- a/docs/docs/advanced/data-sources/write.md
+++ b/docs/docs/advanced/data-sources/write.md
@@ -98,7 +98,7 @@ Now we can use this data source just like we would any other in a signature thro
     ...
     thresholdDataSource, ok := ctx.GetDataSource("my_namespace", "threshold_datasource")
     if !ok {
-        return fmt.Errorf("threshold data source not registered")
+        return errors.New("threshold data source not registered")
     }
     if thresholdDataSource.Version() > 1 {
         return fmt.Errorf("threshold data source version not supported, please update this signature")

--- a/docs/docs/events/builtin/network/index.md
+++ b/docs/docs/events/builtin/network/index.md
@@ -122,7 +122,7 @@ func (sig *e2eDNS) GetSelectedEvents() ([]detect.SignatureEventSelector, error) 
 func (sig *e2eDNS) OnEvent(event protocol.Event) error {
     eventObj, ok := event.Payload.(trace.Event)
     if !ok {
-        return fmt.Errorf("failed to cast event's payload")
+        return errors.New("failed to cast event's payload")
     }
 
     if eventObj.EventName == "net_packet_dns" {

--- a/docs/docs/events/custom/golang.md
+++ b/docs/docs/events/custom/golang.md
@@ -89,7 +89,7 @@ There are 2 ways you can get your own golang signatures working with tracee.
                     }
                 }
             default:
-                return fmt.Errorf("failed to cast event's payload")
+                return errors.New("failed to cast event's payload")
             }
 
             return nil

--- a/pkg/capabilities/capabilities.go
+++ b/pkg/capabilities/capabilities.go
@@ -1,6 +1,7 @@
 package capabilities
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -461,7 +462,7 @@ func couldNotFindCapability(c string) error {
 }
 
 func couldNotReadPerfEventParanoid() error {
-	return fmt.Errorf("could not read procfs perf_event_paranoid")
+	return errors.New("could not read procfs perf_event_paranoid")
 }
 
 func couldNotSetProc(e error) error {

--- a/pkg/cgroup/errors.go
+++ b/pkg/cgroup/errors.go
@@ -1,6 +1,7 @@
 package cgroup
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -11,7 +12,7 @@ func (c *VersionNotSupported) Error() string {
 }
 
 func NoCgroupSupport() error {
-	return fmt.Errorf("could not find cgroup support")
+	return errors.New("could not find cgroup support")
 }
 
 func CouldNotFindOrMountDefaultCgroup(ver CgroupVersion) error {

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -95,6 +95,8 @@ func PrepareCapture(captureSlice []string, newBinary bool) (config.CaptureConfig
 	outDir := "/tmp/tracee"
 	clearDir := false
 
+	// TODO: refactor this to reduce control flow nesting
+	// When done, reduce control-nesting rule to default "5" in .revive.toml
 	for i := range captureSlice {
 		c := captureSlice[i]
 		if strings.HasPrefix(c, "artifact:write") ||

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -220,7 +221,7 @@ func parseFileCaptureOption(arg string, cap string, captureConfig *config.FileCa
 	}
 	optAndValue := strings.SplitN(cap, ":", 2)
 	if len(optAndValue) != 2 || optAndValue[0] != arg {
-		return fmt.Errorf("invalid capture option specified, use '--capture help' for more info")
+		return errors.New("invalid capture option specified, use '--capture help' for more info")
 	}
 	err := parseFileCaptureSubOption(optAndValue[1], captureConfig)
 	return err
@@ -231,18 +232,18 @@ func parseFileCaptureOption(arg string, cap string, captureConfig *config.FileCa
 func parseFileCaptureSubOption(option string, captureConfig *config.FileCaptureConfig) error {
 	optAndValue := strings.SplitN(option, "=", 2)
 	if len(optAndValue) != 2 || len(optAndValue[1]) == 0 {
-		return fmt.Errorf("invalid capture option specified, use '--capture help' for more info")
+		return errors.New("invalid capture option specified, use '--capture help' for more info")
 	}
 	opt := optAndValue[0]
 	value := optAndValue[1]
 	switch opt {
 	case "path":
 		if !strings.HasSuffix(option, "*") {
-			return fmt.Errorf("file path filter should end with *")
+			return errors.New("file path filter should end with *")
 		}
 		pathPrefix := strings.TrimSuffix(value, "*")
 		if len(pathPrefix) == 0 {
-			return fmt.Errorf("capture path filter cannot be empty")
+			return errors.New("capture path filter cannot be empty")
 		}
 		captureConfig.PathFilter = append(captureConfig.PathFilter, pathPrefix)
 	case "type":

--- a/pkg/cmd/flags/dnscache.go
+++ b/pkg/cmd/flags/dnscache.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,7 +32,7 @@ func PrepareDnsCache(cacheSlice []string) (dnscache.Config, error) {
 
 	for _, slice := range cacheSlice {
 		if strings.HasPrefix(slice, "help") {
-			return config, fmt.Errorf(dnsCacheHelp())
+			return config, errors.New(dnsCacheHelp())
 		}
 		if slice == "enable" {
 			continue

--- a/pkg/cmd/flags/errors.go
+++ b/pkg/cmd/flags/errors.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -21,7 +22,7 @@ func InvalidScopeOptionError(expr string, newBinary bool) error {
 }
 
 func InvalidFlagEmpty() error {
-	return fmt.Errorf("empty flag")
+	return errors.New("empty flag")
 }
 
 func InvalidFilterFlagFormat(expression string) error {

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -154,8 +154,6 @@ func setOption(cfg *config.OutputConfig, option string, newBinary bool) error {
 			}
 
 			return nil
-		} else {
-			goto invalidOption
 		}
 
 	invalidOption:

--- a/pkg/cmd/flags/proctree.go
+++ b/pkg/cmd/flags/proctree.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -44,7 +45,7 @@ func PrepareProcTree(cacheSlice []string) (proctree.ProcTreeConfig, error) {
 
 	for _, slice := range cacheSlice {
 		if strings.HasPrefix(slice, "help") {
-			return config, fmt.Errorf(procTreeHelp())
+			return config, errors.New(procTreeHelp())
 		}
 		if strings.HasPrefix(slice, "none") {
 			return config, nil
@@ -110,7 +111,7 @@ func PrepareProcTree(cacheSlice []string) (proctree.ProcTreeConfig, error) {
 	}
 
 	if cacheSet && config.Source == proctree.SourceNone {
-		return config, fmt.Errorf("proctree cache was set but no source was given")
+		return config, errors.New("proctree cache was set but no source was given")
 	}
 
 	if config.Source != proctree.SourceNone {

--- a/pkg/cmd/gptdocs.go
+++ b/pkg/cmd/gptdocs.go
@@ -86,11 +86,11 @@ func (r GPTDocsRunner) Run(ctx context.Context) error {
 				return
 			case f := <-wrkChannel:
 				fmt.Printf("WORKING (%v)...\n", f)
-			case r := <-retChannel:
-				if r.err != nil {
-					fmt.Printf("ERROR (%v): %v\n", r.eventName, r.err)
+			case workRet := <-retChannel:
+				if workRet.err != nil {
+					fmt.Printf("ERROR (%v): %v\n", workRet.eventName, workRet.err)
 				} else {
-					fmt.Printf("GENERATED (%v): %v\n", r.eventName, r.fileName)
+					fmt.Printf("GENERATED (%v): %v\n", workRet.eventName, workRet.fileName)
 				}
 			default:
 				time.Sleep(10 * time.Millisecond)

--- a/pkg/cmd/gptdocs.go
+++ b/pkg/cmd/gptdocs.go
@@ -251,7 +251,7 @@ given syscall. The template for this markdown file is the following:
 	choicesStr := strings.Join(choices, "")
 
 	if len(choicesStr) <= 10 {
-		return fileName, fmt.Errorf("no output from OpenAI")
+		return fileName, errors.New("no output from OpenAI")
 	}
 
 	footNote := `

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -430,8 +430,13 @@ type forwardEventPrinter struct {
 	outPath string
 	url     *url.URL
 	client  *forward.Client
+
+	// revive:disable:struct-tag
+
 	// These parameters can be set up from the URL
 	tag string `default:"tracee"`
+
+	// revive:enable:struct-tag
 }
 
 func getParameterValue(parameters url.Values, key string, defaultValue string) string {

--- a/pkg/containers/runtime/containerd.go
+++ b/pkg/containers/runtime/containerd.go
@@ -115,6 +115,8 @@ func (e *containerdEnricher) isSandbox(labels map[string]string) bool {
 	return labels[ContainerTypeContainerdLabel] == "sandbox"
 }
 
+// revive:disable:confusing-results
+
 func (e *containerdEnricher) getImageInfoStore(ctx context.Context, image string) (string, string, error) {
 	r, err := e.images.Get(ctx, image)
 	if err != nil {
@@ -125,6 +127,10 @@ func (e *containerdEnricher) getImageInfoStore(ctx context.Context, image string
 	d := r.Target.Digest.String()
 	return i, d, nil
 }
+
+// revive:enable:confusing-results
+
+// revive:disable:confusing-results
 
 func (e *containerdEnricher) getImageInfoCri(ctx context.Context, image string) (string, string, error) {
 	var imageName, imageDigest string
@@ -162,3 +168,5 @@ func (e *containerdEnricher) getImageInfoCri(ctx context.Context, image string) 
 	}
 	return imageName, imageDigest, nil
 }
+
+// revive:enable:confusing-results

--- a/pkg/dnscache/dnscache.go
+++ b/pkg/dnscache/dnscache.go
@@ -2,7 +2,6 @@ package dnscache
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -60,7 +59,7 @@ func (nc *DNSCache) Add(event *trace.Event) error {
 	}
 
 	if len(dns.Questions) != 1 {
-		return fmt.Errorf("wrong number of requests found")
+		return errors.New("wrong number of requests found")
 	}
 
 	// transaction lock

--- a/pkg/ebpf/probes/arch_amd64.go
+++ b/pkg/ebpf/probes/arch_amd64.go
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 package probes
 

--- a/pkg/ebpf/probes/arch_arm64.go
+++ b/pkg/ebpf/probes/arch_arm64.go
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 package probes
 

--- a/pkg/ebpf/processor_proctree.go
+++ b/pkg/ebpf/processor_proctree.go
@@ -1,7 +1,7 @@
 package ebpf
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/pkg/events/parse"
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -17,7 +17,7 @@ import (
 // procTreeForkProcessor handles process fork events.
 func (t *Tracee) procTreeForkProcessor(event *trace.Event) error {
 	if t.processTree == nil {
-		return fmt.Errorf("process tree is disabled")
+		return errors.New("process tree is disabled")
 	}
 
 	var err error
@@ -106,7 +106,7 @@ func (t *Tracee) procTreeForkProcessor(event *trace.Event) error {
 // procTreeExecProcessor handles process exec events.
 func (t *Tracee) procTreeExecProcessor(event *trace.Event) error {
 	if t.processTree == nil {
-		return fmt.Errorf("process tree is disabled")
+		return errors.New("process tree is disabled")
 	}
 	if event.HostProcessID != event.HostThreadID {
 		return nil // check FeedFromExec for TODO of execve() handled by threads
@@ -189,7 +189,7 @@ func (t *Tracee) procTreeExecProcessor(event *trace.Event) error {
 // procTreeExitProcessor handles process exit events.
 func (t *Tracee) procTreeExitProcessor(event *trace.Event) error {
 	if t.processTree == nil {
-		return fmt.Errorf("process tree is disabled")
+		return errors.New("process tree is disabled")
 	}
 	if event.HostProcessID != event.HostThreadID {
 		return nil // check FeedFromExec for TODO of execve() handled by threads

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	gocontext "context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -986,7 +987,7 @@ func (t *Tracee) validateKallsymsDependencies() {
 				return nil
 			}
 			if !validateEvent(eventNode.GetID()) {
-				return []dependencies.Action{dependencies.NewCancelNodeAddAction(fmt.Errorf("event is missing ksymbols"))}
+				return []dependencies.Action{dependencies.NewCancelNodeAddAction(errors.New("event is missing ksymbols"))}
 			}
 			return nil
 		})

--- a/pkg/errfmt/errfmt_test.go
+++ b/pkg/errfmt/errfmt_test.go
@@ -2,7 +2,6 @@ package errfmt
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"gotest.tools/assert"
@@ -27,13 +26,13 @@ func TestErrorf(t *testing.T) {
 			name:   "non-empty format string",
 			format: "an error occurred",
 			args:   []interface{}{},
-			want:   fmt.Errorf("errfmt.TestErrorf.func1: an error occurred"),
+			want:   errors.New("errfmt.TestErrorf.func1: an error occurred"),
 		},
 		{
 			name:   "format string with arguments",
 			format: "an error occurred, %d",
 			args:   []interface{}{42},
-			want:   fmt.Errorf("errfmt.TestErrorf.func1: an error occurred, 42"),
+			want:   errors.New("errfmt.TestErrorf.func1: an error occurred, 42"),
 		},
 	}
 
@@ -69,7 +68,7 @@ func TestWrapError(t *testing.T) {
 		{
 			name: "non-nil error",
 			err:  errors.New("an error occurred"),
-			want: fmt.Errorf("errfmt.TestWrapError.func1: an error occurred"),
+			want: errors.New("errfmt.TestWrapError.func1: an error occurred"),
 		},
 	}
 

--- a/pkg/events/core_amd64.go
+++ b/pkg/events/core_amd64.go
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 package events
 

--- a/pkg/events/core_arm64.go
+++ b/pkg/events/core_arm64.go
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 package events
 

--- a/pkg/events/derive/derive_test.go
+++ b/pkg/events/derive/derive_test.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -21,7 +22,7 @@ func Test_DeriveEvent(t *testing.T) {
 	noDerivationEventID := events.ID(13)
 	alwaysDeriveError := func() DeriveFunction {
 		return func(e trace.Event) ([]trace.Event, []error) {
-			return []trace.Event{}, []error{fmt.Errorf("derive error")}
+			return []trace.Event{}, []error{errors.New("derive error")}
 		}
 	}
 	mockDerivationTable := Table{
@@ -65,7 +66,7 @@ func Test_DeriveEvent(t *testing.T) {
 					EventID: int(deriveEventID),
 				},
 			},
-			expectedErrors: []error{deriveError(failEventID, fmt.Errorf("derive error"))},
+			expectedErrors: []error{deriveError(failEventID, errors.New("derive error"))},
 		},
 	}
 
@@ -130,7 +131,7 @@ func Test_DeriveSingleEvent(t *testing.T) {
 	noDeriveEventArgs := func(event trace.Event) ([]interface{}, error) {
 		return nil, nil
 	}
-	deriveArgsError := fmt.Errorf("fail derive args")
+	deriveArgsError := errors.New("fail derive args")
 	failDeriveEventArgs := func(event trace.Event) ([]interface{}, error) {
 		return nil, deriveArgsError
 	}
@@ -252,25 +253,25 @@ func TestDeriveMultipleEvents(t *testing.T) {
 		},
 		{
 			Name:           "Fail derive argument function for 1 event",
-			ExpectedErrors: []error{fmt.Errorf(deriveArgsError)},
+			ExpectedErrors: []error{errors.New(deriveArgsError)},
 			ArgsDeriveFunc: func(event trace.Event) ([][]interface{}, []error) {
-				return nil, []error{fmt.Errorf(deriveArgsError)}
+				return nil, []error{errors.New(deriveArgsError)}
 			},
 			DerivedEventsAmount: 0,
 		},
 		{
 			Name:           "Fail derive argument function for 2 event",
-			ExpectedErrors: []error{fmt.Errorf(deriveArgsError), fmt.Errorf(deriveArgsError)},
+			ExpectedErrors: []error{errors.New(deriveArgsError), errors.New(deriveArgsError)},
 			ArgsDeriveFunc: func(event trace.Event) ([][]interface{}, []error) {
-				return nil, []error{fmt.Errorf(deriveArgsError), fmt.Errorf(deriveArgsError)}
+				return nil, []error{errors.New(deriveArgsError), errors.New(deriveArgsError)}
 			},
 			DerivedEventsAmount: 0,
 		},
 		{
 			Name:           "Succeed in derive event arguments and fail derive another event arguments",
-			ExpectedErrors: []error{fmt.Errorf(deriveArgsError)},
+			ExpectedErrors: []error{errors.New(deriveArgsError)},
 			ArgsDeriveFunc: func(event trace.Event) ([][]interface{}, []error) {
-				return [][]interface{}{{1, 2}}, []error{fmt.Errorf(deriveArgsError)}
+				return [][]interface{}{{1, 2}}, []error{errors.New(deriveArgsError)}
 			},
 			DerivedEventsAmount: 1,
 		},
@@ -284,9 +285,9 @@ func TestDeriveMultipleEvents(t *testing.T) {
 		},
 		{
 			Name:           "Fail new event creation and derive args",
-			ExpectedErrors: []error{fmt.Errorf(deriveArgsError), fmt.Errorf("error deriving event \"%s\": expected %d arguments but given %d", eventDefinition.GetName(), len(eventDefinition.GetFields()), 3)},
+			ExpectedErrors: []error{errors.New(deriveArgsError), fmt.Errorf("error deriving event \"%s\": expected %d arguments but given %d", eventDefinition.GetName(), len(eventDefinition.GetFields()), 3)},
 			ArgsDeriveFunc: func(event trace.Event) ([][]interface{}, []error) {
-				return [][]interface{}{{1, 2, 3}}, []error{fmt.Errorf(deriveArgsError)}
+				return [][]interface{}{{1, 2, 3}}, []error{errors.New(deriveArgsError)}
 			},
 			DerivedEventsAmount: 0,
 		},

--- a/pkg/events/derive/errors.go
+++ b/pkg/events/derive/errors.go
@@ -1,6 +1,7 @@
 package derive
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aquasecurity/tracee/pkg/events"
@@ -23,19 +24,19 @@ func alreadyRegisteredError(from, to events.ID) error {
 //
 
 func noPayloadError() error {
-	return fmt.Errorf("no payload ?")
+	return errors.New("no payload ?")
 }
 
 func emptyPayloadError() error {
-	return fmt.Errorf("empty payload ?")
+	return errors.New("empty payload ?")
 }
 
 func nonByteArgError() error {
-	return fmt.Errorf("non []byte argument ?")
+	return errors.New("non []byte argument ?")
 }
 
 func parsePacketError() error {
-	return fmt.Errorf("could not parse packet")
+	return errors.New("could not parse packet")
 }
 
 func notProtoPacketError(proto string) error {

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -111,10 +111,16 @@ func getPktMeta(srcIP, dstIP net.IP, srcPort, dstPort uint16, proto uint8, lengt
 	}
 }
 
+// revive:disable:function-result-limit
+// revive:disable:confusing-results
+
 // swapSrcDst swaps the source and destination IP addresses and ports.
 func swapSrcDst(s, d net.IP, sp, dp uint16) (net.IP, net.IP, uint16, uint16) {
 	return d, s, dp, sp
 }
+
+// revive:enable:confusing-results
+// revive:enable:function-result-limit
 
 // getPacketDirection returns the packet direction from the event.
 func getPacketDirection(event *trace.Event) trace.PacketDirection {
@@ -227,6 +233,8 @@ func getLayer3IPv6FromPacket(packet gopacket.Packet) (*layers.IPv6, error) {
 	return ipv6, nil
 }
 
+// revive:disable:confusing-results
+
 // getSrcDstFromLayer3 returns the source and destination IP addresses from the layer 3.
 func getSrcDstFromLayer3(layer3 gopacket.NetworkLayer) (net.IP, net.IP, error) {
 	switch v := layer3.(type) {
@@ -238,6 +246,10 @@ func getSrcDstFromLayer3(layer3 gopacket.NetworkLayer) (net.IP, net.IP, error) {
 	return nil, nil, errors.New("wrong layer 3 protocol type")
 }
 
+// revive:enable:confusing-results
+
+// revive:disable:confusing-results
+
 // getLayer3SrcDstFromPacket returns the source and destination IP addresses from the packet.
 func getLayer3SrcDstFromPacket(packet gopacket.Packet) (net.IP, net.IP, error) {
 	layer3, err := getLayer3FromPacket(packet)
@@ -246,6 +258,8 @@ func getLayer3SrcDstFromPacket(packet gopacket.Packet) (net.IP, net.IP, error) {
 	}
 	return getSrcDstFromLayer3(layer3)
 }
+
+// revive:enable:confusing-results
 
 // getLayer3TypeFromFlag returns the layer 3 protocol type from a given flag.
 func getLayer3TypeFromFlag(layer3TypeFlag int) (gopacket.LayerType, error) {
@@ -341,6 +355,8 @@ func getLayer4ProtoFromPacket(packet gopacket.Packet) (uint8, error) {
 	return 0, errors.New("wrong layer 4 protocol type")
 }
 
+// revive:disable:confusing-results
+
 // getLayer4SrcPortDstPortFromPacket returns the source and destination ports from the packet.
 func getLayer4SrcPortDstPortFromPacket(packet gopacket.Packet) (uint16, uint16, error) {
 	layer4, err := getLayer4FromPacket(packet)
@@ -355,6 +371,8 @@ func getLayer4SrcPortDstPortFromPacket(packet gopacket.Packet) (uint16, uint16, 
 	}
 	return 0, 0, errors.New("wrong layer 4 protocol type")
 }
+
+// revive:enable:confusing-results
 
 //
 // Special Layer (Some consider it as Layer 4, others Layer 3)

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -3,7 +3,7 @@ package derive
 import (
 	"bufio"
 	"bytes"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 	"strings"
@@ -196,7 +196,7 @@ func getLayer3FromPacket(packet gopacket.Packet) (gopacket.NetworkLayer, error) 
 	case (*layers.IPv4):
 	case (*layers.IPv6):
 	default:
-		return nil, fmt.Errorf("wrong layer 3 protocol type")
+		return nil, errors.New("wrong layer 3 protocol type")
 	}
 	return layer3, nil
 }
@@ -209,7 +209,7 @@ func getLayer3IPv4FromPacket(packet gopacket.Packet) (*layers.IPv4, error) {
 	}
 	ipv4, ok := layer3.(*layers.IPv4)
 	if !ok {
-		return nil, fmt.Errorf("wrong layer 3 protocol type")
+		return nil, errors.New("wrong layer 3 protocol type")
 	}
 	return ipv4, nil
 }
@@ -222,7 +222,7 @@ func getLayer3IPv6FromPacket(packet gopacket.Packet) (*layers.IPv6, error) {
 	}
 	ipv6, ok := layer3.(*layers.IPv6)
 	if !ok {
-		return nil, fmt.Errorf("wrong layer 3 protocol type")
+		return nil, errors.New("wrong layer 3 protocol type")
 	}
 	return ipv6, nil
 }
@@ -235,7 +235,7 @@ func getSrcDstFromLayer3(layer3 gopacket.NetworkLayer) (net.IP, net.IP, error) {
 	case (*layers.IPv6):
 		return v.SrcIP, v.DstIP, nil
 	}
-	return nil, nil, fmt.Errorf("wrong layer 3 protocol type")
+	return nil, nil, errors.New("wrong layer 3 protocol type")
 }
 
 // getLayer3SrcDstFromPacket returns the source and destination IP addresses from the packet.
@@ -255,7 +255,7 @@ func getLayer3TypeFromFlag(layer3TypeFlag int) (gopacket.LayerType, error) {
 	case familyIPv6:
 		return layers.LayerTypeIPv6, nil
 	}
-	return 0, fmt.Errorf("wrong layer 3 type")
+	return 0, errors.New("wrong layer 3 type")
 }
 
 // getLayer3TypeFlagFromEvent returns the layer 3 protocol type from a given event.
@@ -266,7 +266,7 @@ func getLayer3TypeFlagFromEvent(event *trace.Event) (int, error) {
 	case event.ReturnValue&familyIPv6 == familyIPv6:
 		return familyIPv6, nil
 	}
-	return 0, fmt.Errorf("wrong layer 3 ret value flag")
+	return 0, errors.New("wrong layer 3 ret value flag")
 }
 
 // getLengthFromPacket returns the packet length from a given packet.
@@ -281,7 +281,7 @@ func getLengthFromPacket(packet gopacket.Packet) (uint32, error) {
 	case (*layers.IPv6):
 		return uint32(v.Length), nil
 	}
-	return 0, fmt.Errorf("wrong layer 3 protocol type")
+	return 0, errors.New("wrong layer 3 protocol type")
 }
 
 //
@@ -295,7 +295,7 @@ func getLayer4FromPacket(packet gopacket.Packet) (gopacket.TransportLayer, error
 	case (*layers.TCP):
 	case (*layers.UDP):
 	default:
-		return nil, fmt.Errorf("wrong layer 4 protocol type")
+		return nil, errors.New("wrong layer 4 protocol type")
 	}
 	return layer4, nil
 }
@@ -308,7 +308,7 @@ func getLayer4TCPFromPacket(packet gopacket.Packet) (*layers.TCP, error) {
 	}
 	tcp, ok := layer4.(*layers.TCP)
 	if !ok {
-		return nil, fmt.Errorf("wrong layer 4 protocol type")
+		return nil, errors.New("wrong layer 4 protocol type")
 	}
 	return tcp, nil
 }
@@ -321,7 +321,7 @@ func getLayer4UDPFromPacket(packet gopacket.Packet) (*layers.UDP, error) {
 	}
 	udp, ok := layer4.(*layers.UDP)
 	if !ok {
-		return nil, fmt.Errorf("wrong layer 4 protocol type")
+		return nil, errors.New("wrong layer 4 protocol type")
 	}
 	return udp, nil
 }
@@ -338,7 +338,7 @@ func getLayer4ProtoFromPacket(packet gopacket.Packet) (uint8, error) {
 	case (*layers.UDP):
 		return IPPROTO_UDP, nil
 	}
-	return 0, fmt.Errorf("wrong layer 4 protocol type")
+	return 0, errors.New("wrong layer 4 protocol type")
 }
 
 // getLayer4SrcPortDstPortFromPacket returns the source and destination ports from the packet.
@@ -353,7 +353,7 @@ func getLayer4SrcPortDstPortFromPacket(packet gopacket.Packet) (uint16, uint16, 
 	case (*layers.UDP):
 		return uint16(v.SrcPort), uint16(v.DstPort), nil
 	}
-	return 0, 0, fmt.Errorf("wrong layer 4 protocol type")
+	return 0, 0, errors.New("wrong layer 4 protocol type")
 }
 
 //
@@ -365,11 +365,11 @@ func getLayerICMPFromPacket(packet gopacket.Packet) (*layers.ICMPv4, error) {
 	// ICMP might be considered Layer 3 (per OSI) or Layer 4 (per TCP/IP).
 	layer := packet.Layer(layers.LayerTypeICMPv4)
 	if layer == nil {
-		return nil, fmt.Errorf("wrong layer protocol type")
+		return nil, errors.New("wrong layer protocol type")
 	}
 	icmp, ok := layer.(*layers.ICMPv4)
 	if !ok {
-		return nil, fmt.Errorf("wrong layer protocol type")
+		return nil, errors.New("wrong layer protocol type")
 	}
 	return icmp, nil
 }
@@ -379,11 +379,11 @@ func getLayerICMPv6FromPacket(packet gopacket.Packet) (*layers.ICMPv6, error) {
 	// ICMP might be considered Layer 3 (per OSI) or Layer 4 (per TCP/IP).
 	layer := packet.Layer(layers.LayerTypeICMPv6)
 	if layer == nil {
-		return nil, fmt.Errorf("wrong layer protocol type")
+		return nil, errors.New("wrong layer protocol type")
 	}
 	icmp, ok := layer.(*layers.ICMPv6)
 	if !ok {
-		return nil, fmt.Errorf("wrong layer protocol type")
+		return nil, errors.New("wrong layer protocol type")
 	}
 	return icmp, nil
 }
@@ -401,14 +401,14 @@ func getLayer7DNSFromPacket(packet gopacket.Packet) (*layers.DNS, error) {
 	case (*layers.DNS):
 		return l7, nil
 	}
-	return nil, fmt.Errorf("wrong layer 7 protocol type")
+	return nil, errors.New("wrong layer 7 protocol type")
 }
 
 // getLayer7FromPacket returns the layer 7 protocol from the packet.
 func getLayer7FromPacket(packet gopacket.Packet) (gopacket.ApplicationLayer, error) {
 	layer7 := packet.ApplicationLayer()
 	if layer7 == nil {
-		return nil, fmt.Errorf("wrong layer 7 protocol type")
+		return nil, errors.New("wrong layer 7 protocol type")
 	}
 	return layer7, nil
 }

--- a/pkg/events/ftrace.go
+++ b/pkg/events/ftrace.go
@@ -359,6 +359,8 @@ func splitCallback(callback string) (string, int64, string) {
 	return funcName, offset, owner
 }
 
+// revive:disable:confusing-results
+
 // fetchTrampAndCallback extracts the trampoline and the callback
 func fetchTrampAndCallback(ftraceParts []string, i *int) (string, string) {
 	trampoline := ""
@@ -385,6 +387,8 @@ func fetchTrampAndCallback(ftraceParts []string, i *int) (string, string) {
 
 	return trampoline, callback
 }
+
+// revive:enable:confusing-results
 
 // getCallback extracts the callback
 func getCallback(ftraceParts []string) string {

--- a/pkg/events/parsers/data_parsers.go
+++ b/pkg/events/parsers/data_parsers.go
@@ -2,6 +2,7 @@ package parsers
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -2958,7 +2959,7 @@ func ParseGUPFlagsCurrentOS(rawValue uint64) (systemFunctionArgument, error) {
 	case newVersionsParsing:
 		return ParseGUPFlags(rawValue), nil
 	default:
-		return nil, fmt.Errorf("no parsing function for GUP flags was found to this OD version")
+		return nil, errors.New("no parsing function for GUP flags was found to this OD version")
 	}
 }
 

--- a/pkg/events/parsers/data_parsers_amd64.go
+++ b/pkg/events/parsers/data_parsers_amd64.go
@@ -1,5 +1,4 @@
 //go:build amd64
-// +build amd64
 
 package parsers
 

--- a/pkg/events/parsers/data_parsers_arm64.go
+++ b/pkg/events/parsers/data_parsers_arm64.go
@@ -1,5 +1,4 @@
 //go:build arm64
-// +build arm64
 
 package parsers
 

--- a/pkg/events/sorting/sorting_test.go
+++ b/pkg/events/sorting/sorting_test.go
@@ -2,7 +2,7 @@ package sorting
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sort"
 	"testing"
 	"time"
@@ -302,13 +302,13 @@ func retrieveEventsFromSorter(expectedEventsAmount int, sorterOutputChan <-chan 
 			outputList = append(outputList, *event)
 			eventsReceived++
 			if eventsReceived > expectedEventsAmount {
-				return outputList, fmt.Errorf("more events returned from sorter than expected")
+				return outputList, errors.New("more events returned from sorter than expected")
 			}
 		case err := <-fatalErrorsChan:
 			return nil, err
 		case <-ticker.C:
 			if eventsReceived != expectedEventsAmount {
-				return nil, fmt.Errorf("not all events received until timeout")
+				return nil, errors.New("not all events received until timeout")
 			}
 			return outputList, nil
 		}

--- a/pkg/filehash/cache.go
+++ b/pkg/filehash/cache.go
@@ -1,6 +1,7 @@
 package filehash
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -68,7 +69,7 @@ func (c *Cache) Get(k *Key) (string, error) {
 	}
 
 	if key == "" {
-		return "", fmt.Errorf("empty key given")
+		return "", errors.New("empty key given")
 	}
 
 	var fileHash string

--- a/pkg/filters/errors.go
+++ b/pkg/filters/errors.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -25,7 +26,7 @@ func InvalidValueMax(value string, max int) error {
 }
 
 func InvalidFilterType() error {
-	return fmt.Errorf("operator not supported for the event and data arg")
+	return errors.New("operator not supported for the event and data arg")
 }
 
 func InvalidEventName(event string) error {
@@ -41,5 +42,5 @@ func InvalidScopeField(field string) error {
 }
 
 func FailedToRetreiveHostNS() error {
-	return fmt.Errorf("failed to retrieve host mount namespace")
+	return errors.New("failed to retrieve host mount namespace")
 }

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -1,11 +1,12 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 )
 
 func PolicyNilError() error {
-	return fmt.Errorf("policy cannot be nil")
+	return errors.New("policy cannot be nil")
 }
 
 func PoliciesMaxExceededError() error {

--- a/pkg/signatures/benchmark/signature/golang/anti_debugging.go
+++ b/pkg/signatures/benchmark/signature/golang/anti_debugging.go
@@ -1,6 +1,7 @@
 package golang
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aquasecurity/tracee/pkg/events/parsers"
@@ -50,7 +51,7 @@ func (sig *antiDebugging) OnEvent(event protocol.Event) error {
 	ee, ok := event.Payload.(trace.Event)
 
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 	if ee.EventName != "ptrace" {
 		return nil

--- a/pkg/signatures/benchmark/signature/golang/code_injection.go
+++ b/pkg/signatures/benchmark/signature/golang/code_injection.go
@@ -1,6 +1,7 @@
 package golang
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -61,7 +62,7 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 	ee, ok := event.Payload.(trace.Event)
 
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 	switch ee.EventName {
 	case "open", "openat":
@@ -94,7 +95,7 @@ func (sig *codeInjection) OnEvent(event protocol.Event) error {
 
 		requestString, ok := request.Value.(string)
 		if !ok {
-			return fmt.Errorf("failed to cast request's value")
+			return errors.New("failed to cast request's value")
 		}
 
 		if requestString == "PTRACE_POKETEXT" || requestString == "PTRACE_POKEDATA" {

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -64,7 +65,7 @@ func (engine *Engine) Stats() *metrics.Stats {
 // Signatures are not loaded at this point, Init must be called to perform config side effects.
 func NewEngine(config Config, sources EventSources, output chan *detect.Finding) (*Engine, error) {
 	if sources.Tracee == nil || output == nil {
-		return nil, fmt.Errorf("nil input received")
+		return nil, errors.New("nil input received")
 	}
 	engine := Engine{}
 	engine.waitGroup = sync.WaitGroup{}

--- a/pkg/utils/environment/amount_cpus.go
+++ b/pkg/utils/environment/amount_cpus.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -35,25 +36,25 @@ func parsePossibleCPUAmountFromCPUFileFormat(cpuFileContent string) (int, error)
 	var usedSize, groupSize int
 	bitmapsRegions := strings.Split(cpuFileContent, ",")
 	if len(bitmapsRegions) > 1 {
-		return 0, fmt.Errorf("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
+		return 0, errors.New("possible cpus should be following indexes starting with 0, so multiple regions is not allowed")
 	}
 	cpusAmount := 0
 	n, _ := fmt.Sscanf(bitmapsRegions[0], "%d-%d:%d/%d", &rangeStart, &rangeEnd, &usedSize, &groupSize)
 	switch n {
 	case singleValue:
 		if rangeStart != 0 {
-			return 0, fmt.Errorf("possible cpus must start from the index 0, so single CPU index value must be 0")
+			return 0, errors.New("possible cpus must start from the index 0, so single CPU index value must be 0")
 		}
 		cpusAmount = 1
 	case rangeValues:
 		if rangeStart != 0 {
-			return 0, fmt.Errorf("possible cpus should be following indexes range starting with 0")
+			return 0, errors.New("possible cpus should be following indexes range starting with 0")
 		}
 		cpusAmount = rangeEnd - rangeStart + 1
 	case rangeValuesWithGroups:
-		return 0, fmt.Errorf("possible cpus should be following indexes, but received groups format")
+		return 0, errors.New("possible cpus should be following indexes, but received groups format")
 	default:
-		return 0, fmt.Errorf("unknown possible cpu file format")
+		return 0, errors.New("unknown possible cpu file format")
 	}
 	return cpusAmount, nil
 }

--- a/pkg/utils/environment/kernel_version.go
+++ b/pkg/utils/environment/kernel_version.go
@@ -1,6 +1,7 @@
 package environment
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -25,7 +26,7 @@ func checkEnvPath(env string) (string, error) {
 func UnameRelease() (string, error) {
 	var uname syscall.Utsname
 	if err := syscall.Uname(&uname); err != nil {
-		return "", fmt.Errorf("could not get utsname")
+		return "", errors.New("could not get utsname")
 	}
 
 	var buf [65]byte
@@ -43,7 +44,7 @@ func UnameRelease() (string, error) {
 func UnameMachine() (string, error) {
 	var uname syscall.Utsname
 	if err := syscall.Uname(&uname); err != nil {
-		return "", fmt.Errorf("could not get utsname")
+		return "", errors.New("could not get utsname")
 	}
 
 	var buf [65]byte

--- a/pkg/utils/environment/osinfo.go
+++ b/pkg/utils/environment/osinfo.go
@@ -208,7 +208,7 @@ func (btfi *OSInfo) discoverOSDistro() error {
 	var err error
 
 	if btfi.osReleaseFilePath == "" {
-		return fmt.Errorf("should specify os-release filepath")
+		return errors.New("should specify os-release filepath")
 	}
 
 	file, err := os.Open(btfi.osReleaseFilePath)
@@ -294,5 +294,5 @@ func Lockdown() (LockdownMode, error) {
 		}
 	}
 
-	return NOVALUE, fmt.Errorf("could not get lockdown mode")
+	return NOVALUE, errors.New("could not get lockdown mode")
 }

--- a/signatures/golang/anti_debugging_ptraceme.go
+++ b/signatures/golang/anti_debugging_ptraceme.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -48,7 +48,7 @@ func (sig *AntiDebuggingPtraceme) GetSelectedEvents() ([]detect.SignatureEventSe
 func (sig *AntiDebuggingPtraceme) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/aslr_inspection.go
+++ b/signatures/golang/aslr_inspection.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -47,7 +47,7 @@ func (sig *AslrInspection) GetSelectedEvents() ([]detect.SignatureEventSelector,
 func (sig *AslrInspection) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/cgroup_notify_on_release_modification.go
+++ b/signatures/golang/cgroup_notify_on_release_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"path"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -48,7 +48,7 @@ func (sig *CgroupNotifyOnReleaseModification) GetSelectedEvents() ([]detect.Sign
 func (sig *CgroupNotifyOnReleaseModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/cgroup_release_agent_modification.go
+++ b/signatures/golang/cgroup_release_agent_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"path"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -49,7 +49,7 @@ func (sig *CgroupReleaseAgentModification) GetSelectedEvents() ([]detect.Signatu
 func (sig *CgroupReleaseAgentModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	basename := ""

--- a/signatures/golang/core_pattern_modification.go
+++ b/signatures/golang/core_pattern_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -48,7 +48,7 @@ func (sig *CorePatternModification) GetSelectedEvents() ([]detect.SignatureEvent
 func (sig *CorePatternModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/default_loader_modification.go
+++ b/signatures/golang/default_loader_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -52,7 +52,7 @@ func (sig *DefaultLoaderModification) GetSelectedEvents() ([]detect.SignatureEve
 func (sig *DefaultLoaderModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	path := ""

--- a/signatures/golang/disk_mount.go
+++ b/signatures/golang/disk_mount.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -48,7 +48,7 @@ func (sig *DiskMount) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 func (sig *DiskMount) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/docker_abuse.go
+++ b/signatures/golang/docker_abuse.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -49,7 +49,7 @@ func (sig *DockerAbuse) GetSelectedEvents() ([]detect.SignatureEventSelector, er
 func (sig *DockerAbuse) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	path := ""

--- a/signatures/golang/dropped_executable.go
+++ b/signatures/golang/dropped_executable.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -45,7 +45,7 @@ func (sig *DroppedExecutable) GetSelectedEvents() ([]detect.SignatureEventSelect
 func (sig *DroppedExecutable) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/dynamic_code_loading.go
+++ b/signatures/golang/dynamic_code_loading.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -47,7 +47,7 @@ func (sig *DynamicCodeLoading) GetSelectedEvents() ([]detect.SignatureEventSelec
 func (sig *DynamicCodeLoading) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/examples/example.go
+++ b/signatures/golang/examples/example.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -47,7 +47,7 @@ func (sig *counter) OnEvent(event protocol.Event) error {
 	ee, ok := event.Payload.(trace.Event)
 
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	if ee.ArgsNum > 0 && ee.Args[0].Name == "pathname" && strings.HasPrefix(ee.Args[0].Value.(string), "yo") {

--- a/signatures/golang/fileless_execution.go
+++ b/signatures/golang/fileless_execution.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -45,7 +45,7 @@ func (sig *FilelessExecution) GetSelectedEvents() ([]detect.SignatureEventSelect
 func (sig *FilelessExecution) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/hidden_file_created.go
+++ b/signatures/golang/hidden_file_created.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -48,7 +48,7 @@ func (sig *HiddenFileCreated) GetSelectedEvents() ([]detect.SignatureEventSelect
 func (sig *HiddenFileCreated) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/illegitimate_shell.go
+++ b/signatures/golang/illegitimate_shell.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -49,7 +49,7 @@ func (sig *IllegitimateShell) GetSelectedEvents() ([]detect.SignatureEventSelect
 func (sig *IllegitimateShell) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/k8s_service_account_token.go
+++ b/signatures/golang/k8s_service_account_token.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -53,7 +53,7 @@ func (sig *K8SServiceAccountToken) GetSelectedEvents() ([]detect.SignatureEventS
 func (sig *K8SServiceAccountToken) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/kernel_module_loading.go
+++ b/signatures/golang/kernel_module_loading.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -44,7 +44,7 @@ func (sig *KernelModuleLoading) GetSelectedEvents() ([]detect.SignatureEventSele
 func (sig *KernelModuleLoading) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/kubernetes_api_connection.go
+++ b/signatures/golang/kubernetes_api_connection.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -47,7 +47,7 @@ func (sig *K8sApiConnection) GetSelectedEvents() ([]detect.SignatureEventSelecto
 func (sig *K8sApiConnection) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	containerID := eventObj.Container.ID

--- a/signatures/golang/kubernetes_certificate_theft_attempt.go
+++ b/signatures/golang/kubernetes_certificate_theft_attempt.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -51,7 +51,7 @@ func (sig *KubernetesCertificateTheftAttempt) GetSelectedEvents() ([]detect.Sign
 func (sig *KubernetesCertificateTheftAttempt) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	path := ""

--- a/signatures/golang/ld_preload.go
+++ b/signatures/golang/ld_preload.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -52,7 +52,7 @@ func (sig *LdPreload) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 func (sig *LdPreload) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/proc_fops_hooking.go
+++ b/signatures/golang/proc_fops_hooking.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -45,7 +45,7 @@ func (sig *ProcFopsHooking) GetSelectedEvents() ([]detect.SignatureEventSelector
 func (sig *ProcFopsHooking) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/proc_kcore_read.go
+++ b/signatures/golang/proc_kcore_read.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -48,7 +48,7 @@ func (sig *ProcKcoreRead) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 func (sig *ProcKcoreRead) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/proc_mem_access.go
+++ b/signatures/golang/proc_mem_access.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -51,7 +51,7 @@ func (sig *ProcMemAccess) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 func (sig *ProcMemAccess) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/proc_mem_code_injection.go
+++ b/signatures/golang/proc_mem_code_injection.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -51,7 +51,7 @@ func (sig *ProcMemCodeInjection) GetSelectedEvents() ([]detect.SignatureEventSel
 func (sig *ProcMemCodeInjection) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/process_vm_write_code_injection.go
+++ b/signatures/golang/process_vm_write_code_injection.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -46,7 +46,7 @@ func (sig *ProcessVmWriteCodeInjection) GetSelectedEvents() ([]detect.SignatureE
 func (sig *ProcessVmWriteCodeInjection) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/ptrace_code_injection.go
+++ b/signatures/golang/ptrace_code_injection.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -50,7 +50,7 @@ func (sig *PtraceCodeInjection) GetSelectedEvents() ([]detect.SignatureEventSele
 func (sig *PtraceCodeInjection) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/rcd_modification.go
+++ b/signatures/golang/rcd_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"path"
 	"strings"
 
@@ -55,7 +55,7 @@ func (sig *RcdModification) GetSelectedEvents() ([]detect.SignatureEventSelector
 func (sig *RcdModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/sched_debug_recon.go
+++ b/signatures/golang/sched_debug_recon.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -47,7 +47,7 @@ func (sig *SchedDebugRecon) GetSelectedEvents() ([]detect.SignatureEventSelector
 func (sig *SchedDebugRecon) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/scheduled_task_modification.go
+++ b/signatures/golang/scheduled_task_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"path"
 	"strings"
 
@@ -55,7 +55,7 @@ func (sig *ScheduledTaskModification) GetSelectedEvents() ([]detect.SignatureEve
 func (sig *ScheduledTaskModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/stdio_over_socket.go
+++ b/signatures/golang/stdio_over_socket.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -48,7 +48,7 @@ func (sig *StdioOverSocket) GetSelectedEvents() ([]detect.SignatureEventSelector
 func (sig *StdioOverSocket) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	var sockfd int

--- a/signatures/golang/sudoers_modification.go
+++ b/signatures/golang/sudoers_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -51,7 +51,7 @@ func (sig *SudoersModification) GetSelectedEvents() ([]detect.SignatureEventSele
 func (sig *SudoersModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	path := ""

--- a/signatures/golang/syscall_table_hooking.go
+++ b/signatures/golang/syscall_table_hooking.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -44,7 +44,7 @@ func (sig *SyscallTableHooking) GetSelectedEvents() ([]detect.SignatureEventSele
 func (sig *SyscallTableHooking) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/golang/system_request_key_config_modification.go
+++ b/signatures/golang/system_request_key_config_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -47,7 +47,7 @@ func (sig *SystemRequestKeyConfigModification) GetSelectedEvents() ([]detect.Sig
 func (sig *SystemRequestKeyConfigModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("invalid event")
+		return errors.New("invalid event")
 	}
 
 	switch eventObj.EventName {

--- a/signatures/helpers/arguments_helpers.go
+++ b/signatures/helpers/arguments_helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	b64 "encoding/base64"
+	"errors"
 	"fmt"
 
 	"github.com/aquasecurity/tracee/types/trace"
@@ -156,12 +157,12 @@ func GetRawAddrArgumentByName(event trace.Event, argName string) (map[string]str
 		addr = make(map[string]string)
 		stringInterMap, isStringInterMap := arg.Value.(map[string]interface{})
 		if !isStringInterMap {
-			return addr, fmt.Errorf("couldn't convert arg to addr")
+			return addr, errors.New("couldn't convert arg to addr")
 		}
 		for k, v := range stringInterMap {
 			s, isString := v.(string)
 			if !isString {
-				return addr, fmt.Errorf("couldn't convert arg to addr")
+				return addr, errors.New("couldn't convert arg to addr")
 			}
 			addr[k] = s
 		}
@@ -205,7 +206,7 @@ func getHookedSymbolData(v interface{}) (trace.HookedSymbolData, error) {
 
 	hookedSymbolMap, ok := v.(map[string]interface{})
 	if !ok {
-		return symbol, fmt.Errorf("can't convert hooked symbol to map[string]interface{}")
+		return symbol, errors.New("can't convert hooked symbol to map[string]interface{}")
 	}
 
 	for key, value := range hookedSymbolMap {

--- a/signatures/helpers/helpers.go
+++ b/signatures/helpers/helpers.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"syscall"
@@ -52,7 +53,7 @@ func IsElf(bytesArray []byte) bool {
 func GetFamilyFromRawAddr(addr map[string]string) (string, error) {
 	family, exists := addr["sa_family"]
 	if !exists {
-		return "", fmt.Errorf("family not found in address")
+		return "", errors.New("family not found in address")
 	}
 
 	return family, nil
@@ -97,15 +98,15 @@ func GetIPFromRawAddr(addr map[string]string) (string, error) {
 	case "AF_INET":
 		ip, exists = addr["sin_addr"]
 		if !exists {
-			return "", fmt.Errorf("ip not found in address")
+			return "", errors.New("ip not found in address")
 		}
 	case "AF_INET6":
 		ip, exists = addr["sin6_addr"]
 		if !exists {
-			return "", fmt.Errorf("ip not found in address")
+			return "", errors.New("ip not found in address")
 		}
 	default:
-		return "", fmt.Errorf("address family not supported")
+		return "", errors.New("address family not supported")
 	}
 
 	return ip, nil
@@ -124,15 +125,15 @@ func GetPortFromRawAddr(addr map[string]string) (string, error) {
 	case "AF_INET":
 		port, exists = addr["sin_port"]
 		if !exists {
-			return "", fmt.Errorf("port not found in address")
+			return "", errors.New("port not found in address")
 		}
 	case "AF_INET6":
 		port, exists = addr["sin6_port"]
 		if !exists {
-			return "", fmt.Errorf("port not found in address")
+			return "", errors.New("port not found in address")
 		}
 	default:
-		return "", fmt.Errorf("address family not supported")
+		return "", errors.New("address family not supported")
 	}
 
 	return port, nil
@@ -151,10 +152,10 @@ func GetPathFromRawAddr(addr map[string]string) (string, error) {
 	case "AF_UNIX":
 		path, exists = addr["sun_path"]
 		if !exists {
-			return "", fmt.Errorf("path not found in address")
+			return "", errors.New("path not found in address")
 		}
 	default:
-		return "", fmt.Errorf("address family not supported")
+		return "", errors.New("address family not supported")
 	}
 
 	return path, nil

--- a/signatures/helpers/proctree.go
+++ b/signatures/helpers/proctree.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -26,7 +27,7 @@ func InitProcessTreeDS(ds detect.DataSource) *ProcessTreeDS {
 func GetProcessTreeDataSource(ctx detect.SignatureContext) (*ProcessTreeDS, error) {
 	processTreeDataSource, ok := ctx.GetDataSource("tracee", "process_tree")
 	if !ok {
-		return nil, fmt.Errorf("data source tracee/process_tree is not registered")
+		return nil, errors.New("data source tracee/process_tree is not registered")
 	}
 
 	if processTreeDataSource.Version() > 1 {

--- a/tests/e2e-inst-signatures/e2e-bpf_attach.go
+++ b/tests/e2e-inst-signatures/e2e-bpf_attach.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/pkg/events/parsers"
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -39,7 +39,7 @@ func (sig *e2eBpfAttach) GetSelectedEvents() ([]detect.SignatureEventSelector, e
 func (sig *e2eBpfAttach) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-containers_data_source.go
+++ b/tests/e2e-inst-signatures/e2e-containers_data_source.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -18,10 +19,10 @@ func (sig *e2eContainersDataSource) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
 	containersData, ok := ctx.GetDataSource("tracee", "containers")
 	if !ok {
-		return fmt.Errorf("containers data source not registered")
+		return errors.New("containers data source not registered")
 	}
 	if containersData.Version() > 1 {
-		return fmt.Errorf("containers data source version not supported, please update this signature")
+		return errors.New("containers data source version not supported, please update this signature")
 	}
 	sig.containersData = containersData
 	return nil
@@ -47,7 +48,7 @@ func (sig *e2eContainersDataSource) GetSelectedEvents() ([]detect.SignatureEvent
 func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {
@@ -63,7 +64,7 @@ func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
 
 		containerId := eventObj.Container.ID
 		if containerId == "" {
-			return fmt.Errorf("received non container event")
+			return errors.New("received non container event")
 		}
 
 		container, err := sig.containersData.Get(containerId)
@@ -73,7 +74,7 @@ func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
 
 		containerIdData, ok := container["container_id"].(string)
 		if !ok {
-			return fmt.Errorf("failed to extract container id from container data")
+			return errors.New("failed to extract container id from container data")
 		}
 
 		if containerIdData != containerId {

--- a/tests/e2e-inst-signatures/e2e-dns_data_source.go
+++ b/tests/e2e-inst-signatures/e2e-dns_data_source.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aquasecurity/tracee/types/detect"
@@ -17,10 +18,10 @@ func (sig *e2eDnsDataSource) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
 	dnsData, ok := ctx.GetDataSource("tracee", "dns")
 	if !ok {
-		return fmt.Errorf("dns data source not registered")
+		return errors.New("dns data source not registered")
 	}
 	if dnsData.Version() > 1 {
-		return fmt.Errorf("dns data source version not supported, please update this signature")
+		return errors.New("dns data source version not supported, please update this signature")
 	}
 	sig.dnsData = dnsData
 	return nil
@@ -46,7 +47,7 @@ func (sig *e2eDnsDataSource) GetSelectedEvents() ([]detect.SignatureEventSelecto
 func (sig *e2eDnsDataSource) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {
@@ -62,18 +63,18 @@ func (sig *e2eDnsDataSource) OnEvent(event protocol.Event) error {
 
 		ipResults, ok := dns["ip_addresses"].([]string)
 		if !ok {
-			return fmt.Errorf("failed to extract ip results")
+			return errors.New("failed to extract ip results")
 		}
 		if len(ipResults) < 1 {
-			return fmt.Errorf("ip results were empty")
+			return errors.New("ip results were empty")
 		}
 
 		dnsResults, ok := dns["dns_queries"].([]string)
 		if !ok {
-			return fmt.Errorf("failed to extract dns results")
+			return errors.New("failed to extract dns results")
 		}
 		if len(dnsResults) < 1 {
-			return fmt.Errorf("dns results were empty")
+			return errors.New("dns results were empty")
 		}
 		if dnsResults[0] != "google.com" {
 			return fmt.Errorf("bad dns query: %s", dnsResults[0])

--- a/tests/e2e-inst-signatures/e2e-file_modification.go
+++ b/tests/e2e-inst-signatures/e2e-file_modification.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -39,7 +39,7 @@ func (sig *e2eFileModification) GetSelectedEvents() ([]detect.SignatureEventSele
 func (sig *e2eFileModification) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-ftrace_hook.go
+++ b/tests/e2e-inst-signatures/e2e-ftrace_hook.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eFtraceHook) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 func (sig *e2eFtraceHook) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-hooked_syscall.go
+++ b/tests/e2e-inst-signatures/e2e-hooked_syscall.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eHookedSyscall) GetSelectedEvents() ([]detect.SignatureEventSelecto
 func (sig *e2eHookedSyscall) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-process_execute_failed.go
+++ b/tests/e2e-inst-signatures/e2e-process_execute_failed.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 	"sync"
 
@@ -49,7 +49,7 @@ func (sig *e2eProcessExecuteFailed) GetSelectedEvents() ([]detect.SignatureEvent
 func (sig *e2eProcessExecuteFailed) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-proctree_data_source.go
+++ b/tests/e2e-inst-signatures/e2e-proctree_data_source.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -64,7 +65,7 @@ func (sig *e2eProcessTreeDataSource) GetSelectedEvents() (
 func (sig *e2eProcessTreeDataSource) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {
@@ -151,22 +152,22 @@ func (sig *e2eProcessTreeDataSource) checkThread(eventObj *trace.Event) error {
 
 	// Compare
 	if threadInfo.Tid != eventObj.HostThreadID {
-		return fmt.Errorf(debugFn("no match for tid"))
+		return errors.New(debugFn("no match for tid"))
 	}
 	if threadInfo.Pid != eventObj.HostProcessID {
-		return fmt.Errorf(debugFn("no match for pid"))
+		return errors.New(debugFn("no match for pid"))
 	}
 	if threadInfo.NsTid != eventObj.ThreadID {
-		return fmt.Errorf(debugFn("no match for ns tid"))
+		return errors.New(debugFn("no match for ns tid"))
 	}
 	if int(threadInfo.StartTime.UnixNano()) != eventObj.ThreadStartTime {
-		return fmt.Errorf(debugFn("no match for start time"))
+		return errors.New(debugFn("no match for start time"))
 	}
 	if threadTimeInfo.Timestamp != queryTime {
-		return fmt.Errorf(debugFn("no match for info timestamp"))
+		return errors.New(debugFn("no match for info timestamp"))
 	}
 	if threadInfo.Name != eventObj.ProcessName {
-		return fmt.Errorf(debugFn("no match for thread name"))
+		return errors.New(debugFn("no match for thread name"))
 	}
 
 	return nil
@@ -203,19 +204,19 @@ func (sig *e2eProcessTreeDataSource) checkProcess(eventObj *trace.Event) error {
 
 	// Compare
 	if processInfo.Pid != eventObj.HostProcessID {
-		return fmt.Errorf(debugFn("no match for pid"))
+		return errors.New(debugFn("no match for pid"))
 	}
 	if processInfo.NsPid != eventObj.ProcessID {
-		return fmt.Errorf(debugFn("no match for ns pid"))
+		return errors.New(debugFn("no match for ns pid"))
 	}
 	if processInfo.Ppid != eventObj.HostParentProcessID {
-		return fmt.Errorf(debugFn("no match for ppid"))
+		return errors.New(debugFn("no match for ppid"))
 	}
 	if int(processInfo.StartTime.UnixNano()) != eventObj.ThreadStartTime {
-		return fmt.Errorf(debugFn("no match for start time"))
+		return errors.New(debugFn("no match for start time"))
 	}
 	if processTimeInfo.Timestamp != queryTime {
-		return fmt.Errorf(debugFn("no match for timestamp"))
+		return errors.New(debugFn("no match for timestamp"))
 	}
 
 	// Check if the process lists itself in the list of its threads (case #1)
@@ -227,7 +228,7 @@ func (sig *e2eProcessTreeDataSource) checkProcess(eventObj *trace.Event) error {
 		}
 	}
 	if !threadExist {
-		return fmt.Errorf(debugFn("process not listed as thread"))
+		return errors.New(debugFn("process not listed as thread"))
 	}
 
 	// TODO
@@ -243,7 +244,7 @@ func (sig *e2eProcessTreeDataSource) checkProcess(eventObj *trace.Event) error {
 	// 	return err
 	// }
 	// if processInfo.ExecutionBinary.Path != pathname {
-	// 	return fmt.Errorf(debug("no match for pathname"))
+	// 	return errors.New(debug("no match for pathname"))
 	// }
 
 	return nil
@@ -306,10 +307,10 @@ func (sig *e2eProcessTreeDataSource) checkLineage(eventObj *trace.Event) error {
 
 		// Compare
 		if !compareMaps(compareBase.Info.ThreadsIds, given.Info.ThreadsIds) {
-			return fmt.Errorf(debug("threads do not match"))
+			return errors.New(debug("threads do not match"))
 		}
 		if !compareMaps(compareBase.Info.ChildProcessesIds, given.Info.ChildProcessesIds) {
-			return fmt.Errorf(debug("children do not match"))
+			return errors.New(debug("children do not match"))
 		}
 
 		// Zero fields that can't be compared (timing, maps, etc)
@@ -328,7 +329,7 @@ func (sig *e2eProcessTreeDataSource) checkLineage(eventObj *trace.Event) error {
 			// given.Info.Pid, given.Info.Ppid, given.Info.ExecTime, given.Info.EntityId,
 			// given.Info.Cmd, given.Info.ExecutionBinary.Path,
 			// )
-			return fmt.Errorf(debug("process in lineage does not match"))
+			return errors.New(debug("process in lineage does not match"))
 		}
 
 		return nil

--- a/tests/e2e-inst-signatures/e2e-security_inode_rename.go
+++ b/tests/e2e-inst-signatures/e2e-security_inode_rename.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -39,7 +39,7 @@ func (sig *e2eSecurityInodeRename) GetSelectedEvents() ([]detect.SignatureEventS
 func (sig *e2eSecurityInodeRename) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-security_path_notify.go
+++ b/tests/e2e-inst-signatures/e2e-security_path_notify.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -42,7 +42,7 @@ func (sig *e2eSecurityPathNotify) GetSelectedEvents() ([]detect.SignatureEventSe
 func (sig *e2eSecurityPathNotify) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-set_fs_pwd.go
+++ b/tests/e2e-inst-signatures/e2e-set_fs_pwd.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"kernel.org/pub/linux/libs/security/libcap/cap"
@@ -66,7 +66,7 @@ func (sig *e2eSetFsPwd) GetSelectedEvents() ([]detect.SignatureEventSelector, er
 func (sig *e2eSetFsPwd) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-signature_derivation.go
+++ b/tests/e2e-inst-signatures/e2e-signature_derivation.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/types/detect"
 	"github.com/aquasecurity/tracee/types/protocol"
@@ -37,7 +37,7 @@ func (sig *e2eSignatureDerivation) GetSelectedEvents() ([]detect.SignatureEventS
 func (sig *e2eSignatureDerivation) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-stack_pivot.go
+++ b/tests/e2e-inst-signatures/e2e-stack_pivot.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -40,7 +40,7 @@ func (sig *e2eStackPivot) GetSelectedEvents() ([]detect.SignatureEventSelector, 
 func (sig *e2eStackPivot) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-suspicious_syscall_source.go
+++ b/tests/e2e-inst-signatures/e2e-suspicious_syscall_source.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -43,7 +43,7 @@ func (sig *e2eSuspiciousSyscallSource) GetSelectedEvents() ([]detect.SignatureEv
 func (sig *e2eSuspiciousSyscallSource) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-vfs_write.go
+++ b/tests/e2e-inst-signatures/e2e-vfs_write.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -39,7 +39,7 @@ func (sig *e2eVfsWrite) GetSelectedEvents() ([]detect.SignatureEventSelector, er
 func (sig *e2eVfsWrite) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-vfs_writev.go
+++ b/tests/e2e-inst-signatures/e2e-vfs_writev.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -39,7 +39,7 @@ func (sig *e2eVfsWritev) GetSelectedEvents() ([]detect.SignatureEventSelector, e
 func (sig *e2eVfsWritev) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-inst-signatures/e2e-writeable_data_source.go
+++ b/tests/e2e-inst-signatures/e2e-writeable_data_source.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/aquasecurity/tracee/types/detect"
@@ -17,10 +18,10 @@ func (sig *e2eWritableDatasourceSig) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
 	writable, ok := ctx.GetDataSource("e2e_inst", "demo")
 	if !ok {
-		return fmt.Errorf("containers data source not registered")
+		return errors.New("containers data source not registered")
 	}
 	if writable.Version() > 1 {
-		return fmt.Errorf("containers data source version not supported, please update this signature")
+		return errors.New("containers data source version not supported, please update this signature")
 	}
 	sig.writable = writable
 	return nil
@@ -46,7 +47,7 @@ func (sig *e2eWritableDatasourceSig) GetSelectedEvents() ([]detect.SignatureEven
 func (sig *e2eWritableDatasourceSig) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {
@@ -62,7 +63,7 @@ func (sig *e2eWritableDatasourceSig) OnEvent(event protocol.Event) error {
 
 		data, ok := container["value"].(string)
 		if !ok {
-			return fmt.Errorf("failed to unwrap value from writable data")
+			return errors.New("failed to unwrap value from writable data")
 		}
 
 		if data != "moment" {

--- a/tests/e2e-net-signatures/e2e-dns.go
+++ b/tests/e2e-net-signatures/e2e-dns.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -53,7 +53,7 @@ func (sig *e2eDNS) GetSelectedEvents() ([]detect.SignatureEventSelector, error) 
 func (sig *e2eDNS) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	if eventObj.EventName == "net_packet_dns" {

--- a/tests/e2e-net-signatures/e2e-http.go
+++ b/tests/e2e-net-signatures/e2e-http.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -46,7 +46,7 @@ func (sig *e2eHTTP) GetSelectedEvents() ([]detect.SignatureEventSelector, error)
 func (sig *e2eHTTP) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	if eventObj.ProcessName != "curl" {

--- a/tests/e2e-net-signatures/e2e-httprequest.go
+++ b/tests/e2e-net-signatures/e2e-httprequest.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -46,7 +46,7 @@ func (sig *e2eHTTPRequest) GetSelectedEvents() ([]detect.SignatureEventSelector,
 func (sig *e2eHTTPRequest) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	if eventObj.ProcessName != "curl" {

--- a/tests/e2e-net-signatures/e2e-httpresponse.go
+++ b/tests/e2e-net-signatures/e2e-httpresponse.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
@@ -46,7 +46,7 @@ func (sig *e2eHTTPResponse) GetSelectedEvents() ([]detect.SignatureEventSelector
 func (sig *e2eHTTPResponse) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	if eventObj.EventName == "net_packet_http_response" {

--- a/tests/e2e-net-signatures/e2e-icmp.go
+++ b/tests/e2e-net-signatures/e2e-icmp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eICMP) GetSelectedEvents() ([]detect.SignatureEventSelector, error)
 func (sig *e2eICMP) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-net-signatures/e2e-icmpv6.go
+++ b/tests/e2e-net-signatures/e2e-icmpv6.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eICMPv6) GetSelectedEvents() ([]detect.SignatureEventSelector, erro
 func (sig *e2eICMPv6) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-net-signatures/e2e-ipv4.go
+++ b/tests/e2e-net-signatures/e2e-ipv4.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eIPv4) GetSelectedEvents() ([]detect.SignatureEventSelector, error)
 func (sig *e2eIPv4) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-net-signatures/e2e-ipv6.go
+++ b/tests/e2e-net-signatures/e2e-ipv6.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eIPv6) GetSelectedEvents() ([]detect.SignatureEventSelector, error)
 func (sig *e2eIPv6) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-net-signatures/e2e-tcp.go
+++ b/tests/e2e-net-signatures/e2e-tcp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eTCP) GetSelectedEvents() ([]detect.SignatureEventSelector, error) 
 func (sig *e2eTCP) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/e2e-net-signatures/e2e-udp.go
+++ b/tests/e2e-net-signatures/e2e-udp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/aquasecurity/tracee/signatures/helpers"
 	"github.com/aquasecurity/tracee/types/detect"
@@ -38,7 +38,7 @@ func (sig *e2eUDP) GetSelectedEvents() ([]detect.SignatureEventSelector, error) 
 func (sig *e2eUDP) OnEvent(event protocol.Event) error {
 	eventObj, ok := event.Payload.(trace.Event)
 	if !ok {
-		return fmt.Errorf("failed to cast event's payload")
+		return errors.New("failed to cast event's payload")
 	}
 
 	switch eventObj.EventName {

--- a/tests/integration/capture_test.go
+++ b/tests/integration/capture_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -289,7 +290,7 @@ func readWritePipe(t *testing.T, captureDir string, workingDir string) error {
 	}
 	statInfo, ok := finfo.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("type assertion failed: expected *syscall.Stat_t")
+		return errors.New("type assertion failed: expected *syscall.Stat_t")
 	}
 	inode := statInfo.Ino
 
@@ -410,7 +411,7 @@ func findProcessPcapFile(dir string, processName string) (string, error) {
 		}
 	}
 	if !found {
-		return "", fmt.Errorf("could not find ping pcap")
+		return "", errors.New("could not find ping pcap")
 	}
 
 	return pcap, nil

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -2735,7 +2736,7 @@ func ExpectAtLeastOneForEach(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 					case string:
 						actVal, ok := actArg.Value.(string)
 						if !ok {
-							return false, fmt.Errorf("failed to cast arg's value")
+							return false, errors.New("failed to cast arg's value")
 						}
 						if strings.Contains(v, "*") {
 							v = strings.ReplaceAll(v, "*", "")
@@ -2901,7 +2902,7 @@ func ExpectAnyOfEvts(t *testing.T, cmdEvents []cmdEvents, actual *eventBuffer, u
 					case string:
 						actVal, ok := actArg.Value.(string)
 						if !ok {
-							return fmt.Errorf("failed to cast arg's value")
+							return errors.New("failed to cast arg's value")
 						}
 						if strings.Contains(v, "*") {
 							v = strings.ReplaceAll(v, "*", "")
@@ -3023,7 +3024,7 @@ func ExpectAllEvtsEqualToOne(t *testing.T, cmdEvents []cmdEvents, actual *eventB
 					case string:
 						actVal, ok := actArg.Value.(string)
 						if !ok {
-							return fmt.Errorf("failed to cast arg's value")
+							return errors.New("failed to cast arg's value")
 						}
 						if strings.Contains(v, "*") {
 							v = strings.ReplaceAll(v, "*", "")
@@ -3131,7 +3132,7 @@ func ExpectAllInOrderSequentially(t *testing.T, cmdEvents []cmdEvents, actual *e
 				case string:
 					actVal, ok := actArg.Value.(string)
 					if !ok {
-						return fmt.Errorf("failed to cast arg's value")
+						return errors.New("failed to cast arg's value")
 					}
 					if strings.Contains(v, "*") {
 						v = strings.ReplaceAll(v, "*", "")

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -174,7 +175,7 @@ func waitForTraceeStart(trc *tracee.Tracee) error {
 				return nil
 			}
 		case <-timeoutTicker.C:
-			return fmt.Errorf("timed out on waiting for tracee to start")
+			return errors.New("timed out on waiting for tracee to start")
 		}
 	}
 }
@@ -196,7 +197,7 @@ func waitForTraceeStop(trc *tracee.Tracee) error {
 				return nil
 			}
 		case <-timeoutTicker.C:
-			return fmt.Errorf("timed out on stopping tracee")
+			return errors.New("timed out on stopping tracee")
 		}
 	}
 }

--- a/tests/perftests/metrics_test.go
+++ b/tests/perftests/metrics_test.go
@@ -2,6 +2,7 @@ package perftests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -83,7 +84,7 @@ func checkIfPprofExist() error {
 		return nil
 	}
 
-	return fmt.Errorf("pprof not enabled")
+	return errors.New("pprof not enabled")
 }
 
 //

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -4,6 +4,7 @@ package trace
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -232,7 +233,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argValue, ok := arg.Value.([]interface{})
 			if !ok {
-				return fmt.Errorf("const char*const*: type error")
+				return errors.New("const char*const*: type error")
 			}
 			arg.Value = jsonConvertToStringSlice(argValue)
 		} else {
@@ -243,7 +244,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			protoIPv4Map, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol IPv4: type error")
+				return errors.New("protocol IPv4: type error")
 			}
 			argProtoIPv4, err = jsonConvertToProtoIPv4Arg(protoIPv4Map)
 			if err != nil {
@@ -257,7 +258,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			protoIPv6Map, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol IPv6: type error")
+				return errors.New("protocol IPv6: type error")
 			}
 			argProtoIPv6, err = jsonConvertToProtoIPv6Arg(protoIPv6Map)
 			if err != nil {
@@ -271,7 +272,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			protoTCPMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol TCP: type error")
+				return errors.New("protocol TCP: type error")
 			}
 			argProtoTCP, err = jsonConvertToProtoTCPArg(protoTCPMap)
 			if err != nil {
@@ -285,7 +286,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			protoUDPMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol UDP: type error")
+				return errors.New("protocol UDP: type error")
 			}
 			argProtoUDP, err = jsonConvertToProtoUDPArg(protoUDPMap)
 			if err != nil {
@@ -299,7 +300,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			protoICMPMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol ICMP: type error")
+				return errors.New("protocol ICMP: type error")
 			}
 			argProtoICMP, err = jsonConvertToProtoICMPArg(protoICMPMap)
 			if err != nil {
@@ -313,7 +314,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			protoICMPv6Map, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol ICMPv6: type error")
+				return errors.New("protocol ICMPv6: type error")
 			}
 			argProtoICMPv6, err = jsonConvertToProtoICMPv6Arg(protoICMPv6Map)
 			if err != nil {
@@ -327,7 +328,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argPktMetaMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("PktMeta: type error")
+				return errors.New("PktMeta: type error")
 			}
 			argPktMeta, err = jsonConvertToPktMetaArg(argPktMetaMap)
 			if err != nil {
@@ -341,7 +342,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argProtoDnsMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol DNS: type error")
+				return errors.New("protocol DNS: type error")
 			}
 			argProtoDNS, err = jsonConvertToProtoDNSArg(argProtoDnsMap)
 			if err != nil {
@@ -355,13 +356,13 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argDnsQueryDataSlice, ok := arg.Value.([]interface{})
 			if !ok {
-				return fmt.Errorf("protocol Dns Query Data: type error")
+				return errors.New("protocol Dns Query Data: type error")
 			}
 
 			for _, dnsQueryDataElem := range argDnsQueryDataSlice {
 				argDnsQueryDataMap, ok := dnsQueryDataElem.(map[string]interface{})
 				if !ok {
-					return fmt.Errorf("protocol Dns Query Data: type error")
+					return errors.New("protocol Dns Query Data: type error")
 				}
 
 				dnsQuery, err := jsonConvertToDnsQuertDataType(argDnsQueryDataMap)
@@ -379,13 +380,13 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argDnsResponseDataSlice, ok := arg.Value.([]interface{})
 			if !ok {
-				return fmt.Errorf("protocol Dns Response Data: type error")
+				return errors.New("protocol Dns Response Data: type error")
 			}
 
 			for _, dnsResponseDataElem := range argDnsResponseDataSlice {
 				dnsResponseDataMap, ok := dnsResponseDataElem.(map[string]interface{})
 				if !ok {
-					return fmt.Errorf("protocol Dns Response Data: type error")
+					return errors.New("protocol Dns Response Data: type error")
 				}
 
 				dnsResponseData, err := jsonConvertToDnsResponseDataType(dnsResponseDataMap)
@@ -403,7 +404,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argProtoHTTPMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol HTTP: type error")
+				return errors.New("protocol HTTP: type error")
 			}
 			argProtoHTTP, err = jsonConvertToProtoHTTPArg(argProtoHTTPMap)
 			if err != nil {
@@ -417,7 +418,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argProtoHTTPRequestMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol HTTP Request: type error")
+				return errors.New("protocol HTTP Request: type error")
 			}
 			argProtoHTTPRequest, err = jsonConvertToProtoHTTPRequestArg(argProtoHTTPRequestMap)
 			if err != nil {
@@ -431,7 +432,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argProtoHTTPResponseMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("protocol HTTP Response: type error")
+				return errors.New("protocol HTTP Response: type error")
 			}
 			argProtoHTTPResponse, err = jsonConvertToProtoHTTPResponseArg(argProtoHTTPResponseMap)
 			if err != nil {
@@ -445,7 +446,7 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 		if arg.Value != nil {
 			argPacketMetadataMap, ok := arg.Value.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("packet metadata: type error")
+				return errors.New("packet metadata: type error")
 			}
 			if err != nil {
 				return err
@@ -746,20 +747,20 @@ func jsonConvertToProtoDNSArg(argMap map[string]interface{}) (ProtoDNS, error) {
 	// questions conversion
 	questions, exists := argMap["questions"]
 	if !exists {
-		return ProtoDNS{}, fmt.Errorf("questions not found in ProtoDNS arg")
+		return ProtoDNS{}, errors.New("questions not found in ProtoDNS arg")
 	}
 
 	var dnsQuestions []ProtoDNSQuestion
 	if questions != nil {
 		questionsSlice, ok := questions.([]interface{})
 		if !ok {
-			return ProtoDNS{}, fmt.Errorf("questions from ProtoDNS: type error")
+			return ProtoDNS{}, errors.New("questions from ProtoDNS: type error")
 		}
 
 		for _, questionsElem := range questionsSlice {
 			questionsElemMap, ok := questionsElem.(map[string]interface{})
 			if !ok {
-				return ProtoDNS{}, fmt.Errorf("questions from ProtoDNS: type error")
+				return ProtoDNS{}, errors.New("questions from ProtoDNS: type error")
 			}
 
 			question, err := jsonConvertToProtoDNSQuestionType(questionsElemMap)
@@ -774,20 +775,20 @@ func jsonConvertToProtoDNSArg(argMap map[string]interface{}) (ProtoDNS, error) {
 	// answers conversion
 	answers, exists := argMap["answers"]
 	if !exists {
-		return ProtoDNS{}, fmt.Errorf("answers not found in ProtoDNS arg")
+		return ProtoDNS{}, errors.New("answers not found in ProtoDNS arg")
 	}
 
 	var dnsAnswers []ProtoDNSResourceRecord
 	if answers != nil {
 		answersSlice, ok := answers.([]interface{})
 		if !ok {
-			return ProtoDNS{}, fmt.Errorf("answers from ProtoDNS: type error")
+			return ProtoDNS{}, errors.New("answers from ProtoDNS: type error")
 		}
 
 		for _, answersElem := range answersSlice {
 			answersElemMap, ok := answersElem.(map[string]interface{})
 			if !ok {
-				return ProtoDNS{}, fmt.Errorf("answers from ProtoDNS: type error")
+				return ProtoDNS{}, errors.New("answers from ProtoDNS: type error")
 			}
 
 			answer, err := jsonConvertToProtoDNSResourceRecordType(answersElemMap)
@@ -802,20 +803,20 @@ func jsonConvertToProtoDNSArg(argMap map[string]interface{}) (ProtoDNS, error) {
 	// authorities conversion
 	authorities, exists := argMap["authorities"]
 	if !exists {
-		return ProtoDNS{}, fmt.Errorf("authorities not found in ProtoDNS arg")
+		return ProtoDNS{}, errors.New("authorities not found in ProtoDNS arg")
 	}
 
 	var dnsAuthorities []ProtoDNSResourceRecord
 	if authorities != nil {
 		authoritiesSlice, ok := authorities.([]interface{})
 		if !ok {
-			return ProtoDNS{}, fmt.Errorf("authorities from ProtoDNS: type error")
+			return ProtoDNS{}, errors.New("authorities from ProtoDNS: type error")
 		}
 
 		for _, authoritiesElem := range authoritiesSlice {
 			authoritiesElemMap, ok := authoritiesElem.(map[string]interface{})
 			if !ok {
-				return ProtoDNS{}, fmt.Errorf("authorities from ProtoDNS: type error")
+				return ProtoDNS{}, errors.New("authorities from ProtoDNS: type error")
 			}
 
 			authority, err := jsonConvertToProtoDNSResourceRecordType(authoritiesElemMap)
@@ -830,20 +831,20 @@ func jsonConvertToProtoDNSArg(argMap map[string]interface{}) (ProtoDNS, error) {
 	// additionals conversion
 	additionals, exists := argMap["additionals"]
 	if !exists {
-		return ProtoDNS{}, fmt.Errorf("additionals not found in ProtoDNS arg")
+		return ProtoDNS{}, errors.New("additionals not found in ProtoDNS arg")
 	}
 
 	var dnsAdditionals []ProtoDNSResourceRecord
 	if additionals != nil {
 		additionalsSlice, ok := additionals.([]interface{})
 		if !ok {
-			return ProtoDNS{}, fmt.Errorf("additionals from ProtoDNS: type error")
+			return ProtoDNS{}, errors.New("additionals from ProtoDNS: type error")
 		}
 
 		for _, additionalsElem := range additionalsSlice {
 			additionalsElemMap, ok := additionalsElem.(map[string]interface{})
 			if !ok {
-				return ProtoDNS{}, fmt.Errorf("additionals from ProtoDNS: type error")
+				return ProtoDNS{}, errors.New("additionals from ProtoDNS: type error")
 			}
 
 			additional, err := jsonConvertToProtoDNSResourceRecordType(additionalsElemMap)
@@ -924,14 +925,14 @@ func jsonConvertToProtoDNSResourceRecordType(argMap map[string]interface{}) (Pro
 	// []string conversion
 	txts, exists := argMap["TXTs"]
 	if !exists {
-		return ProtoDNSResourceRecord{}, fmt.Errorf("TXTs not found in ProtoDNSResourceRecord arg")
+		return ProtoDNSResourceRecord{}, errors.New("TXTs not found in ProtoDNSResourceRecord arg")
 	}
 
 	var txtsValue []string
 	if txts != nil {
 		txtsInterfaceSlice, ok := txts.([]interface{})
 		if !ok {
-			return ProtoDNSResourceRecord{}, fmt.Errorf("TXTs from ProtoDNSResourceRecord: type error")
+			return ProtoDNSResourceRecord{}, errors.New("TXTs from ProtoDNSResourceRecord: type error")
 		}
 
 		txtsValue = jsonConvertToStringSlice(txtsInterfaceSlice)
@@ -943,14 +944,14 @@ func jsonConvertToProtoDNSResourceRecordType(argMap map[string]interface{}) (Pro
 	// SOA conversion
 	soa, exists := argMap["SOA"]
 	if !exists {
-		return ProtoDNSResourceRecord{}, fmt.Errorf("SOA not found in ProtoDNSResourceRecord arg")
+		return ProtoDNSResourceRecord{}, errors.New("SOA not found in ProtoDNSResourceRecord arg")
 	}
 
 	var protoDNSSOA ProtoDNSSOA
 	if soa != nil {
 		soaMap, ok := soa.(map[string]interface{})
 		if !ok {
-			return ProtoDNSResourceRecord{}, fmt.Errorf("SOA from ProtoDNSResourceRecord: type error")
+			return ProtoDNSResourceRecord{}, errors.New("SOA from ProtoDNSResourceRecord: type error")
 		}
 
 		protoDNSSOA, err = jsonConvertToProtoDNSSOAType(soaMap)
@@ -962,14 +963,14 @@ func jsonConvertToProtoDNSResourceRecordType(argMap map[string]interface{}) (Pro
 	// SRV conversion
 	srv, exists := argMap["SRV"]
 	if !exists {
-		return ProtoDNSResourceRecord{}, fmt.Errorf("SRV not found in ProtoDNSResourceRecord arg")
+		return ProtoDNSResourceRecord{}, errors.New("SRV not found in ProtoDNSResourceRecord arg")
 	}
 
 	var protoDNSSRV ProtoDNSSRV
 	if srv != nil {
 		srvMap, ok := srv.(map[string]interface{})
 		if !ok {
-			return ProtoDNSResourceRecord{}, fmt.Errorf("SRV from ProtoDNSResourceRecord: type error")
+			return ProtoDNSResourceRecord{}, errors.New("SRV from ProtoDNSResourceRecord: type error")
 		}
 
 		protoDNSSRV, err = jsonConvertToProtoDNSSRVType(srvMap)
@@ -981,14 +982,14 @@ func jsonConvertToProtoDNSResourceRecordType(argMap map[string]interface{}) (Pro
 	// MX conversion
 	mx, exists := argMap["MX"]
 	if !exists {
-		return ProtoDNSResourceRecord{}, fmt.Errorf("MX not found in ProtoDNSResourceRecord arg")
+		return ProtoDNSResourceRecord{}, errors.New("MX not found in ProtoDNSResourceRecord arg")
 	}
 
 	var protoDNSMX ProtoDNSMX
 	if mx != nil {
 		mxMap, ok := mx.(map[string]interface{})
 		if !ok {
-			return ProtoDNSResourceRecord{}, fmt.Errorf("MX from ProtoDNSResourceRecord: type error")
+			return ProtoDNSResourceRecord{}, errors.New("MX from ProtoDNSResourceRecord: type error")
 		}
 
 		protoDNSMX, err = jsonConvertToProtoDNSMXType(mxMap)
@@ -1000,20 +1001,20 @@ func jsonConvertToProtoDNSResourceRecordType(argMap map[string]interface{}) (Pro
 	// OPT conversion
 	opt, exists := argMap["OPT"]
 	if !exists {
-		return ProtoDNSResourceRecord{}, fmt.Errorf("OPT not found in ProtoDNSResourceRecord arg")
+		return ProtoDNSResourceRecord{}, errors.New("OPT not found in ProtoDNSResourceRecord arg")
 	}
 
 	var dnsOpts []ProtoDNSOPT
 	if opt != nil {
 		optSlice, ok := opt.([]interface{})
 		if !ok {
-			return ProtoDNSResourceRecord{}, fmt.Errorf("OPT from ProtoDNSResourceRecord: type error")
+			return ProtoDNSResourceRecord{}, errors.New("OPT from ProtoDNSResourceRecord: type error")
 		}
 
 		for _, optElem := range optSlice {
 			optElemMap, ok := optElem.(map[string]interface{})
 			if !ok {
-				return ProtoDNSResourceRecord{}, fmt.Errorf("OPT from ProtoDNSResourceRecord: type error")
+				return ProtoDNSResourceRecord{}, errors.New("OPT from ProtoDNSResourceRecord: type error")
 			}
 
 			dnsOpt, err := jsonConvertToProtoDNSOPTType(optElemMap)
@@ -1028,14 +1029,14 @@ func jsonConvertToProtoDNSResourceRecordType(argMap map[string]interface{}) (Pro
 	// URI conversion
 	uri, exists := argMap["URI"]
 	if !exists {
-		return ProtoDNSResourceRecord{}, fmt.Errorf("URI not found in ProtoDNSResourceRecord arg")
+		return ProtoDNSResourceRecord{}, errors.New("URI not found in ProtoDNSResourceRecord arg")
 	}
 
 	var protoDNSURI ProtoDNSURI
 	if uri != nil {
 		uriMap, ok := uri.(map[string]interface{})
 		if !ok {
-			return ProtoDNSResourceRecord{}, fmt.Errorf("URI from ProtoDNSResourceRecord: type error")
+			return ProtoDNSResourceRecord{}, errors.New("URI from ProtoDNSResourceRecord: type error")
 		}
 
 		protoDNSURI, err = jsonConvertToProtoDNSURIType(uriMap)
@@ -1252,14 +1253,14 @@ func jsonConvertToDnsResponseDataType(argMap map[string]interface{}) (DnsRespons
 
 	queryData, exists := argMap["query_data"]
 	if !exists {
-		return DnsResponseData{}, fmt.Errorf("query_data not found in DnsResponseData arg")
+		return DnsResponseData{}, errors.New("query_data not found in DnsResponseData arg")
 	}
 
 	var dnsQuery DnsQueryData
 	if queryData != nil {
 		queryDataMap, ok := queryData.(map[string]interface{})
 		if !ok {
-			return DnsResponseData{}, fmt.Errorf("query_data from DnsResponseData: type error")
+			return DnsResponseData{}, errors.New("query_data from DnsResponseData: type error")
 		}
 
 		var err error
@@ -1273,20 +1274,20 @@ func jsonConvertToDnsResponseDataType(argMap map[string]interface{}) (DnsRespons
 
 	dnsAnswer, exists := argMap["dns_answer"]
 	if !exists {
-		return DnsResponseData{}, fmt.Errorf("dns_answer not found in DnsResponseData arg")
+		return DnsResponseData{}, errors.New("dns_answer not found in DnsResponseData arg")
 	}
 
 	var dnsAnswers []DnsAnswer
 	if dnsAnswer != nil {
 		dnsAnswerSlice, ok := dnsAnswer.([]interface{})
 		if !ok {
-			return DnsResponseData{}, fmt.Errorf("dns_answer from DnsResponseData: type error")
+			return DnsResponseData{}, errors.New("dns_answer from DnsResponseData: type error")
 		}
 
 		for _, dnsAnswerElem := range dnsAnswerSlice {
 			dnsAnswerElemMap, ok := dnsAnswerElem.(map[string]interface{})
 			if !ok {
-				return DnsResponseData{}, fmt.Errorf("dns_answer from DnsResponseData: type error")
+				return DnsResponseData{}, errors.New("dns_answer from DnsResponseData: type error")
 			}
 
 			dnsAns, err := jsonConvertToDnsAnswerType(dnsAnswerElemMap)


### PR DESCRIPTION
### 1. Explain what the PR does

9d4db16a7 **chore(lint): bump errcheck to 1.9.0**
c91a672ea **chore(lint): bump staticcheck to 2025.1**
a7ddd1e0b **chore(lint): consider to enable revive rules**
2f3c7566b **chore(lint): apply revive modifies-value-receiver rule**
890ab299b **chore(lint): apply revive control-nesting rule**
678ee8ddc **chore(lint): apply revive redundant-build-tag rule**
ba660be4c **chore(lint): apply revive superfluous-else rule**
00f6f457a **chore(lint): apply revive use-errors-new rule**
312406668 **chore(lint): bump revive to 1.7.0**

### 2. Explain how to test it


### 3. Other comments
