### PR TITLE
feat: add heartbeat event

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -1061,6 +1061,17 @@ int lkm_seeker_modtree_loop(struct pt_regs *ctx)
     return -1;
 }
 
+SEC("uprobe/capture_heartbeat")
+int heartbeat_capture(struct pt_regs *ctx)
+{
+    controlplane_signal_t *signal = init_controlplane_signal(SIGNAL_HEARTBEAT);
+    if (unlikely(signal == NULL))
+        return 0;
+
+    signal_perf_submit(ctx, signal);
+    return 0;
+}
+
 statfunc int find_modules_from_mod_tree(program_data_t *p)
 {
     char mod_tree_sym[9] = "mod_tree";

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -152,6 +152,7 @@ enum signal_event_id_e
     SIGNAL_SCHED_PROCESS_FORK,
     SIGNAL_SCHED_PROCESS_EXEC,
     SIGNAL_SCHED_PROCESS_EXIT,
+    SIGNAL_HEARTBEAT,
 };
 
 typedef struct args {

--- a/pkg/ebpf/controlplane/controller.go
+++ b/pkg/ebpf/controlplane/controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aquasecurity/tracee/pkg/bufferdecoder"
 	"github.com/aquasecurity/tracee/pkg/containers"
+	"github.com/aquasecurity/tracee/pkg/ebpf/heartbeat"
 	"github.com/aquasecurity/tracee/pkg/errfmt"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/logger"
@@ -169,6 +170,8 @@ func (ctrl *Controller) processSignal(signal *signal) error {
 		}
 
 		return ctrl.procTreeExitProcessor(signal.args)
+	case events.SignalHeartbeat:
+		heartbeat.SendPulse()
 	}
 
 	return nil

