### PR TITLE
Decode fixes

### DIFF
--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -321,7 +321,7 @@ func (t *Tracee) processTriggeredEvent(event *trace.Event) error {
 
 // processPrintSyscallTable processes a print_syscall_table event.
 func (t *Tracee) processPrintMemDump(event *trace.Event) error {
-	address, err := parse.ArgVal[uintptr](event.Args, "address")
+	address, err := parse.ArgVal[trace.Pointer](event.Args, "address")
 	if err != nil || address == 0 {
 		return errfmt.Errorf("error parsing print_mem_dump args: %v", err)
 	}

--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -132,7 +132,7 @@ func (e Event) ToProtocol() protocol.Event {
 // Type alias for data fields representing pointers.
 // uintptr is insufficient since it is architecture dependent.
 // Uint64 itself is irrepresentative of the purpose.
-type Pointer = uint64
+type Pointer uint64
 
 // Argument holds the information for one argument
 type Argument struct {


### PR DESCRIPTION
### 1. Explain what the PR does

ef15d765f **types: fix trace.Pointer type alias**
89a93fe1b **fix(ebpf): process memdump argument parsing**


ef15d765f **types: fix trace.Pointer type alias**

```
Was accidentally set to a type equivalence in d87b151864.
This caused code which meant to apply only to the nominal type to also
apply to uint64 types in general (for example hex formatting when parsing
data fields).
```

89a93fe1b **fix(ebpf): process memdump argument parsing**

```
Processor function of print_mem_dump unwrapped into uintptr instead of the new trace.Pointer
```

### 2. Explain how to test it


### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
