### PR TITLE
chore(deps): bump go toolchain to 1.24.2

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/aquasecurity/tracee/api
 
 go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	google.golang.org/grpc v1.71.1

--- a/cmd/traceectl/go.mod
+++ b/cmd/traceectl/go.mod
@@ -2,7 +2,7 @@ module github.com/aquasecurity/tracee/cmd/traceectl
 
 go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/aquasecurity/table v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/aquasecurity/tracee
 
 go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/IBM/fluent-forward-go v0.3.0

--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -2,7 +2,7 @@ module github.com/aquasecurity/tracee/signatures/helpers
 
 go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require github.com/aquasecurity/tracee/types v0.0.0-20250328183453-448ef27793c2
 

--- a/types/go.mod
+++ b/types/go.mod
@@ -2,7 +2,7 @@ module github.com/aquasecurity/tracee/types
 
 go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION

### 1. Explain what the PR does

33ed7fbbd **chore(deps): bump go toolchain to 1.24.2**

https://go.dev/doc/devel/release#go1.24.minor

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
