### PR TITLE
chore(ci): dependabot gomod for sec updates only

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,8 +5,19 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    commit-message:
+      prefix: '[dependabot][github-actions] - '
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/builder"
+    commit-message:
+      prefix: '[dependabot][docker] - '
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod"
     directories:
       - "/"
@@ -14,9 +25,13 @@ updates:
       - "/types"
       - "/signatures/helpers"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directories:
-      - "/builder"
-    schedule:
-      interval: "weekly"
+      interval: "daily"
+    commit-message:
+      prefix: '[dependabot][gomod-security] - '
+    groups:
+      # Group security updates for golang dependencies
+      # into a single pull request
+      golang:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
### 1. Explain what the PR does

b52078308 **chore(ci): dependabot gomod for sec updates only**

```
Dependabot is now set to run daily for Go modules, but it will only
create pull requests for security-related updates. Version bumps for
gomod non-security updates will be handled manually, as we have many
dependencies that require thorough testing.

It also adds a prefix to the commit message to make it easier to
identify the purpose of the commit.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
