### PR TITLE
perf: reduce pipeline-channel-size default from 10000 to 1000

### DIFF
--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -210,7 +210,7 @@ func initCmd() error {
 
 	rootCmd.Flags().Int(
 		"pipeline-channel-size",
-		10000,
+		1000,
 		"<size>\t\t\t\tSize, in event objects, of each pipeline stage's output channel",
 	)
 	err = viper.BindPFlag("pipeline-channel-size", rootCmd.Flags().Lookup("pipeline-channel-size"))

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -154,7 +154,7 @@ A complete config file with all available options can be found [here](https://gi
 
 - **`--pipeline-channel-size`**: Specifies the size of each pipeline stage's output channel.
 
-  Default: `10000`
+  Default: `1000`
 
   YAML:
   ```yaml


### PR DESCRIPTION
### 1. Explain what the PR does

Reduces memory usage when pipeline channels are full, from ~8.4MB to ~840KB per channel. Also enables faster backpressure detection when consumers cannot keep up with event rates.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
