### PR TITLE
Fix events exclude docs

### DIFF
--- a/docs/docs/flags/events.1.md
+++ b/docs/docs/flags/events.1.md
@@ -85,12 +85,6 @@ Available only for:
   --events 'open*'
   ```
 
-- To exclude events prefixed by "open" or "dup", use the following flag:
-
-  ```console
-  --events '-open*,-dup*'
-  ```
-
 - To trace all file-system related events, use the following flag:
 
   ```console

--- a/docs/man/events.1
+++ b/docs/man/events.1
@@ -104,15 +104,6 @@ To trace only events prefixed by \[lq]open\[rq], use the following flag:
 .EE
 .RE
 .IP \[bu] 2
-To exclude events prefixed by \[lq]open\[rq] or \[lq]dup\[rq], use the
-following flag:
-.RS 2
-.IP
-.EX
-\-\-events \[aq]\-open*,\-dup*\[aq]
-.EE
-.RE
-.IP \[bu] 2
 To trace all file\-system related events, use the following flag:
 .RS 2
 .IP


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/4707

- fix events documentation, exclusion example not supported
- re-generate man pages with (make -f builder/Makefile.man) 