### PR TITLE
Set default buffer pages apprioprate for page size

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -172,10 +172,11 @@ func initCmd() error {
 
 	// Buffer/Cache flags
 
+	defaultBufferPages := (4096 * 1024) / os.Getpagesize() // 4 MB of contiguous pages
 	rootCmd.Flags().IntP(
 		"perf-buffer-size",
 		"b",
-		1024, // 4 MB of contiguous pages
+		defaultBufferPages,
 		"<size>\t\t\t\tSize, in pages, of the internal perf ring buffer used to submit events from the kernel",
 	)
 	err = viper.BindPFlag("perf-buffer-size", rootCmd.Flags().Lookup("perf-buffer-size"))
@@ -185,7 +186,7 @@ func initCmd() error {
 
 	rootCmd.Flags().Int(
 		"blob-perf-buffer-size",
-		1024, // 4 MB of contiguous pages
+		defaultBufferPages,
 		"<size>\t\t\t\tSize, in pages, of the internal perf ring buffer used to send blobs from the kernel",
 	)
 	err = viper.BindPFlag("blob-perf-buffer-size", rootCmd.Flags().Lookup("blob-perf-buffer-size"))

--- a/tests/integration/tracee.go
+++ b/tests/integration/tracee.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -94,8 +95,9 @@ func startTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 
 	cfg.Capture = capture
 
-	cfg.PerfBufferSize = 1024
-	cfg.BlobPerfBufferSize = 1024
+	defaultBufferPages := (4096 * 1024) / os.Getpagesize() // 4 MB of contiguous pages
+	cfg.PerfBufferSize = defaultBufferPages
+	cfg.BlobPerfBufferSize = defaultBufferPages
 	cfg.PipelineChannelSize = 10000
 
 	// No process tree in the integration tests


### PR DESCRIPTION
The 1024 default for `--perf-buffer-size` and `--blob-perf-buffer-size` assumes a 4KB page size to give 4MB of contiguous memory per perfbuffer. But Arm and Powerpc architectures can have page sizes of 64KB and that could require a lot of memory on servers with many cores as perfbuffers are per cpu. Fix by calculating the defaults to give 4MB per perfbuffer.

<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

Close: #4817 

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
