### PR TITLE
chore(go): bump toolchain to go1.24.1 - 1st

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,6 +2,8 @@ module github.com/aquasecurity/tracee/api
 
 go 1.24
 
+toolchain go1.24.1
+
 require (
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.6

--- a/types/go.mod
+++ b/types/go.mod
@@ -2,7 +2,7 @@ module github.com/aquasecurity/tracee/types
 
 go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
### 1. Explain what the PR does

3587efe59 **chore(api): align go toolchain**
448ef2779 **chore(types): bump toolchain to go1.24.1**


448ef2779 **chore(types): bump toolchain to go1.24.1**

```
go1.24.1 (released 2025-03-04) includes security fixes to the net/http
package, as well as bug fixes to cgo, the compiler, the go command, and
the reflect, runtime, and syscall packages.

https://github.com/golang/go/issues?q=milestone%3AGo1.24.1%20label%3ACherryPickApproved
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
