### PR TITLE
Fix clang issue

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -360,9 +360,9 @@ statfunc int save_str_arr_to_buf(args_buffer_t *buf, const char __user *const __
     }
     // handle truncated argument list
     char ellipsis[] = "...";
-    if (buf->offset > ARGS_BUF_SIZE - MAX_STRING_SIZE - sizeof(int))
-        // not enough space - return
-        goto out;
+
+    // Clamp buffer offset to prevent overflow
+    update_min(buf->offset, ARGS_BUF_SIZE - MAX_STRING_SIZE - sizeof(int));
 
     // Read into buffer
     int sz = bpf_probe_read_str(&(buf->args[buf->offset + sizeof(int)]), MAX_STRING_SIZE, ellipsis);

--- a/pkg/ebpf/c/common/common.h
+++ b/pkg/ebpf/c/common/common.h
@@ -125,8 +125,8 @@ static __inline int strncmp(char *str1, char *str2, int n)
         ({                                                                                         \
             asm volatile("if %[size] <= %[max_size] goto +1;\n"                                    \
                          "%[size] = %[max_size];\n"                                                \
-                         :                                                                         \
-                         : [size] "r"(__var), [max_size] "r"(__max_const));                        \
+                         : [size] "+r"(__var)                                                      \
+                         : [max_size] "r"(__max_const));                                           \
         })
 #endif
 

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -756,7 +756,7 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     return 0;
 }
 
-#define MAX_NUM_MODULES          420
+#define MAX_NUM_MODULES          330
 #define MAX_MODULES_MAP_ENTRIES  2 * MAX_NUM_MODULES
 #define MOD_TREE_LOOP_ITERATIONS 240
 #define MOD_TREE_LOOP_DEPTH      14


### PR DESCRIPTION
### 1. Explain what the PR does

First commit:

```
    ebpf: fix update_min macro to properly modify original variable
    
    The update_min macro was broken because it lacked output constraints in its
    inline assembly, causing it to only work on a register copy without writing
    back to the original variable.
    
    Add the missing '+r' output constraint to [size] parameter so the macro can
    actually modify the original variable instead of just working on a register copy.
    
    This fix is needed for the macro to work correctly with struct fields like
    buf->offset, not just local variables.
```


Second commit:

```
    ebpf: fix buffer bounds checking for clang 15 compatibility
    
    Replace explicit bounds checks with the fixed update_min macro in buffer
    functions to help the BPF verifier understand memory access safety with
    newer clang versions.
    
    The issue occurs because clang 15+ optimizes arithmetic differently,
    making it harder for the BPF verifier to prove memory access safety.
    The update_min macro provides explicit constraints the verifier can
    understand.
    
    Also reduce MAX_NUM_MODULES from 420 to 330 as a workaround for BPF verifier
    complexity limits.
```

Fixes: #4397 

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
