### PR TITLE
fix: add toolchain

### DIFF
--- a/cmd/traceectl/go.mod
+++ b/cmd/traceectl/go.mod
@@ -2,6 +2,8 @@ module github.com/aquasecurity/tracee/cmd/traceectl
 
 go 1.24
 
+toolchain go1.24.1
+
 require (
 	github.com/aquasecurity/table v1.8.0
 	github.com/aquasecurity/tracee/api v0.0.0-20240918153521-1b3f9e8657e0


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

4762acf45 **fix: add toolchain**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->

I was getting this error when compiling Tracee. So after adding the toolchain the compilation get back to normal.

```
make -C cmd/traceectl all
cp cmd/traceectl/dist/traceectl ./dist/
echo "Moved traceectl binary to ./dist"
mkdir -p dist
go build \
        -ldflags "-X main.version=v0.23.0-84-gd87b15186" \
        -o dist/traceectl \
        main.go 
go: downloading go1.24 (linux/amd64)
go: download go1.24 for linux/amd64: toolchain not available
make[1]: *** [Makefile:12: build] Error 1
Moved traceectl binary to ./dist
rm .check_pkg-config
```
