### PR TITLE
Add probes compatibility and events dependencies fallbacks

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -7353,20 +7353,20 @@ int tracepoint__exec_test(struct bpf_raw_tracepoint_args *ctx)
     if (!evaluate_scope_filters(&p))
         return 0;
 
-    if (!reset_event(p.event, EXEC_TEST))
-        return 0;
-    if (evaluate_scope_filters(&p))
-        ret |= events_perf_submit(&p, 0);
+    if (reset_event(p.event, EXEC_TEST)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
 
-    if (!reset_event(p.event, TEST_MISSING_KSYMBOLS))
-        return 0;
-    if (evaluate_scope_filters(&p))
-        ret |= events_perf_submit(&p, 0);
+    if (reset_event(p.event, TEST_MISSING_KSYMBOLS)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
 
-    if (!reset_event(p.event, TEST_FAILED_ATTACH))
-        return 0;
-    if (evaluate_scope_filters(&p))
-        ret |= events_perf_submit(&p, 0);
+    if (reset_event(p.event, TEST_FAILED_ATTACH)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
 
     return 0;
 }

--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -7368,5 +7368,43 @@ int tracepoint__exec_test(struct bpf_raw_tracepoint_args *ctx)
             ret |= events_perf_submit(&p, 0);
     }
 
+    if (reset_event(p.event, KERNEL_VERSION_INCOMPATIBLE)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
+
+    if (reset_event(p.event, KERNEL_VERSION_INCOMPATIBLE_WITH_FALLBACK)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
+
+    if (reset_event(p.event, EVENT_WITH_MULTIPLE_FALLBACKS)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
+
+    if (reset_event(p.event, EVENT_WITH_FAILED_DEPENDENCY)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
+
+    if (reset_event(p.event, SHARED_PROBE_EVENT_A)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
+
+    if (reset_event(p.event, SHARED_PROBE_EVENT_B)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
+
+    return 0;
+}
+
+SEC("kprobe/kernel_version_incompatible_probe")
+int BPF_KPROBE(kernel_version_incompatible_probe)
+{
+    // This probe is designed to be incompatible with current kernel versions
+    // It will be filtered out by the compatibility check
     return 0;
 }

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -147,6 +147,12 @@ typedef struct event_context {
     X(EXEC_TEST, = 8000)                                                                           \
     X(TEST_MISSING_KSYMBOLS, )                                                                     \
     X(TEST_FAILED_ATTACH, )                                                                        \
+    X(KERNEL_VERSION_INCOMPATIBLE, )                                                               \
+    X(KERNEL_VERSION_INCOMPATIBLE_WITH_FALLBACK, )                                                 \
+    X(EVENT_WITH_FAILED_DEPENDENCY, )                                                              \
+    X(EVENT_WITH_MULTIPLE_FALLBACKS, )                                                             \
+    X(SHARED_PROBE_EVENT_A, )                                                                      \
+    X(SHARED_PROBE_EVENT_B, )                                                                      \
     // ...
 
 #ifndef EXTENDED_BUILD

--- a/pkg/ebpf/event_parameters.go
+++ b/pkg/ebpf/event_parameters.go
@@ -108,7 +108,7 @@ func registerSyscallChecker(t *Tracee, eventParams []map[string]filters.Filter[*
 	probeGroupName := "syscall_checkers"
 	probeGroup, ok := t.extraProbes[probeGroupName]
 	if !ok {
-		probeGroup = probes.NewProbeGroup(t.bpfModule, map[probes.Handle]probes.Probe{})
+		probeGroup = probes.NewProbeGroup(t.bpfModule, map[probes.Handle]probes.Probe{}, map[probes.Handle]*probes.ProbeCompatibility{})
 		t.extraProbes[probeGroupName] = probeGroup
 	}
 

--- a/pkg/ebpf/probes/compatibility.go
+++ b/pkg/ebpf/probes/compatibility.go
@@ -1,0 +1,89 @@
+package probes
+
+import (
+	"strings"
+
+	"github.com/aquasecurity/tracee/pkg/utils/environment"
+)
+
+// ProbeCompatibility stores the requirements for a probe to be used.
+// It is used to check if a probe is compatible with the current OS.
+type ProbeCompatibility struct {
+	probe        Handle
+	requirements []ProbeRequirement
+}
+
+func NewProbeCompatibility(probe Handle, requirements []ProbeRequirement) *ProbeCompatibility {
+	return &ProbeCompatibility{
+		probe:        probe,
+		requirements: requirements,
+	}
+}
+
+// IsCompatible checks if the probe is compatible with the current OS.
+func (p *ProbeCompatibility) IsCompatible(osInfo OSInfoProvider) (bool, error) {
+	isAllCompatible := true
+	for _, requirement := range p.requirements {
+		isCompatible, err := requirement.IsCompatible(osInfo)
+		if err != nil {
+			return false, err
+		}
+		isAllCompatible = isAllCompatible && isCompatible
+	}
+	return isAllCompatible, nil
+}
+
+// ProbeRequirement is an interface that defines the requirements for a probe to be used.
+type ProbeRequirement interface {
+	IsCompatible(osInfo OSInfoProvider) (bool, error)
+}
+
+// KernelVersionRequirement is a requirement that checks if the kernel version and distro are compatibles.
+type KernelVersionRequirement struct {
+	distro           string
+	minKernelVersion string
+	maxKernelVersion string
+}
+
+// NewKernelVersionRequirement creates a new KernelVersionRequirement.
+func NewKernelVersionRequirement(distro, minKernelVersion, maxKernelVersion string) *KernelVersionRequirement {
+	return &KernelVersionRequirement{
+		distro:           distro,
+		minKernelVersion: minKernelVersion,
+		maxKernelVersion: maxKernelVersion,
+	}
+}
+
+// IsCompatible checks if the kernel version and distro are compatibles.
+func (k *KernelVersionRequirement) IsCompatible(osInfo OSInfoProvider) (bool, error) {
+	// If distro is specified, check if it matches
+	// Only if the distro is matching then the kernel version is relevant.
+	// Empty distro means that the kernel version is relevant for all distros.
+	if k.distro != "" && osInfo.GetOSReleaseID().String() != strings.ToLower(k.distro) {
+		return true, nil
+	}
+
+	// If minKernelVersion is specified, check if osInfo.KernelVersion >= minKernelVersion
+	if k.minKernelVersion != "" {
+		comparison, err := osInfo.CompareOSBaseKernelRelease(k.minKernelVersion)
+		if err != nil {
+			return false, err
+		}
+		if comparison == environment.KernelVersionNewer {
+			return false, nil
+		}
+	}
+
+	// If maxKernelVersion is specified, check if osInfo.KernelVersion <= maxKernelVersion
+	if k.maxKernelVersion != "" {
+		comparison, err := osInfo.CompareOSBaseKernelRelease(k.maxKernelVersion)
+		if err != nil {
+			return false, err
+		}
+		if comparison == environment.KernelVersionOlder {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/ebpf/probes/compatibility_test.go
+++ b/pkg/ebpf/probes/compatibility_test.go
@@ -1,0 +1,404 @@
+package probes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/utils/environment"
+)
+
+// mockOSInfo implements OSInfoProvider for testing
+type mockOSInfo struct {
+	kernelRelease string
+	osReleaseID   environment.OSReleaseID
+}
+
+func newMockOSInfo(kernelRelease, osReleaseIDStr string) *mockOSInfo {
+	var osReleaseID environment.OSReleaseID
+	switch strings.ToLower(osReleaseIDStr) {
+	case "ubuntu":
+		osReleaseID = environment.UBUNTU
+	case "centos":
+		osReleaseID = environment.CENTOS
+	case "debian":
+		osReleaseID = environment.DEBIAN
+	case "rhel":
+		osReleaseID = environment.RHEL
+	default:
+		osReleaseID = 0 // Default/undefined OS release ID
+	}
+
+	return &mockOSInfo{
+		kernelRelease: kernelRelease,
+		osReleaseID:   osReleaseID,
+	}
+}
+
+func (m *mockOSInfo) GetOSReleaseID() environment.OSReleaseID {
+	return m.osReleaseID
+}
+
+func (m *mockOSInfo) CompareOSBaseKernelRelease(version string) (environment.KernelVersionComparison, error) {
+	return environment.CompareKernelRelease(m.kernelRelease, version)
+}
+
+func TestKernelVersionRequirement_Basic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		distro           string
+		minKernelVersion string
+		maxKernelVersion string
+		currentKernel    string
+		currentDistro    string
+		expectedResult   bool
+		expectedError    bool
+	}{
+		{
+			name:             "no restrictions - always compatible",
+			distro:           "",
+			minKernelVersion: "",
+			maxKernelVersion: "",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+			expectedError:    false,
+		},
+		{
+			name:             "minimum version requirement - compatible",
+			distro:           "",
+			minKernelVersion: "5.0.0",
+			maxKernelVersion: "",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+			expectedError:    false,
+		},
+		{
+			name:             "minimum version requirement - incompatible",
+			distro:           "",
+			minKernelVersion: "5.15.0",
+			maxKernelVersion: "",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   false,
+			expectedError:    false,
+		},
+		{
+			name:             "maximum version requirement - compatible",
+			distro:           "",
+			minKernelVersion: "",
+			maxKernelVersion: "5.15.0",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+			expectedError:    false,
+		},
+		{
+			name:             "maximum version requirement - incompatible",
+			distro:           "",
+			minKernelVersion: "",
+			maxKernelVersion: "5.5.0",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   false,
+			expectedError:    false,
+		},
+		{
+			name:             "distro specific - matching distro, compatible version",
+			distro:           "ubuntu",
+			minKernelVersion: "5.0.0",
+			maxKernelVersion: "",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+			expectedError:    false,
+		},
+		{
+			name:             "distro specific - non-matching distro, ignored version check",
+			distro:           "centos",
+			minKernelVersion: "5.15.0",
+			maxKernelVersion: "",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+			expectedError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create kernel version requirement
+			req := NewKernelVersionRequirement(tt.distro, tt.minKernelVersion, tt.maxKernelVersion)
+
+			// Verify constructor worked correctly
+			assert.Equal(t, tt.distro, req.distro)
+			assert.Equal(t, tt.minKernelVersion, req.minKernelVersion)
+			assert.Equal(t, tt.maxKernelVersion, req.maxKernelVersion)
+
+			// Create test OSInfo
+			osInfo := newMockOSInfo(tt.currentKernel, tt.currentDistro)
+
+			// Test the IsCompatible method
+			result, err := req.IsCompatible(osInfo)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedResult, result,
+					"Expected %v for kernel %s (distro: %s) with requirement (distro: %s, min: %s, max: %s)",
+					tt.expectedResult, tt.currentKernel, tt.currentDistro, tt.distro, tt.minKernelVersion, tt.maxKernelVersion)
+			}
+		})
+	}
+}
+
+// scenario represents a test scenario for kernel version compatibility
+type scenario struct {
+	kernelVersion string
+	distro        string
+	expected      bool
+}
+
+func TestKernelVersionRequirement_RealWorldScenarios(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		requirement *KernelVersionRequirement
+		scenarios   []scenario
+	}{
+		{
+			name:        "Ubuntu LTS minimum kernel 5.4.0",
+			requirement: NewKernelVersionRequirement("ubuntu", "5.4.0", ""),
+			scenarios: []scenario{
+				{"5.4.0-74-generic", "ubuntu", true},
+				{"5.11.0-31-generic", "ubuntu", true},
+				{"4.15.0-76-generic", "ubuntu", false},
+				{"5.4.0-74-generic", "debian", true}, // Different distro, requirement ignored
+			},
+		},
+		{
+			name:        "Feature deprecated after kernel 5.14",
+			requirement: NewKernelVersionRequirement("", "", "5.14.0"),
+			scenarios: []scenario{
+				{"5.13.0", "ubuntu", true},
+				{"5.14.0", "ubuntu", true},
+				{"5.15.0", "ubuntu", false},
+				{"6.0.0", "ubuntu", false},
+			},
+		},
+		{
+			name:        "CentOS kernel range",
+			requirement: NewKernelVersionRequirement("centos", "4.18.0", "5.10.0"),
+			scenarios: []scenario{
+				{"4.18.0-305.el8", "centos", true},
+				{"4.20.0", "centos", true},
+				{"5.10.0", "centos", true},
+				{"4.15.0", "centos", false},
+				{"5.15.0", "centos", false},
+				{"4.15.0", "ubuntu", true}, // Different distro, requirement ignored
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, scenario := range tt.scenarios {
+				t.Run(scenario.kernelVersion+"_"+scenario.distro, func(t *testing.T) {
+					osInfo := newMockOSInfo(scenario.kernelVersion, scenario.distro)
+
+					result, err := tt.requirement.IsCompatible(osInfo)
+					require.NoError(t, err)
+					assert.Equal(t, scenario.expected, result,
+						"Kernel %s on %s should be %v for requirement (distro: %s, min: %s, max: %s)",
+						scenario.kernelVersion, scenario.distro, scenario.expected,
+						tt.requirement.distro, tt.requirement.minKernelVersion, tt.requirement.maxKernelVersion)
+				})
+			}
+		})
+	}
+}
+
+func TestProbeCompatibility_Basic(t *testing.T) {
+	t.Parallel()
+
+	// Test ProbeCompatibility constructor and basic functionality
+	req1 := NewKernelVersionRequirement("", "5.0.0", "")
+	req2 := NewKernelVersionRequirement("ubuntu", "", "6.0.0")
+
+	tests := []struct {
+		name         string
+		probe        Handle
+		requirements []ProbeRequirement
+	}{
+		{
+			name:         "no requirements",
+			probe:        1, // Mock handle
+			requirements: []ProbeRequirement{},
+		},
+		{
+			name:         "single requirement",
+			probe:        1,
+			requirements: []ProbeRequirement{req1},
+		},
+		{
+			name:         "multiple requirements",
+			probe:        1,
+			requirements: []ProbeRequirement{req1, req2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			compatibility := NewProbeCompatibility(tt.probe, tt.requirements)
+
+			assert.NotNil(t, compatibility)
+			assert.Equal(t, tt.probe, compatibility.probe)
+			assert.Equal(t, len(tt.requirements), len(compatibility.requirements))
+
+			// Verify each requirement is stored correctly
+			for i, req := range tt.requirements {
+				assert.Equal(t, req, compatibility.requirements[i])
+			}
+		})
+	}
+}
+
+func TestProbeCompatibility_MultipleRequirements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		requirements   []ProbeRequirement
+		currentKernel  string
+		currentDistro  string
+		expectedResult bool
+	}{
+		{
+			name:           "no requirements - always compatible",
+			requirements:   []ProbeRequirement{},
+			currentKernel:  "5.10.0",
+			currentDistro:  "ubuntu",
+			expectedResult: true,
+		},
+		{
+			name: "all requirements compatible",
+			requirements: []ProbeRequirement{
+				NewKernelVersionRequirement("", "5.0.0", ""),
+				NewKernelVersionRequirement("", "", "6.0.0"),
+			},
+			currentKernel:  "5.10.0",
+			currentDistro:  "ubuntu",
+			expectedResult: true,
+		},
+		{
+			name: "one requirement incompatible",
+			requirements: []ProbeRequirement{
+				NewKernelVersionRequirement("", "5.0.0", ""),
+				NewKernelVersionRequirement("", "", "5.5.0"), // Max 5.5.0, current is 5.10.0
+			},
+			currentKernel:  "5.10.0",
+			currentDistro:  "ubuntu",
+			expectedResult: false,
+		},
+		{
+			name: "distro-specific requirements",
+			requirements: []ProbeRequirement{
+				NewKernelVersionRequirement("ubuntu", "5.4.0", ""),
+				NewKernelVersionRequirement("centos", "4.18.0", ""),
+			},
+			currentKernel:  "5.10.0",
+			currentDistro:  "ubuntu",
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			compatibility := NewProbeCompatibility(1, tt.requirements)
+			osInfo := newMockOSInfo(tt.currentKernel, tt.currentDistro)
+
+			result, err := compatibility.IsCompatible(osInfo)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func TestKernelVersionRequirement_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		distro           string
+		minKernelVersion string
+		maxKernelVersion string
+		currentKernel    string
+		currentDistro    string
+		expectedResult   bool
+	}{
+		{
+			name:             "equal to minimum version",
+			distro:           "",
+			minKernelVersion: "5.10.0",
+			maxKernelVersion: "",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+		},
+		{
+			name:             "equal to maximum version",
+			distro:           "",
+			minKernelVersion: "",
+			maxKernelVersion: "5.10.0",
+			currentKernel:    "5.10.0",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+		},
+		{
+			name:             "complex ubuntu kernel version",
+			distro:           "",
+			minKernelVersion: "5.4.0",
+			maxKernelVersion: "",
+			currentKernel:    "5.4.0-74-generic",
+			currentDistro:    "ubuntu",
+			expectedResult:   true,
+		},
+		{
+			name:             "complex centos kernel version",
+			distro:           "centos",
+			minKernelVersion: "4.18.0",
+			maxKernelVersion: "",
+			currentKernel:    "4.18.0-305.el8",
+			currentDistro:    "centos",
+			expectedResult:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := NewKernelVersionRequirement(tt.distro, tt.minKernelVersion, tt.maxKernelVersion)
+			osInfo := newMockOSInfo(tt.currentKernel, tt.currentDistro)
+
+			result, err := req.IsCompatible(osInfo)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}

--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -283,12 +283,20 @@ func NewDefaultProbeGroup(module *bpf.Module, netEnabled bool, defaultAutoload b
 		ChmodCommon:                NewTraceProbe(KProbe, "chmod_common", "trace_chmod_common"),
 		SecuritySbUmount:           NewTraceProbe(KProbe, "security_sb_umount", "trace_security_sb_umount"),
 
-		TestUnavailableHook: NewTraceProbe(KProbe, "non_existing_func", "empty_kprobe"),
-		ExecTest:            NewTraceProbe(RawTracepoint, "raw_syscalls:sched_process_exec", "tracepoint__exec_test"),
-		EmptyKprobe:         NewTraceProbe(KProbe, "security_bprm_check", "empty_kprobe"),
+		TestUnavailableHook:            NewTraceProbe(KProbe, "non_existing_func", "empty_kprobe"),
+		ExecTest:                       NewTraceProbe(RawTracepoint, "raw_syscalls:sched_process_exec", "tracepoint__exec_test"),
+		EmptyKprobe:                    NewTraceProbe(KProbe, "security_bprm_check", "empty_kprobe"),
+		KernelVersionIncompatibleProbe: NewTraceProbe(KProbe, "security_bprm_check", "kernel_version_incompatible_probe"),
 	}
 
-	probesRequirements := map[Handle]*ProbeCompatibility{}
+	probesRequirements := map[Handle]*ProbeCompatibility{
+		KernelVersionIncompatibleProbe: NewProbeCompatibility(
+			KernelVersionIncompatibleProbe,
+			[]ProbeRequirement{
+				NewKernelVersionRequirement("", "", "0.0.0"), // Requires kernel up to 0.0.0, so no kernel version is compatible
+			},
+		),
+	}
 
 	if !netEnabled {
 		// disable network cgroup probes (avoid effective CAP_NET_ADMIN if not needed)

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -2,11 +2,19 @@ package probes
 
 import (
 	bpf "github.com/aquasecurity/libbpfgo"
+
+	"github.com/aquasecurity/tracee/pkg/utils/environment"
 )
 
 //
 // Probe
 //
+
+// OSInfoProvider defines the interface for OS information needed by probe compatibility checks
+type OSInfoProvider interface {
+	GetOSReleaseID() environment.OSReleaseID
+	CompareOSBaseKernelRelease(version string) (environment.KernelVersionComparison, error)
+}
 
 type Probe interface {
 	// attach attaches the probe's program to its hook.

--- a/pkg/ebpf/probes/probes.go
+++ b/pkg/ebpf/probes/probes.go
@@ -179,4 +179,5 @@ const (
 	TestUnavailableHook = 1000 + iota
 	ExecTest
 	EmptyKprobe
+	KernelVersionIncompatibleProbe
 )

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -190,6 +190,12 @@ const (
 	ExecTest ID = 8000 + iota
 	MissingKsymbol
 	FailedAttach
+	KernelVersionIncompatible
+	KernelVersionIncompatibleWithFallback
+	EventWithFailedDependency
+	EventWithMultipleFallbacks
+	SharedProbeEventA
+	SharedProbeEventB
 )
 
 //
@@ -13785,7 +13791,7 @@ var CoreEvents = map[ID]Definition{
 		dependencies: Dependencies{
 			probes: []Probe{
 				{handle: probes.ExecTest, required: true},
-				{handle: probes.EmptyKprobe, required: true},
+				{handle: probes.EmptyKprobe, required: true}, // Required for testing kprobe attachment
 			},
 		},
 		fields: []DataField{},
@@ -13805,7 +13811,6 @@ var CoreEvents = map[ID]Definition{
 			probes: []Probe{
 				{handle: probes.ExecTest, required: true},
 			},
-			ids: []ID{ExecTest},
 		},
 	},
 	FailedAttach: {
@@ -13821,7 +13826,141 @@ var CoreEvents = map[ID]Definition{
 				{handle: probes.TestUnavailableHook, required: true},
 				{handle: probes.ExecTest, required: true},
 			},
-			ids: []ID{ExecTest},
+		},
+	},
+	KernelVersionIncompatible: {
+		id:      KernelVersionIncompatible,
+		id32Bit: Sys32Undefined,
+		name:    "kernel_version_incompatible",
+		version: NewVersion(1, 0, 0),
+		syscall: false,
+		sets:    []string{"tests", "dependencies"},
+		fields:  []DataField{},
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.KernelVersionIncompatibleProbe, required: true},
+				{handle: probes.ExecTest, required: true},
+			},
+		},
+	},
+	KernelVersionIncompatibleWithFallback: {
+		id:      KernelVersionIncompatibleWithFallback,
+		id32Bit: Sys32Undefined,
+		name:    "kernel_version_incompatible_with_fallback",
+		version: NewVersion(1, 0, 0),
+		syscall: false,
+		sets:    []string{"tests", "dependencies"},
+		fields:  []DataField{},
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.KernelVersionIncompatibleProbe, required: true},
+				{handle: probes.ExecTest, required: true},
+			},
+			fallbacks: []Dependencies{
+				{
+					probes: []Probe{
+						{handle: probes.ExecTest, required: true},
+						{handle: probes.EmptyKprobe, required: true}, // Required for testing kprobe attachment
+					},
+				},
+			},
+		},
+	},
+	EventWithFailedDependency: {
+		id:      EventWithFailedDependency,
+		id32Bit: Sys32Undefined,
+		name:    "event_with_failed_dependency",
+		version: NewVersion(1, 0, 0),
+		syscall: false,
+		sets:    []string{"tests", "dependencies"},
+		fields:  []DataField{},
+		dependencies: Dependencies{
+			ids: []ID{KernelVersionIncompatible, ExecTest},
+		},
+	},
+	EventWithMultipleFallbacks: {
+		id:      EventWithMultipleFallbacks,
+		id32Bit: Sys32Undefined,
+		name:    "event_with_multiple_fallbacks",
+		version: NewVersion(1, 0, 0),
+		syscall: false,
+		sets:    []string{"tests", "dependencies"},
+		fields:  []DataField{},
+		dependencies: Dependencies{
+			ids: []ID{KernelVersionIncompatible, ExecTest},
+			fallbacks: []Dependencies{
+				{
+					ids: []ID{EventWithFailedDependency, ExecTest},
+				},
+				{
+					ids: []ID{ExecTest},
+					kSymbols: []KSymbol{
+						{symbol: "non_existing_symbol", required: true},
+					},
+				},
+				{
+					ids: []ID{ExecTest},
+				},
+			},
+		},
+	},
+	SharedProbeEventA: {
+		id:      SharedProbeEventA,
+		id32Bit: Sys32Undefined,
+		name:    "shared_probe_event_a",
+		version: NewVersion(1, 0, 0),
+		syscall: false,
+		sets:    []string{"tests", "dependencies"},
+		fields:  []DataField{},
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.KernelVersionIncompatibleProbe, required: true},
+				{handle: probes.ExecTest, required: true},
+			},
+			fallbacks: []Dependencies{
+				{
+					probes: []Probe{
+						{handle: probes.KernelVersionIncompatibleProbe, required: true},
+						{handle: probes.ExecTest, required: true},
+					},
+				},
+				{
+					probes: []Probe{
+						{handle: probes.ExecTest, required: true},
+						{handle: probes.EmptyKprobe, required: true}, // Required for testing kprobe attachment
+					},
+					ids: []ID{ExecTest},
+				},
+			},
+		},
+	},
+	SharedProbeEventB: {
+		id:      SharedProbeEventB,
+		id32Bit: Sys32Undefined,
+		name:    "shared_probe_event_b",
+		version: NewVersion(1, 0, 0),
+		syscall: false,
+		sets:    []string{"tests", "dependencies"},
+		fields:  []DataField{},
+		dependencies: Dependencies{
+			probes: []Probe{
+				{handle: probes.KernelVersionIncompatibleProbe, required: true},
+				{handle: probes.ExecTest, required: true},
+			},
+			fallbacks: []Dependencies{
+				{
+					probes: []Probe{
+						{handle: probes.KernelVersionIncompatibleProbe, required: true},
+						{handle: probes.ExecTest, required: true},
+					},
+				},
+				{
+					probes: []Probe{
+						{handle: probes.ExecTest, required: true},
+						{handle: probes.EmptyKprobe, required: true}, // Required for testing kprobe attachment
+					},
+				},
+			},
 		},
 	},
 }

