### PR TITLE
fix(tests): handle tracee pids correctly

### DIFF
--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -176,7 +176,7 @@ for TEST in $TESTS; do
         ;;
     esac
 
-    $tracee_command &
+    eval "$tracee_command &"
 
     # Wait tracee to start
 
@@ -237,10 +237,10 @@ for TEST in $TESTS; do
 
     # Make sure we exit tracee before checking output and log files
 
-    pid_tracee=$(pgrep -x tracee | xargs)
-    kill -SIGINT "$pid_tracee"
+    mapfile -t tracee_pids < <(pgrep -x tracee)
+    kill -SIGINT "${tracee_pids[@]}"
     sleep $TRACEE_SHUTDOWN_TIMEOUT
-    kill -SIGKILL "$pid_tracee" >/dev/null 2>&1
+    kill -SIGKILL "${tracee_pids[@]}" >/dev/null 2>&1
     sleep 3
 
     # Check if the test has failed or not
@@ -269,13 +269,13 @@ for TEST in $TESTS; do
         echo "$tracee_command" | tr -s ' '
 
         info "Tracee process is running?"
-        traceepids=$(pgrep tracee)
-        if [[ -n $traceepids ]]; then
-            info "YES, Tracee is still running (should not be, fix me!), pids: $traceepids"
+        mapfile -t tracee_pids < <(pgrep -x tracee)
+        if [[ -n "${tracee_pids[*]}" ]]; then
+            info "YES, Tracee is still running (should not be, fix me!), pids: ${tracee_pids[*]}"
             info "Aborting tests"
             break
         else
-            info "NO, Tracee is not running"
+            info "NO, Tracee is not running, as expected"
         fi
         info
     fi


### PR DESCRIPTION
### 1. Explain what the PR does

a75e4a479 **fix(tests): handle tracee pids correctly**

```
Passing it as a single quoted variable fails when there are multiple
pids:
./tests/e2e-inst-test.sh: line 241: kill: 18731 19343: arguments must be process or job IDs

Handle it as an array instead so each pid element is expanded correctly.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

https://github.com/aquasecurity/tracee/actions/runs/13903229340/job/38899944478?pr=4583
