### PR TITLE
feat: add system monitoring utilities package

### DIFF
--- a/pkg/utils/proc/stat.go
+++ b/pkg/utils/proc/stat.go
@@ -90,7 +90,9 @@ const (
 
 // ProcStat represents the minimal required fields of the /proc stat file.
 type ProcStat struct {
-	startTime uint64 // StatStartTime
+	userTime   uint64 // StatUtime
+	systemTime uint64 // StatStime
+	startTime  uint64 // StatStartTime
 	// rss       uint64 // StatRss (parsed as int64)
 }
 
@@ -99,7 +101,9 @@ type procStatValueParser func(value []byte, s *ProcStat)
 // procStatValueParserArray maps the index of the field in the stat file to its respective value parser.
 // If a parser is nil, the field is ignored on parsing.
 var procStatValueParserArray = [StatMaxNumFields]procStatValueParser{
-	StatStartTime: parseStartTime, // StartTime
+	StatUtime:     parseUserTime,   // UserTime
+	StatStime:     parseSystemTime, // SystemTime
+	StatStartTime: parseStartTime,  // StartTime
 }
 
 // statDefaultFields is the default set of fields to parse from the stat file.
@@ -232,6 +236,14 @@ func (s *ProcStat) parse(statBytes []byte, fields []StatField) error {
 
 // stat fields parsers
 
+func parseUserTime(value []byte, s *ProcStat) {
+	s.userTime, _ = ParseUint64(string(value))
+}
+
+func parseSystemTime(value []byte, s *ProcStat) {
+	s.systemTime, _ = ParseUint64(string(value))
+}
+
 func parseStartTime(value []byte, s *ProcStat) {
 	s.startTime, _ = ParseUint64(string(value))
 }
@@ -248,6 +260,16 @@ func parseStartTime(value []byte, s *ProcStat) {
 // GetStartTime returns the time the process started after system boot (in clock ticks).
 func (s *ProcStat) GetStartTime() uint64 {
 	return s.startTime
+}
+
+// GetUserTime returns the user mode jiffies (clock ticks).
+func (s *ProcStat) GetUserTime() uint64 {
+	return s.userTime
+}
+
+// GetSystemTime returns the kernel mode jiffies (clock ticks).
+func (s *ProcStat) GetSystemTime() uint64 {
+	return s.systemTime
 }
 
 // // GetRss returns the resident set memory size.

--- a/pkg/utils/proc/stat_test.go
+++ b/pkg/utils/proc/stat_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// ensure that the test will fail if the ProcStat struct size changes
-	maxProcStatLength = 8
+	maxProcStatLength = 24
 )
 
 // TestProcStat_PrintSizes prints the sizes of the structs used in the ProcStat type.
@@ -69,7 +69,9 @@ func Test_newProcStat(t *testing.T) {
 		{
 			name: "Correct parsing of startTime",
 			expected: ProcStat{
-				startTime: 46236871,
+				userTime:   566,
+				systemTime: 643,
+				startTime:  46236871,
 			},
 		},
 	}
@@ -81,7 +83,14 @@ func Test_newProcStat(t *testing.T) {
 			file := tests.CreateTempFile(t, statContent)
 			defer os.Remove(file.Name())
 
-			result, err := newProcStat(file.Name(), statDefaultFields)
+			result, err := newProcStat(
+				file.Name(),
+				[]StatField{
+					StatUtime,
+					StatStime,
+					StatStartTime,
+				},
+			)
 			if err != nil {
 				t.Fatalf("Error creating new ProcStat: %v", err)
 			}

--- a/pkg/utils/proc/uptime.go
+++ b/pkg/utils/proc/uptime.go
@@ -1,0 +1,69 @@
+package proc
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/aquasecurity/tracee/pkg/errfmt"
+)
+
+const (
+	procUptime        = "/proc/uptime"
+	procUptimeInitBuf = 32 // a round and realistic initial buffer size
+)
+
+type ProcUptime struct {
+	uptime   float64 // System uptime in seconds (includes suspended time)
+	idleTime float64 // Idle time in seconds
+}
+
+func GetUptime() (*ProcUptime, error) {
+	data, err := ReadFile(procUptime, procUptimeInitBuf)
+	if err != nil {
+		return nil, errfmt.Errorf("failed to read %s: %v", procUptime, err)
+	}
+
+	// Find the space separator in the original data
+	spaceIdx := bytes.IndexByte(data, ' ')
+	if spaceIdx <= 0 {
+		return nil, errfmt.Errorf("invalid format in %s: missing or empty first field", procUptime)
+	}
+
+	// Find the end of the second field (trim trailing newline if present)
+	endIdx := len(data)
+	if data[endIdx-1] == '\n' {
+		endIdx--
+	}
+
+	// Ensure there's content for the second field
+	if spaceIdx+1 >= endIdx {
+		return nil, errfmt.Errorf("invalid format in %s: missing or empty second field", procUptime)
+	}
+
+	// Parse uptime (first field: 0 to spaceIdx)
+	uptime, err := strconv.ParseFloat(string(data[:spaceIdx]), 64)
+	if err != nil {
+		return nil, errfmt.Errorf("failed to parse uptime from %s: %v", procUptime, err)
+	}
+
+	// Parse idle time (second field: spaceIdx+1 to endIdx)
+	idleTime, err := strconv.ParseFloat(string(data[spaceIdx+1:endIdx]), 64)
+	if err != nil {
+		return nil, errfmt.Errorf("failed to parse idle time from %s: %v", procUptime, err)
+	}
+
+	return &ProcUptime{
+		uptime:   uptime,
+		idleTime: idleTime,
+	}, nil
+}
+
+// GetUptime returns the system uptime (includes suspended time).
+func (u *ProcUptime) GetUptime() float64 {
+	return u.uptime
+}
+
+// GetIdleTime returns the idle time of the system.
+func (u *ProcUptime) GetIdleTime() float64 {
+	return u.idleTime
+}

--- a/pkg/utils/system/monitor.go
+++ b/pkg/utils/system/monitor.go
@@ -1,0 +1,125 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/aquasecurity/tracee/pkg/utils/proc"
+)
+
+const (
+	// Clock ticks per second - standard for most Linux distributions (CONFIG_HZ_100)
+	// While some kernels use 250, 300, or 1000 Hz, 100 Hz is correct for 99% of systems
+	clockTicksPerSecond = 100.0
+)
+
+// CPUStats represents CPU usage information
+type CPUStats struct {
+	// Raw CPU time values in clock ticks
+	UserTime   uint64
+	SystemTime uint64
+	// System uptime in seconds
+	Uptime float64
+	// Number of CPU cores
+	Cores int
+}
+
+// MemoryStats represents memory usage information
+type MemoryStats struct {
+	// Go runtime memory stats
+	Alloc      uint64 // bytes allocated and still in use
+	TotalAlloc uint64 // bytes allocated (even if freed)
+	Sys        uint64 // bytes obtained from system
+	NumGC      uint32 // number of garbage collections
+	// RSS memory from /proc/self/status
+	RSS uint64 // resident set size in bytes
+}
+
+// GetCPUStats returns current CPU usage statistics by reading /proc/self/stat and /proc/uptime
+func GetCPUStats() (CPUStats, error) {
+	var cpuStats CPUStats
+
+	// Get self stat
+	stat, err := proc.NewProcStatFields(
+		int32(os.Getpid()),
+		[]proc.StatField{
+			proc.StatUtime,
+			proc.StatStime,
+		},
+	)
+	if err != nil {
+		return cpuStats, fmt.Errorf("failed to read process stat: %w", err)
+	}
+
+	// Get system uptime
+	procUptime, err := proc.GetUptime()
+	if err != nil {
+		return cpuStats, fmt.Errorf("failed to get uptime: %w", err)
+	}
+
+	// Fill CPUStats
+	cpuStats.UserTime = stat.GetUserTime()
+	cpuStats.SystemTime = stat.GetSystemTime()
+	cpuStats.Uptime = procUptime.GetUptime()
+	cpuStats.Cores = runtime.NumCPU()
+
+	return cpuStats, nil
+}
+
+// GetMemoryStats returns current memory usage statistics including both Go runtime and RSS memory
+func GetMemoryStats() MemoryStats {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	stats := MemoryStats{
+		Alloc:      m.Alloc,
+		TotalAlloc: m.TotalAlloc,
+		Sys:        m.Sys,
+		NumGC:      m.NumGC,
+	}
+
+	// Get self RSS memory
+	rss, _ := getRSSMemory() // Ignore error, RSS will be 0 if failed
+	stats.RSS = rss
+
+	return stats
+}
+
+// getRSSMemory returns the resident set size (RSS) memory in bytes
+func getRSSMemory() (uint64, error) {
+	status, err := proc.NewProcStatusFields(
+		int32(os.Getpid()),
+		[]proc.StatusField{
+			proc.VmRSS,
+		},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read process status: %w", err)
+	}
+
+	return status.GetVmRSS() * 1024, nil // Convert KB to bytes
+}
+
+// CalculateCPUUsagePercent calculates CPU usage percentage between two CPU stat measurements
+func CalculateCPUUsagePercent(previous, current CPUStats) float64 {
+	if previous.UserTime == 0 && previous.SystemTime == 0 {
+		// First measurement, return 0
+		return 0
+	}
+
+	// Calculate CPU usage rate
+	prevTotal := previous.UserTime + previous.SystemTime
+	currTotal := current.UserTime + current.SystemTime
+	cpuTimeDiff := float64(currTotal - prevTotal)
+	uptimeDiff := current.Uptime - previous.Uptime
+
+	if uptimeDiff <= 0 {
+		return 0
+	}
+
+	// Convert clock ticks to seconds and calculate percentage
+	// Use pre-initialized clock ticks per second (set in init())
+	cpuSecondsDiff := cpuTimeDiff / clockTicksPerSecond
+	return (cpuSecondsDiff / uptimeDiff) * 100.0
+}

--- a/pkg/utils/system/monitor_test.go
+++ b/pkg/utils/system/monitor_test.go
@@ -1,0 +1,265 @@
+package system
+
+import (
+	"testing"
+)
+
+func TestGetMemoryStats(t *testing.T) {
+	stats := GetMemoryStats()
+
+	// Basic sanity checks - memory stats should be non-zero
+	if stats.Alloc == 0 {
+		t.Error("Expected Alloc to be non-zero")
+	}
+	if stats.Sys == 0 {
+		t.Error("Expected Sys to be non-zero")
+	}
+
+	// TotalAlloc should be at least as much as current Alloc
+	if stats.TotalAlloc < stats.Alloc {
+		t.Errorf("Expected TotalAlloc (%d) to be >= Alloc (%d)", stats.TotalAlloc, stats.Alloc)
+	}
+
+	// RSS might be 0 on some systems where /proc/self/status is not readable
+	// so we won't fail the test, but we'll log it
+	t.Logf("Memory stats: Alloc=%d, TotalAlloc=%d, Sys=%d, RSS=%d, NumGC=%d",
+		stats.Alloc, stats.TotalAlloc, stats.Sys, stats.RSS, stats.NumGC)
+}
+
+func TestGetCPUStats(t *testing.T) {
+	stats, err := GetCPUStats()
+	if err != nil {
+		t.Fatalf("GetCPUStats failed: %v", err)
+	}
+
+	// Basic sanity checks
+	if stats.Cores <= 0 {
+		t.Errorf("Expected Cores to be positive, got %d", stats.Cores)
+	}
+	if stats.Uptime <= 0 {
+		t.Errorf("Expected Uptime to be positive, got %f", stats.Uptime)
+	}
+
+	t.Logf("CPU stats: UserTime=%d, SystemTime=%d, Uptime=%f, Cores=%d",
+		stats.UserTime, stats.SystemTime, stats.Uptime, stats.Cores)
+}
+
+func TestCalculateCPUUsagePercent(t *testing.T) {
+	tests := []struct {
+		name     string
+		previous CPUStats
+		current  CPUStats
+		expected float64
+	}{
+		{
+			name:     "first measurement (empty previous)",
+			previous: CPUStats{},
+			current: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     10.0,
+				Cores:      4,
+			},
+			expected: 0.0,
+		},
+		{
+			name: "zero time difference",
+			previous: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     10.0,
+				Cores:      4,
+			},
+			current: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     10.0,
+				Cores:      4,
+			},
+			expected: 0.0,
+		},
+		{
+			name: "negative time difference",
+			previous: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     10.0,
+				Cores:      4,
+			},
+			current: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     9.0, // time went backwards
+				Cores:      4,
+			},
+			expected: 0.0,
+		},
+		{
+			name: "normal usage calculation",
+			previous: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     10.0,
+				Cores:      4,
+			},
+			current: CPUStats{
+				UserTime:   1200, // +200 ticks
+				SystemTime: 600,  // +100 ticks
+				Uptime:     12.0, // +2 seconds
+				Cores:      4,
+			},
+			// Total CPU time: 300 ticks = 3 seconds (at 100 ticks/second)
+			// Wall time: 2 seconds
+			// CPU usage: (3/2) * 100 = 150%
+			expected: 150.0,
+		},
+		{
+			name: "low usage calculation",
+			previous: CPUStats{
+				UserTime:   1000,
+				SystemTime: 500,
+				Uptime:     10.0,
+				Cores:      4,
+			},
+			current: CPUStats{
+				UserTime:   1010, // +10 ticks
+				SystemTime: 510,  // +10 ticks
+				Uptime:     12.0, // +2 seconds
+				Cores:      4,
+			},
+			// Total CPU time: 20 ticks = 0.2 seconds
+			// Wall time: 2 seconds
+			// CPU usage: (0.2/2) * 100 = 10%
+			expected: 10.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateCPUUsagePercent(tt.previous, tt.current)
+
+			// Use a small epsilon for floating point comparison
+			epsilon := 0.001
+			if result < tt.expected-epsilon || result > tt.expected+epsilon {
+				t.Errorf("Expected CPU usage %f, got %f", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestGetCPUStatsConsistency verifies that consecutive calls return increasing values
+func TestGetCPUStatsConsistency(t *testing.T) {
+	first, err := GetCPUStats()
+	if err != nil {
+		t.Fatalf("First GetCPUStats call failed: %v", err)
+	}
+
+	// Do some work to ensure CPU time increases
+	sum := 0
+	for i := 0; i < 100000; i++ {
+		sum += i
+	}
+
+	second, err := GetCPUStats()
+	if err != nil {
+		t.Fatalf("Second GetCPUStats call failed: %v", err)
+	}
+
+	// Uptime should increase or stay the same (might not change in very short intervals)
+	if second.Uptime < first.Uptime {
+		t.Errorf("Expected uptime to not decrease: first=%f, second=%f", first.Uptime, second.Uptime)
+	}
+
+	// CPU time should increase or stay the same (might not change in very short intervals)
+	firstTotal := first.UserTime + first.SystemTime
+	secondTotal := second.UserTime + second.SystemTime
+	if secondTotal < firstTotal {
+		t.Errorf("Expected CPU time to not decrease: first=%d, second=%d", firstTotal, secondTotal)
+	}
+
+	// Cores should be consistent
+	if first.Cores != second.Cores {
+		t.Errorf("Expected consistent core count: first=%d, second=%d", first.Cores, second.Cores)
+	}
+
+	// Calculate usage
+	usage := CalculateCPUUsagePercent(first, second)
+	if usage < 0 {
+		t.Errorf("Expected non-negative CPU usage, got %f", usage)
+	}
+
+	t.Logf("CPU usage between measurements: %f%% (used %d for work)", usage, sum)
+}
+
+// TestGetMemoryStatsConsistency verifies memory stats are reasonable
+func TestGetMemoryStatsConsistency(t *testing.T) {
+	stats := GetMemoryStats()
+
+	// Allocate some memory
+	data := make([]byte, 1024*1024) // 1MB
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	newStats := GetMemoryStats()
+
+	// TotalAlloc should have increased
+	if newStats.TotalAlloc <= stats.TotalAlloc {
+		t.Errorf("Expected TotalAlloc to increase after allocation: before=%d, after=%d",
+			stats.TotalAlloc, newStats.TotalAlloc)
+	}
+
+	// Current alloc might not necessarily increase due to GC, but total should
+	t.Logf("Memory before allocation: Alloc=%d, TotalAlloc=%d", stats.Alloc, stats.TotalAlloc)
+	t.Logf("Memory after allocation: Alloc=%d, TotalAlloc=%d", newStats.Alloc, newStats.TotalAlloc)
+	t.Logf("Allocated data length: %d", len(data))
+}
+
+// TestGetRSSMemoryIntegration tests the RSS memory functionality indirectly
+func TestGetRSSMemoryIntegration(t *testing.T) {
+	// Test that RSS memory is included in memory stats
+	stats := GetMemoryStats()
+
+	// RSS should be reasonable compared to other memory stats
+	if stats.RSS > 0 {
+		// RSS should not be dramatically larger than allocated memory
+		// (allowing for some overhead, but not 100x difference)
+		if stats.RSS > stats.Alloc*100 {
+			t.Logf("Warning: RSS (%d) is much larger than Alloc (%d)", stats.RSS, stats.Alloc)
+		}
+
+		// RSS should be at least some reasonable minimum (1KB)
+		if stats.RSS < 1024 {
+			t.Errorf("RSS seems too small: %d bytes", stats.RSS)
+		}
+	} else {
+		t.Logf("RSS is 0, possibly /proc/self/status is not readable")
+	}
+}
+
+// BenchmarkGetCPUStats benchmarks the CPU stats collection
+func BenchmarkGetCPUStats(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := GetCPUStats()
+		if err != nil {
+			b.Fatalf("GetCPUStats failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkGetMemoryStats benchmarks the memory stats collection
+func BenchmarkGetMemoryStats(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = GetMemoryStats()
+	}
+}
+
+// BenchmarkCalculateCPUUsagePercent benchmarks the CPU usage calculation
+func BenchmarkCalculateCPUUsagePercent(b *testing.B) {
+	previous := CPUStats{UserTime: 1000, SystemTime: 500, Uptime: 10.0, Cores: 4}
+	current := CPUStats{UserTime: 1200, SystemTime: 600, Uptime: 12.0, Cores: 4}
+
+	for i := 0; i < b.N; i++ {
+		_ = CalculateCPUUsagePercent(previous, current)
+	}
+}


### PR DESCRIPTION
### 1. Explain what the PR does

fa064bcf4 **feat: add system monitoring utilities package**

```
Add pkg/utils/system package for Linux system resource monitoring:

 - GetCPUStats(): reads CPU usage from proc stat and system uptime
 - GetMemoryStats(): provides Go runtime memory stats plus RSS from proc status
 - CalculateCPUUsagePercent(): calculates CPU usage percentage between measurements
 - Comprehensive unit tests covering all monitoring functions

Co-authored-by: Geyslan Gregório <geyslan@gmail.com>
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
