### PR TITLE
fix: network event context

### DIFF
--- a/pkg/ebpf/c/common/context.h
+++ b/pkg/ebpf/c/common/context.h
@@ -54,7 +54,11 @@ statfunc int init_task_context(task_context_t *tsk_ctx, struct task_struct *task
     if (is_compat(task))
         tsk_ctx->flags |= IS_COMPAT_FLAG;
 
-    // Program name
+    // Program name - initialize to 0 before getting comm, because in some kernels (5.18-6.3)
+    // the destination buffer is not padded with zeroes (see
+    // https://github.com/torvalds/linux/commit/03b9c7fa3f15f51bcd07f3828c2a01311e7746c4 and
+    // https://github.com/torvalds/linux/commit/f3f21349779776135349a8e6f114a1485b2476b7)
+    __builtin_memset(&tsk_ctx->comm, 0, sizeof(tsk_ctx->comm));
     bpf_get_current_comm(&tsk_ctx->comm, sizeof(tsk_ctx->comm));
 
     // UTS Name

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -6072,6 +6072,10 @@ int BPF_KRETPROBE(trace_ret_sock_alloc_file)
     if (inode == 0)
         return 0;
 
+    // initialize task context before submit since it will not be available when
+    // submitting the network event.
+    init_task_context(&p.event->context.task, p.event->task, p.config->options);
+
     // save context to further create an event when no context exists
     net_task_context_t netctx = {0};
     set_net_task_context(p.event, &netctx);
@@ -6190,6 +6194,10 @@ int BPF_KPROBE(trace_security_socket_recvmsg)
 
     if (!evaluate_scope_filters(&p))
         return 0;
+    
+    // initialize task context before submit since it will not be available when
+    // submitting the network event.
+    init_task_context(&p.event->context.task, p.event->task, p.config->options);
 
     return update_net_inodemap(sock, p.event);
 }
@@ -6215,6 +6223,10 @@ int BPF_KPROBE(trace_security_socket_sendmsg)
 
     if (!evaluate_scope_filters(&p))
         return 0;
+    
+    // initialize task context before submit since it will not be available when
+    // submitting the network event.
+    init_task_context(&p.event->context.task, p.event->task, p.config->options);
 
     return update_net_inodemap(sock, p.event);
 }
@@ -6442,10 +6454,6 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
     //
 
     neteventctx.bytes = 0; // event arg size: no payload by default (changed inside skb prog)
-
-    // initialize task context before submit since it will not be available when
-    // submitting the network event.
-    init_task_context(&eventctx->task, p.event->task, p.config->options);
 
     // TODO: log collisions
     bpf_map_update_elem(cgrpctxmap, &indexer, &neteventctx, BPF_NOEXIST);


### PR DESCRIPTION
Fix incorrect network event context by initializing the task context in the correct places.

This fixes 2 bugs:

Issue #4068 where captured packets and packet events had incorrect context. This is a result of commit f806cb4 that moved the context initialization to the event submit stage.
Context for network events is copied from the regular event context and saved to `inodemap`. Because of the above commit, the context for the regular event was not initialized. An attempted fix was made in commit cf391b4, but the context was initialized in the wrong location, resulting in kernel threads being used as the context in some cases.

Another bug, where in some kernel versions the process name contained leftover data (e.g. "python3\u0000rver"). This is becuase in kernels 5.18-6.3 the desitnation buffer in `bpf_get_current_comm` is not padded with zeroes. This bug only ever affected network events because after the attempted fix in cf391b4, the comm field of the task context was overwritten by a possibly different (and incorrect) name, and part of the previous name that was written in `match_scope_filters` if comm filtering is enabled remained.