### PR TITLE
perf: replace parallel signature engine with sequential processing

### DIFF
--- a/cmd/tracee-rules/main.go
+++ b/cmd/tracee-rules/main.go
@@ -22,10 +22,6 @@ import (
 	"github.com/aquasecurity/tracee/types/detect"
 )
 
-const (
-	signatureBufferFlag = "sig-buffer"
-)
-
 func main() {
 	app := &cli.App{
 		Name:  "tracee-rules",
@@ -130,7 +126,6 @@ func main() {
 			}
 
 			config := engine.Config{
-				SignatureBufferSize: c.Uint(signatureBufferFlag),
 				AvailableSignatures: sigs,
 				SelectedSignatures:  sigs, // In tracee-rules, load all signatures
 				DataSources:         []detect.DataSource{},
@@ -213,11 +208,6 @@ func main() {
 			&cli.BoolFlag{
 				Name:  "list-events",
 				Usage: "print a list of events that currently loaded signatures require",
-			},
-			&cli.UintFlag{
-				Name:  signatureBufferFlag,
-				Usage: "size of the event channel's buffer consumed by signatures",
-				Value: 1000,
 			},
 			&cli.BoolFlag{
 				Name:  server.MetricsEndpointFlag,

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -184,16 +184,6 @@ func initCmd() error {
 		return errfmt.WrapError(err)
 	}
 
-	rootCmd.Flags().Bool(
-		"sequential-signatures",
-		true,
-		"\t\t\t\tUse sequential signature processing for CPU optimization (reduces overhead but loses parallelism)",
-	)
-	err = viper.BindPFlag("sequential-signatures", rootCmd.Flags().Lookup("sequential-signatures"))
-	if err != nil {
-		return errfmt.WrapError(err)
-	}
-
 	// Buffer/Cache flags
 
 	defaultBufferPages := (4096 * 1024) / os.Getpagesize() // 4 MB of contiguous pages

--- a/pkg/analyze/analyze.go
+++ b/pkg/analyze/analyze.go
@@ -53,7 +53,6 @@ func Analyze(cfg Config) {
 		Mode:                engine.ModeAnalyze,
 		AvailableSignatures: signatures,
 		SelectedSignatures:  signatures, // in analyze mode, load all signatures
-		SignatureBufferSize: 1000,
 	}
 
 	// two seperate contexts.

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -367,20 +367,11 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 		logger.Debugw("No-signatures mode enabled, using same signature selection as normal mode for fair comparison")
 	}
 
-	sequentialSignatures := viper.GetBool("sequential-signatures")
-	if sequentialSignatures {
-		logger.Debugw("Sequential signatures mode enabled for CPU optimization")
-	}
-
 	runner.TraceeConfig.EngineConfig = engine.Config{
 		Mode:                engine.ModeSingleBinary,
 		NoSignatures:        noSignaturesMode,
-		UseSequential:       sequentialSignatures,
 		AvailableSignatures: signatures,
 		SelectedSignatures:  selectSignaturesBasedOnPolicies(signatures, initialPolicies),
-		// This used to be a flag, we have removed the flag from this binary to test
-		// if users do use it or not.
-		SignatureBufferSize: 200,
 		DataSources:         dataSources,
 	}
 

--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -28,10 +28,8 @@ const (
 
 // Config defines the engine's configurable values
 type Config struct {
-	Mode                Mode // Engine in pipeline mode, can be ModeRules, ModeAnalyze or ModeSingleBinary
-	NoSignatures        bool // Skip signature processing while keeping events loaded (for performance testing)
-	UseSequential       bool // Use sequential processing for CPU optimization
-	SignatureBufferSize uint
+	Mode                Mode               // Engine in pipeline mode, can be ModeRules, ModeAnalyze or ModeSingleBinary
+	NoSignatures        bool               // Skip signature processing while keeping events loaded (for performance testing)
 	AvailableSignatures []detect.Signature // All available signatures found in signature directories
 	SelectedSignatures  []detect.Signature // Only signatures that should be loaded based on user policies/events
 	DataSources         []detect.DataSource
@@ -39,12 +37,11 @@ type Config struct {
 
 // Engine is a signatures-engine that can process events coming from a set of input sources against a set of loaded signatures, and report the signatures' findings
 type Engine struct {
-	signatures       map[detect.Signature]chan protocol.Event
+	signatures       map[detect.Signature]struct{}
 	signaturesIndex  map[detect.SignatureEventSelector][]detect.Signature
 	signaturesMutex  sync.RWMutex
 	inputs           EventSources
 	output           chan *detect.Finding
-	waitGroup        sync.WaitGroup
 	config           Config
 	stats            metrics.Stats
 	dataSources      map[string]map[string]detect.DataSource
@@ -68,14 +65,13 @@ func NewEngine(config Config, sources EventSources, output chan *detect.Finding)
 		return nil, errors.New("nil input received")
 	}
 	engine := Engine{}
-	engine.waitGroup = sync.WaitGroup{}
 
 	engine.inputs = sources
 	engine.output = output
 	engine.config = config
 
 	engine.signaturesMutex.Lock()
-	engine.signatures = make(map[detect.Signature]chan protocol.Event)
+	engine.signatures = make(map[detect.Signature]struct{})
 	engine.signaturesIndex = make(map[detect.SignatureEventSelector][]detect.Signature)
 	engine.signaturesMutex.Unlock()
 
@@ -84,20 +80,6 @@ func NewEngine(config Config, sources EventSources, output chan *detect.Finding)
 	engine.dataSourcesMutex.Unlock()
 
 	return &engine, nil
-}
-
-// signatureStart is the signature handling business logics.
-func signatureStart(signature detect.Signature, c chan protocol.Event, wg *sync.WaitGroup, noSignatures bool) {
-	for e := range c {
-		if noSignatures {
-			continue // Just drain the channel without processing
-		}
-		if err := signature.OnEvent(e); err != nil {
-			meta, _ := signature.GetMetadata()
-			logger.Errorw("Handling event by signature " + meta.Name + ": " + err.Error())
-		}
-	}
-	wg.Done()
 }
 
 // Init loads and initializes signatures and data sources passed in NewEngine.
@@ -129,32 +111,15 @@ func (engine *Engine) Init() error {
 // note that the input and output channels are created by the consumer and therefore are not closed
 func (engine *Engine) Start(ctx context.Context) {
 	defer engine.unloadAllSignatures()
-
-	if engine.config.UseSequential {
-		logger.Debugw("Starting signature engine in sequential mode for CPU optimization")
-	} else {
-		logger.Debugw("Starting signature engine in parallel mode")
-		// Only start goroutines in parallel mode
-		engine.signaturesMutex.RLock()
-		for s, c := range engine.signatures {
-			engine.waitGroup.Add(1)
-			go signatureStart(s, c, &engine.waitGroup, engine.config.NoSignatures)
-		}
-		engine.signaturesMutex.RUnlock()
-	}
-
+	logger.Debugw("Starting signature engine")
 	engine.consumeSources(ctx)
 }
 
 func (engine *Engine) unloadAllSignatures() {
 	engine.signaturesMutex.Lock()
 	defer engine.signaturesMutex.Unlock()
-	for sig, c := range engine.signatures {
+	for sig := range engine.signatures {
 		sig.Close()
-		// Only close channel if it exists (parallel mode)
-		if c != nil {
-			close(c)
-		}
 		delete(engine.signatures, sig)
 	}
 	engine.signaturesIndex = make(map[detect.SignatureEventSelector][]detect.Signature)
@@ -188,7 +153,6 @@ func (engine *Engine) matchHandler(res *detect.Finding) {
 func (engine *Engine) checkCompletion() bool {
 	if engine.inputs.Tracee == nil {
 		engine.unloadAllSignatures()
-		engine.waitGroup.Wait()
 		return true
 	}
 	return false
@@ -297,17 +261,17 @@ drain:
 }
 
 func (engine *Engine) dispatchEvent(s detect.Signature, event protocol.Event) {
-	if engine.config.UseSequential {
-		// Sequential mode: Direct call for maximum CPU efficiency
-		if !engine.config.NoSignatures {
-			if err := s.OnEvent(event); err != nil {
-				meta, _ := s.GetMetadata()
-				logger.Errorw("Processing event in signature " + meta.Name + ": " + err.Error())
-			}
+	// Early return if NoSignatures is enabled
+	if engine.config.NoSignatures {
+		return
+	}
+
+	if err := s.OnEvent(event); err != nil {
+		if meta, metaErr := s.GetMetadata(); metaErr == nil {
+			logger.Errorw("Processing event in signature", "signature", meta.Name, "error", err)
+		} else {
+			logger.Errorw("Processing event in signature", "signature", "unknown", "error", err, "metadata_error", metaErr)
 		}
-	} else {
-		// Parallel mode: Original channel dispatch
-		engine.signatures[s] <- event
 	}
 }
 
@@ -318,14 +282,6 @@ func (engine *Engine) LoadSignature(signature detect.Signature) (string, error) 
 	id, err := engine.loadSignature(signature)
 	if err != nil {
 		return id, err
-	}
-
-	// Only start goroutine in parallel mode
-	if !engine.config.UseSequential {
-		engine.signaturesMutex.RLock()
-		engine.waitGroup.Add(1)
-		go signatureStart(signature, engine.signatures[signature], &engine.waitGroup, engine.config.NoSignatures)
-		engine.signaturesMutex.RUnlock()
 	}
 
 	metadata, _ := signature.GetMetadata()
@@ -375,14 +331,7 @@ func (engine *Engine) loadSignature(signature detect.Signature) (string, error) 
 	}
 
 	engine.signaturesMutex.Lock()
-	if engine.config.UseSequential {
-		// Sequential mode: No channel needed, store nil
-		engine.signatures[signature] = nil
-	} else {
-		// Parallel mode: Create and store channel
-		c := make(chan protocol.Event, engine.config.SignatureBufferSize)
-		engine.signatures[signature] = c
-	}
+	engine.signatures[signature] = struct{}{}
 	engine.signaturesMutex.Unlock()
 
 	// insert in engine.signaturesIndex map
@@ -428,17 +377,13 @@ func (engine *Engine) UnloadSignature(signatureId string) error {
 	engine.signaturesMutex.Lock()
 	defer engine.signaturesMutex.Unlock()
 	// remove from engine.signatures map
-	c, ok := engine.signatures[signature]
+	_, ok := engine.signatures[signature]
 	if ok {
 		delete(engine.signatures, signature)
 		defer func() {
 			_ = engine.stats.Signatures.Decrement()
 		}()
 		defer signature.Close()
-		// Only close channel if it exists (parallel mode)
-		if c != nil {
-			defer close(c)
-		}
 
 		metadata, _ := signature.GetMetadata()
 		logger.Debugw("Signature unloaded at runtime", "signature", metadata.Name, "event", metadata.EventName, "id", metadata.ID)


### PR DESCRIPTION
### 1. Explain what the PR does

This PR is a follow-up of https://github.com/aquasecurity/tracee/pull/4842
It removes the parallel signature engine in favor of the sequential engine.

- Remove UseSequential flag and conditional logic
- Eliminate per-signature goroutines and channels
- Direct function calls for maximum CPU efficiency
- Reduces CPU usage by ~7-15% and memory by ~6MB

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
