### PR TITLE
Use bounded loops

### DIFF
--- a/pkg/ebpf/c/capture_filtering.h
+++ b/pkg/ebpf/c/capture_filtering.h
@@ -46,8 +46,7 @@ statfunc bool filter_file_path(void *ctx, void *filter_map, struct file *file)
     bool has_filter = false;
     bool filter_match = false;
 
-// Check if the path matches filter prefixes
-#pragma unroll
+    // Check if the path matches filter prefixes
     for (int i = 0; i < 3; i++) {
         int idx = i;
         path_filter_t *filter_p = bpf_map_lookup_elem(filter_map, &idx);
@@ -160,7 +159,7 @@ statfunc bool filter_file_fd(void *ctx, void *filter_map, size_t map_idx, struct
     if (*fds_filter != 0 && *fds_filter & FILTER_FDS_MASK) {
         has_fds_filter = true;
         int standard_fds = get_standard_fds_from_struct_file(file);
-#pragma unroll
+
         for (int fd = STDIN; fd <= STDERR; fd++) {
             bool is_fd = standard_fds & (1 << fd);
             int fd_filter = 1 << (fd + FILTER_FILE_FD_START_BIT);

--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -263,7 +263,7 @@ add_u64_elements_to_buf(args_buffer_t *buf, const u64 __user *ptr, int len, vola
     // save count_off into a new variable to avoid verifier errors
     u32 off = count_off;
     u8 elem_num = 0;
-#pragma unroll
+
     for (int i = 0; i < len; i++) {
         void *addr = &(buf->args[buf->offset]);
         if (buf->offset > ARGS_BUF_SIZE - sizeof(u64))

--- a/pkg/ebpf/c/common/common.h
+++ b/pkg/ebpf/c/common/common.h
@@ -19,58 +19,9 @@ statfunc const char *get_device_name(struct device *dev)
     return kobj.name;
 }
 
-// Workaround: Newer LLVM versions might fail to optimize has_prefix()
-// loop unrolling with the following error:
-//
-//     warning: loop not unrolled: the optimizer was unable to perform
-//     the requested transformation; the transformation might be
-//     disabled or specified as part of an unsupported transformation
-//     ordering
-//
-
-#if defined(__clang__) && __clang_major__ > 13
-
-    #define has_prefix(p, s, n)                                                                    \
-        ({                                                                                         \
-            int rc = 1;                                                                            \
-            char *pre = p, *str = s;                                                               \
-            int z;                                                                                 \
-            _Pragma("unroll") for (z = 0; z < n; pre++, str++, z++)                                \
-            {                                                                                      \
-                if (!*pre) {                                                                       \
-                    rc = 1;                                                                        \
-                    break;                                                                         \
-                } else if (*pre != *str) {                                                         \
-                    rc = 0;                                                                        \
-                    break;                                                                         \
-                }                                                                                  \
-            }                                                                                      \
-            /* if prefix is longer than n, return 0 */                                             \
-            if (z == n && *pre)                                                                    \
-                rc = 0;                                                                            \
-            rc;                                                                                    \
-        })
-
-    #define strncmp(str1, str2, n)                                                                 \
-        ({                                                                                         \
-            int rc = 0;                                                                            \
-            char *s1 = str1, *s2 = str2;                                                           \
-            _Pragma("unroll") for (int z = 0; z < n; s1++, s2++, z++)                              \
-            {                                                                                      \
-                if (*s1 != *s2 || *s1 == '\0' || *s2 == '\0') {                                    \
-                    rc = (unsigned char) *s1 - (unsigned char) *s2;                                \
-                    break;                                                                         \
-                }                                                                                  \
-            }                                                                                      \
-            rc;                                                                                    \
-        })
-
-#else
-
-static __inline int has_prefix(char *prefix, char *str, int n)
+statfunc int has_prefix(char *prefix, char *str, int n)
 {
     int i;
-    #pragma unroll
     for (i = 0; i < n; prefix++, str++, i++) {
         if (!*prefix)
             return 1;
@@ -87,18 +38,15 @@ static __inline int has_prefix(char *prefix, char *str, int n)
     return 1;
 }
 
-static __inline int strncmp(char *str1, char *str2, int n)
+statfunc int strncmp(char *str1, char *str2, int n)
 {
     int i;
-    #pragma unroll
     for (i = 0; i < n; str1++, str2++, i++) {
         if (*str1 != *str2 || *str1 == '\0' || *str2 == '\0')
             return (unsigned char) *str1 - (unsigned char) *str2;
     }
     return 0;
 }
-
-#endif
 
 // helper macros for branch prediction
 #ifndef likely

--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -318,7 +318,6 @@ statfunc void *get_dentry_path_str_buf(struct dentry *dentry, buf_t *out_buf)
 
     u32 buf_off = (MAX_PERCPU_BUFSIZE >> 1);
 
-#pragma unroll
     for (int i = 0; i < MAX_PATH_COMPONENTS; i++) {
         struct dentry *d_parent = get_d_parent_ptr_from_dentry(dentry);
         if (dentry == d_parent) {
@@ -406,7 +405,6 @@ statfunc int get_standard_fds_from_struct_file(struct file *file)
     }
 
     int fds = 0;
-#pragma unroll
     for (int i = STDIN; i <= STDERR; i++) {
         struct file *fd_file = NULL;
         bpf_core_read(&fd_file, sizeof(struct file *), &fd[i]);

--- a/pkg/ebpf/c/common/memory.h
+++ b/pkg/ebpf/c/common/memory.h
@@ -105,10 +105,7 @@ statfunc struct vm_area_struct *find_vma(void *ctx, struct task_struct *task, u6
     struct vm_area_struct *vma = NULL;
     struct rb_node *rb_node = BPF_CORE_READ(mm, mm_rb.rb_node);
 
-#pragma unroll
     for (int i = 0; i < MAX_VMA_RB_TREE_DEPTH; i++) {
-        barrier(); // without this, the compiler refuses to unroll the loop
-
         if (rb_node == NULL)
             break;
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -882,7 +882,6 @@ statfunc int init_shown_modules()
     pos = list_first_entry_ebpf(head, typeof(*pos), list);
     n = pos;
 
-#pragma unroll
     for (int i = 0; i < MAX_NUM_MODULES; i++) {
         pos = n;
         n = list_next_entry_ebpf(n, list);
@@ -1107,7 +1106,6 @@ static __always_inline u64 check_new_mods_only(program_data_t *p)
     pos = list_first_entry_ebpf(head, typeof(*pos), list);
     n = pos;
 
-#pragma unroll
     for (int i = 0; i < MAX_NUM_MODULES; i++) {
         pos = n;
         n = list_next_entry_ebpf(n, list);
@@ -1838,7 +1836,6 @@ int uprobe_seq_ops_trigger(struct pt_regs *ctx)
     u32 count_off = p.event->args_buf.offset + 1;
     save_u64_arr_to_buf(&p.event->args_buf, NULL, 0, 0); // init u64 array with size 0
 
-#pragma unroll
     for (int i = 0; i < NET_SEQ_OPS_TYPES; i++) {
         bpf_probe_read_user(&struct_address, 8, (address_array + i));
         struct seq_operations *seq_ops = (struct seq_operations *) struct_address;
@@ -2319,8 +2316,8 @@ statfunc bool check_file_mount(struct file *file)
 
     struct dentry *dentry = path.dentry;
     struct dentry *root = BPF_CORE_READ(path.mnt, mnt_root);
+
     int i;
-#pragma unroll
     for (i = 0; i < MAX_PATH_COMPONENTS; i++) {
         struct dentry *parent = BPF_CORE_READ(dentry, d_parent);
         if (dentry == root || dentry == parent)
@@ -3148,12 +3145,8 @@ statfunc u32 send_bin_helper(void *ctx, void *prog_array, int tail_call)
     unsigned int full_chunk_num = bin_args->full_size / F_CHUNK_SIZE;
     void *data = file_buf_p->buf;
 
-// Handle full chunks in loop
-#pragma unroll
+    // Handle full chunks in loop
     for (i = 0; i < MAX_BIN_CHUNKS; i++) {
-        // Dummy instruction, as break instruction can't be first with unroll optimization
-        chunk_size = F_CHUNK_SIZE;
-
         if (i == full_chunk_num)
             break;
 
@@ -4165,7 +4158,6 @@ statfunc int handle_bpf_helper_func_id(u32 host_tid, int func_id)
     int arr_num;
     int arr_idx = func_id;
 
-#pragma unroll
     for (int i = 0; i < NUM_OF_HELPERS_ELEMS; i++) {
         arr_num = i;
         if (arr_idx - SIZE_OF_HELPER_ELEM >= 0) {


### PR DESCRIPTION
### 1. Explain what the PR does

efad07cde **chore(ebpf): use bounded loop**

```
Replaced multiple unrolled loops with bounded loops, resulting in a
notable reduction of the final object file size. For example, the
`tracee.bpf.o` file shrank from 15.5 MB to 14.2 MB (~8.6% / ~1.28 MB).

The actual size improvement may be greater, as this reduction reflects
only the current build artifact and likely applies across several BPF
programs.
```

### 2. Explain how to test it


### 3. Other comments

Related: #474