### PR TITLE
fix: improve error messages and embed manual pages in binary

### DIFF
--- a/cmd/tracee-ebpf/main.go
+++ b/cmd/tracee-ebpf/main.go
@@ -104,7 +104,7 @@ func main() {
 			},
 			&cli.StringSliceFlag{
 				Name:  "cri",
-				Usage: "define connected container runtimes. run '--cri help' for more info.",
+				Usage: "define connected container runtimes",
 				Value: cli.NewStringSlice(),
 			},
 			&cli.IntFlag{

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -35,7 +35,7 @@ access to hundreds of events that help you understand how your system behaves.`,
 				// parse all flags
 				if err := cmd.Flags().Parse(args); err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-					fmt.Fprintf(os.Stderr, "Run 'tracee --help' for usage.\n")
+					fmt.Fprintf(os.Stderr, "Run 'tracee --help' or 'tracee man' for usage.\n")
 					os.Exit(1)
 				}
 

--- a/embedded-man.go
+++ b/embedded-man.go
@@ -1,0 +1,8 @@
+package tracee
+
+import (
+	"embed"
+)
+
+//go:embed "docs/man/*.1"
+var ManPagesBundle embed.FS

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -275,7 +275,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 		return runner, err
 	}
 
-	output, err := flags.PrepareOutput(outputFlags, true)
+	output, err := flags.PrepareOutput(outputFlags)
 	if err != nil {
 		return runner, err
 	}

--- a/pkg/cmd/flags/capture.go
+++ b/pkg/cmd/flags/capture.go
@@ -196,7 +196,7 @@ func PrepareCapture(captureSlice []string, newBinary bool) (config.CaptureConfig
 				return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, run 'man capture' for more info")
 			}
 
-			return config.CaptureConfig{}, errfmt.Errorf("invalid capture option specified, use '--capture help' for more info")
+			return config.CaptureConfig{}, InvalidCaptureOptionError()
 		}
 	}
 
@@ -223,7 +223,7 @@ func parseFileCaptureOption(arg string, cap string, captureConfig *config.FileCa
 	}
 	optAndValue := strings.SplitN(cap, ":", 2)
 	if len(optAndValue) != 2 || optAndValue[0] != arg {
-		return errors.New("invalid capture option specified, use '--capture help' for more info")
+		return InvalidCaptureOptionError()
 	}
 	err := parseFileCaptureSubOption(optAndValue[1], captureConfig)
 	return err
@@ -234,7 +234,7 @@ func parseFileCaptureOption(arg string, cap string, captureConfig *config.FileCa
 func parseFileCaptureSubOption(option string, captureConfig *config.FileCaptureConfig) error {
 	optAndValue := strings.SplitN(option, "=", 2)
 	if len(optAndValue) != 2 || len(optAndValue[1]) == 0 {
-		return errors.New("invalid capture option specified, use '--capture help' for more info")
+		return InvalidCaptureOptionError()
 	}
 	opt := optAndValue[0]
 	value := optAndValue[1]

--- a/pkg/cmd/flags/capture_test.go
+++ b/pkg/cmd/flags/capture_test.go
@@ -26,7 +26,7 @@ func TestPrepareCapture(t *testing.T) {
 				testName:        "invalid capture option",
 				captureSlice:    []string{"foo"},
 				expectedCapture: config.CaptureConfig{},
-				expectedError:   errors.New("invalid capture option specified, use '--capture help' for more info"),
+				expectedError:   InvalidCaptureOptionError(),
 			},
 			{
 				testName:      "invalid capture dir",
@@ -37,7 +37,7 @@ func TestPrepareCapture(t *testing.T) {
 				testName:        "invalid capture write filter",
 				captureSlice:    []string{"write="},
 				expectedCapture: config.CaptureConfig{},
-				expectedError:   errors.New("invalid capture option specified, use '--capture help' for more info"),
+				expectedError:   InvalidCaptureOptionError(),
 			},
 			{
 				testName:        "invalid capture write filter 2",

--- a/pkg/cmd/flags/containers.go
+++ b/pkg/cmd/flags/containers.go
@@ -79,7 +79,7 @@ func PrepareContainers(containerFlags []string) (CgroupFlagsResult, error) {
 		} else if strings.HasPrefix(key, "sockets.") {
 			runtimeName := strings.TrimPrefix(key, "sockets.")
 			if !contains(supportedRuntimes, runtimeName) {
-				return CgroupFlagsResult{}, errfmt.Errorf("unsupported container runtime in sockets flag (see --containers help for supported runtimes)")
+				return CgroupFlagsResult{}, UnsupportedContainerRuntimeError()
 			}
 			err := sockets.Register(runtime.FromString(runtimeName), value)
 			if err != nil {

--- a/pkg/cmd/flags/errors.go
+++ b/pkg/cmd/flags/errors.go
@@ -18,7 +18,7 @@ func InvalidScopeOptionError(expr string, newBinary bool) error {
 		return fmt.Errorf("invalid scope option specified (%s), run 'man scope' for more info", expr)
 	}
 
-	return fmt.Errorf("invalid scope option specified (%s), use '--scope help' for more info", expr)
+	return fmt.Errorf("invalid scope option specified (%s), use 'tracee man scope' for more info", expr)
 }
 
 func InvalidFlagEmpty() error {
@@ -35,4 +35,49 @@ func InvalidFlagOperator(expression string) error {
 
 func InvalidFlagValue(expression string) error {
 	return fmt.Errorf("invalid flag value: %s", expression)
+}
+
+// Help-related error messages
+func InvalidCaptureOptionError() error {
+	return errors.New("invalid capture option specified, use 'tracee man capture' for more info")
+}
+
+func InvalidOutputFlagError(flag string) error {
+	return fmt.Errorf("invalid output flag: %s, use 'tracee man output' for more info", flag)
+}
+
+func InvalidOutputOptionError(option string) error {
+	return fmt.Errorf("invalid output option: %s, use 'tracee man output' for more info", option)
+}
+
+func EmptyOutputFlagError(flagType string) error {
+	return fmt.Errorf("%s flag can't be empty, use 'tracee man output' for more info", flagType)
+}
+
+func InvalidOutputURIError(flag, uri string) error {
+	return fmt.Errorf("invalid uri for %s output %q. Use 'tracee man output' for more info", flag, uri)
+}
+
+func DuplicateOutputPathError(path string) error {
+	return fmt.Errorf("cannot use the same path for multiple outputs: %s, use 'tracee man output' for more info", path)
+}
+
+func NoneOutputPathError() error {
+	return errors.New("none output does not support path. Use 'tracee man output' for more info")
+}
+
+func InvalidLogOptionError(opt, details string) error {
+	return fmt.Errorf("invalid log option: %s, %s, use 'tracee man log' for more info", opt, details)
+}
+
+func InvalidLogOptionValueError(opt, details string) error {
+	return fmt.Errorf("invalid log option value: %s, %s, use 'tracee man log' for more info", opt, details)
+}
+
+func UnrecognizedOutputFormatError(format string) error {
+	return fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use 'tracee man output' for more info", format)
+}
+
+func UnsupportedContainerRuntimeError() error {
+	return errors.New("unsupported container runtime in sockets flag (see 'tracee man containers' for supported runtimes)")
 }

--- a/pkg/cmd/flags/logger.go
+++ b/pkg/cmd/flags/logger.go
@@ -53,7 +53,7 @@ func invalidLogOption(err error, opt string, newBinary bool) error {
 		return errfmt.Errorf("invalid log option: %s, %s, run 'man log' for more info", opt, err)
 	}
 
-	return errfmt.Errorf("invalid log option: %s, %s, use '--log help' for more info", opt, err)
+	return InvalidLogOptionError(opt, err.Error())
 }
 
 func invalidLogOptionValue(err error, opt string, newBinary bool) error {
@@ -66,7 +66,7 @@ func invalidLogOptionValue(err error, opt string, newBinary bool) error {
 		return errfmt.Errorf("invalid log option value: %s, %s, use '--help' for more info", opt, err)
 	}
 
-	return errfmt.Errorf("invalid log option value: %s, %s, use '--log help' for more info", opt, err)
+	return InvalidLogOptionValueError(opt, err.Error())
 }
 
 func parseLevel(level string) (logger.Level, error) {

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -25,27 +24,27 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "invalid output flag",
 			outputSlice:   []string{"foo"},
-			expectedError: errors.New("invalid output flag: foo, use '--output help' for more info"),
+			expectedError: InvalidOutputFlagError("foo"),
 		},
 		{
 			testName:      "empty option flag",
 			outputSlice:   []string{"option"},
-			expectedError: errors.New("parseOption: option flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("option"),
 		},
 		{
 			testName:      "empty option flag 2",
 			outputSlice:   []string{"option:"},
-			expectedError: errors.New("parseOption: option flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("option"),
 		},
 		{
 			testName:      "invalid option value",
 			outputSlice:   []string{"option:foo"},
-			expectedError: errors.New("setOption: invalid output option: foo, use '--output help' for more info"),
+			expectedError: InvalidOutputOptionError("foo"),
 		},
 		{
 			testName:      "empty file for format",
 			outputSlice:   []string{"json:"},
-			expectedError: errors.New("parseFormat: format flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("format"),
 		},
 		// formats
 		{
@@ -171,17 +170,17 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "two formats for stdout",
 			outputSlice:   []string{"table", "json"},
-			expectedError: errors.New("parseFormat: cannot use the same path for multiple outputs: stdout, use '--output help' for more info"),
+			expectedError: DuplicateOutputPathError("stdout"),
 		},
 		{
 			testName:      "format for the same file twice",
 			outputSlice:   []string{"table:/tmp/test,/tmp/test"},
-			expectedError: errors.New("parseFormat: cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+			expectedError: DuplicateOutputPathError("/tmp/test"),
 		},
 		{
 			testName:      "two different formats for the same file",
 			outputSlice:   []string{"table:/tmp/test", "json:/tmp/test"},
-			expectedError: errors.New("parseFormat: cannot use the same path for multiple outputs: /tmp/test, use '--output help' for more info"),
+			expectedError: DuplicateOutputPathError("/tmp/test"),
 		},
 		{
 			testName:    "none",
@@ -196,28 +195,28 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "invalid value for none format",
 			outputSlice:   []string{"none:"},
-			expectedError: errors.New("none output does not support path. Use '--output help' for more info"),
+			expectedError: NoneOutputPathError(),
 		},
 		{
 			testName:      "invalid value for none format 2",
 			outputSlice:   []string{"none:/tmp/test"},
-			expectedError: errors.New("none output does not support path. Use '--output help' for more info"),
+			expectedError: NoneOutputPathError(),
 		},
 		// forward
 		{
 			testName:      "empty forward flag",
 			outputSlice:   []string{"forward"},
-			expectedError: errors.New("validateURL: forward flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("forward"),
 		},
 		{
 			testName:      "empty forward flag",
 			outputSlice:   []string{"forward:"},
-			expectedError: errors.New("validateURL: forward flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("forward"),
 		},
 		{
 			testName:      "invalid forward url",
 			outputSlice:   []string{"forward:lalala"},
-			expectedError: errors.New("validateURL: invalid uri for forward output \"lalala\". Use '--output help' for more info"),
+			expectedError: InvalidOutputURIError("forward", "lalala"),
 		},
 		{
 			testName:    "forward",
@@ -233,17 +232,17 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "empty webhook flag",
 			outputSlice:   []string{"webhook"},
-			expectedError: errors.New("validateURL: webhook flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("webhook"),
 		},
 		{
 			testName:      "empty webhook flag",
 			outputSlice:   []string{"webhook:"},
-			expectedError: errors.New("validateURL: webhook flag can't be empty, use '--output help' for more info"),
+			expectedError: EmptyOutputFlagError("webhook"),
 		},
 		{
 			testName:      "invalid webhook url",
 			outputSlice:   []string{"webhook:lalala"},
-			expectedError: errors.New("validateURL: invalid uri for webhook output \"lalala\". Use '--output help' for more info"),
+			expectedError: InvalidOutputURIError("webhook", "lalala"),
 		},
 		{
 			testName:    "webhook",
@@ -311,12 +310,12 @@ func TestPrepareOutput(t *testing.T) {
 		{
 			testName:      "option exec-hash invalid",
 			outputSlice:   []string{"option:exec-hash=notvalid"},
-			expectedError: errors.New("invalid output option: exec-hash=notvalid, use '--output help' for more info"),
+			expectedError: InvalidOutputOptionError("exec-hash=notvalid"),
 		},
 		{
 			testName:      "option exec-hash invalid",
 			outputSlice:   []string{"option:exec-hasha"},
-			expectedError: errors.New("invalid output option: exec-hasha, use '--output help' for more info"),
+			expectedError: InvalidOutputOptionError("exec-hasha"),
 		},
 		{
 			testName:    "option parse-arguments",
@@ -396,7 +395,7 @@ func TestPrepareOutput(t *testing.T) {
 				}
 			}()
 
-			output, err := PrepareOutput(testcase.outputSlice, false)
+			output, err := PrepareOutput(testcase.outputSlice)
 			if err != nil {
 				require.NotNil(t, testcase.expectedError)
 				assert.Contains(t, err.Error(), testcase.expectedError.Error())

--- a/pkg/cmd/flags/tracee_ebpf_output.go
+++ b/pkg/cmd/flags/tracee_ebpf_output.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/tracee/pkg/config"
-	"github.com/aquasecurity/tracee/pkg/errfmt"
 )
 
 func outputHelp() string {
@@ -61,19 +60,19 @@ func TraceeEbpfPrepareOutput(outputSlice []string, newBinary bool) (PrepareOutpu
 		case "out-file":
 			outPath = outputParts[1]
 		case "option":
-			err := setOption(traceeConfig, outputParts[1], newBinary)
+			err := setOption(traceeConfig, outputParts[1])
 			if err != nil {
 				return outConfig, err
 			}
 		default:
-			return outConfig, errfmt.Errorf("invalid output value: %s, use '--output help' for more info", outputParts[1])
+			return outConfig, InvalidOutputFlagError(outputParts[1])
 		}
 	}
 
 	printerConfigs := make([]config.PrinterConfig, 0)
 
 	if printerKind == "table" {
-		if err := setOption(traceeConfig, "parse-arguments", newBinary); err != nil {
+		if err := setOption(traceeConfig, "parse-arguments"); err != nil {
 			return outConfig, err
 		}
 	}
@@ -111,7 +110,7 @@ func validateFormat(printerKind string) error {
 		printerKind != "table-verbose" &&
 		printerKind != "json" &&
 		!strings.HasPrefix(printerKind, "gotemplate=") {
-		return errfmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info", printerKind)
+		return UnrecognizedOutputFormatError(printerKind)
 	}
 
 	return nil

--- a/pkg/cmd/flags/tracee_ebpf_output_test.go
+++ b/pkg/cmd/flags/tracee_ebpf_output_test.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,22 +21,22 @@ func TestPrepareTraceeEbpfOutput(t *testing.T) {
 			testName:    "invalid output option",
 			outputSlice: []string{"foo"},
 			// it's not the preparer job to validate input. in this case foo is considered an implicit output format.
-			expectedError: errors.New("unrecognized output format: foo. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info"),
+			expectedError: UnrecognizedOutputFormatError("foo"),
 		},
 		{
 			testName:      "invalid output option",
 			outputSlice:   []string{"option:"},
-			expectedError: errors.New("invalid output option: , use '--output help' for more info"),
+			expectedError: InvalidOutputOptionError(""),
 		},
 		{
 			testName:      "invalid output option 2",
 			outputSlice:   []string{"option:foo"},
-			expectedError: errors.New("invalid output option: foo, use '--output help' for more info"),
+			expectedError: InvalidOutputOptionError("foo"),
 		},
 		{
 			testName:      "empty val",
 			outputSlice:   []string{"out-file"},
-			expectedError: errors.New("unrecognized output format: out-file. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info"),
+			expectedError: UnrecognizedOutputFormatError("out-file"),
 		},
 		{
 			testName:    "default format",

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -1,7 +1,6 @@
 package printer_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -24,13 +23,13 @@ func TestTraceeEbpfPrepareOutputPrinterConfig(t *testing.T) {
 			testName:        "invalid format",
 			outputSlice:     []string{"notaformat"},
 			expectedPrinter: config.PrinterConfig{},
-			expectedError:   fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info", "notaformat"),
+			expectedError:   flags.UnrecognizedOutputFormatError("notaformat"),
 		},
 		{
 			testName:        "invalid format with format prefix",
 			outputSlice:     []string{"format:notaformat2"},
 			expectedPrinter: config.PrinterConfig{},
-			expectedError:   fmt.Errorf("unrecognized output format: %s. Valid format values: 'table', 'table-verbose', 'json', or 'gotemplate='. Use '--output help' for more info", "notaformat2"),
+			expectedError:   flags.UnrecognizedOutputFormatError("notaformat2"),
 		},
 		{
 			testName:    "default",


### PR DESCRIPTION
### 1. Explain what the PR does

Fixes #4869

- Replace broken '--flag help' suggestions with working 'tracee man <flag>' commands
- Embed manual pages in binary using Go embed for distributed binaries
- Fix 'tracee man cri' command to correctly reference containers.1 file
- Update all flag error messages (output, capture, containers, errors, logger)
- Update test expectations to match new error message format
- Ensure help system works without requiring local docs directory

The previous help system was broken for users of distributed binaries, providing misleading '--output help' style suggestions that don't work. Now all error messages suggest the working 'tracee man <flag>' commands.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
