### PR TITLE
chore(build): introduce BUILD_TYPE_FLAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,7 +449,14 @@ endif
 #
 
 TRACEE_EBPF_OBJ_SRC = ./pkg/ebpf/c/tracee.bpf.c
-TRACEE_EBPF_OBJ_HEADERS = $(shell find pkg/ebpf/c -name *.h)
+TRACEE_EBPF_OBJ_HEADERS = $(shell find pkg/ebpf/c -name *.h) $(wildcard ./pkg/ebpf/c/tracee.bpf*.c)
+
+EXTENDED_BUILD_EXISTS := $(shell [ -f .extended-build ] && echo yes)
+ifeq ($(EXTENDED_BUILD_EXISTS),yes)
+    BUILD_TYPE_FLAG := EXTENDED_BUILD
+else
+    BUILD_TYPE_FLAG := COMMON_BUILD
+endif
 
 .PHONY: bpf
 bpf: $(OUTPUT_DIR)/tracee.bpf.o
@@ -464,6 +471,7 @@ $(OUTPUT_DIR)/tracee.bpf.o: \
 		-D__TARGET_ARCH_$(LINUX_ARCH) \
 		-D__BPF_TRACING__ \
 		-DCORE \
+		-D$(BUILD_TYPE_FLAG) \
 		$(TRACEE_EBPF_CFLAGS) \
 		-I./pkg/ebpf/c/ \
 		-target bpf \

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -8,14 +8,13 @@
 #include <vmlinux_flavors.h>
 #include <vmlinux_missing.h>
 
-#undef container_of
-
 #include <bpf/bpf_core_read.h>
 #include <bpf/bpf_endian.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_tracing.h>
-#include <maps.h>
+
 #include <types.h>
+#include <maps.h>
 #include <capture_filtering.h>
 #include <tracee.h>
 

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -38,123 +38,148 @@ typedef struct event_context {
     u64 matched_policies;
 } event_context_t;
 
