### PR TITLE
fix: remove unneeded SYSLOG capability from base capabilities

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1893,7 +1893,14 @@ func (t *Tracee) triggerMemDump(event trace.Event) []error {
 
 					continue
 				}
-				symbol, err := t.getKernelSymbols().GetSymbolByOwnerAndName(owner, name)
+				var symbol []*environment.KernelSymbol
+				err = capabilities.GetInstance().Specific(
+					func() error {
+						var capErr error
+						symbol, capErr = t.getKernelSymbols().GetSymbolByOwnerAndName(owner, name)
+						return capErr
+					},
+					cap.SYSLOG) // Required to read /proc/kallsyms
 				if err != nil {
 					if owner != "system" {
 						errs = append(errs, errfmt.Errorf("policy %d: invalid symbols provided to print_mem_dump event: %s - %v", p.ID, field, err))
@@ -1903,14 +1910,18 @@ func (t *Tracee) triggerMemDump(event trace.Event) []error {
 
 					// Checking if the user specified a syscall name
 					prefixes := []string{"sys_", "__x64_sys_", "__arm64_sys_"}
-					var errSyscall error
-					for _, prefix := range prefixes {
-						symbol, errSyscall = t.getKernelSymbols().GetSymbolByOwnerAndName(owner, prefix+name)
-						if errSyscall == nil {
-							err = nil
-							break
-						}
-					}
+					err = capabilities.GetInstance().Specific(
+						func() error {
+							var capErr error
+							for _, prefix := range prefixes {
+								symbol, capErr = t.getKernelSymbols().GetSymbolByOwnerAndName(owner, prefix+name)
+								if capErr == nil {
+									break
+								}
+							}
+							return capErr
+						},
+						cap.SYSLOG) // Required to read /proc/kallsyms
 					if err != nil {
 						// syscall not found for the given name using all the prefixes
 						valuesStr := make([]string, 0)

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -12179,11 +12179,6 @@ var CoreEvents = map[ID]Definition{
 				SyscallTableCheck,
 				DoInitModule,
 			},
-			capabilities: Capabilities{
-				base: []cap.Value{
-					cap.SYSLOG, // read /proc/kallsyms
-				},
-			},
 		},
 		sets: []string{},
 		fields: []DataField{
@@ -12542,11 +12537,6 @@ var CoreEvents = map[ID]Definition{
 			ids: []ID{
 				DoInitModule,
 			},
-			capabilities: Capabilities{
-				base: []cap.Value{
-					cap.SYSLOG, // read /proc/kallsyms
-				},
-			},
 		},
 		sets: []string{},
 		fields: []DataField{
@@ -12591,11 +12581,6 @@ var CoreEvents = map[ID]Definition{
 			ids: []ID{
 				PrintNetSeqOps,
 				DoInitModule,
-			},
-			capabilities: Capabilities{
-				base: []cap.Value{
-					cap.SYSLOG, // read /proc/kallsyms
-				},
 			},
 		},
 		sets: []string{},
@@ -12724,11 +12709,6 @@ var CoreEvents = map[ID]Definition{
 				// are resolved dynamically, during runtime depending on the arguments passed to
 				// the event.
 				{symbol: "_stext", required: true},
-			},
-			capabilities: Capabilities{
-				base: []cap.Value{
-					cap.SYSLOG, // read /proc/kallsyms
-				},
 			},
 		},
 		fields: []DataField{

--- a/pkg/events/definition_test.go
+++ b/pkg/events/definition_test.go
@@ -12,11 +12,10 @@ func TestNewDefinition(t *testing.T) {
 	expectedDefinition := Definition{
 		name: "hooked_seq_ops2",
 		dependencies: Dependencies{
-			ids:          []ID{PrintNetSeqOps, DoInitModule},
-			kSymbols:     []KSymbol{},
-			probes:       []Probe{},
-			tailCalls:    []TailCall{},
-			capabilities: Capabilities{},
+			ids:       []ID{PrintNetSeqOps, DoInitModule},
+			kSymbols:  []KSymbol{},
+			probes:    []Probe{},
+			tailCalls: []TailCall{},
 		},
 		sets: []string{"signatures"},
 	}


### PR DESCRIPTION
### 1. Explain what the PR does

Remove SYSLOG from base capabilities of hooked_syscall, hooked_seq_ops, hooked_proc_fops, and print_mem_dump events. Add proper capability elevation when kallsyms access is actually needed.

Fixes #3079

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
