### PR TITLE
fix(ebpf): sockaddr_un length

### DIFF
--- a/pkg/bufferdecoder/eventsreader.go
+++ b/pkg/bufferdecoder/eventsreader.go
@@ -206,7 +206,7 @@ func readSockaddrFromBuff(ebpfMsgDecoder *EbpfDecoder) (map[string]string, error
 					char        sun_path[108];  // Pathname
 			};
 		*/
-		sunPath, err := readVarStringFromBuffer(ebpfMsgDecoder, 108)
+		sunPath, err := readSunPathFromBuff(ebpfMsgDecoder, 108)
 		if err != nil {
 			return nil, errfmt.Errorf("error parsing sockaddr_un: %v", err)
 		}
@@ -309,35 +309,52 @@ func readStringFromBuff(ebpfMsgDecoder *EbpfDecoder) (string, error) {
 	return string(res), nil
 }
 
-// readVarStringFromBuffer reads a null-terminated string from the ebpf buffer where the size is not
-// known. The helper will read from the buffer char-by-char until it hits the null terminator
-// or the given max length. The cursor will then skip to the point in the buffer after the max length.
-func readVarStringFromBuffer(decoder *EbpfDecoder, max int) (string, error) {
+// readSunPathFromBuff reads a null-terminated string from the eBPF buffer, up to `max` bytes.
+// Characters are read one by one until a NUL byte or the max limit is reached.
+// If the first byte is NUL and the second is not, it's treated as an abstract socket and
+// the first byte is replaced with '@'.
+// After reading, the decoder cursor advances past `max` bytes in the buffer.
+func readSunPathFromBuff(decoder *EbpfDecoder, max int) (string, error) {
+	if max <= 0 {
+		return "", errfmt.Errorf("max to decode sun_path must be greater than 0")
+	}
+
 	var err error
 	var char int8
 	res := make([]byte, 0, max)
 
-	err = decoder.DecodeInt8(&char)
-	if err != nil {
-		return "", errfmt.Errorf("error reading null terminated string: %v", err)
-	}
-
-	count := 1 // first char is already decoded
-	for char != 0 && count < max {
-		res = append(res, byte(char))
-
-		// decode next char
+	count := 0
+	for i := 0; i < max; i++ {
 		err = decoder.DecodeInt8(&char)
 		if err != nil {
-			return "", errfmt.Errorf("error reading null terminated string: %v", err)
+			return "", errfmt.Errorf("error reading sun_path: %v", err)
 		}
 		count++
+
+		if char == 0 {
+			// char as NUL may signal the end of the string or an abstract socket
+			// https://elixir.bootlin.com/linux/v6.13.4/source/net/unix/af_unix.c#L72
+			// https://man7.org/linux/man-pages/man7/unix.7.html
+			if i > 0 {
+				// NUL found after the first char means the end of the string
+				break
+			}
+		}
+
+		res = append(res, byte(char))
 	}
 
-	// The exact reason for this Trim is not known, so remove it for now,
-	// since it increases processing time.
-	// res = bytes.TrimLeft(res[:], "\000")
-	decoder.MoveCursor(max - count) // skip the cursor to the desired endpoint
+	if res[0] == 0 {
+		if len(res) == 1 {
+			res = []byte{} // empty string
+		} else {
+			// abstract socket - res[0] = NUL && res[1] != NUL
+			// https://elixir.bootlin.com/linux/v6.13.4/source/net/unix/af_unix.c#L3438
+			res[0] = '@'
+		}
+	}
+
+	decoder.MoveCursor(max - count) // move cursor to the desired endpoint
 	return string(res), nil
 }
 

--- a/pkg/bufferdecoder/eventsreader_bench_test.go
+++ b/pkg/bufferdecoder/eventsreader_bench_test.go
@@ -7,52 +7,62 @@ import (
 
 var present = NewTypeDecoder()
 
-func BenchmarkReadStringVarFromBuff_ShortString(b *testing.B) {
+func Benchmark_readSunPathFromBuff_ShortString(b *testing.B) {
 	buffer := []byte{'H', 'e', 'l', 'l', 'o', 0}
 	max := 10
 	var str string
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		decoder := New(buffer, present)
-		str, _ = readVarStringFromBuffer(decoder, max)
+		str, _ = readSunPathFromBuff(decoder, max)
 	}
 	_ = str
 }
 
-func BenchmarkReadStringVarFromBuff_MediumString(b *testing.B) {
+func Benchmark_readSunPathFromBuff_MediumString(b *testing.B) {
 	buffer := []byte{'T', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't', 0}
 	max := 20
 	var str string
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		decoder := New(buffer, present)
-		str, _ = readVarStringFromBuffer(decoder, max)
+		str, _ = readSunPathFromBuff(decoder, max)
 	}
 	_ = str
 }
 
-func BenchmarkReadStringVarFromBuff_LongString(b *testing.B) {
+func Benchmark_readSunPathFromBuff_AbstractSocket(b *testing.B) {
+	buffer := []byte{0, 'A', 'b', 's', 't', 'r', 'a', 'c', 't', 0}
+	max := 10
+	var str string
+
+	for b.Loop() {
+		decoder := New(buffer, present)
+		str, _ = readSunPathFromBuff(decoder, max)
+	}
+	_ = str
+}
+
+func Benchmark_readSunPathFromBuff_LongString(b *testing.B) {
 	buffer := append(bytes.Repeat([]byte{'A'}, 10000), 0)
 	max := 10000
 	var str string
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		decoder := New(buffer, present)
-		str, _ = readVarStringFromBuffer(decoder, max)
+		str, _ = readSunPathFromBuff(decoder, max)
 	}
 	_ = str
 }
 
-func BenchmarkReadStringVarFromBuff_LongStringLowMax(b *testing.B) {
+func Benchmark_readSunPathFromBuff_LongStringLowMax(b *testing.B) {
 	buffer := bytes.Repeat([]byte{'A'}, 10000)
 	max := 100
 	var str string
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		decoder := New(buffer, present)
-		str, _ = readVarStringFromBuffer(decoder, max)
+		str, _ = readSunPathFromBuff(decoder, max)
 	}
 	_ = str
 }

--- a/pkg/bufferdecoder/eventsreader_test.go
+++ b/pkg/bufferdecoder/eventsreader_test.go
@@ -124,10 +124,31 @@ func TestReadArgFromBuff(t *testing.T) {
 			name: "sockAddrT - AF_UNIX",
 			input: []byte{0,
 				1, 0, // sa_family=AF_UNIX
-				47, 116, 109, 112, 47, 115, 111, 99, 107, 101, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 101, 110, 0, 0, 0, // sun_path=/tmp/socket
+				47, 116, 109, 112, 47, 115, 111, 99, 107, 101, 116, 0, // sun_path=/tmp/socket
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 101, 110, 0, 0, 0,
 			},
 			fields:      []events.DataField{{DecodeAs: data.SOCK_ADDR_T, ArgMeta: trace.ArgMeta{Name: "sockAddr0"}}},
 			expectedArg: map[string]string{"sa_family": "AF_UNIX", "sun_path": "/tmp/socket"},
+		},
+		{
+			name: "sockAddrT - AF_UNIX (abstract socket)",
+			input: []byte{0,
+				1, 0, // sa_family=AF_UNIX
+				// it must be 108 bytes long
+				0, 115, 111, 109, 101, 116, 104, 105, 110, 103, 0, // sun_path=@something
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			},
+			fields:      []events.DataField{{DecodeAs: data.SOCK_ADDR_T, ArgMeta: trace.ArgMeta{Name: "sockAddr0"}}},
+			expectedArg: map[string]string{"sa_family": "AF_UNIX", "sun_path": "@something"},
 		},
 		{
 			name:          "unknown",
@@ -180,7 +201,7 @@ func TestReadArgFromBuff(t *testing.T) {
 	}
 }
 
-func TestReadStringVarFromBuff(t *testing.T) {
+func Test_readSunPathFromBuff(t *testing.T) {
 	tests := []struct {
 		name           string
 		buffer         []byte
@@ -201,7 +222,7 @@ func TestReadStringVarFromBuff(t *testing.T) {
 			name:           "Buffer with same length as max without null terminator",
 			buffer:         []byte{'H', 'e', 'l', 'l', 'o'},
 			max:            5,
-			expected:       "Hell",
+			expected:       "Hello",
 			expectedCursor: 5,
 			expectError:    false,
 		},
@@ -209,7 +230,7 @@ func TestReadStringVarFromBuff(t *testing.T) {
 			name:           "Buffer longer than max length without null terminator",
 			buffer:         []byte{'H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd'},
 			max:            5,
-			expected:       "Hell",
+			expected:       "Hello",
 			expectedCursor: 5,
 			expectError:    false,
 		},
@@ -219,14 +240,22 @@ func TestReadStringVarFromBuff(t *testing.T) {
 			max:            0,
 			expected:       "",
 			expectedCursor: 0,
-			expectError:    false,
+			expectError:    true,
 		},
 		{
 			name:           "Buffer started with null terminator",
-			buffer:         []byte{0, 'N', 'u', 'l', 'l', 0, 'W', 'o', 'r', 'l', 'd'},
-			max:            6,
+			buffer:         []byte{0, 'A', 'b', 's', 't', 'r', 'a', 'c', 't', 0, 'd'},
+			max:            10,
+			expected:       "@Abstract",
+			expectedCursor: 10,
+			expectError:    false,
+		},
+		{
+			name:           "Zeroed buffer",
+			buffer:         []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			max:            10,
 			expected:       "",
-			expectedCursor: 6,
+			expectedCursor: 10,
 			expectError:    false,
 		},
 		{
@@ -252,7 +281,7 @@ func TestReadStringVarFromBuff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			decoder := New(tt.buffer, dataPresentor)
-			actual, err := readVarStringFromBuffer(decoder, tt.max)
+			actual, err := readSunPathFromBuff(decoder, tt.max)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -452,7 +452,8 @@ statfunc int save_sockaddr_to_buf(args_buffer_t *buf, struct socket *sock, u8 in
         get_network_details_from_sock_v4(sk, &net_details, 0);
         get_local_sockaddr_in_from_network_details(&local, &net_details, family);
 
-        save_to_submit_buf(buf, (void *) &local, bpf_core_type_size(struct sockaddr_in), index);
+        // NOTE: for stack allocated, use sizeof instead of bpf_core_type_size
+        save_to_submit_buf(buf, (void *) &local, sizeof(local), index);
     } else if (family == AF_INET6) {
         net_conn_v6_t net_details = {};
         struct sockaddr_in6 local;
@@ -460,12 +461,16 @@ statfunc int save_sockaddr_to_buf(args_buffer_t *buf, struct socket *sock, u8 in
         get_network_details_from_sock_v6(sk, &net_details, 0);
         get_local_sockaddr_in6_from_network_details(&local, &net_details, family);
 
-        save_to_submit_buf(buf, (void *) &local, bpf_core_type_size(struct sockaddr_in6), index);
+        // NOTE: for stack allocated, use sizeof instead of bpf_core_type_size
+        save_to_submit_buf(buf, (void *) &local, sizeof(local), index);
     } else if (family == AF_UNIX) {
         struct unix_sock *unix_sk = (struct unix_sock *) sk;
         struct sockaddr_un sockaddr = get_unix_sock_addr(unix_sk);
-        save_to_submit_buf(buf, (void *) &sockaddr, bpf_core_type_size(struct sockaddr_un), index);
+
+        // NOTE: for stack allocated, use sizeof instead of bpf_core_type_size
+        save_to_submit_buf(buf, (void *) &sockaddr, sizeof(sockaddr), index);
     }
+
     return 0;
 }
 

--- a/pkg/ebpf/c/common/network.h
+++ b/pkg/ebpf/c/common/network.h
@@ -369,11 +369,18 @@ statfunc struct sockaddr_un get_unix_sock_addr(struct unix_sock *sock)
 {
     struct unix_address *addr = BPF_CORE_READ(sock, addr);
     int len = BPF_CORE_READ(addr, len);
+
+    // name is a flexible array member (struct sockaddr_un[])
+    struct sockaddr_un *sockaddr_src = (struct sockaddr_un *) addr->name;
     struct sockaddr_un sockaddr = {};
-    // NOTE(nadav.str): stack allocated, so runtime core size check is avoided
-    if (len <= sizeof(struct sockaddr_un)) {
-        bpf_probe_read(&sockaddr, len, addr->name);
-    }
+    sockaddr.sun_family = BPF_CORE_READ(sockaddr_src, sun_family);
+
+    // https://elixir.bootlin.com/linux/v6.13.4/source/net/unix/af_unix.c#L363
+    len -= offsetof(struct sockaddr_un, sun_path);
+    update_min(len, UNIX_PATH_MAX); // truncate if too long for our buffer
+
+    bpf_core_read(&sockaddr.sun_path, len, &sockaddr_src->sun_path);
+
     return sockaddr;
 }
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -513,8 +513,8 @@ statfunc int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd)
         get_network_details_from_sock_v4(sk, &net_details, 0);
         get_remote_sockaddr_in_from_network_details(&remote, &net_details, family);
 
-        save_to_submit_buf(
-            &(p->event->args_buf), &remote, bpf_core_type_size(struct sockaddr_in), 2);
+        // NOTE: for stack allocated, use sizeof instead of bpf_core_type_size
+        save_to_submit_buf(&(p->event->args_buf), &remote, sizeof(remote), 2);
     } else if (family == AF_INET6) {
         net_conn_v6_t net_details = {};
         struct sockaddr_in6 remote;
@@ -522,14 +522,14 @@ statfunc int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd)
         get_network_details_from_sock_v6(sk, &net_details, 0);
         get_remote_sockaddr_in6_from_network_details(&remote, &net_details, family);
 
-        save_to_submit_buf(
-            &(p->event->args_buf), &remote, bpf_core_type_size(struct sockaddr_in6), 2);
+        // NOTE: for stack allocated, use sizeof instead of bpf_core_type_size
+        save_to_submit_buf(&(p->event->args_buf), &remote, sizeof(remote), 2);
     } else if (family == AF_UNIX) {
         struct unix_sock *unix_sk = (struct unix_sock *) sk;
         struct sockaddr_un sockaddr = get_unix_sock_addr(unix_sk);
 
-        save_to_submit_buf(
-            &(p->event->args_buf), &sockaddr, bpf_core_type_size(struct sockaddr_un), 2);
+        // NOTE: for stack allocated, use sizeof instead of bpf_core_type_size
+        save_to_submit_buf(&(p->event->args_buf), &sockaddr, sizeof(sockaddr), 2);
     }
 
     return events_perf_submit(p, 0);

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -613,14 +613,16 @@ struct unix_sock {
     struct unix_address *addr;
 };
 
+#define UNIX_PATH_MAX 108
+
 struct sockaddr_un {
     __kernel_sa_family_t sun_family;
-    char sun_path[108];
+    char sun_path[UNIX_PATH_MAX];
 };
 
 struct unix_address {
     int len;
-    struct sockaddr_un name[0];
+    struct sockaddr_un name[];
 };
 
 struct ipv6_pinfo {


### PR DESCRIPTION
Close: #4219
Close: #1129

### 1. Explain what the PR does

71b9d2d6 **fix(decoder): treat abstract socket in decoder**

```
Abstract sockets were being ignored by readSunPathFromBuff() - former
readStringVarFromBuff() - in the decoder.
```

c883776c **fix(ebpf): correct sockaddr_un size handling**

```
In security_socket_connect, sun_path may not be NUL-terminated.
Therefore, sockaddr_un should be read based on the addrlen argument
provided, rather than assuming a fixed size.
```

e3b085df **fix(ebpf): read sockaddr_un members individually**

```
- Read sockaddr_un members individually to prevent offset issues,
especially since the destination struct (on the stack) may not be
aligned with the source struct (from the kernel).

This also:

- Treat len member as the sun_path length, not the struct size.

- Change all related bpf_core_type_size() calls to use sizeof() instead.

- Create a new update_min() function macro to update the minimum value
of a variable using a register to satisfy the verifier.
```

### 2. Explain how to test it

Running these one should see the right sun_path without truncation.

`tracee -e socket_accept,accept4,security_socket_connect,connect -s comm=nc`

```
# Filesystem socket (stream)
nc -Ul /tmp/sock &
nc -U /tmp/sock

# Filesystem socket (datagram)
nc -Uul /tmp/sock &
nc -Uu /tmp/sock

# Abstract socket (stream)
nc -Ul @"blihhhx" &
nc -U @"blihhhx"

# Abstract socket (datagram)
nc -Uul @"blihhhy" &
nc -Uu @"blihhhy"
```

### 3. Other comments

See also https://github.com/aquasecurity/tracee/pull/4634#issuecomment-2779702634