-enum event_id_e
-{
-    // Net events IDs
-    NET_PACKET_BASE = 700,
-    NET_PACKET_RAW,
-    NET_PACKET_IP,
-    NET_PACKET_TCP,
-    NET_PACKET_UDP,
-    NET_PACKET_ICMP,
-    NET_PACKET_ICMPV6,
-    NET_PACKET_DNS,
-    NET_PACKET_HTTP,
-    NET_CAPTURE_BASE,
-    NET_FLOW_BASE,
-    MAX_NET_EVENT_ID,
-    // Common event IDs
-    RAW_SYS_ENTER,
-    RAW_SYS_EXIT,
-    SCHED_PROCESS_FORK,
-    SCHED_PROCESS_EXEC,
-    SCHED_PROCESS_EXIT,
-    SCHED_SWITCH,
-    DO_EXIT,
-    CAP_CAPABLE,
-    VFS_WRITE,
-    VFS_WRITEV,
-    VFS_READ,
-    VFS_READV,
-    MEM_PROT_ALERT,
-    COMMIT_CREDS,
-    SWITCH_TASK_NS,
-    MAGIC_WRITE,
-    CGROUP_ATTACH_TASK,
-    CGROUP_MKDIR,
-    CGROUP_RMDIR,
-    SECURITY_BPRM_CHECK,
-    SECURITY_FILE_OPEN,
-    SECURITY_INODE_UNLINK,
-    SECURITY_SOCKET_CREATE,
-    SECURITY_SOCKET_LISTEN,
-    SECURITY_SOCKET_CONNECT,
-    SECURITY_SOCKET_ACCEPT,
-    SECURITY_SOCKET_BIND,
-    SECURITY_SOCKET_SETSOCKOPT,
-    SECURITY_SB_MOUNT,
-    SECURITY_BPF,
-    SECURITY_BPF_MAP,
-    SECURITY_KERNEL_READ_FILE,
-    SECURITY_INODE_MKNOD,
-    SECURITY_POST_READ_FILE,
-    SECURITY_INODE_SYMLINK,
-    SECURITY_MMAP_FILE,
-    SECURITY_FILE_MPROTECT,
-    SOCKET_DUP,
-    ZEROED_INODES,
-    __KERNEL_WRITE,
-    PROC_CREATE,
-    KPROBE_ATTACH,
-    CALL_USERMODE_HELPER,
-    DIRTY_PIPE_SPLICE,
-    DEBUGFS_CREATE_FILE,
-    SYSCALL_TABLE_CHECK,
-    DEBUGFS_CREATE_DIR,
-    DEVICE_ADD,
-    REGISTER_CHRDEV,
-    SHARED_OBJECT_LOADED,
-    DO_INIT_MODULE,
-    SOCKET_ACCEPT,
-    LOAD_ELF_PHDRS,
-    HOOKED_PROC_FOPS,
-    PRINT_NET_SEQ_OPS,
-    TASK_RENAME,
-    SECURITY_INODE_RENAME,
-    DO_SIGACTION,
-    BPF_ATTACH,
-    KALLSYMS_LOOKUP_NAME,
-    DO_MMAP,
-    PRINT_MEM_DUMP,
-    VFS_UTIMES,
-    DO_TRUNCATE,
-    FILE_MODIFICATION,
-    INOTIFY_WATCH,
-    SECURITY_BPF_PROG,
-    PROCESS_EXECUTE_FAILED,
-    SECURITY_PATH_NOTIFY,
-    SET_FS_PWD,
-    SUSPICIOUS_SYSCALL_SOURCE,
-    STACK_PIVOT,
-    HIDDEN_KERNEL_MODULE_SEEKER,
-    MODULE_LOAD,
-    MODULE_FREE,
-    EXECUTE_FINISHED,
-    PROCESS_EXECUTE_FAILED_INTERNAL,
-    SECURITY_TASK_SETRLIMIT,
-    SECURITY_SETTIME64,
-    CHMOD_COMMON,
-    OPEN_FILE_NS,
-    OPEN_FILE_MOUNT,
-    SECURITY_SB_UMOUNT,
-    MAX_EVENT_ID,
-    NO_EVENT_SUBMIT,
+#define EVENT_ID_LIST_NET                                                                          \
+    X(NET_PACKET_BASE, = 700)                                                                      \
+    X(NET_PACKET_RAW, )                                                                            \
+    X(NET_PACKET_IP, )                                                                             \
+    X(NET_PACKET_TCP, )                                                                            \
+    X(NET_PACKET_UDP, )                                                                            \
+    X(NET_PACKET_ICMP, )                                                                           \
+    X(NET_PACKET_ICMPV6, )                                                                         \
+    X(NET_PACKET_DNS, )                                                                            \
+    X(NET_PACKET_HTTP, )                                                                           \
+    X(NET_CAPTURE_BASE, )                                                                          \
+    X(NET_FLOW_BASE, )                                                                             \
+    X(MAX_NET_EVENT_ID, )                                                                          \
+    // ...
 
-    // Test events IDs
-    EXEC_TEST = 8000,
-    TEST_MISSING_KSYMBOLS,
-    TEST_FAILED_ATTACH,
-};
+#define EVENT_ID_LIST_COMMON                                                                       \
+    X(RAW_SYS_ENTER, )                                                                             \
+    X(RAW_SYS_EXIT, )                                                                              \
+    X(SCHED_PROCESS_FORK, )                                                                        \
+    X(SCHED_PROCESS_EXEC, )                                                                        \
+    X(SCHED_PROCESS_EXIT, )                                                                        \
+    X(SCHED_SWITCH, )                                                                              \
+    X(DO_EXIT, )                                                                                   \
+    X(CAP_CAPABLE, )                                                                               \
+    X(VFS_WRITE, )                                                                                 \
+    X(VFS_WRITEV, )                                                                                \
+    X(VFS_READ, )                                                                                  \
+    X(VFS_READV, )                                                                                 \
+    X(MEM_PROT_ALERT, )                                                                            \
+    X(COMMIT_CREDS, )                                                                              \
+    X(SWITCH_TASK_NS, )                                                                            \
+    X(MAGIC_WRITE, )                                                                               \
+    X(CGROUP_ATTACH_TASK, )                                                                        \
+    X(CGROUP_MKDIR, )                                                                              \
+    X(CGROUP_RMDIR, )                                                                              \
+    X(SECURITY_BPRM_CHECK, )                                                                       \
+    X(SECURITY_FILE_OPEN, )                                                                        \
+    X(SECURITY_INODE_UNLINK, )                                                                     \
+    X(SECURITY_SOCKET_CREATE, )                                                                    \
+    X(SECURITY_SOCKET_LISTEN, )                                                                    \
+    X(SECURITY_SOCKET_CONNECT, )                                                                   \
+    X(SECURITY_SOCKET_ACCEPT, )                                                                    \
+    X(SECURITY_SOCKET_BIND, )                                                                      \
+    X(SECURITY_SOCKET_SETSOCKOPT, )                                                                \
+    X(SECURITY_SB_MOUNT, )                                                                         \
+    X(SECURITY_BPF, )                                                                              \
+    X(SECURITY_BPF_MAP, )                                                                          \
+    X(SECURITY_KERNEL_READ_FILE, )                                                                 \
+    X(SECURITY_INODE_MKNOD, )                                                                      \
+    X(SECURITY_POST_READ_FILE, )                                                                   \
+    X(SECURITY_INODE_SYMLINK, )                                                                    \
+    X(SECURITY_MMAP_FILE, )                                                                        \
+    X(SECURITY_FILE_MPROTECT, )                                                                    \
+    X(SOCKET_DUP, )                                                                                \
+    X(ZEROED_INODES, )                                                                             \
+    X(__KERNEL_WRITE, )                                                                            \
+    X(PROC_CREATE, )                                                                               \
+    X(KPROBE_ATTACH, )                                                                             \
+    X(CALL_USERMODE_HELPER, )                                                                      \
+    X(DIRTY_PIPE_SPLICE, )                                                                         \
+    X(DEBUGFS_CREATE_FILE, )                                                                       \
+    X(SYSCALL_TABLE_CHECK, )                                                                       \
+    X(DEBUGFS_CREATE_DIR, )                                                                        \
+    X(DEVICE_ADD, )                                                                                \
+    X(REGISTER_CHRDEV, )                                                                           \
+    X(SHARED_OBJECT_LOADED, )                                                                      \
+    X(DO_INIT_MODULE, )                                                                            \
+    X(SOCKET_ACCEPT, )                                                                             \
+    X(LOAD_ELF_PHDRS, )                                                                            \
+    X(HOOKED_PROC_FOPS, )                                                                          \
+    X(PRINT_NET_SEQ_OPS, )                                                                         \
+    X(TASK_RENAME, )                                                                               \
+    X(SECURITY_INODE_RENAME, )                                                                     \
+    X(DO_SIGACTION, )                                                                              \
+    X(BPF_ATTACH, )                                                                                \
+    X(KALLSYMS_LOOKUP_NAME, )                                                                      \
+    X(DO_MMAP, )                                                                                   \
+    X(PRINT_MEM_DUMP, )                                                                            \
+    X(VFS_UTIMES, )                                                                                \
+    X(DO_TRUNCATE, )                                                                               \
+    X(FILE_MODIFICATION, )                                                                         \
+    X(INOTIFY_WATCH, )                                                                             \
+    X(SECURITY_BPF_PROG, )                                                                         \
+    X(PROCESS_EXECUTE_FAILED, )                                                                    \
+    X(SECURITY_PATH_NOTIFY, )                                                                      \
+    X(SET_FS_PWD, )                                                                                \
+    X(SUSPICIOUS_SYSCALL_SOURCE, )                                                                 \
+    X(STACK_PIVOT, )                                                                               \
+    X(HIDDEN_KERNEL_MODULE_SEEKER, )                                                               \
+    X(MODULE_LOAD, )                                                                               \
+    X(MODULE_FREE, )                                                                               \
+    X(EXECUTE_FINISHED, )                                                                          \
+    X(PROCESS_EXECUTE_FAILED_INTERNAL, )                                                           \
+    X(SECURITY_TASK_SETRLIMIT, )                                                                   \
+    X(SECURITY_SETTIME64, )                                                                        \
+    X(CHMOD_COMMON, )                                                                              \
+    X(OPEN_FILE_NS, )                                                                              \
+    X(OPEN_FILE_MOUNT, )                                                                           \
+    X(SECURITY_SB_UMOUNT, )                                                                        \
+    // ...
 
