### PR TITLE
perf(ebpf): improve decodeEvents

### DIFF
--- a/pkg/ebpf/capture.go
+++ b/pkg/ebpf/capture.go
@@ -1,7 +1,6 @@
 package ebpf
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -136,7 +135,7 @@ func (t *Tracee) handleFileCaptures(ctx context.Context) {
 					t.handleError(err)
 					continue
 				}
-				bpfName := string(bytes.TrimRight(bpfObjectMeta.Name[:], "\x00"))
+				bpfName := utils.TrimTrailingNUL(bpfObjectMeta.Name[:])
 				filename = fmt.Sprintf("bpf.name-%s", bpfName)
 				if bpfObjectMeta.Pid != 0 {
 					filename = fmt.Sprintf("%s.pid-%d", filename, bpfObjectMeta.Pid)

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -275,7 +275,13 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 			evt.Metadata = nil
 			// compute hashes using normalized times
 			evt.ThreadEntityId = utils.HashTaskID(eCtx.HostTid, uint64(evt.ThreadStartTime))
-			evt.ProcessEntityId = utils.HashTaskID(eCtx.HostPid, traceetime.BootToEpochNS(eCtx.LeaderStartTime))
+			if eCtx.HostTid == eCtx.HostPid && eCtx.StartTime == eCtx.LeaderStartTime {
+				// If the thread is the leader (i.e., HostTid == HostPid and StartTime == LeaderStartTime),
+				// then ProcessEntityId and ThreadEntityId are identical and can be shared.
+				evt.ProcessEntityId = evt.ThreadEntityId
+			} else {
+				evt.ProcessEntityId = utils.HashTaskID(eCtx.HostPid, traceetime.BootToEpochNS(eCtx.LeaderStartTime))
+			}
 			evt.ParentEntityId = utils.HashTaskID(eCtx.HostPpid, traceetime.BootToEpochNS(eCtx.ParentStartTime))
 
 			// If there aren't any policies that need filtering in userland, tracee **may** skip

--- a/pkg/ebpf/events_pipeline_bench_test.go
+++ b/pkg/ebpf/events_pipeline_bench_test.go
@@ -1,7 +1,6 @@
 package ebpf
 
 import (
-	"bytes"
 	"sync"
 	"testing"
 	"time"
@@ -87,8 +86,8 @@ func BenchmarkGetEventFromPool(b *testing.B) {
 				evt.UserID = int(ctx.Uid)
 				evt.MountNS = int(ctx.MntID)
 				evt.PIDNS = int(ctx.PidID)
-				evt.ProcessName = string(bytes.TrimRight(ctx.Comm[:], "\x00"))
-				evt.HostName = string(bytes.TrimRight(ctx.UtsName[:], "\x00"))
+				evt.ProcessName = string(utils.TrimTrailingNUL(ctx.Comm[:]))
+				evt.HostName = string(utils.TrimTrailingNUL(ctx.UtsName[:]))
 				evt.CgroupID = uint(ctx.CgroupID)
 				evt.ContainerID = containerData.ID
 				evt.Container = containerData
@@ -247,8 +246,8 @@ func BenchmarkNewEventObject(b *testing.B) {
 					UserID:                int(ctx.Uid),
 					MountNS:               int(ctx.MntID),
 					PIDNS:                 int(ctx.PidID),
-					ProcessName:           string(bytes.TrimRight(ctx.Comm[:], "\x00")),
-					HostName:              string(bytes.TrimRight(ctx.UtsName[:], "\x00")),
+					ProcessName:           string(utils.TrimTrailingNUL(ctx.Comm[:])),
+					HostName:              string(utils.TrimTrailingNUL(ctx.UtsName[:])),
 					CgroupID:              uint(ctx.CgroupID),
 					ContainerID:           containerData.ID,
 					Container:             containerData,

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -1,7 +1,6 @@
 package ebpf
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -334,7 +333,7 @@ func (t *Tracee) processPrintMemDump(event *trace.Event) error {
 	if err := unix.Uname(&utsName); err != nil {
 		return errfmt.WrapError(err)
 	}
-	arch = string(bytes.TrimRight(utsName.Machine[:], "\x00"))
+	arch = string(utils.TrimTrailingNUL(utsName.Machine[:]))
 	err = events.SetArgValue(event, "arch", arch)
 	if err != nil {
 		return err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -63,3 +63,23 @@ func ReverseString(s string) string {
 	}
 	return string(bytes)
 }
+
+// TrimTrailingNUL returns a subslice of the input with all trailing NUL bytes (0x00) removed.
+// It performs a reverse scan and returns b[:end], avoiding any allocations.
+//
+// This function is optimized for fixed-size, ASCII-compatible C-style buffers where padding
+// with trailing NULs may occur.
+//
+// Note:
+//   - The returned slice shares memory with the original input.
+//   - If you need an independent string or slice, copy it manually.
+//   - This function is not safe for UTF-8 or multibyte character data; it assumes ASCII content only.
+func TrimTrailingNUL(b []byte) []byte {
+	end := len(b)
+
+	for end > 0 && b[end-1] == 0 {
+		end--
+	}
+
+	return b[:end]
+}

--- a/pkg/utils/utils_bench_test.go
+++ b/pkg/utils/utils_bench_test.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+)
+
+var result []byte
+
+func BenchmarkBytesTrimRight_WithNUL(b *testing.B) {
+	var arr [64]byte
+	for i := 0; i < 61; i++ {
+		arr[i] = 'A'
+	}
+	// last 3 bytes are \x00 by default
+
+	for b.Loop() {
+		result = bytes.TrimRight(arr[:], "\x00")
+	}
+	_ = result
+}
+
+func BenchmarkBytesTrimRight_NoNUL(b *testing.B) {
+	var arr [64]byte
+	for i := 0; i < 64; i++ {
+		arr[i] = 'A'
+	}
+
+	for b.Loop() {
+		result = bytes.TrimRight(arr[:], "\x00")
+	}
+	_ = result
+}
+
+func BenchmarkTrimTrailingNUL_WithNUL(b *testing.B) {
+	var arr [64]byte
+	for i := 0; i < 61; i++ {
+		arr[i] = 'A'
+	}
+	// last 3 bytes are \x00 by default
+
+	for b.Loop() {
+		result = TrimTrailingNUL(arr[:])
+	}
+	_ = result
+}
+
+func BenchmarkTrimTrailingNUL_NoNUL(b *testing.B) {
+	var arr [64]byte
+	for i := 0; i < 64; i++ {
+		arr[i] = 'A'
+	}
+
+	for b.Loop() {
+		result = TrimTrailingNUL(arr[:])
+	}
+	_ = result
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrimTrailingNUL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "no NUL",
+			input:    []byte("hello"),
+			expected: []byte("hello"),
+		},
+		{
+			name:     "single trailing NUL",
+			input:    []byte("hello\x00"),
+			expected: []byte("hello"),
+		},
+		{
+			name:     "multiple trailing NULs",
+			input:    []byte("hello\x00\x00\x00"),
+			expected: []byte("hello"),
+		},
+		{
+			name:     "intermediate NUL (preserved)",
+			input:    []byte("he\x00llo\x00"),
+			expected: []byte("he\x00llo"),
+		},
+		{
+			name:     "all NULs",
+			input:    []byte("\x00\x00\x00"),
+			expected: []byte(""),
+		},
+		{
+			name:     "empty slice",
+			input:    []byte(""),
+			expected: []byte(""),
+		},
+		{
+			name:     "no trailing NUL but contains middle NUL",
+			input:    []byte("\x00he\x00llo"),
+			expected: []byte("\x00he\x00llo"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, TrimTrailingNUL(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
### 1. Explain what the PR does

3b8c0f615 **perf(ebpf): improve NUL byte trimming**

```
Introduce utils.TrimTrailingNUL function to handle NUL byte trimming
in a more efficient manner.

Running tool: /home/gg/.goenv/versions/1.24.0/bin/go test -benchmem
-run=^$ -tags ebpf -bench
^(BenchmarkBytesTrimRight_WithNUL|BenchmarkBytesTrimRight_NoNUL|
BenchmarkTrimTrailingNUL_WithNUL|BenchmarkTrimTrailingNUL_NoNUL)$
github.com/aquasecurity/tracee/pkg/utils -benchtime=200000000x -count=5 timeout=5m

goos: linux
goarch: amd64
pkg: github.com/aquasecurity/tracee/pkg/utils
cpu: AMD Ryzen 9 7950X 16-Core Processor

| Benchmark               | Avg Time (ns/op) | Improvement vs TrimRight |
|-------------------------|------------------|--------------------------|
| TrimTrailingNUL_WithNUL | 1.980 ns         | 17.1% faster             |
| BytesTrimRight_WithNUL  | 2.388 ns         | —                        |
| TrimTrailingNUL_NoNUL   | 1.311 ns         | 26.9% faster             |
| BytesTrimRight_NoNUL    | 1.794 ns         | —                        |
```

d7861e6c5 **perf(ebpf): improve decodeEvents (HashTaskID)**

```
Metrics from local benchmarking on a AMD Ryzen 9 7950X 16-Core Processor
with 64GB RAM running 6.12.25-1-MANJARO. The stress test was run
with 8mi events triggered in 8 threads.

- CPU time

| Function     | Before    | After     | Change    | Improvement (%) |
|--------------|-----------|-----------|-----------|-----------------|
| decodeEvents | 26.87 sec | 25.22 sec | -1.65 sec | 6.14%           |
| HashTaskID   | 0.38 sec  | 0.34 sec  | -0.04 sec | 10.53%          |

- Memory

| Metric        | Function     | Before  | After   | Change   | Improv. (%) |
|---------------|--------------|---------|---------|----------|-------------|
| alloc_space   | decodeEvents | 8.52 GB | 8.48 GB | -0.04 GB | 0.47%       |
| inuse_objects | decodeEvents | 1.17 K  | 0.85 K  | -0.32 K  | 27.35%      |
| alloc_objects | decodeEvents | 91.96 M | 89.31 M | -2.65 M  | 2.88%       |
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
