### PR TITLE
fix(libcap): bump libcap to v1.2.75 & libpsx to v1.2.76-rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
 	k8s.io/cri-api v0.32.2
-	kernel.org/pub/linux/libs/security/libcap/cap v1.2.73
+	kernel.org/pub/linux/libs/security/libcap/cap v1.2.75
 	sigs.k8s.io/controller-runtime v0.20.3
 )
 
@@ -166,5 +166,5 @@ require (
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.75 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/IBM/fluent-forward-go v0.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61
+	github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250318181534-c412f162778b
 	github.com/aquasecurity/tracee/api v0.0.0-20250328183514-3587efe59aa3
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250328185402-7b0abdab8d1a
 	github.com/aquasecurity/tracee/types v0.0.0-20250328183453-448ef27793c2

--- a/go.mod
+++ b/go.mod
@@ -166,5 +166,5 @@ require (
 	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	kernel.org/pub/linux/libs/security/libcap/psx v1.2.75 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/Microsoft/hcsshim v0.12.3 h1:LS9NXqXhMoqNCplK1ApmVSfB4UnVLRDWRapB6EIl
 github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6CtY2Qg/JVQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61 h1:EdqmOm8rk/FMtYetPcceDdW27lZxXzpHZw8XpF3lG+g=
-github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250117141322-c0ac6035ae61/go.mod h1:HB2DYWHuMraOB0IFcfjL8tsxN8TcFOdWKTrNqnHrTrs=
+github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250318181534-c412f162778b h1:yiYeg2DIkX55/OyaQDqH2hSSC3xEEh2LgwfScWONXak=
+github.com/aquasecurity/libbpfgo v0.8.0-libbpf-1.5.0.20250318181534-c412f162778b/go.mod h1:5LblNhDPCqk7aGIfNdsEZ4wGZHQcK/SKXAfq6PZ6pPQ=
 github.com/aquasecurity/tracee/api v0.0.0-20250328183514-3587efe59aa3 h1:aHFO+4QfwCgiw7zBbjgjSAKYOCQNWOuWsxw2aKVtD8c=
 github.com/aquasecurity/tracee/api v0.0.0-20250328183514-3587efe59aa3/go.mod h1:lmNPMqX5KAX82roDAUPtfU4AwfheAqELgjuxLERY6tM=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250328185402-7b0abdab8d1a h1:jM+32KWKmajomCI67raiVr5MsAAsnuMC/Ev1KXC7dyU=

--- a/go.sum
+++ b/go.sum
@@ -1399,10 +1399,10 @@ k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJ
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73 h1:Th2b8jljYqkyZKS3aD3N9VpYsQpHuXLgea+SZUIfODA=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73/go.mod h1:hbeKwKcboEsxARYmcy/AdPVN11wmT/Wnpgv4k4ftyqY=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 h1:SEAEUiPVylTD4vqqi+vtGkSnXeP2FcRO3FoZB1MklMw=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75 h1:f78VOelVeTl82xITLNCvtOQ6yHbrsL2X8lSs2kJ6laE=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75/go.mod h1:/0v7MsGCcYOmU5VrtrvcjgqCar2mdCr/STymAGfd57A=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.75 h1:cTgLaDzZqsIoKDomWTT6GEKKIdowAz5gwfKhfKhRP50=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.75/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -1401,8 +1401,9 @@ k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6J
 k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 kernel.org/pub/linux/libs/security/libcap/cap v1.2.75 h1:f78VOelVeTl82xITLNCvtOQ6yHbrsL2X8lSs2kJ6laE=
 kernel.org/pub/linux/libs/security/libcap/cap v1.2.75/go.mod h1:/0v7MsGCcYOmU5VrtrvcjgqCar2mdCr/STymAGfd57A=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.75 h1:cTgLaDzZqsIoKDomWTT6GEKKIdowAz5gwfKhfKhRP50=
 kernel.org/pub/linux/libs/security/libcap/psx v1.2.75/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 h1:Tq5hYNtVgkIUTv+5BtOZjC5JB4s8TutijJE5vBaoW84=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
Close: #4678 

### 1. Explain what the PR does

fd2186731 **fix(deps): bump psx to v1.2.76-rc1**
fa56872e2 **fix(deps): bump to libbpfgo using libcap v1.2.75**
7fd451953 **fix(deps): bump libcap to v1.2.75**


fd2186731 **fix(deps): bump psx to v1.2.76-rc1**

```
- https://github.com/aquasecurity/tracee/pull/4688#issuecomment-2764255447
- https://web.git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?h=psx/v1.2.76-rc1&id=07d8ce731d5fe9063abfef4a77306e273b18b5f3
```

7fd451953 **fix(deps): bump libcap to v1.2.75**

```
The regression introduced in v1.2.72
https://bugzilla.kernel.org/show_bug.cgi?id=219687

was fixed since 1.2.74
https://web.git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=025f28ca4fe085fbcbf7933d53a42d335744e553

Nevertheless, this bumps libcap to v1.2.75 to match with the upstream
libbpfgo version.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
