### PR TITLE
fix(ci): github actions do not support yaml anchor

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,7 +3,7 @@ name: "CodeQL Advanced"
 on:
   workflow_dispatch: {}
 
-  push: &common-config
+  push:
     branches:
       - "main"
       - "release-v*.*.*"
@@ -13,7 +13,13 @@ on:
       - "**/*.go"
 
   pull_request:
-    <<: *common-config
+    branches:
+      - "main"
+      - "release-v*.*.*"
+    paths:
+      - "**/*.c"
+      - "**/*.h"
+      - "**/*.go"
 
 jobs:
   analyze:


### PR DESCRIPTION
### 1. Explain what the PR does

0be708fe6 **fix(ci): github actions do not support yaml anchor**

```
The anchor was introduced in 8d9ba5d.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
