### PR TITLE
Fast e2e

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -311,6 +311,7 @@ jobs:
       - graas_ami-${{ matrix.ami }}_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}_${{ matrix.sufix }}
       - EXECUTION_TYPE=LONG
     strategy:
+      fail-fast: false
       matrix:
         include: ${{fromJson(needs.generate-matrix.outputs.matrix01)}}
     env:

--- a/pkg/containers/containers.go
+++ b/pkg/containers/containers.go
@@ -253,6 +253,7 @@ func (c *Manager) EnrichCgroupInfo(cgroupId uint64) (Container, error) {
 		}
 		c.cgroupsMap[uint32(cgroupId)] = info
 		c.containerMap[containerId] = container
+		cont = container
 	}
 
 	return cont, nil

--- a/pkg/ebpf/c/common/memory.h
+++ b/pkg/ebpf/c/common/memory.h
@@ -81,7 +81,7 @@ statfunc struct mount *real_mount(struct vfsmount *mnt)
  * To be extra safe and accomodate for VMA counts higher than 1000,
  * we define the max traversal depth as 25.
  */
-#define MAX_VMA_RB_TREE_DEPTH 25
+#define MAX_VMA_RB_TREE_DEPTH 35
 
 static bool alerted_find_vma_unsupported = false;
 
@@ -114,12 +114,14 @@ statfunc struct vm_area_struct *find_vma(void *ctx, struct task_struct *task, u6
         unsigned long vm_end = BPF_CORE_READ(tmp, vm_end);
 
         if (vm_end > addr) {
-            vma = tmp;
-            if (vm_start <= addr)
+            if (vm_start <= addr) {
+                vma = tmp;
                 break;
+            }
             rb_node = BPF_CORE_READ(rb_node, rb_left);
-        } else
+        } else {
             rb_node = BPF_CORE_READ(rb_node, rb_right);
+        }
     }
 
     return vma;

--- a/tests/e2e-inst-signatures/e2e-containers_data_source.go
+++ b/tests/e2e-inst-signatures/e2e-containers_data_source.go
@@ -64,7 +64,7 @@ func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
 
 		containerId := eventObj.Container.ID
 		if containerId == "" {
-			return errors.New("received non container event")
+			return fmt.Errorf("received non container event: %+v", eventObj)
 		}
 
 		container, err := sig.containersData.Get(containerId)
