### PR TITLE
Revert "fix(decoder): treat abstract socket in decoder"

### DIFF
--- a/pkg/bufferdecoder/eventsreader_bench_test.go
+++ b/pkg/bufferdecoder/eventsreader_bench_test.go
@@ -7,62 +7,52 @@ import (
 
 var present = NewTypeDecoder()
 
-func Benchmark_readSunPathFromBuff_ShortString(b *testing.B) {
+func BenchmarkReadStringVarFromBuff_ShortString(b *testing.B) {
 	buffer := []byte{'H', 'e', 'l', 'l', 'o', 0}
 	max := 10
 	var str string
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		decoder := New(buffer, present)
-		str, _ = readSunPathFromBuff(decoder, max)
+		str, _ = readVarStringFromBuffer(decoder, max)
 	}
 	_ = str
 }
 
-func Benchmark_readSunPathFromBuff_MediumString(b *testing.B) {
+func BenchmarkReadStringVarFromBuff_MediumString(b *testing.B) {
 	buffer := []byte{'T', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't', 0}
 	max := 20
 	var str string
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		decoder := New(buffer, present)
-		str, _ = readSunPathFromBuff(decoder, max)
+		str, _ = readVarStringFromBuffer(decoder, max)
 	}
 	_ = str
 }
 
-func Benchmark_readSunPathFromBuff_AbstractSocket(b *testing.B) {
-	buffer := []byte{0, 'A', 'b', 's', 't', 'r', 'a', 'c', 't', 0}
-	max := 10
-	var str string
-
-	for b.Loop() {
-		decoder := New(buffer, present)
-		str, _ = readSunPathFromBuff(decoder, max)
-	}
-	_ = str
-}
-
-func Benchmark_readSunPathFromBuff_LongString(b *testing.B) {
+func BenchmarkReadStringVarFromBuff_LongString(b *testing.B) {
 	buffer := append(bytes.Repeat([]byte{'A'}, 10000), 0)
 	max := 10000
 	var str string
 
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		decoder := New(buffer, present)
-		str, _ = readSunPathFromBuff(decoder, max)
+		str, _ = readVarStringFromBuffer(decoder, max)
 	}
 	_ = str
 }
 
-func Benchmark_readSunPathFromBuff_LongStringLowMax(b *testing.B) {
+func BenchmarkReadStringVarFromBuff_LongStringLowMax(b *testing.B) {
 	buffer := bytes.Repeat([]byte{'A'}, 10000)
 	max := 100
 	var str string
 
-	for b.Loop() {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
 		decoder := New(buffer, present)
-		str, _ = readSunPathFromBuff(decoder, max)
+		str, _ = readVarStringFromBuffer(decoder, max)
 	}
 	_ = str
 }


### PR DESCRIPTION
This reverts commit 71b9d2d6046bdcd81254e10cfdaba278990a31d2.

Commit introduced errors decoding some security_socket_connect events in the internal e2e tests. We leave aside the eBPF fixes done in the including PR.