### PR TITLE
fix(events): [2]int type presentation

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -762,7 +762,7 @@ var CoreEvents = map[ID]Definition{
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		fields: []DataField{
-			{DecodeAs: data.INT_ARR_2_T, ArgMeta: trace.ArgMeta{Type: "[2]int32", Name: "pipefd"}},
+			{DecodeAs: data.INT_ARR_2_T, ArgMeta: trace.ArgMeta{Type: "[2]int", Name: "pipefd"}},
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -1516,7 +1516,7 @@ var CoreEvents = map[ID]Definition{
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "domain"}},
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "type"}},
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "protocol"}},
-			{DecodeAs: data.INT_ARR_2_T, ArgMeta: trace.ArgMeta{Type: "[2]int32", Name: "sv"}},
+			{DecodeAs: data.INT_ARR_2_T, ArgMeta: trace.ArgMeta{Type: "[2]int", Name: "sv"}},
 		},
 		dependencies: Dependencies{
 			probes: []Probe{
@@ -7334,7 +7334,7 @@ var CoreEvents = map[ID]Definition{
 		syscall: true,
 		sets:    []string{"syscalls", "ipc", "ipc_pipe"},
 		fields: []DataField{
-			{DecodeAs: data.INT_ARR_2_T, ArgMeta: trace.ArgMeta{Type: "[2]int32", Name: "pipefd"}},
+			{DecodeAs: data.INT_ARR_2_T, ArgMeta: trace.ArgMeta{Type: "[2]int", Name: "pipefd"}},
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "flags"}},
 		},
 		dependencies: Dependencies{


### PR DESCRIPTION
### 1. Explain what the PR does

commit 08f1768390f3df0005686d2f37d782821a858246
```
Author: Nadav Strahilevitz <nadav.strahilevitz@aquasec.com>
Date:   Tue Jul 22 13:51:15 2025 +0000

    fix(events): [2]int type presentation
    
    Aligns the presentation type to match the decode type default.
    
    Fixes: #4796
```
### 2. Explain how to test it

1. tracee --events pipe --events pipe2 --events socketpair
2. No decode failures

### 3. Other comments

Fixes #4796