### PR TITLE
build: add -failfast flag to test-unit target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -868,6 +868,7 @@ test-unit: \
 		-short \
 		-race \
 		-shuffle on \
+		-failfast \
 		-v \
 		-coverprofile=coverage.txt \
 		./cmd/... \


### PR DESCRIPTION
### 1. Explain what the PR does

Stop testing on first failure to make debugging easier. This prevents having to scroll through multiple test failures to find the root cause of issues.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