--- a/pkg/ebpf/heartbeat/heartbeat.go
+++ b/pkg/ebpf/heartbeat/heartbeat.go
@@ -1,0 +1,136 @@
+package heartbeat
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+var instance *Heartbeat
+var once sync.Once
+var closeOncePulse sync.Once
+
+// Heartbeat represents the liveness detection logic, tracking pulse intervals
+// and determining whether the system is healthy based on activity.
+type Heartbeat struct {
+	ctx       context.Context
+	pulse     chan struct{}
+	mu        sync.RWMutex
+	isHealthy bool
+	interval  time.Duration
+	timeout   time.Duration
+	callback  func()
+}
+
+// Init initializes the singleton Heartbeat instance and starts the internal monitor.
+// It ensures that the heartbeat is only initialized once with the provided context,
+// heartbeat interval, and timeout duration.
+func Init(ctx context.Context, interval, timeout time.Duration) {
+	once.Do(func() {
+		instance = &Heartbeat{
+			pulse:     make(chan struct{}, 1),
+			mu:        sync.RWMutex{},
+			isHealthy: false,
+			ctx:       ctx,
+			interval:  interval,
+			timeout:   timeout,
+		}
+		instance.monitor()
+	})
+}
+
+// GetInstance returns the singleton instance of Heartbeat.
+func GetInstance() *Heartbeat {
+	return instance
+}
+
+// SetCallback assigns a custom callback function to be executed on each heartbeat tick.
+func (h *Heartbeat) SetCallback(cb func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.callback = cb
+}
+
+// Start begins the heartbeat pulse loop, which triggers the callback function
+// at the configured interval until the context is cancelled.
+func (h *Heartbeat) Start() {
+	go func() {
+		ticker := time.NewTicker(h.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				h.mu.RLock()
+				cb := h.callback
+				h.mu.RUnlock()
+				if cb != nil {
+					cb()
+				}
+			case <-h.ctx.Done():
+				h.close()
+				return
+			}
+		}
+	}()
+}
+
+// SendPulse provides a public way to manually send a heartbeat signal.
+func SendPulse() {
+	select {
+	case GetInstance().pulse <- struct{}{}:
+	default:
+		// Channel was full; drop the pulse instead of blocking
+	}
+}
+
+// monitor periodically checks if heartbeats are received within the allowed timeout window.
+// If no pulse is received in time, the health status is set to false.
+func (h *Heartbeat) monitor() {
+	go func() {
+		timer := time.NewTimer(h.timeout)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-h.ctx.Done():
+				h.close()
+				return
+			case <-h.pulse:
+				h.setHealth(true)
+				if !timer.Stop() {
+					<-timer.C
+				}
+				timer.Reset(h.timeout)
+			case <-timer.C:
+				h.setHealth(false)
+				timer.Reset(h.timeout)
+			}
+		}
+	}()
+}
+
+// setHealth safely updates the internal health status.
+func (h *Heartbeat) setHealth(status bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.isHealthy = status
+}
+
+// IsAlive returns the current health status of the Heartbeat instance.
+func (h *Heartbeat) IsAlive() bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.isHealthy
+}
+
+// close safely closes the heartbeat pulse channel.
+//
+// It ensures that the channel is closed only once using sync.Once to prevent
+// panics due to multiple close attempts. This method should be called during
+// shutdown or cleanup to signal that no more heartbeat pulses will be sent.
+func (h *Heartbeat) close() {
+	closeOncePulse.Do(func() {
+		close(h.pulse)
+	})
+}

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -234,6 +234,7 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool) (*ProbeGroup, err
 		SignalSchedProcessFork:     NewTraceProbe(RawTracepoint, "sched:sched_process_fork", "sched_process_fork_signal"),
 		SignalSchedProcessExec:     NewTraceProbe(RawTracepoint, "sched:sched_process_exec", "sched_process_exec_signal"),
 		SignalSchedProcessExit:     NewTraceProbe(RawTracepoint, "sched:sched_process_exit", "sched_process_exit_signal"),
+		SignalHeartbeat:            NewUprobe("heartbeat_event", "heartbeat_capture", binaryPath, "github.com/aquasecurity/tracee/pkg/server/http.invokeHeartbeat"),
 		ExecuteFinishedX86:         NewTraceProbe(KretProbe, "__x64_sys_execve", "trace_execute_finished"),
 		ExecuteAtFinishedX86:       NewTraceProbe(KretProbe, "__x64_sys_execveat", "trace_execute_finished"),
 		ExecuteFinishedCompatX86:   NewTraceProbe(KretProbe, "__ia32_compat_sys_execve", "trace_execute_finished"),

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -139,6 +139,7 @@ const (
 	SignalSchedProcessFork
 	SignalSchedProcessExec
 	SignalSchedProcessExit
+	SignalHeartbeat
 	ExecuteFinishedX86
 	ExecuteAtFinishedX86
 	ExecuteFinishedCompatX86

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -175,6 +175,7 @@ const (
 	SignalSchedProcessFork
 	SignalSchedProcessExec
 	SignalSchedProcessExit
+	SignalHeartbeat
 )
 
 // Signature events
@@ -13282,6 +13283,19 @@ var CoreEvents = map[ID]Definition{
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "exit_code"}},
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "signal_code"}},
 			{DecodeAs: data.BOOL_T, ArgMeta: trace.ArgMeta{Type: "bool", Name: "process_group_exit"}},
+		},
+	},
+	SignalHeartbeat: {
+		id:       SignalHeartbeat,
+		id32Bit:  Sys32Undefined,
+		name:     "heartbeat_event",
+		version:  NewVersion(1, 0, 0),
+		internal: true,
+		sets:     []string{"default"},
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.SignalHeartbeat, required: true},
+			},
 		},
 	},
 	//


### PR DESCRIPTION
Fixes: #3123 
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

This change introduces a heartbeat event in Tracee to enhance health monitoring and improve /healthz endpoint readiness/liveness. The heartbeat is generated every second by a Go function, which is then captured by a uprobe in the eBPF layer. This ensures that Tracee is actively processing events and functioning correctly.

Key changes:
* Introduced a periodic heartbeat event using a Go function running every second.
* Attached a uprobe to capture the heartbeat when the function is invoked.
* Ensures tracee is processing events generated at bpf layer


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

1. run tracee command by enabling healthz flag
`tracee --healthz --http-listen-addr=:8080`

    expectations: heartbeat_event are generated 
 
2.  `curl http://localhost:8080/healthz`
    expectations: status should return OK

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
