### PR TITLE
fix integration tests and related

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -909,6 +909,7 @@ test-integration: \
 			-X main.version=\"$(VERSION)\" \
 			" \
 		-shuffle on \
+		-timeout 20m \
 		-race \
 		-v \
 		-p 1 \

--- a/tests/integration/capture_test.go
+++ b/tests/integration/capture_test.go
@@ -90,6 +90,11 @@ func Test_TraceeCapture(t *testing.T) {
 			// start tracee
 			ready, runErr := running.Start(20 * time.Second)
 			require.NoError(t, runErr)
+			defer func() {
+				if errs := running.Stop(); len(errs) > 0 {
+					t.Logf("failed to stop tracee: %v", errs)
+				}
+			}()
 
 			r := <-ready // block until tracee is ready (or not)
 			switch r {

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -195,14 +195,15 @@ func Test_EventsDependencies(t *testing.T) {
 				goto cleanup
 			}
 
-			closeLogsDone()
-			if !<-logsResultChan {
-				t.Logf("Test %s failed: not all logs were found", t.Name())
-				failed = true
-			}
 		cleanup:
 			// ensure that logsDone is closed
 			closeLogsDone()
+			if !<-logsResultChan { // always consume the result channel
+				if !failed {
+					t.Logf("Test %s failed: not all logs were found", t.Name())
+					failed = true
+				}
+			}
 			restoreLogger()
 			cancel()
 			errStop := waitForTraceeStop(trc)

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1828,10 +1828,10 @@ func Test_EventFilters(t *testing.T) {
 					// Running the commands inside a container caused duplicate
 					// security_file_open events to be generated. This is why the events are duplicated.
 					[]trace.Event{
-						expectEvent(anyHost, "more", anyProcessorID, 1, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/etc/ld.so.cache")),
-						expectEvent(anyHost, "more", anyProcessorID, 1, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/etc/ld.so.cache")),
-						expectEvent(anyHost, "more", anyProcessorID, 1, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-3"), orPolIDs(1, 3), expectArg("pathname", "/etc/netconfig")),
-						expectEvent(anyHost, "more", anyProcessorID, 1, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-3"), orPolIDs(1, 3), expectArg("pathname", "/etc/netconfig")),
+						expectEvent(anyHost, "more", anyProcessorID, anyPID, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/etc/ld.so.cache")),
+						expectEvent(anyHost, "more", anyProcessorID, anyPID, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-2"), orPolIDs(1, 2), expectArg("pathname", "/etc/ld.so.cache")),
+						expectEvent(anyHost, "more", anyProcessorID, anyPID, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-3"), orPolIDs(1, 3), expectArg("pathname", "/etc/netconfig")),
+						expectEvent(anyHost, "more", anyProcessorID, anyPID, 0, events.SecurityFileOpen, orPolNames("sfo-pol-1", "sfo-pol-3"), orPolIDs(1, 3), expectArg("pathname", "/etc/netconfig")),
 					},
 					[]string{},
 				),

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -2311,19 +2311,28 @@ func Test_EventFilters(t *testing.T) {
 			}
 			config.InitialPolicies = initialPolicies
 
-			ctx, cancel := context.WithCancel(context.Background())
+			traceeTimeout := 60 * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), traceeTimeout)
+			defer func() {
+				if ctx.Err() != nil {
+					if ctx.Err() == context.DeadlineExceeded {
+						t.Log("  Tracee timedout")
+					} else {
+						t.Logf("  %v", ctx.Err())
+					}
+				}
+				cancel()
+			}()
 
 			// start tracee
 			trc, err := startTracee(ctx, t, config, nil, nil)
 			if err != nil {
-				cancel()
 				t.Fatal(err)
 			}
 
 			t.Logf("  --- started tracee ---")
 			err = waitForTraceeStart(trc)
 			if err != nil {
-				cancel()
 				t.Fatal(err)
 			}
 

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -548,50 +548,53 @@ func Test_EventFilters(t *testing.T) {
 		},
 		// TODO: Add pid>0 pid<1000
 		// TODO: Add u>0 u!=1000
-		{
-			// This test is a bit tricky, as it relies on the environment where the test is run.
-			// The main goal is to ensure that at least one event coming from pid 0 (swapper) is captured.
-			name: "pid: event: data: trace event sched_switch with data from pid 0",
-			policyFiles: []testutils.PolicyFileWithID{
-				{
-					Id: 1,
-					PolicyFile: v1beta1.PolicyFile{
-						Metadata: v1beta1.Metadata{
-							Name: "pid-0-event-data",
-						},
-						Spec: k8s.PolicySpec{
-							Scope: []string{
-								"pid=0",
-							},
-							DefaultActions: []string{"log"},
-							Rules: []k8s.Rule{
-								{
-									Event:   "sched_switch",
-									Filters: []string{},
-								},
-							},
-						},
-					},
-				},
-			},
-			cmdEvents: []cmdEvents{
-				newCmdEvents(
-					// Do not execute any command; simply wait to capture background system activity (primarily from Tracee).
-					// During this waiting period, the system is expected to produce numerous 'sched_switch' events
-					// from the 'swapper' process (pid 0), even in minimal environments with only one CPU.
-					expectFromSystem,
-					100*time.Millisecond, // wait
-					0,                    // this value is ignored when 'expectFromSystem' is used
-					[]trace.Event{
-						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-data"), orPolIDs(1)),
-					},
-					[]string{},
-				),
-			},
-			useSyscaller: false,
-			coolDown:     1 * time.Second,
-			test:         ExpectAllEvtsEqualToOne,
-		},
+		// {
+		//   Disabled due to flaky behavior in some environments, see:
+		//   https://github.com/aquasecurity/tracee/issues/4799#issuecomment-3018918112
+		//
+		// 	// This test is a bit tricky, as it relies on the environment where the test is run.
+		// 	// The main goal is to ensure that at least one event coming from pid 0 (swapper) is captured.
+		// 	name: "pid: event: data: trace event sched_switch with data from pid 0",
+		// 	policyFiles: []testutils.PolicyFileWithID{
+		// 		{
+		// 			Id: 1,
+		// 			PolicyFile: v1beta1.PolicyFile{
+		// 				Metadata: v1beta1.Metadata{
+		// 					Name: "pid-0-event-data",
+		// 				},
+		// 				Spec: k8s.PolicySpec{
+		// 					Scope: []string{
+		// 						"pid=0",
+		// 					},
+		// 					DefaultActions: []string{"log"},
+		// 					Rules: []k8s.Rule{
+		// 						{
+		// 							Event:   "sched_switch",
+		// 							Filters: []string{},
+		// 						},
+		// 					},
+		// 				},
+		// 			},
+		// 		},
+		// 	},
+		// 	cmdEvents: []cmdEvents{
+		// 		newCmdEvents(
+		// 			// Do not execute any command; simply wait to capture background system activity (primarily from Tracee).
+		// 			// During this waiting period, the system is expected to produce numerous 'sched_switch' events
+		// 			// from the 'swapper' process (pid 0), even in minimal environments with only one CPU.
+		// 			expectFromSystem,
+		// 			100*time.Millisecond, // wait
+		// 			0,                    // this value is ignored when 'expectFromSystem' is used
+		// 			[]trace.Event{
+		// 				expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-data"), orPolIDs(1)),
+		// 			},
+		// 			[]string{},
+		// 		),
+		// 	},
+		// 	useSyscaller: false,
+		// 	coolDown:     1 * time.Second,
+		// 	test:         ExpectAllEvtsEqualToOne,
+		// },
 		{
 			name: "pid: trace events from pid 1",
 			policyFiles: []testutils.PolicyFileWithID{

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -548,6 +549,8 @@ func Test_EventFilters(t *testing.T) {
 		// TODO: Add pid>0 pid<1000
 		// TODO: Add u>0 u!=1000
 		{
+			// This test is a bit tricky, as it relies on the environment where the test is run.
+			// The main goal is to ensure that at least one event coming from pid 0 (swapper) is captured.
 			name: "pid: event: data: trace event sched_switch with data from pid 0",
 			policyFiles: []testutils.PolicyFileWithID{
 				{
@@ -563,10 +566,8 @@ func Test_EventFilters(t *testing.T) {
 							DefaultActions: []string{"log"},
 							Rules: []k8s.Rule{
 								{
-									Event: "sched_switch",
-									Filters: []string{
-										"data.next_comm=systemd",
-									},
+									Event:   "sched_switch",
+									Filters: []string{},
 								},
 							},
 						},
@@ -575,18 +576,21 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"kill -SIGUSR1 1", // systemd: try to reconnect to the D-Bus bus
-					500*time.Millisecond,
-					1*time.Second,
+					// Do not execute any command; simply wait to capture background system activity (primarily from Tracee).
+					// During this waiting period, the system is expected to produce numerous 'sched_switch' events
+					// from the 'swapper' process (pid 0), even in minimal environments with only one CPU.
+					expectFromSystem,
+					100*time.Millisecond, // wait
+					0,                    // this value is ignored when 'expectFromSystem' is used
 					[]trace.Event{
-						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-data"), orPolIDs(1), expectArg("next_comm", "systemd")),
+						expectEvent(anyHost, anyComm, anyProcessorID, 0, 0, events.SchedSwitch, orPolNames("pid-0-event-data"), orPolIDs(1)),
 					},
 					[]string{},
 				),
 			},
 			useSyscaller: false,
 			coolDown:     1 * time.Second,
-			test:         ExpectAtLeastOneForEach,
+			test:         ExpectAllEvtsEqualToOne,
 		},
 		{
 			name: "pid: trace events from pid 1",
@@ -2377,6 +2381,9 @@ func Test_EventFilters(t *testing.T) {
 }
 
 const (
+	expectFromSystem    = ""
+	expectFromSystemPid = math.MaxInt
+
 	anyProcessorID = -1
 	anyHost        = ""
 	anyComm        = ""
@@ -2486,14 +2493,20 @@ func runCmd(t *testing.T, cmd cmdEvents, expectedEvts int, actual *eventBuffer, 
 		err error
 	)
 
-	if useSyscaller {
-		formatCmdEvents(&cmd)
-	}
+	if cmd.runCmd == expectFromSystem {
+		pid = expectFromSystemPid
 
-	t.Logf("  >>> running: %s", cmd.runCmd)
-	pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
-	if err != nil {
-		return proc{}, err
+		t.Log("  >>> expect events from system")
+	} else {
+		if useSyscaller {
+			formatCmdEvents(&cmd)
+		}
+
+		t.Logf("  >>> running: %s", cmd.runCmd)
+		pid, err = testutils.ExecPinnedCmdWithTimeout(cmd.runCmd, cmd.timeout)
+		if err != nil {
+			return proc{}, err
+		}
 	}
 
 	err = waitForTraceeOutputEvents(t, cmd.waitFor, actual, expectedEvts, failOnTimeout)

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -217,7 +217,7 @@ func waitForTraceeOutputEvents(t *testing.T, waitFor time.Duration, actual *even
 	timeoutTicker := time.NewTicker(timeout)
 	defer timeoutTicker.Stop()
 
-	t.Logf("  . waiting for at least %d event(s) for %s", expectedEvts, timeout.String())
+	t.Logf("  . waiting for at least %d event(s), up to %s", expectedEvts, timeout.String())
 	defer t.Logf("  . done waiting for %d event(s)", expectedEvts)
 
 	for {


### PR DESCRIPTION
Close: #4799
Close: #4782 
Close: #4192
Relate: #4068

### 1. Explain what the PR does

33bcc1a9c **chore(tests): disable pid 0 swapper (sched_switch)**
711da2f77 **fix(tests): pid 0 event from swapper**
651f5ff85 **fix(tests): pidToCheck special pids**
c16b7dd09 **fix(tests): dependencies and logger**
4a60cabfd **chore(tests): increase integration test timeout**
54df2c847 **fix(tests): fix a container events test case**
78dd6257d **fix(pcaps): replace slashes in ProcessName**


33bcc1a9c **chore(tests): disable pid 0 swapper (sched_switch)**

```
Even though the failure rate has been reduced, the test still
occasionally fails in specific environments. See:
https://github.com/aquasecurity/tracee/issues/4799#issuecomment-3018918112
```

711da2f77 **fix(tests): pid 0 event from swapper**

```
This also adds a command-line flag to allow tests to expect system events
(expectFromSystem) instead of events generated by running specific
commands.
```

4a60cabfd **chore(tests): increase integration test timeout**

```
This also adds a timeout for Tracee running instance.
```

54df2c847 **fix(tests): fix a container events test case**

```
When events come from a container, the actual pid is not previously
known, so it must not be checked.
```

78dd6257d **fix(pcaps): replace slashes in ProcessName**

```
When captures are generated from a ProcessName containing slashes,
the resulting capture file path becomes invalid. This commit replaces
slashes in ProcessName with underscores, ensuring all generated paths
are valid and compatible with the filesystem.

This also:

- Add MkdirAllAtExist() and refactor mkdirForPcapType().
- Add an extra Stop for Tracee to ensure that it is finished even in the
  case of an error.
```

### 2. Explain how to test it


### 3. Other comments