--- a/pkg/events/definition_dependencies.go
+++ b/pkg/events/definition_dependencies.go
@@ -13,6 +13,8 @@ type Dependencies struct {
 	probes       []Probe
 	tailCalls    []TailCall
 	capabilities Capabilities
+	// fallbacks contains alternative dependency sets to try if the primary dependencies fail
+	fallbacks []Dependencies
 }
 
 func NewDependencies(
@@ -28,6 +30,26 @@ func NewDependencies(
 		probes:       givenProbes,
 		tailCalls:    givenTailCalls,
 		capabilities: givenCapabilities,
+		fallbacks:    nil,
+	}
+}
+
+// NewDependenciesWithFallbacks creates a Dependencies struct with fallback dependency sets
+func NewDependenciesWithFallbacks(
+	givenIDs []ID,
+	givenkSymbols []KSymbol,
+	givenProbes []Probe,
+	givenTailCalls []TailCall,
+	givenCapabilities Capabilities,
+	fallbacks []Dependencies,
+) Dependencies {
+	return Dependencies{
+		ids:          givenIDs,
+		kSymbols:     givenkSymbols,
+		probes:       givenProbes,
+		tailCalls:    givenTailCalls,
+		capabilities: givenCapabilities,
+		fallbacks:    fallbacks,
 	}
 }
 
