### PR TITLE
fix: ebpf max inst limit

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -757,7 +757,7 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     return 0;
 }
 
-#define MAX_NUM_MODULES          440
+#define MAX_NUM_MODULES          420
 #define MAX_MODULES_MAP_ENTRIES  2 * MAX_NUM_MODULES
 #define MOD_TREE_LOOP_ITERATIONS 240
 #define MOD_TREE_LOOP_DEPTH      14


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

If the current version of Tracee is compiled with `METRICS=1`, we should get a error during run. Tested on x86-64.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
