### PR TITLE
chore(go): bump go.mod to use latest pkgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/IBM/fluent-forward-go v0.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61
-	github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72
+	github.com/aquasecurity/tracee/api v0.0.0-20250225150010-27311e99d782
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250123101549-f57a1ebab93a
-	github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155
+	github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782
 	github.com/containerd/containerd v1.7.25
 	github.com/docker/docker v27.5.1+incompatible
 	github.com/golang/protobuf v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -403,12 +403,12 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61 h1:EdqmOm8rk/FMtYetPcceDdW27lZxXzpHZw8XpF3lG+g=
 github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61/go.mod h1:HB2DYWHuMraOB0IFcfjL8tsxN8TcFOdWKTrNqnHrTrs=
-github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72 h1:M1G3ttGcozWGfMMlD2nbdCgskGkAHSIVMsodRykOYSE=
-github.com/aquasecurity/tracee/api v0.0.0-20250117110942-a403bd985f72/go.mod h1:mSYGLfhjpcLq78gjb4/XDQaY8DhfpDNAuLD0tvU2bZc=
+github.com/aquasecurity/tracee/api v0.0.0-20250225150010-27311e99d782 h1:iNbiOTk56YHCQWiHiBk16QIc8dkJultsjXdu2oOZwfY=
+github.com/aquasecurity/tracee/api v0.0.0-20250225150010-27311e99d782/go.mod h1:YqeOSry7W9xFV0y1T4gRzFN75IMYdbORcY6LPFDisek=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250123101549-f57a1ebab93a h1:xCyaZJpgUgtpjKgrjQffKAjhz9jw3c0niMwtre2gh/E=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250123101549-f57a1ebab93a/go.mod h1:ea2x/5u4oOKJiuZsbPaa9WJlldZehprNsCTNhjeWYrs=
-github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155 h1:SOcc74U3FXyGJFfSV1QvI0I8VmXBHneq2y9suAdqmT4=
-github.com/aquasecurity/tracee/types v0.0.0-20250117124739-92cb7e0f7155/go.mod h1:qG8nK8fjdHLTWAlTqDjCdxBuBUge2PyK5SHX/tfrxfY=
+github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782 h1:Ru13qtB0ktZV1vA5tKRnPJpOcu767OIXa+4JVUa5VXc=
+github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782/go.mod h1:JngSfuKDDXeWGRvedo88R6YMpTrsbISgMLlSOHmDGV0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -4,10 +4,9 @@ go 1.24
 
 toolchain go1.24.0
 
-require github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863
+require github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 )

--- a/signatures/helpers/go.sum
+++ b/signatures/helpers/go.sum
@@ -1,10 +1,10 @@
-github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863 h1:domVTTQICTuCvX+ZW5EjvdUBz8EH7FedBj5lRqwpgf4=
-github.com/aquasecurity/tracee/types v0.0.0-20241008181102-d40bc1f81863/go.mod h1:Jwh9OOuiMHXDoGQY12N9ls5YB+j1FlRcXvFMvh1CmIU=
+github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782 h1:Ru13qtB0ktZV1vA5tKRnPJpOcu767OIXa+4JVUa5VXc=
+github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782/go.mod h1:JngSfuKDDXeWGRvedo88R6YMpTrsbISgMLlSOHmDGV0=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### 1. Explain what the PR does

3d4b390e0 **chore(go): bump go.mod to use latest pkgs**

```
Bump main and signatures/helpers go.mod to use latest api and types pkg.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
