### PR TITLE
build: add BPF debug stripping option to reduce object file size by ~3MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ CMD_RM ?= rm
 CMD_SED ?= sed
 CMD_STATICCHECK ?= staticcheck
 CMD_STRIP ?= llvm-strip
+CMD_OBJCOPY ?= llvm-objcopy
 CMD_TOUCH ?= touch
 CMD_TR ?= tr
 CMD_PROTOC ?= protoc
@@ -173,6 +174,9 @@ ifeq ($(METRICS),1)
 	BPF_DEBUG_FLAG += -DMETRICS
 endif
 
+# Strip debug symbols from BPF object
+STRIP_BPF_DEBUG ?= 0
+
 ifeq ($(UNAME_M),x86_64)
 	ARCH = x86_64
 	LINUX_ARCH = x86
@@ -213,6 +217,7 @@ env:
 	@echo "CMD_SED                  $(CMD_SED)"
 	@echo "CMD_STATICCHECK          $(CMD_STATICCHECK)"
 	@echo "CMD_STRIP                $(CMD_STRIP)"
+	@echo "CMD_OBJCOPY              $(CMD_OBJCOPY)"
 	@echo "CMD_TOUCH                $(CMD_TOUCH)"
 	@echo "CMD_TR                   $(CMD_TR)"
 	@echo "CMD_PROTOC               $(CMD_PROTOC)"
@@ -246,6 +251,7 @@ env:
 	@echo ---------------------------------------
 	@echo "DEBUG                    $(DEBUG)"
 	@echo "GO_DEBUG_FLAG            $(GO_DEBUG_FLAG)"
+	@echo "STRIP_BPF_DEBUG          $(STRIP_BPF_DEBUG)"
 	@echo ---------------------------------------
 	@echo "CUSTOM_CGO_CFLAGS        $(CUSTOM_CGO_CFLAGS)"
 	@echo "CUSTOM_CGO_LDFLAGS       $(CUSTOM_CGO_LDFLAGS)"
@@ -487,6 +493,9 @@ $(OUTPUT_DIR)/tracee.bpf.o: \
 		-mcpu=$(BPF_VCPU) \
 		-c $(TRACEE_EBPF_OBJ_SRC) \
 		-o $@
+ifeq ($(STRIP_BPF_DEBUG),1)
+	$(CMD_OBJCOPY) --strip-debug $@
+endif
 
 .PHONY: clean-bpf
 clean-bpf:

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -150,6 +150,7 @@ RELEASE_GITHUB ?= 1
 release: override BTFHUB=1
 release: override STATIC=0
 release: override SNAPSHOT=0
+release: override STRIP_BPF_DEBUG=1
 
 .PHONY: release
 release: \
@@ -226,7 +227,7 @@ alpine-prepare:
 .PHONY: build-tracee-container
 build-tracee-container: alpine-prepare
 # build official container image (CO-RE obj)
-	BTFHUB=$(BTFHUB) STATIC=$(STATIC) SNAPSHOT=$(SNAPSHOT) RELEASE_VERSION=$(RELEASE_VERSION) \
+	BTFHUB=$(BTFHUB) STATIC=$(STATIC) SNAPSHOT=$(SNAPSHOT) STRIP_BPF_DEBUG=$(STRIP_BPF_DEBUG) RELEASE_VERSION=$(RELEASE_VERSION) \
 		$(MAKE) -f builder/Makefile.tracee-container build-tracee
 
 #
@@ -241,7 +242,7 @@ ubuntu-prepare:
 .PHONY: build-tracee-binary-static
 build-tracee-binary-static: ubuntu-prepare
 # static
-	BTFHUB=0 STATIC=1 RELEASE_VERSION=$(RELEASE_VERSION) \
+	BTFHUB=0 STATIC=1 STRIP_BPF_DEBUG=$(STRIP_BPF_DEBUG) RELEASE_VERSION=$(RELEASE_VERSION) \
 		$(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="tracee-ebpf tracee" && \
 		$(CMD_MV) dist/tracee-ebpf dist/tracee-ebpf-static && \
 		$(CMD_MV) dist/tracee dist/tracee-static
@@ -249,7 +250,7 @@ build-tracee-binary-static: ubuntu-prepare
 .PHONY: build-tracee-binary-shared
 build-tracee-binary-shared: ubuntu-prepare
 # shared libs
-	BTFHUB=0 STATIC=0 RELEASE_VERSION=$(RELEASE_VERSION) \
+	BTFHUB=0 STATIC=0 STRIP_BPF_DEBUG=$(STRIP_BPF_DEBUG) RELEASE_VERSION=$(RELEASE_VERSION) \
 		$(MAKE) -f builder/Makefile.tracee-make ubuntu-make ARG="all"
 
 .PHONY: copy-man


### PR DESCRIPTION
### 1. Explain what the PR does

- Add STRIP_BPF_DEBUG option (default: disabled) to strip debug symbols
- When enabled, reduces BPF object size from 12MB to 9MB (25% reduction)

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
