### PR TITLE
gitignore: add clangd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 # needed for the makefile btfhub building logic
 *.md5
 
+# ignore clangd files
+.clangd
+
 # ignore local and temporary packaging files
 debian
 .ubuntu*


### PR DESCRIPTION
### 1. Explain what the PR does

Add .clangd to .gitignore to exclude clangd language server cache files from version control.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
