### PR TITLE
fix(events/derive): prevent pointer aliasing in cached derived events**

### DIFF
--- a/pkg/events/derive/derive.go
+++ b/pkg/events/derive/derive.go
@@ -163,3 +163,27 @@ func makeDeriveBase(eventID events.ID) deriveBase {
 		Fields: def.GetFields(),
 	}
 }
+
+// shallowCopyEvent creates a shallow copy of the given trace.Event.
+// It allocates a new trace.Event struct, copies all top-level fields, and creates a new Args slice,
+// copying each trace.Argument value. However, any reference types within trace.Argument (such as Value),
+// or other reference-type fields in trace.Event (e.g., slices, maps, pointers, or structs containing them),
+// are not deeply copied. Changes to nested reference data (like a map or slice in an argument's Value)
+// will affect both the original and the copy.
+//
+// Note: This includes strings - while immutable, their backing arrays may be shared if derived from a slice.
+// Modifying the original backing array (e.g., via a byte slice) can affect both the original and copied event.
+//
+// In summary, this function duplicates the event structure and its argument list, but does NOT deep copy
+// any nested reference data.
+func shallowCopyEvent(event *trace.Event) *trace.Event {
+	if event == nil {
+		return nil
+	}
+
+	evtCopy := *event
+	evtCopy.Args = make([]trace.Argument, len(event.Args))
+	copy(evtCopy.Args, event.Args)
+
+	return &evtCopy
+}

--- a/pkg/events/derive/hidden_kernel_module.go
+++ b/pkg/events/derive/hidden_kernel_module.go
@@ -92,7 +92,9 @@ func deriveHiddenKernelModulesArgs() multiDeriveArgsFunction {
 		} else if flags&kset != 0 || flags&modTree != 0 {
 			// These types of scan only happens once on tracee's startup.
 			// Cache results and only send them out when receiving that the history scan finished successfully
-			eventsFromHistoryScan.Add(event, struct{}{})
+
+			evtCopy := shallowCopyEvent(event)
+			eventsFromHistoryScan.Add(evtCopy, struct{}{})
 			return nil, nil
 		} else if flags&historyScanFinished != 0 {
 			// Happens only once on tracee's startup when the scan finished (successfully/unsuccessfully)

--- a/pkg/events/derive/process_execute_failed.go
+++ b/pkg/events/derive/process_execute_failed.go
@@ -95,7 +95,8 @@ func (gen *ExecFailedGenerator) handleExecFinished(event *trace.Event) (*trace.E
 func (gen *ExecFailedGenerator) handleExecBaseEvent(event *trace.Event) (*trace.Event, error) {
 	// We don't have the execution end info - cache current event and wait for it to be received
 	// This is the expected flow, as the execution finished event come chronology after
-	gen.baseEvents.Add(event.HostProcessID, event)
+	evtCopy := shallowCopyEvent(event)
+	gen.baseEvents.Add(event.HostProcessID, evtCopy)
 	return nil, nil
 }
 
@@ -104,7 +105,7 @@ func (gen *ExecFailedGenerator) generateEvent(
 	baseEvent *trace.Event,
 	execInfo execEndInfo,
 ) (*trace.Event, error) {
-	newEvent := *baseEvent
+	newEvent := shallowCopyEvent(baseEvent)
 	newEvent.Timestamp = execInfo.timestamp
 	newEvent.EventID = gen.deriveBase.ID
 	newEvent.EventName = gen.deriveBase.Name
@@ -114,7 +115,7 @@ func (gen *ExecFailedGenerator) generateEvent(
 	newEvent.Args[parse.ArgIndex(newEvent.Args, "argv")] = execInfo.args[parse.ArgIndex(execInfo.args, "argv")]
 	newEvent.Args[parse.ArgIndex(newEvent.Args, "envp")] = execInfo.args[parse.ArgIndex(execInfo.args, "envp")]
 
-	return &newEvent, nil
+	return newEvent, nil
 }
 
 func isFailedExec(returnCode int) bool {


### PR DESCRIPTION
### 1. Explain what the PR does

bf4c015ee **fix(events/derive): prevent pointer aliasing in cached derived events**

```
Commit 7147abc converted derived functions to use pointers to trace.Event
assuming original events wouldn't be modified during derivation. However,
some derived events cached original pointers, causing issues when events
were later modified.

Changes:
- Add shallowCopyEvent() helper to safely copy trace.Event structs
- Fix hidden_kernel_module and process_execute_failed to cache copies

This ensures cached events are independent of originals, preventing
unintended side effects from subsequent modifications.
```

### 2. Explain how to test it


### 3. Other comments


