### PR TITLE
fix(traceectl): fix printer process field access

### DIFF
--- a/cmd/traceectl/pkg/cmd/printer/printer.go
+++ b/cmd/traceectl/pkg/cmd/printer/printer.go
@@ -84,7 +84,7 @@ func (p tableEventPrinter) Print(event *pb.Event) {
 		event.Timestamp.AsTime().Format("15:04:05.00000"),
 		event.Name,
 		strings.Join(event.Policies.Matched, ","),
-		strconv.Itoa(int(event.Context.Process.Pid.Value)),
+		strconv.Itoa(int(event.Workload.Process.Pid.Value)),
 		eventData,
 	)
 }


### PR DESCRIPTION
### 1. Explain what the PR does

traceectl printer had references to an old grpc api which brought up compilation errors.
### 2. Explain how to test it

compiling traceectl will emit no errors

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
