### PR TITLE
chore(go): bump to use latest types

### DIFF
--- a/signatures/helpers/go.mod
+++ b/signatures/helpers/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.2
 
-require github.com/aquasecurity/tracee/types v0.0.0-20250328183453-448ef27793c2
+require github.com/aquasecurity/tracee/types v0.0.0-20250422170923-9462459c9cc2
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/signatures/helpers/go.sum
+++ b/signatures/helpers/go.sum
@@ -1,7 +1,5 @@
-github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782 h1:Ru13qtB0ktZV1vA5tKRnPJpOcu767OIXa+4JVUa5VXc=
-github.com/aquasecurity/tracee/types v0.0.0-20250225150010-27311e99d782/go.mod h1:JngSfuKDDXeWGRvedo88R6YMpTrsbISgMLlSOHmDGV0=
-github.com/aquasecurity/tracee/types v0.0.0-20250328183453-448ef27793c2 h1:OX7UJ7BXFopJ/k4hmLOhIkHEzrcFrUYXNMM9g71rgBs=
-github.com/aquasecurity/tracee/types v0.0.0-20250328183453-448ef27793c2/go.mod h1:mtNc+4VNzY34ityBampLsTr4dJ6JbCZfoNKJIn0DKAs=
+github.com/aquasecurity/tracee/types v0.0.0-20250422170923-9462459c9cc2 h1:Rg6ElMjU7+Rx/sURXLlYlKC+uI+1ZqEmpDNLf6BVQs0=
+github.com/aquasecurity/tracee/types v0.0.0-20250422170923-9462459c9cc2/go.mod h1:Garhl9pem8cnEgD0iHHwGcHn2HD5dteENk3YcOBPYU4=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=


### PR DESCRIPTION
### 1. Explain what the PR does

f661492c4 **chore(go): bump to use latest types**

```
Bump signatures/helpers go.mod to use latest types.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
