### PR TITLE
Release v0.23.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/apimachinery v0.30.1
 	k8s.io/client-go v0.30.1
 	k8s.io/cri-api v0.30.1
-	kernel.org/pub/linux/libs/security/libcap/cap v1.2.73
+	kernel.org/pub/linux/libs/security/libcap/cap v1.2.75
 	sigs.k8s.io/controller-runtime v0.18.2
 )
 
@@ -170,5 +170,5 @@ require (
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 // indirect
+	kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1403,10 +1403,11 @@ k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f h1:0LQagt0gDpKqvIkAMPaRGc
 k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f/go.mod h1:S9tOR0FxgyusSNR+MboCuiDpVWkAifZvaYI1Q2ubgro=
 k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 h1:jgGTlFYnhF1PM1Ax/lAlxUPE+KfCIXHaathvJg1C3ak=
 k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73 h1:Th2b8jljYqkyZKS3aD3N9VpYsQpHuXLgea+SZUIfODA=
-kernel.org/pub/linux/libs/security/libcap/cap v1.2.73/go.mod h1:hbeKwKcboEsxARYmcy/AdPVN11wmT/Wnpgv4k4ftyqY=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73 h1:SEAEUiPVylTD4vqqi+vtGkSnXeP2FcRO3FoZB1MklMw=
-kernel.org/pub/linux/libs/security/libcap/psx v1.2.73/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75 h1:f78VOelVeTl82xITLNCvtOQ6yHbrsL2X8lSs2kJ6laE=
+kernel.org/pub/linux/libs/security/libcap/cap v1.2.75/go.mod h1:/0v7MsGCcYOmU5VrtrvcjgqCar2mdCr/STymAGfd57A=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.75/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1 h1:Tq5hYNtVgkIUTv+5BtOZjC5JB4s8TutijJE5vBaoW84=
+kernel.org/pub/linux/libs/security/libcap/psx v1.2.76-rc1/go.mod h1:+l6Ee2F59XiJ2I6WR5ObpC1utCQJZ/VLsEbQCD8RG24=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/ebpf/perf_count.go
+++ b/pkg/ebpf/perf_count.go
@@ -30,6 +30,10 @@ func (t *Tracee) countPerfEventSubmissions(ctx context.Context) {
 
 	evtStatZero := eventStatsValues{}
 	for _, id := range t.policyManager.EventsToSubmit() {
+		if id >= events.MaxCommonID {
+			continue
+		}
+
 		key := uint32(id)
 		err := evtsCountsBPFMap.Update(unsafe.Pointer(&key), unsafe.Pointer(&evtStatZero))
 		if err != nil {


### PR DESCRIPTION
### 1. Explain what the PR does

2ea27b575 **PR #4688: fix(deps): bump libcap to v1.2.75 & libpsx to v1.2.76-rc1**
5fdc7f3a8 **PR #4631: fix(ebpf): profile only common events**


2ea27b575 **PR #4688: fix(deps): bump libcap to v1.2.75 & libpsx to v1.2.76-rc1**

```
fix(deps): bump libcap to v1.2.75

The regression introduced in v1.2.72
https://bugzilla.kernel.org/show_bug.cgi?id=219687

was fixed since 1.2.74
https://web.git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=025f28ca4fe085fbcbf7933d53a42d335744e553

Nevertheless, this bumps libcap to v1.2.75 to match with the upstream
libbpfgo version.

commit: main@7fd451953, backport

---

fix(deps): bump psx to v1.2.76-rc1

- https://github.com/aquasecurity/tracee/pull/4688#issuecomment-2764255447
- https://web.git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?h=psx/v1.2.76-rc1&id=07d8ce731d5fe9063abfef4a77306e273b18b5f3

commit: main@fd2186731f, cherry-pick
```

5fdc7f3a8 **PR #4631: fix(ebpf): profile only common events**

```
fix(ebpf): profile only common events (#4631)

commit: main@a43ec17a6, cherry-pick
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
