### PR TITLE
fix(ebpf): profile only common events

### DIFF
--- a/pkg/ebpf/perf_count.go
+++ b/pkg/ebpf/perf_count.go
@@ -30,6 +30,10 @@ func (t *Tracee) countPerfEventSubmissions(ctx context.Context) {
 
 	evtStatZero := eventStatsValues{}
 	for _, id := range t.policyManager.EventsToSubmit() {
+		if id >= events.MaxCommonID {
+			continue
+		}
+
 		key := uint32(id)
 		err := evtsCountsBPFMap.Update(unsafe.Pointer(&key), unsafe.Pointer(&evtStatZero))
 		if err != nil {


### PR DESCRIPTION
Close: #4614

### 1. Explain what the PR does

d55202c5d **fix(ebpf): profile only common events**

### 2. Explain how to test it

`METRICS=1 make tracee`
`sudo ./dist/tracee -e security_file_open,anti_debugging,net_packet_tcp -o none --metrics --pyroscope --pprof`

Outputs only common events metrics.

```json
{"level":"info","ts":1740578919.9102988,"msg":"Event submit attempts","net_packet_base":0,"net_packet_tcp_base":1108,"security_file_open":76195,"ptrace":0,"total":77303}
{"level":"info","ts":1740578919.9103284,"msg":"Event submit failures","net_packet_tcp_base":0,"security_file_open":0,"ptrace":0,"net_packet_base":0,"total":0}
```

The same can be observed in grafana:

![image](https://github.com/user-attachments/assets/e2586e6f-fc41-4573-96e7-76938b6188ab)


### 3. Other comments

