### PR TITLE
Check probes support

### DIFF
--- a/pkg/cmd/initialize/kernelconfig.go
+++ b/pkg/cmd/initialize/kernelconfig.go
@@ -17,11 +17,11 @@ func KernelConfig() (*environment.KernelConfig, error) {
 	kernelConfig.AddNeeded(environment.CONFIG_BPF, environment.BUILTIN)
 	kernelConfig.AddNeeded(environment.CONFIG_BPF_SYSCALL, environment.BUILTIN)
 	kernelConfig.AddNeeded(environment.CONFIG_KPROBE_EVENTS, environment.BUILTIN)
+	kernelConfig.AddNeeded(environment.CONFIG_UPROBE_EVENTS, environment.BUILTIN)
 	kernelConfig.AddNeeded(environment.CONFIG_BPF_EVENTS, environment.BUILTIN)
-	missing := kernelConfig.CheckMissing()
-	if len(missing) > 0 {
+	for _, missingOpt := range kernelConfig.CheckMissing() {
 		// do not fail if there are missing options, let it fail later by trying
-		logger.Warnw("KConfig: could not detect kconfig options", "options", missing)
+		logger.Warnw("KConfig: could not detect kconfig option", "option", missingOpt)
 	}
 
 	return kernelConfig, nil

--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -1183,6 +1183,16 @@ struct perf_event {
     struct trace_event_call *tp_event;
 };
 
+// #if defined(CONFIG_KPROBE_EVENTS) || defined(CONFIG_UPROBE_EVENTS)
+enum perf_probe_config
+{
+    PERF_PROBE_CONFIG_IS_RETPROBE = 1U << 0,
+};
+
+// #ifdef CONFIG_UPROBES
+struct uprobe_task {
+};
+
 struct bpf_verifier_env {
     struct bpf_prog *prog;
 };

--- a/pkg/utils/environment/kernel_config.go
+++ b/pkg/utils/environment/kernel_config.go
@@ -337,9 +337,9 @@ func (k *KernelConfig) GetValueString(option KernelConfigOption) (string, error)
 // and it will return false if the KernelConfigOption is not set (# XXXXX is not set)
 //
 // Examples:
-// kernelConfig.Exists(helpers.CONFIG_BPF)
-// kernelConfig.Exists(helpers.CONFIG_BPF_PRELOAD)
-// kernelConfig.Exists(helpers.CONFIG_HZ)
+// kernelConfig.Exists(environment.CONFIG_BPF)
+// kernelConfig.Exists(environment.CONFIG_BPF_PRELOAD)
+// kernelConfig.Exists(environment.CONFIG_HZ)
 func (k *KernelConfig) Exists(option KernelConfigOption) bool {
 	if _, ok := k.configs[option]; ok {
 		return true
@@ -388,9 +388,9 @@ func (k *KernelConfig) CheckMissing() []KernelConfigOption {
 // AddNeeded adds a KernelConfigOption and its value, if needed, as required for further checks with CheckMissing
 //
 // Examples:
-// kernelConfig.AddNeeded(helpers.CONFIG_BPF, helpers.ANY)
-// kernelConfig.AddNeeded(helpers.CONFIG_BPF_PRELOAD, helpers.ANY)
-// kernelConfig.AddNeeded(helpers.CONFIG_HZ, "250")
+// kernelConfig.AddNeeded(environment.CONFIG_BPF, environment.ANY)
+// kernelConfig.AddNeeded(environment.CONFIG_BPF_PRELOAD, environment.ANY)
+// kernelConfig.AddNeeded(environment.CONFIG_HZ, "250")
 func (k *KernelConfig) AddNeeded(option KernelConfigOption, value interface{}) {
 	if _, ok := kernelConfigKeyIDToString[option]; ok {
 		k.needed[option] = value

--- a/pkg/utils/environment/osinfo.go
+++ b/pkg/utils/environment/osinfo.go
@@ -154,8 +154,8 @@ func GetOSInfo() (*OSInfo, error) {
 // OSInfo object contains all OS relevant information
 //
 // OSRelease is relevant to examples such as:
-// 1) OSInfo.OSReleaseInfo[helpers.OS_KERNEL_RELEASE] => will provide $(uname -r) string
-// 2) if OSInfo.GetReleaseID() == helpers.UBUNTU => {} will allow running code in specific distribution
+// 1) OSInfo.OSReleaseInfo[environment.OS_KERNEL_RELEASE] => will provide $(uname -r) string
+// 2) if OSInfo.GetReleaseID() == environment.UBUNTU => {} will allow running code in specific distribution
 type OSInfo struct {
 	osReleaseFieldValues map[OSReleaseField]string
 	osReleaseID          OSReleaseID


### PR DESCRIPTION
Close: #4649 

### 1. Explain what the PR does

23c4855cd **fix(ebpf): check kprobe and uprobe support**
4c24eb205 **fix(environment): update comments**
ad668f628 **fix(initialize)!: add CONFIG_UPROBE_EVENTS as needed**


ad668f628 **fix(initialize)!: add CONFIG_UPROBE_EVENTS as needed**

```
BREAKING CHANGE: missing kconfig output changed.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

Tested by @TrueBad0ur. https://github.com/aquasecurity/tracee/issues/4649#issuecomment-2848657935