-enum signal_event_id_e
+#define EVENT_ID_LIST_LAST                                                                         \
+    X(MAX_EVENT_ID, )                                                                              \
+    X(NO_EVENT_SUBMIT, )
+
+#define EVENT_ID_LIST_TEST                                                                         \
+    X(EXEC_TEST, = 8000)                                                                           \
+    X(TEST_MISSING_KSYMBOLS, )                                                                     \
+    X(TEST_FAILED_ATTACH, )                                                                        \
+    // ...
+
+#ifndef EXTENDED_BUILD
+typedef enum event_id_e
 {
-    SIGNAL_CGROUP_MKDIR = 5000,
-    SIGNAL_CGROUP_RMDIR,
-    SIGNAL_SCHED_PROCESS_FORK,
-    SIGNAL_SCHED_PROCESS_EXEC,
-    SIGNAL_SCHED_PROCESS_EXIT,
-    SIGNAL_HEARTBEAT,
-};
+    #define X(name, val) name val,
+    // clang-format off
+    EVENT_ID_LIST_NET
+    EVENT_ID_LIST_COMMON
+    EVENT_ID_LIST_LAST
+    EVENT_ID_LIST_TEST
+    // clang-format on
+    #undef X
+} event_id_e;
+#endif // #ifndef EXTENDED_BUILD
+
+#define SIGNAL_EVENT_ID_LIST                                                                       \
+    X(SIGNAL_CGROUP_MKDIR, = 5000)                                                                 \
+    X(SIGNAL_CGROUP_RMDIR, )                                                                       \
+    X(SIGNAL_SCHED_PROCESS_FORK, )                                                                 \
+    X(SIGNAL_SCHED_PROCESS_EXEC, )                                                                 \
+    X(SIGNAL_SCHED_PROCESS_EXIT, )                                                                 \
+    X(SIGNAL_HEARTBEAT, )                                                                          \
+    // ...
+
+#ifndef EXTENDED_BUILD
+typedef enum signal_event_id_e
+{
+    #define X(name, val) name val,
+    SIGNAL_EVENT_ID_LIST
+    #undef X
+} signal_event_id_e;
+#endif // #ifndef EXTENDED_BUILD
 
 typedef struct args {
     unsigned long args[6];
@@ -186,10 +211,18 @@ enum argument_type_e
 
 #define ARG_TYPE_MAX_ARRAY (u8) TIMESPEC_T // last element defined in argument_type_e
 
-enum internal_hook_e
+#define INTERNAL_HOOK_LIST                                                                         \
+    X(EXEC_BINPRM, = 80000)                                                                        \
+    // ...
+
+#ifndef EXTENDED_BUILD
+typedef enum internal_hook_e
 {
-    EXEC_BINPRM = 80000,
-};
+    #define X(name, val) name val,
+    INTERNAL_HOOK_LIST
+    #undef X
+} internal_hook_e;
+#endif // #ifndef EXTENDED_BUILD
 
 enum mem_prot_alert_e
 {


### PR DESCRIPTION
### 1. Explain what the PR does

9d2c1b2d3 **chore(build): introduce BUILD_TYPE_FLAG**

```
This makes use of x-macros to make extendable build types.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
