### PR TITLE
feat(policies): add sets support

### DIFF
--- a/pkg/events/definition_group.go
+++ b/pkg/events/definition_group.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"slices"
 	"sort"
 	"sync"
 
@@ -233,6 +234,20 @@ func (d *DefinitionGroup) GetTailCalls(evtsToSubmit []ID) []TailCall {
 	}
 
 	return tailCalls
+}
+
+// IsASet returns true if the set name is a set.
+func (d *DefinitionGroup) IsASet(setName string) bool {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+
+	for _, def := range d.definitions {
+		if slices.Contains(def.sets, setName) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Errors

--- a/pkg/events/definition_group_test.go
+++ b/pkg/events/definition_group_test.go
@@ -222,6 +222,39 @@ func TestDefinitionGroup_IDs32ToIDs(t *testing.T) {
 	require.Equal(t, idS32ToIDs[id2+1000], id2)                  // same definition ID
 }
 
+// TestDefinitionGroup_IsASet tests that IsASet returns true if the set name exists in any definition.
+func TestDefinitionGroup_IsASet(t *testing.T) {
+	t.Parallel()
+
+	defGroup := NewDefinitionGroup()
+
+	id1 := ID(1)
+	id2 := ID(2)
+	id3 := ID(3)
+
+	// Create definitions with different sets
+	def1 := NewDefinition(id1, id1+1000, "def1", version, "", "", false, false, []string{"set1", "set2"}, Dependencies{}, nil, nil)
+	def2 := NewDefinition(id2, id2+1000, "def2", version, "", "", false, false, []string{"set2", "set3"}, Dependencies{}, nil, nil)
+	def3 := NewDefinition(id3, id3+1000, "def3", version, "", "", false, false, []string{}, Dependencies{}, nil, nil) // no sets
+
+	err := defGroup.AddBatch(map[ID]Definition{id1: def1, id2: def2, id3: def3})
+	require.NoError(t, err)
+
+	// Test existing sets
+	require.True(t, defGroup.IsASet("set1")) // exists in def1
+	require.True(t, defGroup.IsASet("set2")) // exists in both def1 and def2
+	require.True(t, defGroup.IsASet("set3")) // exists in def2
+
+	// Test non-existing sets
+	require.False(t, defGroup.IsASet("set4"))     // doesn't exist
+	require.False(t, defGroup.IsASet("nonexist")) // doesn't exist
+	require.False(t, defGroup.IsASet(""))         // empty string
+
+	// Test with empty definition group
+	emptyDefGroup := NewDefinitionGroup()
+	require.False(t, emptyDefGroup.IsASet("set1")) // no definitions at all
+}
+
 //
 // Thread Safety
 //

--- a/pkg/policy/v1beta1/policy_file.go
+++ b/pkg/policy/v1beta1/policy_file.go
@@ -245,10 +245,19 @@ func validateEvent(policyName, eventName string) error {
 		return errfmt.Errorf("policy %s, event cannot be empty", policyName)
 	}
 
-	_, ok := events.Core.GetDefinitionIDByName(eventName)
-	if !ok {
-		return errfmt.Errorf("policy %s, event %s is not valid", policyName, eventName)
+	eventNames := strings.Split(eventName, ",")
+	for _, event := range eventNames {
+		if events.Core.IsASet(event) {
+			continue
+		}
+
+		e := strings.TrimPrefix(event, "-")
+		_, ok := events.Core.GetDefinitionIDByName(e)
+		if !ok {
+			return errfmt.Errorf("policy %s, event %s is not valid", policyName, event)
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/policy/v1beta1/policy_file_test.go
+++ b/pkg/policy/v1beta1/policy_file_test.go
@@ -513,6 +513,46 @@ func TestPolicyValidate(t *testing.T) {
 			expectedError: errors.New("v1beta1.validateEventData: policy empty-args-value, data pathname value can't be empty"),
 		},
 		{
+			testName: "sets",
+			policy: PolicyFile{
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
+				Metadata: Metadata{
+					Name: "sets",
+				},
+				Spec: k8s.PolicySpec{
+					Scope:          []string{"global"},
+					DefaultActions: []string{"log"},
+					Rules: []k8s.Rule{
+						{
+							Event: "signatures",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			testName: "sets without specific event",
+			policy: PolicyFile{
+				APIVersion: "tracee.aquasec.com/v1beta1",
+				Kind:       "Policy",
+				Metadata: Metadata{
+					Name: "sets-without-specific-event",
+				},
+				Spec: k8s.PolicySpec{
+					Scope:          []string{"global"},
+					DefaultActions: []string{"log"},
+					Rules: []k8s.Rule{
+						{
+							Event: "signatures,-openat",
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			testName: "signature filter data",
 			policy: PolicyFile{
 				APIVersion: "tracee.aquasec.com/v1beta1",


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/tracee/issues/3751 https://github.com/aquasecurity/tracee/issues/4706

It should be able to support a policy like:

```
apiVersion: tracee.aquasec.com/v1beta1
kind: Policy
metadata:
  name: sample
  annotations:
    description: sample
spec:
  scope:
    - global
  rules:
    - event: signatures,-dynamic_code_loading

```