@@ -74,7 +74,7 @@ func (sig *e2eContainersDataSource) OnEvent(event protocol.Event) error {
 
 		containerIdData, ok := container["container_id"].(string)
 		if !ok {
-			return errors.New("failed to extract container id from container data")
+			return fmt.Errorf("failed to extract container id (\"%s\") from container data", containerId)
 		}
 
 		if containerIdData != containerId {

--- a/tests/e2e-inst-signatures/e2e-security_path_notify.go
+++ b/tests/e2e-inst-signatures/e2e-security_path_notify.go
@@ -12,6 +12,7 @@ import (
 
 type e2eSecurityPathNotify struct {
 	cb             detect.SignatureHandler
+	log            detect.Logger
 	found_dnotify  bool
 	found_inotify  bool
 	found_fanotify bool
@@ -19,6 +20,7 @@ type e2eSecurityPathNotify struct {
 
 func (sig *e2eSecurityPathNotify) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
+	sig.log = ctx.Logger
 	return nil
 }
 
@@ -56,10 +58,13 @@ func (sig *e2eSecurityPathNotify) OnEvent(event protocol.Event) error {
 
 		if strings.HasSuffix(pathName, "/dnotify_test") {
 			sig.found_dnotify = true
+			sig.log.Infow("found dnotify_test", "pathname", pathName)
 		} else if strings.HasSuffix(pathName, "/inotify_test") {
 			sig.found_inotify = true
+			sig.log.Infow("found inotify_test", "pathname", pathName)
 		} else if strings.HasSuffix(pathName, "/fanotify_test") {
 			sig.found_fanotify = true
+			sig.log.Infow("found fanotify_test", "pathname", pathName)
 		} else {
 			return nil
 		}

--- a/tests/e2e-inst-signatures/e2e-stack_pivot.go
+++ b/tests/e2e-inst-signatures/e2e-stack_pivot.go
@@ -11,12 +11,13 @@ import (
 
 type e2eStackPivot struct {
 	cb            detect.SignatureHandler
-	falsePositive bool
+	log           detect.Logger
+	falsePositive bool // TODO: re-figure out how to handle false positives, currently they get triggered by other tests
 }
 
 func (sig *e2eStackPivot) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
-
+	sig.log = ctx.Logger
 	return nil
 }
 

--- a/tests/e2e-net-signatures/e2e-dns.go
+++ b/tests/e2e-net-signatures/e2e-dns.go
@@ -23,6 +23,7 @@ type e2eDNS struct {
 	foundNS  bool
 	foundSOA bool
 	cb       detect.SignatureHandler
+	log      detect.Logger
 }
 
 func (sig *e2eDNS) Init(ctx detect.SignatureContext) error {
@@ -30,6 +31,7 @@ func (sig *e2eDNS) Init(ctx detect.SignatureContext) error {
 	sig.foundMX = false  // proforma
 	sig.foundNS = false  // proforma
 	sig.foundSOA = false // proforma
+	sig.log = ctx.Logger
 	return nil
 }
 
@@ -73,14 +75,17 @@ func (sig *e2eDNS) OnEvent(event protocol.Event) error {
 				if answer.MX.Name == "smtp.google.com" &&
 					answer.MX.Preference == 10 {
 					sig.foundMX = true
+					sig.log.Infow("found MX", "name", answer.MX.Name, "preference", answer.MX.Preference)
 				}
 				// check if NS works
 				if answer.NS == "ns1.google.com" {
 					sig.foundNS = true
+					sig.log.Infow("found NS", "name", answer.NS)
 				}
 				// check if SOA works
 				if answer.SOA.RName == "dns-admin.google.com" {
 					sig.foundSOA = true
+					sig.log.Infow("found SOA", "name", answer.SOA.RName)
 				}
 			}
 		}

--- a/tests/e2e-net-signatures/e2e-http.go
+++ b/tests/e2e-net-signatures/e2e-http.go
@@ -18,11 +18,13 @@ import (
 //        This will cause it trigger once and reset it status.
 
 type e2eHTTP struct {
-	cb detect.SignatureHandler
+	cb  detect.SignatureHandler
+	log detect.Logger
 }
 
 func (sig *e2eHTTP) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
+	sig.log = ctx.Logger
 	return nil
 }
 
@@ -74,10 +76,12 @@ func (sig *e2eHTTP) OnEvent(event protocol.Event) error {
 		}
 
 		if !testHttpDirectionAndPacketDirection(&md, &http) {
+			sig.log.Infow("direction mismatch", "direction", http.Direction, "packet_direction", md.Direction)
 			return nil
 		}
 
 		if !strings.HasPrefix(http.Protocol, "HTTP/") {
+			sig.log.Infow("not HTTP", "protocol", http.Protocol)
 			return nil
 		}
 

--- a/tests/e2e-net-signatures/e2e-httprequest.go
+++ b/tests/e2e-net-signatures/e2e-httprequest.go
@@ -18,11 +18,13 @@ import (
 //        This will cause it trigger once and reset it status.
 
 type e2eHTTPRequest struct {
-	cb detect.SignatureHandler
+	cb  detect.SignatureHandler
+	log detect.Logger
 }
 
 func (sig *e2eHTTPRequest) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
+	sig.log = ctx.Logger
 	return nil
 }
 
@@ -65,6 +67,11 @@ func (sig *e2eHTTPRequest) OnEvent(event protocol.Event) error {
 		}
 
 		if !strings.HasPrefix(httpRequest.Protocol, "HTTP/") {
+			return nil
+		}
+
+		if !strings.HasSuffix(httpRequest.Host, "google.com") {
+			sig.log.Infow("not google.com", "host", httpRequest.Host)
 			return nil
 		}
 

--- a/tests/e2e-net-signatures/e2e-httpresponse.go
+++ b/tests/e2e-net-signatures/e2e-httpresponse.go
@@ -18,11 +18,13 @@ import (
 //        This will cause it trigger once and reset it status.
 
 type e2eHTTPResponse struct {
-	cb detect.SignatureHandler
+	cb  detect.SignatureHandler
+	log detect.Logger
 }
 
 func (sig *e2eHTTPResponse) Init(ctx detect.SignatureContext) error {
 	sig.cb = ctx.Callback
+	sig.log = ctx.Logger
 	return nil
 }
 
@@ -61,6 +63,16 @@ func (sig *e2eHTTPResponse) OnEvent(event protocol.Event) error {
 		}
 
 		if !strings.HasPrefix(httpResponse.Protocol, "HTTP/") {
+			sig.log.Infow("not HTTP", "protocol", httpResponse.Protocol)
+			return nil
+		}
+
+		location := httpResponse.Headers["Location"]
+		if len(location) == 0 {
+			return nil
+		}
+		if !strings.Contains(location[0], "google.com") {
+			sig.log.Infow("not google.com", "location", location[0])
 			return nil
 		}
 

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -43,7 +43,7 @@ if [[ $KERNEL_MAJ -lt 5 && "$KERNEL" != *"el8"* ]]; then
 fi
 
 # run CO-RE IPv4 test only by default
-TESTS=${NETTESTS:=IPv4}
+TESTS=${NETTESTS:=DNS HTTP IPv4 IPv6 ICMP ICMPv6 TCP UDP}
 
 # startup needs
 rm -rf $TRACEE_TMP_DIR/* || error_exit "could not delete $TRACEE_TMP_DIR"
@@ -78,91 +78,93 @@ fi
 # if any test has failed
 anyerror=""
 
+rm -f $SCRIPT_TMP_DIR/build-$$
+
+logfile=$SCRIPT_TMP_DIR/tracee-log-$$
+outputfile=$SCRIPT_TMP_DIR/output-$$
+
+tracee_command="./dist/tracee \
+    --install-path $TRACEE_TMP_DIR \
+    --cache cache-type=mem \
+    --cache mem-cache-size=512 \
+    --output json:$outputfile \
+    --log file:$logfile \
+    --policy ./tests/policies/net/ \
+    --signatures-dir ./dist/e2e-net-signatures/"
+
+eval "$tracee_command &"
+
+# wait tracee to be started (30 sec most)
+times=0
+timedout=0
+while true; do
+    times=$(($times + 1))
+    sleep 1
+    if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
+        info
+        info "UP AND RUNNING"
+        info
+        break
+    fi
+
+    if [[ $times -gt $TRACEE_STARTUP_TIMEOUT ]]; then
+        timedout=1
+        break
+    fi
+done
+
+# tracee could not start for some reason, check stderr
+if [[ $timedout -eq 1 ]]; then
+    info
+    info "TIMEDOUT"
+    info
+    cat $logfile
+
+    exit 1
+fi
+
+# give some time for tracee to settle
+sleep 3
+
 # run tests
+info "= RUNNING TESTS ================================================"
+info
 for TEST in $TESTS; do
 
     info
-    info "= TEST: $TEST =============================================="
+    info "= $TEST TEST RUNNING =========================================="
     info
 
-    rm -f $SCRIPT_TMP_DIR/build-$$
-
-    tracee_command="./dist/tracee \
-        --install-path $TRACEE_TMP_DIR \
-        --cache cache-type=mem \
-        --cache mem-cache-size=512 \
-        --output json \
-        --scope comm=ping,nc,nslookup,isc-net-0000,isc-worker0000,curl \
-        --signatures-dir ./dist/e2e-net-signatures/ 2>&1 \
-        | tee $SCRIPT_TMP_DIR/build-$$"
-
-    eval "$tracee_command &"
-
-    # wait tracee to be started (30 sec most)
-    times=0
-    timedout=0
-    while true; do
-        times=$(($times + 1))
-        sleep 1
-        if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
-            info
-            info "UP AND RUNNING"
-            info
-            break
-        fi
-
-        if [[ $times -gt $TRACEE_STARTUP_TIMEOUT ]]; then
-            timedout=1
-            break
-        fi
-    done
-
-    # tracee could not start for some reason, check stderr
-    if [[ $timedout -eq 1 ]]; then
-        info
-        info "$TEST: FAILED. ERRORS:"
-        info
-        cat $SCRIPT_TMP_DIR/build-$$
-
-        anyerror="${anyerror}$TEST,"
-        continue
-    fi
-
-    # give some time for tracee to settle
-    sleep 3
-
+    info "running test $TEST"
     # run test scripts
     timeout --preserve-status $TRACEE_RUN_TIMEOUT \
         ./tests/e2e-net-signatures/scripts/${TEST,,}.sh
 
-    # so event can be processed and detected
-    sleep 3
+done
 
-    ## cleanup at EXIT
+# so events can be processed and detected
+sleep 5
 
-    # make sure we exit both to start them again
+mapfile -t tracee_pids < <(pgrep -x tracee)
+kill -SIGINT "${tracee_pids[@]}"
+sleep $TRACEE_SHUTDOWN_TIMEOUT
+# make sure tracee is exited with SIGKILL
+kill -SIGKILL "${tracee_pids[@]}" >/dev/null 2>&1
 
-    mapfile -t tracee_pids < <(pgrep -x tracee)
-
-    kill -SIGINT "${tracee_pids[@]}"
-
-    sleep $TRACEE_SHUTDOWN_TIMEOUT
-
-    # make sure tracee is exited with SIGKILL
-    kill -SIGKILL "${tracee_pids[@]}" >/dev/null 2>&1
-
-    # give a little break for OS noise to reduce
-    sleep 3
-
+info "= CHECKING TESTS RESULTS ======================================"
+info
+for TEST in $TESTS; do
     found=0
-    cat $SCRIPT_TMP_DIR/build-$$ | grep "\"signatureID\":\"$TEST\"" -B2 && found=1
+    cat $outputfile | grep "\"signatureID\":\"$TEST\"" -B2 && found=1
     info
     if [[ $found -eq 1 ]]; then
         info "$TEST: SUCCESS"
     else
         anyerror="${anyerror}$TEST,"
         info "$TEST: FAILED, stderr from tracee:"
-        cat $SCRIPT_TMP_DIR/build-$$
+        cat $logfile
+        info "$TEST: FAILED, stdout from tracee:"
+        cat $outputfile
         
         info "Tracee command:"
         echo "$tracee_command" | tr -s ' '
@@ -177,14 +179,16 @@ for TEST in $TESTS; do
             info "NO, Tracee is not running, as expected"
         fi
         info
+
+        info
     fi
     info
-
-    rm -f $SCRIPT_TMP_DIR/build-$$
-
-    # cleanup leftovers
-    rm -rf $TRACEE_TMP_DIR
 done
+
+# Cleanup leftovers
+rm -f $outputfile
+rm -f $logfile
+rm -rf $TRACEE_TMP_DIR
 
 info
 if [[ $anyerror != "" ]]; then

--- a/tests/policies/inst/bpf_attach.yaml
+++ b/tests/policies/inst/bpf_attach.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: bpf-attach-test
+  annotations:
+    description: test tracee's bpf attach events
+spec:
+  scope: 
+    - comm=tracee
+  rules:
+    - event: BPF_ATTACH

--- a/tests/policies/inst/containers_ds.yaml
+++ b/tests/policies/inst/containers_ds.yaml
@@ -1,0 +1,12 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: containers-ds-test
+  annotations:
+    description: test tracee's containers data source events
+spec:
+  scope: 
+    - container=new
+    - comm=ls
+  rules:
+    - event: CONTAINERS_DATA_SOURCE

--- a/tests/policies/inst/dns_ds.yaml
+++ b/tests/policies/inst/dns_ds.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: dns-ds-test
+  annotations:
+    description: test tracee's dns data source events
+spec:
+  scope: 
+    - comm=ping
+  rules:
+    - event: DNS_DATA_SOURCE

--- a/tests/policies/inst/file_modification.yaml
+++ b/tests/policies/inst/file_modification.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: file-modification-test
+  annotations:
+    description: test tracee's file modification events
+spec:
+  scope: 
+    - comm=echo,write
+  rules:
+    - event: FILE_MODIFICATION

--- a/tests/policies/inst/ftrace_hook.yaml
+++ b/tests/policies/inst/ftrace_hook.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: ftrace-hook-test
+  annotations:
+    description: test tracee's ftrace hook events
+spec:
+  scope: 
+    - global # TODO: what is the scope for this event?
+  rules:
+    - event: FTRACE_HOOK

--- a/tests/policies/inst/hooked_syscall.yaml
+++ b/tests/policies/inst/hooked_syscall.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: hooked-syscall-test
+  annotations:
+    description: test tracee's hooked syscall events
+spec:
+  scope: 
+    - global # TODO: what is the scope for this event?
+  rules:
+    - event: HOOKED_SYSCALL

--- a/tests/policies/inst/process_execute_failed.yaml
+++ b/tests/policies/inst/process_execute_failed.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: execute-failed-test
+  annotations:
+    description: test tracee's execute failed events
+spec:
+  scope: 
+    - comm=process_execute
+  rules:
+    - event: PROCESS_EXECUTE_FAILED

--- a/tests/policies/inst/proctree_ds.yaml
+++ b/tests/policies/inst/proctree_ds.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: proctree-ds-test
+  annotations:
+    description: test tracee's proctree data source events
+spec: 
+  scope: 
+    - comm=proctreetester
+  rules:
+    - event: PROCTREE_DATA_SOURCE

--- a/tests/policies/inst/security_inode_rename.yaml
+++ b/tests/policies/inst/security_inode_rename.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: security-inode-rename-test
+  annotations:
+    description: test tracee's security inode rename events
+spec:
+  scope: 
+    - comm=echo,mv
+  rules:
+    - event: SECURITY_INODE_RENAME

--- a/tests/policies/inst/security_path_notify.yaml
+++ b/tests/policies/inst/security_path_notify.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: security-path-notify-test
+  annotations:
+    description: test tracee's security path notify events
+spec:
+  scope: 
+    - comm=fsnotify_tester
+  rules:
+    - event: SECURITY_PATH_NOTIFY

--- a/tests/policies/inst/setfspwd.yaml
+++ b/tests/policies/inst/setfspwd.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: set-fs-pwd-test
+  annotations:
+    description: test tracee's setfs pwd events
+spec:
+  scope: 
+    - comm=set_fs_pwd.sh
+  rules:
+    - event: SET_FS_PWD

--- a/tests/policies/inst/stack_pivot.yaml
+++ b/tests/policies/inst/stack_pivot.yaml
@@ -1,0 +1,14 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: stack-pivot-test
+  annotations:
+    description: test tracee's stack pivot events
+spec:
+  scope: 
+    - global
+  rules:
+    - event: STACK_PIVOT # e2e signature for tracing
+    - event: stack_pivot # actual event to pass the parameters
+      filters:
+        - args.syscall=exit_group,getpid,write,openat,mmap,execve,fork,clone,recvmsg,gettid,epoll_wait,poll,recvfrom

--- a/tests/policies/inst/suspicious_syscall_source.yaml
+++ b/tests/policies/inst/suspicious_syscall_source.yaml
@@ -1,0 +1,14 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: suspicious-syscall-src-test
+  annotations:
+    description: test tracee's suspicious syscall source events
+spec:
+  scope: 
+    - comm=sys_src_tester
+  rules:
+    - event: SUSPICIOUS_SYSCALL_SOURCE # e2e signature for tracing
+    - event: suspicious_syscall_source # actual event to pass the parameters
+      filters:
+      - args.syscall=exit

--- a/tests/policies/inst/vfs_write.yaml
+++ b/tests/policies/inst/vfs_write.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: vfs-write-test
+  annotations:
+    description: test tracee's vfs write events
+spec:
+  scope: 
+    - comm=echo,write
+  rules:
+    - event: VFS_WRITE

--- a/tests/policies/inst/writable_ds.yaml
+++ b/tests/policies/inst/writable_ds.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: writable-ds-test
+  annotations:
+    description: test tracee's writable data source events
+spec:
+  scope: 
+    - comm=ds_writer
+  rules:
+    - event: WRITABLE_DATA_SOURCE

--- a/tests/policies/kernel/kernel.yaml
+++ b/tests/policies/kernel/kernel.yaml
@@ -1,0 +1,40 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: kernel-test
+  annotations:
+    description: test tracee's kernel events
+spec:
+  scope: 
+    - container=new
+  rules:
+    - event: stdio_over_socket
+    - event: k8s_api_connection
+    - event: aslr_inspection
+    - event: proc_mem_code_injection
+    - event: docker_abuse
+    - event: scheduled_task_mod
+    - event: ld_preload
+    - event: cgroup_notify_on_release
+    - event: default_loader_mod
+    - event: sudoers_modification
+    - event: sched_debug_recon
+    - event: system_request_key_mod
+    - event: cgroup_release_agent
+    - event: rcd_modification
+    - event: core_pattern_modification
+    - event: proc_kcore_read
+    - event: proc_mem_access
+    - event: hidden_file_created
+    - event: anti_debugging
+    - event: ptrace_code_injection
+    - event: process_vm_write_inject
+    - event: disk_mount
+    - event: dynamic_code_loading
+    - event: fileless_execution
+    - event: illegitimate_shell
+    - event: kernel_module_loading
+    - event: k8s_cert_theft
+    - event: proc_fops_hooking
+    - event: syscall_hooking
+    - event: dropped_executable

--- a/tests/policies/net/dns.yaml
+++ b/tests/policies/net/dns.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: dns-test
+  annotations:
+    description: test tracee's dns events
+spec:
+  scope: 
+    - comm=nslookup,isc-net-0000,isc-worker0000 # nslookup uses these commands internally
+  rules:
+    - event: DNS

--- a/tests/policies/net/http.yaml
+++ b/tests/policies/net/http.yaml
@@ -1,0 +1,13 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: http-test
+  annotations:
+    description: test tracee's http events
+spec:
+  scope: 
+    - comm=curl
+  rules:
+    - event: HTTP
+    - event: HTTPRequest
+    - event: HTTPResponse

--- a/tests/policies/net/icmp.yaml
+++ b/tests/policies/net/icmp.yaml
@@ -1,0 +1,12 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: icmp-test
+  annotations:
+    description: test tracee's icmp events
+spec:
+  scope: 
+    - comm=ping
+  rules:
+    - event: ICMP
+    - event: ICMPv6

--- a/tests/policies/net/ip.yaml
+++ b/tests/policies/net/ip.yaml
@@ -1,0 +1,12 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: ip-test
+  annotations:
+    description: test tracee's ip events
+spec:
+  scope: 
+    - comm=ping
+  rules:
+    - event: IPv4
+    - event: IPv6

--- a/tests/policies/net/tcp.yaml
+++ b/tests/policies/net/tcp.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: tcp-test
+  annotations:
+    description: test tracee's tcp events
+spec:
+  scope: 
+    - comm=nc
+  rules:
+    - event: TCP

--- a/tests/policies/net/udp.yaml
+++ b/tests/policies/net/udp.yaml
@@ -1,0 +1,11 @@
+apiVersion: tracee.aquasec.com/v1beta1
+kind: Policy
+metadata:
+  name: udp-test
+  annotations:
+    description: test tracee's udp events
+spec:
+  scope: 
+    - comm=nc
+  rules:
+    - event: UDP


### PR DESCRIPTION
### 1. Explain what the PR does


7af368649 **refactor(e2e): run e2e tests faster (in parallel)**
04c491dd4 **fix(ebpf): stack_pivot fixes**
6b6b06b04 **fix(containers): return enriched container**


7af368649 **refactor(e2e): run e2e tests faster (in parallel)**

```
- E2E tests now trigger test scripts in parallel
- Detection happens after tracee exits from the output file
- Split the events and scopes per test into policy files
- Add logging to some e2e signatures for debugging
- Add some new validation checks in the e2e signatures
```

04c491dd4 **fix(ebpf): stack_pivot fixes**

```
- Don't return latest vma found if none found
- Increase tree size to reduce false positive chance
```

6b6b06b04 **fix(containers): return enriched container**

```
The returned container was not updated to its enriched counterpart after success.
```

### 2. Explain how to test it

1. Look at the tests below
2. They should be green and take about 10 minutes
3. Rejoice

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
