### PR TITLE
fix(ebpf): fix exec_test probe reset logic

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -7353,20 +7353,20 @@ int tracepoint__exec_test(struct bpf_raw_tracepoint_args *ctx)
     if (!evaluate_scope_filters(&p))
         return 0;
 
-    if (!reset_event(p.event, EXEC_TEST))
-        return 0;
-    if (evaluate_scope_filters(&p))
-        ret |= events_perf_submit(&p, 0);
+    if (reset_event(p.event, EXEC_TEST)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
 
-    if (!reset_event(p.event, TEST_MISSING_KSYMBOLS))
-        return 0;
-    if (evaluate_scope_filters(&p))
-        ret |= events_perf_submit(&p, 0);
+    if (reset_event(p.event, TEST_MISSING_KSYMBOLS)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
 
-    if (!reset_event(p.event, TEST_FAILED_ATTACH))
-        return 0;
-    if (evaluate_scope_filters(&p))
-        ret |= events_perf_submit(&p, 0);
+    if (reset_event(p.event, TEST_FAILED_ATTACH)) {
+        if (evaluate_scope_filters(&p))
+            ret |= events_perf_submit(&p, 0);
+    }
 
     return 0;
 }


### PR DESCRIPTION
The probes logic return if a reset fails.
However, a reset fails for event not chosen.
This cause a bug that tests fail if not all test events are chosen.

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
