### PR TITLE
Fix signature loading

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -131,7 +131,8 @@ func main() {
 
 			config := engine.Config{
 				SignatureBufferSize: c.Uint(signatureBufferFlag),
-				Signatures:          sigs,
+				AvailableSignatures: sigs,
+				SelectedSignatures:  sigs, // In tracee-rules, load all signatures
 				DataSources:         []detect.DataSource{},
 			}
 			e, err := engine.NewEngine(config, inputs, output)

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -51,7 +51,8 @@ func Analyze(cfg Config) {
 
 	engineConfig := engine.Config{
 		Mode:                engine.ModeAnalyze,
-		Signatures:          signatures,
+		AvailableSignatures: signatures,
+		SelectedSignatures:  signatures, // in analyze mode, load all signatures
 		SignatureBufferSize: 1000,
 		SigNameToEventID:    sigNamesToIds,
 	}

--- a/pkg/signatures/benchmark/benchmark_test.go
+++ b/pkg/signatures/benchmark/benchmark_test.go
@@ -75,7 +75,8 @@ func BenchmarkEngineWithCodeInjectionSignature(b *testing.B) {
 				require.NoError(b, err, bc.name)
 
 				config := engine.Config{
-					Signatures: []detect.Signature{s},
+					AvailableSignatures: []detect.Signature{s},
+					SelectedSignatures:  []detect.Signature{s},
 				}
 
 				e, err := engine.NewEngine(config, inputs, output)
@@ -136,7 +137,8 @@ func BenchmarkEngineWithNSignatures(b *testing.B) {
 					output := make(chan *detect.Finding, inputEventsCount*len(sigs))
 
 					config := engine.Config{
-						Signatures: sigs,
+						AvailableSignatures: sigs,
+						SelectedSignatures:  sigs,
 					}
 
 					e, err := engine.NewEngine(config, inputs, output)

--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -355,7 +355,8 @@ func TestEngine_ConsumeSources(t *testing.T) {
 				return nil
 			}
 
-			tc.config.Signatures = sigs
+			tc.config.AvailableSignatures = sigs
+			tc.config.SelectedSignatures = sigs
 
 			e, err := NewEngine(tc.config, inputs, outputChan)
 			require.NoError(t, err, "constructing engine")
@@ -422,7 +423,7 @@ func TestEngine_GetSelectedEvents(t *testing.T) {
 		},
 	}
 
-	config := Config{Signatures: sigs}
+	config := Config{AvailableSignatures: sigs, SelectedSignatures: sigs}
 	e, err := NewEngine(config, EventSources{Tracee: make(chan protocol.Event)}, make(chan *detect.Finding))
 	require.NoError(t, err, "constructing engine")
 


### PR DESCRIPTION
### 1. Explain what the PR does

Fix and optimize signature loading

First commit:
```
    fix: optimize signature loading by filtering based on policy requirements
    
    Previously, Tracee would start goroutines for ALL available signatures
    during initialization, regardless of whether they were actually needed
    based on the configured policies. This led to unnecessary resource usage
    when many signatures were available but only a subset was required.
    
    Changes:
    - Introduce AvailableSignatures vs SelectedSignatures distinction in engine.Config
    - Add selectSignaturesBasedOnPolicies() function to filter signatures based on policy event requirements
    - Update engine.Init() to only load SelectedSignatures instead of all available signatures
    - Ensure only policy-required signatures get goroutines started via loadSignature()
    
    Performance improvement:
    - Before: N available signatures = N goroutines started
    - After: Only signatures required by policies get goroutines started
    
    This optimization significantly reduces memory usage and improves startup
    performance for deployments with many available signatures but restrictive
    policies.
```

Second commit:

```
    Optimize EnableEvent/DisableEvent to control signature goroutines
    
    Previously, EnableEvent/DisableEvent only controlled event emission via policy
    flags, but signature goroutines continued running even when disabled, wasting
    CPU and memory resources.
    
    Now these API functions also call LoadSignature/UnloadSignature to dynamically
    start/stop signature processing goroutines, providing true resource optimization
    for signature events.
    
    Key changes:
    - EnableEvent: loads signature and starts goroutine for signature events
    - DisableEvent: unloads signature and stops goroutine for signature events
    - Maintains full backward compatibility for non-signature events
    - Adds signature detection using eventDef.IsSignature()
    - Includes proper error handling and logging
    
    This optimization allows runtime control of signature resource usage without
    requiring a Tracee restart.
```

Third commit:
```
    Use signature ID for duplicate checking in loadSignature
    
    - Change loadSignature to use signature ID instead of object identity for duplicate checking
    - Makes it consistent with UnloadSignature which also uses signature ID
    - Improves robustness by not relying on object identity
    - Fixes potential issues if signature objects are recreated or cloned in the future
```



### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