@@ -73,8 +95,33 @@ func (d Dependencies) GetCapabilities() Capabilities {
 	return d.capabilities
 }
 
-// Probe
+// GetFallbacks returns the fallback dependency sets
+func (d Dependencies) GetFallbacks() []Dependencies {
+	if d.fallbacks == nil {
+		return []Dependencies{}
+	}
+	return d.fallbacks
+}
 
+// HasFallbacks returns true if this Dependencies has fallback sets defined
+func (d Dependencies) HasFallbacks() bool {
+	return len(d.fallbacks) > 0
+}
+
+// GetFallbackAt returns the fallback dependency set at the specified index
+func (d Dependencies) GetFallbackAt(index int) (Dependencies, bool) {
+	if index < 0 || index >= len(d.fallbacks) {
+		return Dependencies{}, false
+	}
+	return d.fallbacks[index], true
+}
+
+// AddFallback adds a fallback dependency set to existing dependencies
+func (d *Dependencies) AddFallback(fallback Dependencies) {
+	d.fallbacks = append(d.fallbacks, fallback)
+}
+
+// Probe
 type Probe struct {
 	handle   probes.Handle
 	required bool // tracee fails if probe can't be attached

--- a/pkg/events/dependencies/actions.go
+++ b/pkg/events/dependencies/actions.go
@@ -11,25 +11,63 @@ type Action interface{}
 
 // CancelNodeAddAction cancels the process of adding a node to the manager.
 //
-// This method will:
-// 1. Cancel the addition of the specified node.
-// 2. Cancel the addition of all dependent nodes.
-// 3. Remove any dependencies that are no longer referenced by other nodes.
+// When this action is executed:
+// 1. The specified node is removed from the manager (if it was already added).
+// 2. All dependent events that rely on this node will fail to be added.
+// 3. When dependent events fail, they will attempt to use fallback dependencies if available.
+// 4. If no fallback dependencies are available, the dependent events will also be removed.
+// 5. Any dependencies that are no longer referenced by other nodes are removed.
 //
-// The overall effect is similar to calling RemoveEvent directly on the manager,
-// but with additional safeguards and order of operations to ensure proper cleanup
-// and consistency within the system.
+// This creates a cascade effect where cancelling one node can cause multiple
+// dependent events to either use alternative dependencies or be removed entirely.
 //
 // Note:
 // - This action does not prevent other watchers from being notified.
-// - When the node addition is cancelled, event removal watchers will be invoked to allow for cleanup operations.
+// - Dependent events will try fallback mechanisms before being removed.
+// - This is different from FailNodeAddAction: the cancelled node itself will not try to use its own fallbacks.
+// - All other effects (dependent events trying fallbacks, cleanup of unused dependencies) are the same as FailNodeAddAction.
 //
 // It is recommended to use CancelNodeAddAction instead of directly calling RemoveEvent
-// to ensure that the cancellation and cleanup processes are handled in the correct order.
+// to ensure that the cancellation and fallback processes are handled in the correct order.
 type CancelNodeAddAction struct {
 	Reason error
 }
 
 func NewCancelNodeAddAction(reason error) *CancelNodeAddAction {
 	return &CancelNodeAddAction{Reason: reason}
+}
+
+// FailNodeAddAction marks the addition of a node as failed in the manager.
+//
+// This action is used to indicate that the process of adding a node has encountered
+// an error or failure condition. When this action is executed:
+// 1. The node addition process is marked as failed.
+// 2. The failure reason is recorded for debugging and error handling purposes.
+// 3. Fallback mechanisms are triggered to attempt alternative dependency configurations.
+// 4. If fallbacks are available, the system will try to use them instead of completely failing.
+// 5. Any dependencies that are no longer referenced by other nodes are removed.
+//
+// The failure reason should provide clear information about what went wrong during
+// the node addition process, which can be useful for:
+// - Debugging and troubleshooting
+// - Error reporting and logging
+// - Understanding why fallback mechanisms were triggered
+// - Notifying other components about the failure
+//
+// Note:
+// - This action triggers fallback mechanisms, unlike CancelNodeAddAction which causes immediate removal.
+// - If fallbacks are available, the dependent event may still be added successfully using alternative dependencies.
+// - If no fallbacks are available, the dependent event will also fail.
+// - It is important to provide a meaningful error reason for proper error handling.
+type FailNodeAddAction struct {
+	Reason error
+}
+
+// NewFailNodeAddAction creates a new FailNodeAddAction with the specified failure reason.
+//
+// The reason parameter should contain a descriptive error message explaining why
+// the node addition failed. This information will be used for error handling,
+// debugging, and potentially for user-facing error messages.
+func NewFailNodeAddAction(reason error) *FailNodeAddAction {
+	return &FailNodeAddAction{Reason: reason}
 }

--- a/pkg/events/dependencies/errors.go
+++ b/pkg/events/dependencies/errors.go
@@ -28,6 +28,28 @@ func (cancelErr *ErrNodeAddCancelled) AddReason(reason error) {
 	cancelErr.Reasons = append(cancelErr.Reasons, reason)
 }
 
+// ErrNodeAddFailed is the error produced when failing a node add to the manager
+// using the FailNodeAddAction Action. This triggers fallback mechanisms.
+type ErrNodeAddFailed struct {
+	Reasons []error
+}
+
+func NewErrNodeAddFailed(reasons []error) *ErrNodeAddFailed {
+	return &ErrNodeAddFailed{Reasons: reasons}
+}
+
+func (failErr *ErrNodeAddFailed) Error() string {
+	var errorsStrings []string
+	for _, err := range failErr.Reasons {
+		errorsStrings = append(errorsStrings, err.Error())
+	}
+	return fmt.Sprintf("node add was failed, reasons: \"%s\"", strings.Join(errorsStrings, "\", \""))
+}
+
+func (failErr *ErrNodeAddFailed) AddReason(reason error) {
+	failErr.Reasons = append(failErr.Reasons, reason)
+}
+
 var (
 	ErrNodeType     = errors.New("unsupported node type")
 	ErrNodeNotFound = errors.New("node not found")

--- a/pkg/events/dependencies/manager.go
+++ b/pkg/events/dependencies/manager.go
@@ -1,6 +1,7 @@
 package dependencies
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -30,6 +31,11 @@ type Manager struct {
 	onAdd              map[NodeType][]func(node interface{}) []Action
 	onRemove           map[NodeType][]func(node interface{}) []Action
 	dependenciesGetter func(events.ID) events.Dependencies
+	// Track failed probes and events to avoid bugs with shared dependencies with fallbacks or other event
+	failedProbes map[probes.Handle]struct{}
+	failedEvents map[events.ID]struct{}
+
+	processingEvents map[events.ID]struct{} // Track events currently being processed - safeguard against recursive calls
 }
 
 func NewDependenciesManager(dependenciesGetter func(events.ID) events.Dependencies) *Manager {
@@ -40,6 +46,9 @@ func NewDependenciesManager(dependenciesGetter func(events.ID) events.Dependenci
 		onAdd:              make(map[NodeType][]func(node interface{}) []Action),
 		onRemove:           make(map[NodeType][]func(node interface{}) []Action),
 		dependenciesGetter: dependenciesGetter,
+		failedProbes:       make(map[probes.Handle]struct{}),
+		failedEvents:       make(map[events.ID]struct{}),
+		processingEvents:   make(map[events.ID]struct{}), // Initialize processing state
 	}
 }
 
@@ -127,15 +136,28 @@ func (m *Manager) RemoveEvent(id events.ID) error {
 	return m.removeEvent(id)
 }
 
+// removeEvent removes the given event from the tree.
+// It also fails all dependent events.
+// removeEventNode should be used instead if you already have node reference to avoid search failures.
 func (m *Manager) removeEvent(id events.ID) error {
 	node := m.getEventNode(id)
 	if node == nil {
 		return ErrNodeNotFound
 	}
+	return m.removeEventNode(node)
+}
 
-	m.removeEventNodeFromDependencies(node)
-	m.removeNode(node)
-	m.removeEventDependents(node)
+// removeEventNode removes the given event node from the tree.
+// It also fails all dependent events.
+// This is the function to call with a node that might not be already registered in the tree.
+// In general, it should be used if you already have node reference to avoid search failures.
+func (m *Manager) removeEventNode(eventNode *EventNode) error {
+	eventName := events.Core.GetDefinitionByID(eventNode.GetID()).GetName()
+	logger.Debugw("Removing event from tree", "event", eventName)
+
+	m.removeEventNodeFromDependencies(eventNode)
+	m.removeNode(eventNode)
+	m.failEventDependents(eventNode)
 
 	return nil
 }
@@ -146,6 +168,21 @@ func (m *Manager) removeEvent(id events.ID) error {
 // If the event exists in the tree, it will only update its dependents or its explicitlySelected
 // value if it is built without dependents.
 func (m *Manager) buildEvent(id events.ID, dependentEvents []events.ID) (*EventNode, error) {
+	logger.Debugw("Building event", "event", id)
+
+	// Check if already processing this event (prevents loops)
+	if _, processing := m.processingEvents[id]; processing {
+		return nil, fmt.Errorf("event %v is currently being processed", id)
+	}
+
+	if _, failed := m.failedEvents[id]; failed {
+		return nil, fmt.Errorf("event %v previously failed to add", id)
+	}
+
+	// Mark as processing
+	m.processingEvents[id] = struct{}{}
+	defer delete(m.processingEvents, id) // Always cleanup
+
 	explicitlySelected := len(dependentEvents) == 0
 	node := m.getEventNode(id)
 	if node != nil {
@@ -155,6 +192,7 @@ func (m *Manager) buildEvent(id events.ID, dependentEvents []events.ID) (*EventN
 		for _, dependent := range dependentEvents {
 			node.addDependent(dependent)
 		}
+		logger.Debugw("Event already exists", "event", id)
 		return node, nil
 	}
 	// Create node for the given ID and dependencies
@@ -165,16 +203,23 @@ func (m *Manager) buildEvent(id events.ID, dependentEvents []events.ID) (*EventN
 	}
 	_, err := m.buildEventNode(node)
 	if err != nil {
-		m.removeEventNodeFromDependencies(node)
-		return nil, err
+		err = m.handleEventAddError(node, err)
+		if err != nil {
+			m.failedEvents[id] = struct{}{}
+			logger.Debugw("Event failed to build", "event", id, "error", err)
+			return nil, err
+		}
 	}
 	err = m.addNode(node)
 	if err != nil {
-		m.removeEventNodeFromDependencies(node)
-		// As the add watchers were called, remove watchers need to be called to clean after them.
-		m.triggerOnRemove(node)
-		return nil, err
+		err = m.handleEventAddError(node, err)
+		if err != nil {
+			m.failedEvents[id] = struct{}{}
+			logger.Debugw("Event failed to add", "event", id, "error", err)
+			return nil, err
+		}
 	}
+	logger.Debugw("Event built successfully", "event", id)
 	return node, nil
 }
 
@@ -184,6 +229,7 @@ func (m *Manager) buildEventNode(eventNode *EventNode) (*EventNode, error) {
 	// Get the dependency event IDs
 	dependenciesIDs := eventNode.GetDependencies().GetIDs()
 
+	// Build probe dependencies
 	for _, probe := range eventNode.GetDependencies().GetProbes() {
 		err := m.buildProbe(probe.GetHandle(), eventNode.GetID())
 		if err != nil {
@@ -208,6 +254,17 @@ func (m *Manager) buildEventNode(eventNode *EventNode) (*EventNode, error) {
 			[]events.ID{eventNode.GetID()},
 		)
 		if err != nil {
+			// If a dependency was cancelled, convert to failure for this dependent event
+			// This ensures dependent events use fallback mechanisms instead of being cancelled
+			var cancelErr *ErrNodeAddCancelled
+			if errors.As(err, &cancelErr) {
+				// Convert cancellation to failure for dependent events
+				failureReasons := make([]error, len(cancelErr.Reasons))
+				for i, reason := range cancelErr.Reasons {
+					failureReasons[i] = fmt.Errorf("dependency cancelled: %w", reason)
+				}
+				return nil, NewErrNodeAddFailed(failureReasons)
+			}
 			return nil, err
 		}
 	}
@@ -224,11 +281,13 @@ func (m *Manager) addEventNode(eventNode *EventNode) {
 	m.events[eventNode.GetID()] = eventNode
 }
 
-// removeEventNode removes the node from the tree.
-func (m *Manager) removeEventNode(eventNode *EventNode) {
+// removeEventNodeFromTree removes the node from the tree.
+func (m *Manager) removeEventNodeFromTree(eventNode *EventNode) {
 	delete(m.events, eventNode.GetID())
 }
 
+// addNode adds a node generically to the tree and triggers the on-add watchers.
+// It returns an error if the node is not of a valid type, or if the on-add watchers return an error.
 func (m *Manager) addNode(node interface{}) error {
 	nodeType, err := getNodeType(node)
 	if err != nil {
@@ -244,11 +303,13 @@ func (m *Manager) addNode(node interface{}) error {
 	case EventNodeType:
 		m.addEventNode(node.(*EventNode))
 	case ProbeNodeType:
-		m.addProbe(node.(*ProbeNode))
+		m.addProbeNodeToTree(node.(*ProbeNode))
 	}
 	return nil
 }
 
+// removeNode removes a node generically from the tree and triggers the on-remove watchers.
+// It returns an error if the node is not of a valid type, or if the on-remove watchers return an error.
 func (m *Manager) removeNode(node interface{}) {
 	nodeType, err := getNodeType(node)
 	if err != nil {
@@ -260,13 +321,14 @@ func (m *Manager) removeNode(node interface{}) {
 
 	switch nodeType {
 	case EventNodeType:
-		m.removeEventNode(node.(*EventNode))
+		m.removeEventNodeFromTree(node.(*EventNode))
 	case ProbeNodeType:
-		m.removeProbe(node.(*ProbeNode))
+		m.removeProbeNodeFromTree(node.(*ProbeNode))
 	}
 }
 
 // triggerOnAdd triggers all on-add watchers and handle their returned actions.
+// As the tree supports cancelling or failing node add actions, it will return an error if the node add was cancelled or failed.
 func (m *Manager) triggerOnAdd(node interface{}) error {
 	nodeType, err := getNodeType(node)
 	if err != nil {
@@ -284,20 +346,35 @@ func (m *Manager) triggerOnAdd(node interface{}) error {
 	}
 
 	var cancelNodeAddErr *ErrNodeAddCancelled
+	var failNodeAddErr *ErrNodeAddFailed
 	shouldCancel := false
+	shouldFail := false
+
 	for _, action := range actions {
 		switch typedAction := action.(type) {
 		case *CancelNodeAddAction:
 			shouldCancel = true
 			if cancelNodeAddErr == nil {
-				err = NewErrNodeAddCancelled([]error{typedAction.Reason})
+				cancelNodeAddErr = NewErrNodeAddCancelled([]error{typedAction.Reason})
 			} else {
 				cancelNodeAddErr.AddReason(typedAction.Reason)
 			}
+		case *FailNodeAddAction:
+			shouldFail = true
+			if failNodeAddErr == nil {
+				failNodeAddErr = NewErrNodeAddFailed([]error{typedAction.Reason})
+			} else {
+				failNodeAddErr.AddReason(typedAction.Reason)
+			}
 		}
 	}
+
+	// Cancellation takes priority over failure
 	if shouldCancel {
 		return cancelNodeAddErr
+	}
+	if shouldFail {
+		return failNodeAddErr
 	}
 	return nil
 }
@@ -367,13 +444,13 @@ func (m *Manager) removeEventNodeFromDependencies(eventNode *EventNode) {
 	}
 }
 
-// removeEventDependents removes all dependent events from the tree
-func (m *Manager) removeEventDependents(eventNode *EventNode) {
+// failEventDependents fails all dependent events from the tree
+func (m *Manager) failEventDependents(eventNode *EventNode) {
 	for _, dependentEvent := range eventNode.GetDependents() {
-		err := m.removeEvent(dependentEvent)
+		_, err := m.failEvent(dependentEvent)
 		if err != nil {
 			eventName := events.Core.GetDefinitionByID(dependentEvent).GetName()
-			logger.Debugw("failed to remove dependent event", "event", eventName, "error", err)
+			logger.Debugw("failed to fail dependent event", "event", eventName, "error", err)
 		}
 	}
 }
@@ -382,12 +459,18 @@ func (m *Manager) getProbe(handle probes.Handle) *ProbeNode {
 	return m.probes[handle]
 }
 
+// buildProbe adds the probe dependent to the probe node.
+// It also creates the probe node if it does not exist in the tree.
 func (m *Manager) buildProbe(handle probes.Handle, dependent events.ID) error {
+	if _, failed := m.failedProbes[handle]; failed {
+		return fmt.Errorf("probe %v previously failed to add", handle)
+	}
 	probeNode, ok := m.probes[handle]
 	if !ok {
 		probeNode = NewProbeNode(handle, []events.ID{dependent})
 		err := m.addNode(probeNode)
 		if err != nil {
+			m.failedProbes[handle] = struct{}{}
 			return err
 		}
 	} else {
@@ -396,11 +479,141 @@ func (m *Manager) buildProbe(handle probes.Handle, dependent events.ID) error {
 	return nil
 }
 
-func (m *Manager) addProbe(probeNode *ProbeNode) {
+func (m *Manager) addProbeNodeToTree(probeNode *ProbeNode) {
 	m.probes[probeNode.GetHandle()] = probeNode
 }
 
-// removeNode removes the node from the tree.
-func (m *Manager) removeProbe(handle *ProbeNode) {
+// removeProbeNodeFromTree removes the node from the tree.
+func (m *Manager) removeProbeNodeFromTree(handle *ProbeNode) {
 	delete(m.probes, handle.GetHandle())
+}
+
+// FailEvent is similar to RemoveEvent, except for the fact that instead of
+// removing the current event immediately, it will try to use its fallback dependencies first.
+// The old events dependencies of it will be removed in any case.
+// The event will be removed if it has no fallback though, and with it the events
+// that depend on it will fail as well.
+// The return value specifies if the event was removed or not from the tree and any error that occurred.
+func (m *Manager) FailEvent(id events.ID) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.failEvent(id)
+}
+
+// failEvent attempts to switch the given event dependencies to its next available fallback ones.
+// It removes the event's current dependencies and tries each fallback in order.
+// If a fallback is successfully applied (i.e., buildEventNode succeeds), the function returns (false, nil),
+// indicating the event was not removed but switched to a fallback.
+// If no fallbacks are available or all fail, the event is removed and the function returns (true, error),
+// where the error is from the removal or nil if successful.
+func (m *Manager) failEvent(eventID events.ID) (bool, error) {
+	// Check if already processing this event (prevents loops)
+	if _, processing := m.processingEvents[eventID]; processing {
+		return false, fmt.Errorf("event %v is currently being processed", eventID)
+	}
+
+	node := m.getEventNode(eventID)
+	if node == nil {
+		return false, ErrNodeNotFound
+	}
+
+	// Mark as processing
+	m.processingEvents[eventID] = struct{}{}
+	defer delete(m.processingEvents, eventID) // Always cleanup
+
+	return m.failEventNode(node)
+}
+
+func (m *Manager) failEventNode(node *EventNode) (bool, error) {
+	eventName := events.Core.GetDefinitionByID(node.GetID()).GetName()
+	logger.Debugw("Failing event", "event", eventName)
+	// Try fallbacks in a loop until one succeeds or we run out
+	for node.hasMoreFallbacks() {
+		m.removeEventNodeFromDependencies(node)
+		if !node.fallback() {
+			break
+		}
+		logger.Debugw("Switching to fallback", "event", eventName, "fallback number", node.currentFallbackIndex)
+
+		_, err := m.buildEventNode(node)
+		if err == nil {
+			logger.Debugw("Successfully switched to fallback", "event", eventName)
+			return false, nil
+		}
+		logger.Debugw("Failed to switch to fallback", "event", eventName, "fallback number", node.currentFallbackIndex, "error", err)
+	}
+	logger.Debugw("All fallbacks failed, removing event", "event", eventName)
+	return true, m.removeEventNode(node)
+}
+
+// handleEventAddError handles the error of adding a node to the tree.
+// As errors in adding a node to the tree are caused either by dependencies failure or by add-watchers actions,
+// it will determine the handling strategy based on the error type.
+func (m *Manager) handleEventAddError(node *EventNode, err error) error {
+	var cancelErr *ErrNodeAddCancelled
+
+	if errors.As(err, &cancelErr) {
+		// Cancellation: immediate removal, no fallbacks
+		// No need to fail event dependents, as they will fail using event add failure error handling
+		eventName := events.Core.GetDefinitionByID(node.GetID()).GetName()
+		logger.Debugw("Event add cancelled", "event", eventName)
+		m.removeEventNodeFromDependencies(node)
+		m.removeNode(node)
+		return err
+	}
+	// Failure: try fallbacks
+	removed, failEventErr := m.failEventNode(node)
+	if failEventErr != nil {
+		logger.Errorw("Failed to fail", "error", failEventErr)
+		m.removeEventNodeFromDependencies(node)
+		return err
+	}
+	if removed {
+		// All fallbacks exhausted, event was removed
+		return err
+	}
+	// Fallback succeeded, no error to return
+	return nil
+}
+
+// FailProbe marks a probe as failed and fails all events that depend on it.
+func (m *Manager) FailProbe(handle probes.Handle) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Mark probe as failed
+	m.failedProbes[handle] = struct{}{}
+
+	m.removeProbe(handle)
+
+	return nil
+}
+
+// removeProbe removes the probe from the tree and fails all dependent events.
+func (m *Manager) removeProbe(handle probes.Handle) {
+	probeNode := m.getProbe(handle)
+	if probeNode == nil {
+		return
+	}
+
+	// Get all events that depend on this probe directly from the probe node
+	dependentEvents := probeNode.GetDependents()
+
+	// Remove the probe node from the tree
+	m.removeNode(probeNode)
+
+	// Fail all dependent events
+	for _, eventID := range dependentEvents {
+		// Check if the event is still in the tree and not being processed
+		if m.getEventNode(eventID) != nil {
+			if _, processing := m.processingEvents[eventID]; !processing {
+				_, err := m.failEvent(eventID)
+				if err != nil {
+					eventName := events.Core.GetDefinitionByID(eventID).GetName()
+					logger.Warnw("failed to fail dependent event", "event", eventName, "error", err)
+				}
+			}
+		}
+	}
 }

--- a/pkg/events/dependencies/manager_test.go
+++ b/pkg/events/dependencies/manager_test.go
@@ -197,6 +197,8 @@ func TestManager_AddEvent(t *testing.T) {
 					_, err := m.GetProbe(handle)
 					assert.ErrorIs(t, err, ErrNodeNotFound, handle)
 				}
+				_, err = m.GetEvent(testCase.eventToAdd)
+				assert.ErrorIs(t, err, ErrNodeNotFound, testCase.eventToAdd)
 				assert.Len(t, eventsAdditions, len(testCase.deps))
 				assert.Len(t, eventsRemove, len(testCase.deps))
 				assert.ElementsMatch(t, eventsAdditions, eventsRemove)
@@ -314,10 +316,7 @@ func TestManager_RemoveEvent(t *testing.T) {
 				events.ID(4): events.NewDependencies(
 					[]events.ID{events.ID(3)},
 					nil,
-					[]events.Probe{
-						events.NewProbe(probes.SchedProcessExec, true),
-						events.NewProbe(probes.SchedProcessFork, true),
-					},
+					nil,
 					nil,
 					events.Capabilities{},
 				),
@@ -498,14 +497,20 @@ func TestManager_UnselectEvent(t *testing.T) {
 				events.ID(4): events.NewDependencies(
 					[]events.ID{events.ID(3)},
 					nil,
-					nil,
+					[]events.Probe{
+						events.NewProbe(probes.SchedProcessExec, true),
+						events.NewProbe(probes.SchedProcessFork, true),
+					},
 					nil,
 					events.Capabilities{},
 				),
 				events.ID(1): events.NewDependencies(
 					[]events.ID{events.ID(2)},
 					nil,
-					nil,
+					[]events.Probe{
+						events.NewProbe(probes.SchedProcessExec, true),
+						events.NewProbe(probes.SchedProcessExit, true),
+					},
 					nil,
 					events.Capabilities{},
 				),
@@ -560,4 +565,658 @@ func TestManager_UnselectEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManager_FailEvent(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		preAddedEvents         []events.ID
+		eventToAdd             events.ID
+		deps                   map[events.ID]events.Dependencies
+		expectedRemovedEvents  []events.ID
+		expectedExistingEvents map[events.ID][]events.ID
+		expectEventRemoved     bool
+	}{
+		{
+			name:       "no dependencies with no fallback",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): {},
+			},
+			expectedRemovedEvents:  []events.ID{events.ID(1)},
+			expectedExistingEvents: map[events.ID][]events.ID{},
+			expectEventRemoved:     true,
+		},
+		{
+			name:       "no dependencies with empty fallback",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): events.NewDependenciesWithFallbacks(
+					[]events.ID{},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+					[]events.Dependencies{{}},
+				),
+			},
+			expectedRemovedEvents: []events.ID{},
+			expectedExistingEvents: map[events.ID][]events.ID{
+				1: {},
+			},
+			expectEventRemoved: false,
+		},
+		{
+			name:       "no dependencies with fallback with dependencies",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): events.NewDependenciesWithFallbacks(
+					[]events.ID{},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+					[]events.Dependencies{
+						events.NewDependencies(
+							[]events.ID{2},
+							nil,
+							nil,
+							nil,
+							events.Capabilities{},
+						),
+					},
+				),
+				events.ID(2): {},
+			},
+			expectedRemovedEvents: []events.ID{},
+			expectedExistingEvents: map[events.ID][]events.ID{
+				1: {2},
+				2: {},
+			},
+			expectEventRemoved: false,
+		},
+		{
+			name:       "event with dependency with empty dependency fallback",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): events.NewDependenciesWithFallbacks(
+					[]events.ID{events.ID(2)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+					[]events.Dependencies{{}},
+				),
+				events.ID(2): {},
+			},
+			expectedRemovedEvents: []events.ID{events.ID(2)},
+			expectedExistingEvents: map[events.ID][]events.ID{
+				1: {},
+			},
+			expectEventRemoved: false,
+		},
+		{
+			name:       "event with multiple dependencies without fallback",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): events.NewDependencies(
+					[]events.ID{events.ID(2)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(2): events.NewDependencies(
+					[]events.ID{events.ID(3)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(3): {},
+			},
+			expectedRemovedEvents:  []events.ID{events.ID(1), events.ID(2), events.ID(3)},
+			expectedExistingEvents: map[events.ID][]events.ID{},
+			expectEventRemoved:     true,
+		},
+		{
+			name:       "event with fallback event with dependencies",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): events.NewDependenciesWithFallbacks(
+					[]events.ID{},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+					[]events.Dependencies{
+						events.NewDependencies(
+							[]events.ID{2},
+							nil,
+							nil,
+							nil,
+							events.Capabilities{},
+						),
+					},
+				),
+				events.ID(2): events.NewDependencies(
+					[]events.ID{events.ID(3)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(3): {},
+			},
+			expectedRemovedEvents: []events.ID{},
+			expectedExistingEvents: map[events.ID][]events.ID{
+				1: {2},
+				2: {3},
+				3: {},
+			},
+			expectEventRemoved: false,
+		},
+		{
+			name:           "multi levels dependency event with no fallback which is a dependency",
+			eventToAdd:     events.ID(1),
+			preAddedEvents: []events.ID{events.ID(4)},
+			deps: map[events.ID]events.Dependencies{
+				events.ID(4): events.NewDependencies(
+					[]events.ID{events.ID(1)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(1): events.NewDependencies(
+					[]events.ID{events.ID(2)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(2): events.NewDependencies(
+					[]events.ID{events.ID(3)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(3): {},
+			},
+			expectedRemovedEvents:  []events.ID{1, 2, 3, 4},
+			expectedExistingEvents: map[events.ID][]events.ID{},
+			expectEventRemoved:     true,
+		},
+		{
+			name:           "multi levels dependency event with no fallback which shares dependency",
+			eventToAdd:     events.ID(1),
+			preAddedEvents: []events.ID{events.ID(4)},
+			deps: map[events.ID]events.Dependencies{
+				events.ID(4): events.NewDependencies(
+					[]events.ID{events.ID(3)},
+					nil,
+					[]events.Probe{
+						events.NewProbe(probes.SchedProcessExec, true),
+						events.NewProbe(probes.SchedProcessFork, true),
+					},
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(1): events.NewDependencies(
+					[]events.ID{events.ID(2)},
+					nil,
+					[]events.Probe{
+						events.NewProbe(probes.SchedProcessExec, true),
+						events.NewProbe(probes.SchedProcessExit, true),
+					},
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(2): events.NewDependencies(
+					[]events.ID{events.ID(3)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				events.ID(3): {},
+			},
+			expectedRemovedEvents: []events.ID{events.ID(1), events.ID(2)},
+			expectedExistingEvents: map[events.ID][]events.ID{
+				4: {3},
+				3: {},
+			},
+			expectEventRemoved: true,
+		},
+		{
+			name:       "event with multiple fallbacks available",
+			eventToAdd: events.ID(1),
+			deps: map[events.ID]events.Dependencies{
+				events.ID(1): events.NewDependenciesWithFallbacks(
+					[]events.ID{events.ID(2)}, // Primary dependency
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+					[]events.Dependencies{
+						// First fallback - depends on event 3
+						events.NewDependencies(
+							[]events.ID{events.ID(3)},
+							nil,
+							nil,
+							nil,
+							events.Capabilities{},
+						),
+						// Second fallback - empty dependencies
+						{},
+					},
+				),
+				events.ID(2): {},
+				events.ID(3): {},
+			},
+			expectedRemovedEvents: []events.ID{events.ID(2)},
+			expectedExistingEvents: map[events.ID][]events.ID{
+				1: {3}, // First fallback will be used
+				3: {},
+			},
+			expectEventRemoved: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Create a new Manager instance
+			m := NewDependenciesManager(getTestDependenciesFunc(testCase.deps))
+
+			var eventsRemove []events.ID
+
+			// Count removes
+			m.SubscribeRemove(
+				EventNodeType,
+				func(node interface{}) []Action {
+					removeEventNode, ok := node.(*EventNode)
+					require.True(t, ok)
+					eventsRemove = append(eventsRemove, removeEventNode.GetID())
+					return nil
+				},
+			)
+
+			for _, preAddedEvent := range testCase.preAddedEvents {
+				_, err := m.SelectEvent(preAddedEvent)
+				require.NoError(t, err)
+			}
+
+			_, err := m.SelectEvent(testCase.eventToAdd)
+			require.NoError(t, err)
+
+			// Call FailEvent
+			removed, err := m.FailEvent(testCase.eventToAdd)
+			require.NoError(t, err)
+
+			// Check if event was removed as expected
+			assert.Equal(t, testCase.expectEventRemoved, removed)
+
+			// Verify removed events
+			for _, id := range testCase.expectedRemovedEvents {
+				_, err := m.GetEvent(events.ID(id))
+				assert.ErrorIs(t, err, ErrNodeNotFound, "Event %d should be removed", id)
+				assert.Contains(t, eventsRemove, events.ID(id), "Event %d should be in removed list", id)
+			}
+
+			// Verify existing events and their dependencies
+			for id, expectedDeps := range testCase.expectedExistingEvents {
+				node, err := m.GetEvent(events.ID(id))
+				require.NoError(t, err, "Event %d should exist", id)
+
+				actualDeps := node.GetDependencies().GetIDs()
+				assert.ElementsMatch(t, expectedDeps, actualDeps, "Event %d dependencies mismatch", id)
+
+				// Verify it's not in removed list
+				assert.NotContains(t, eventsRemove, events.ID(id), "Event %d should not be removed", id)
+			}
+		})
+	}
+}
+
+func TestManager_FailEvent_MultipleFallbacks(t *testing.T) {
+	// Test to demonstrate first fallback failing, second succeeding
+	// We'll use an add watcher to cancel the first fallback dependency
+
+	deps := map[events.ID]events.Dependencies{
+		events.ID(1): events.NewDependenciesWithFallbacks(
+			[]events.ID{events.ID(2)}, // Primary dependency
+			nil,
+			nil,
+			nil,
+			events.Capabilities{},
+			[]events.Dependencies{
+				// First fallback - depends on event 3 (will be cancelled)
+				events.NewDependencies(
+					[]events.ID{events.ID(3)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+				// Second fallback - depends on event 4 (will succeed)
+				events.NewDependencies(
+					[]events.ID{events.ID(4)},
+					nil,
+					nil,
+					nil,
+					events.Capabilities{},
+				),
+			},
+		),
+		events.ID(2): {},
+		events.ID(3): {},
+		events.ID(4): {},
+	}
+
+	m := NewDependenciesManager(getTestDependenciesFunc(deps))
+
+	// Add watcher that cancels event 3 addition (dependent event 1 will fail and use next fallback)
+	m.SubscribeAdd(
+		EventNodeType,
+		func(node interface{}) []Action {
+			newEventNode, ok := node.(*EventNode)
+			if !ok {
+				return nil
+			}
+			if newEventNode.GetID() == events.ID(3) {
+				return []Action{NewCancelNodeAddAction(errors.New("event 3 cancelled"))}
+			}
+			return nil
+		},
+	)
+
+	var eventsRemove []events.ID
+	m.SubscribeRemove(EventNodeType, func(node interface{}) []Action {
+		eventsRemove = append(eventsRemove, node.(*EventNode).GetID())
+		return nil
+	})
+
+	// Add event successfully with primary dependencies
+	_, err := m.SelectEvent(events.ID(1))
+	require.NoError(t, err)
+
+	// Verify primary dependency exists
+	node, err := m.GetEvent(events.ID(1))
+	require.NoError(t, err)
+	assert.Equal(t, []events.ID{events.ID(2)}, node.GetDependencies().GetIDs())
+
+	// Call FailEvent - should try first fallback (fails due to cancellation), then second fallback (succeeds)
+	removed, err := m.FailEvent(events.ID(1))
+	require.NoError(t, err)
+	assert.False(t, removed) // Event should not be removed
+
+	// Verify event now uses second fallback (depends on event 4)
+	node, err = m.GetEvent(events.ID(1))
+	require.NoError(t, err)
+	assert.Equal(t, []events.ID{events.ID(4)}, node.GetDependencies().GetIDs())
+
+	// Verify event 4 exists
+	_, err = m.GetEvent(events.ID(4))
+	require.NoError(t, err)
+
+	// Verify original dependency (event 2) was removed
+	assert.Contains(t, eventsRemove, events.ID(2))
+}
+
+func TestManager_FailureVsCancellation(t *testing.T) {
+	t.Run("FailNodeAddAction triggers fallbacks", func(t *testing.T) {
+		deps := map[events.ID]events.Dependencies{
+			events.ID(1): events.NewDependenciesWithFallbacks(
+				[]events.ID{events.ID(2)}, // Primary dependency
+				nil,
+				nil,
+				nil,
+				events.Capabilities{},
+				[]events.Dependencies{
+					// Fallback - empty dependencies
+					{},
+				},
+			),
+			events.ID(2): {},
+		}
+
+		m := NewDependenciesManager(getTestDependenciesFunc(deps))
+
+		// Add watcher that fails (not cancels) event 2 addition
+		m.SubscribeAdd(
+			EventNodeType,
+			func(node interface{}) []Action {
+				newEventNode, ok := node.(*EventNode)
+				if !ok {
+					return nil
+				}
+				if newEventNode.GetID() == events.ID(1) {
+					return []Action{NewFailNodeAddAction(errors.New("event 1 failed"))}
+				}
+				return nil
+			},
+		)
+
+		// Try to add event 1 - should succeed using fallback when event 2 fails
+		eventNode, err := m.SelectEvent(events.ID(1))
+		require.NoError(t, err)
+		assert.NotNil(t, eventNode)
+
+		// Verify event 1 uses fallback (empty dependencies)
+		assert.Empty(t, eventNode.GetDependencies().GetIDs())
+
+		// Verify event 2 was not added
+		_, err = m.GetEvent(events.ID(2))
+		assert.ErrorIs(t, err, ErrNodeNotFound)
+	})
+
+	t.Run("CancelNodeAddAction causes immediate removal", func(t *testing.T) {
+		deps := map[events.ID]events.Dependencies{
+			events.ID(1): events.NewDependenciesWithFallbacks(
+				[]events.ID{events.ID(2)}, // Primary dependency
+				nil,
+				nil,
+				nil,
+				events.Capabilities{},
+				[]events.Dependencies{},
+			),
+			events.ID(2): {},
+		}
+
+		m := NewDependenciesManager(getTestDependenciesFunc(deps))
+
+		var eventsRemove []events.ID
+		m.SubscribeRemove(EventNodeType, func(node interface{}) []Action {
+			eventNode, ok := node.(*EventNode)
+			if !ok {
+				return nil
+			}
+			eventsRemove = append(eventsRemove, eventNode.GetID())
+			return nil
+		})
+
+		// Add watcher that cancels event 2 addition
+		m.SubscribeAdd(
+			EventNodeType,
+			func(node interface{}) []Action {
+				newEventNode, ok := node.(*EventNode)
+				if !ok {
+					return nil
+				}
+				if newEventNode.GetID() == events.ID(2) {
+					return []Action{NewCancelNodeAddAction(errors.New("event 2 cancelled"))}
+				}
+				return nil
+			},
+		)
+
+		// Try to add event 1 - should fail because dependency was cancelled and no fallbacks work
+		_, err := m.SelectEvent(events.ID(1))
+		require.Error(t, err)
+
+		// Should be a failed error (converted from cancellation) since this is a dependent event
+		var failErr *ErrNodeAddFailed
+		assert.True(t, errors.As(err, &failErr))
+
+		// Verify neither event was added
+		_, err = m.GetEvent(events.ID(1))
+		assert.ErrorIs(t, err, ErrNodeNotFound)
+		_, err = m.GetEvent(events.ID(2))
+		assert.ErrorIs(t, err, ErrNodeNotFound)
+	})
+
+	t.Run("Dependent event uses fallback when dependency is cancelled", func(t *testing.T) {
+		deps := map[events.ID]events.Dependencies{
+			events.ID(1): events.NewDependenciesWithFallbacks(
+				[]events.ID{events.ID(2)}, // Primary dependency
+				nil,
+				nil,
+				nil,
+				events.Capabilities{},
+				[]events.Dependencies{
+					// Fallback - depends on event 3
+					events.NewDependencies(
+						[]events.ID{events.ID(3)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					),
+				},
+			),
+			events.ID(2): {},
+			events.ID(3): {},
+		}
+
+		m := NewDependenciesManager(getTestDependenciesFunc(deps))
+
+		// Add watcher that cancels event 2 addition
+		m.SubscribeAdd(
+			EventNodeType,
+			func(node interface{}) []Action {
+				newEventNode, ok := node.(*EventNode)
+				if !ok {
+					return nil
+				}
+				if newEventNode.GetID() == events.ID(2) {
+					return []Action{NewCancelNodeAddAction(errors.New("event 2 cancelled"))}
+				}
+				return nil
+			},
+		)
+
+		// Try to add event 1 - should succeed using fallback when event 2 is cancelled
+		eventNode, err := m.SelectEvent(events.ID(1))
+		require.NoError(t, err)
+		assert.NotNil(t, eventNode)
+
+		// Verify event 1 uses fallback (depends on event 3)
+		assert.Equal(t, []events.ID{events.ID(3)}, eventNode.GetDependencies().GetIDs())
+
+		// Verify event 3 was added
+		_, err = m.GetEvent(events.ID(3))
+		assert.NoError(t, err)
+
+		// Verify event 2 was not added
+		_, err = m.GetEvent(events.ID(2))
+		assert.ErrorIs(t, err, ErrNodeNotFound)
+	})
+}
+
+func TestManager_FailEvent_ProbeFailures(t *testing.T) {
+	// Test basic FailEvent functionality without mocking
+	deps := map[events.ID]events.Dependencies{
+		events.ID(1): events.NewDependenciesWithFallbacks(
+			[]events.ID{},
+			nil,
+			[]events.Probe{events.NewProbe(probes.SchedProcessExec, true)},
+			nil,
+			events.Capabilities{},
+			[]events.Dependencies{
+				events.NewDependencies(
+					[]events.ID{},
+					nil,
+					[]events.Probe{events.NewProbe(probes.SchedProcessExit, true)},
+					nil,
+					events.Capabilities{},
+				),
+			},
+		),
+	}
+
+	m := NewDependenciesManager(getTestDependenciesFunc(deps))
+
+	// Add event successfully
+	_, err := m.SelectEvent(events.ID(1))
+	require.NoError(t, err)
+
+	// Verify event exists with primary dependencies
+	node, err := m.GetEvent(events.ID(1))
+	require.NoError(t, err)
+
+	primaryProbes := node.GetDependencies().GetProbes()
+	require.Len(t, primaryProbes, 1)
+	assert.Equal(t, probes.SchedProcessExec, primaryProbes[0].GetHandle())
+
+	// Test FailEvent on existing event with fallbacks
+	removed, err := m.FailEvent(events.ID(1))
+	require.NoError(t, err)
+
+	// Since we can't mock probe failures, the fallback should succeed
+	// (empty dependencies build successfully)
+	assert.False(t, removed) // Event should not be removed
+
+	// Verify event still exists after FailEvent
+	_, err = m.GetEvent(events.ID(1))
+	require.NoError(t, err)
+}
+
+func TestManager_FailEvent_NonExistentEvent(t *testing.T) {
+	m := NewDependenciesManager(getTestDependenciesFunc(map[events.ID]events.Dependencies{}))
+
+	// Try to fail an event that doesn't exist
+	removed, err := m.FailEvent(events.ID(999))
+	require.ErrorIs(t, err, ErrNodeNotFound)
+	assert.False(t, removed)
+}
+
+func TestManager_FailEvent_EventWithoutFallbacks(t *testing.T) {
+	deps := map[events.ID]events.Dependencies{
+		events.ID(1): events.NewDependencies(
+			[]events.ID{events.ID(2)},
+			nil,
+			[]events.Probe{events.NewProbe(probes.SchedProcessExec, true)},
+			nil,
+			events.Capabilities{},
+		),
+		events.ID(2): {},
+	}
+
+	m := NewDependenciesManager(getTestDependenciesFunc(deps))
+
+	var removedEvents []events.ID
+	m.SubscribeRemove(EventNodeType, func(node interface{}) []Action {
+		removedEvents = append(removedEvents, node.(*EventNode).GetID())
+		return nil
+	})
+
+	// Add event
+	_, err := m.SelectEvent(events.ID(1))
+	require.NoError(t, err)
+
+	// Fail event (no fallbacks available)
+	removed, err := m.FailEvent(events.ID(1))
+	require.NoError(t, err)
+	assert.True(t, removed) // Event should be removed
+
+	// Verify event and its dependencies are removed
+	_, err = m.GetEvent(events.ID(1))
+	assert.ErrorIs(t, err, ErrNodeNotFound)
+	_, err = m.GetEvent(events.ID(2))
+	assert.ErrorIs(t, err, ErrNodeNotFound)
+
+	// Verify removal events were triggered
+	assert.Contains(t, removedEvents, events.ID(1))
+	assert.Contains(t, removedEvents, events.ID(2))
 }


### PR DESCRIPTION
### 1. Explain what the PR does

Add probes compatibility which allow to define  in advance cases where the probe will fail, enabling the cancellation of the probe. Currently only implemented kernel version requirement for the compatibility.
Using it, introduce events dependencies fallbacks, which add the option to use different dependencies if the previous ones has failed for some reason.
This together with the autoload feature in the PR #4857 will enable the option to create probes that are not supported by all kernels and used only in the supporting ones, while using a fallback mechanism for unsupporting ones.

### 2. Explain how to test it

Added unit tests and integration tests, so using the `make test-unit` and `make test-integration` commands.

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
