### PR TITLE
feat: add comprehensive code coverage with Codecov integration

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -192,9 +192,18 @@ jobs:
       - name: Run Unit Tests
         run: |
           make test-unit
+      - name: Upload Unit Test Coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.txt
+          flags: unit
+          name: unit-tests
+          fail_ci_if_error: false
       - name: Run Scripts Unit Tests
         run: |
           make run-scripts-test-unit
+
   #
   # INTEGRATION TESTS
   #
@@ -214,6 +223,14 @@ jobs:
       - name: Run Integration Tests
         run: |
           sudo env "PATH=$PATH" make test-integration
+      - name: Upload Integration Test Coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./integration-coverage.txt
+          flags: integration
+          name: integration-tests
+          fail_ci_if_error: false
   #
   # PERFORMANCE TESTS
   #

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ deploy/helm/tracee/charts/
 .vscode
 .idea
 coverage.txt
+integration-coverage.txt
+coverage.html
 compile_commands.json
 .cache*
 .trunk*

--- a/Makefile
+++ b/Makefile
@@ -874,6 +874,7 @@ test-unit: \
 		-failfast \
 		-v \
 		-coverprofile=coverage.txt \
+		-covermode=atomic \
 		$(if $(TEST),-run $(TEST)) \
 		$(if $(PKG),./$(PKG)/...,./cmd/... ./pkg/... ./signatures/...)
 
@@ -887,7 +888,6 @@ test-types: \
 		-race \
 		-shuffle on \
 		-v \
-		-coverprofile=coverage.txt \
 		./...
 
 SCRIPTS_TEST_DIR = scripts
@@ -896,6 +896,23 @@ SCRIPTS_TEST_DIR = scripts
 run-scripts-test-unit:
 #
 	@$(SCRIPTS_TEST_DIR)/run_test_scripts.sh
+
+#
+# coverage targets
+#
+
+.PHONY: coverage
+coverage: test-unit
+#
+	@echo "Unit test coverage:"
+	@$(CMD_GO) tool cover -func=coverage.txt
+
+.PHONY: coverage-html
+coverage-html: test-unit
+#
+	@echo "Generating HTML coverage report..."
+	@$(CMD_GO) tool cover -html=coverage.txt -o coverage.html
+	@echo "Coverage report generated: coverage.html"
 
 #
 # integration tests
@@ -929,6 +946,8 @@ test-integration: \
 		-v \
 		-p 1 \
 		-count=1 \
+		-coverprofile=integration-coverage.txt \
+		-covermode=atomic \
 		./tests/integration/... \
 
 .PHONY: test-upstream-libbpfgo

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,56 @@
+# Codecov configuration for Tracee
+# This file configures how code coverage is measured and reported
+
+coverage:
+  status:
+    project:
+      default:
+        target: 75%           # Overall project coverage target
+        threshold: 1%         # Allow 1% decrease without failing
+        if_ci_failed: error   # Fail if CI failed
+    patch:
+      default:
+        target: 80%           # New code should have higher coverage
+        threshold: 5%         # Allow some flexibility for new features
+        if_ci_failed: error
+
+  ignore:
+    # Ignore generated files and vendor dependencies
+    - "3rdparty/**/*"
+    - "vendor/**/*"
+    - "**/*.pb.go"
+    - "**/mock_*.go"
+    - "**/*_mock.go"
+    - "**/testdata/**/*"
+    - "tests/**/*"
+    - "**/*_test.go"
+    # Ignore build and CI scripts
+    - "scripts/**/*"
+    - "builder/**/*"
+    - "deploy/**/*"
+    # Ignore documentation
+    - "docs/**/*"
+    - "examples/**/*"
+    - "brand/**/*"
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes
+  show_carryforward_flags: true
+
+flags:
+  unit:
+    paths:
+      - cmd/
+      - pkg/
+      - signatures/
+  integration:
+    paths:
+      - cmd/
+      - pkg/
+
+github_checks:
+  annotations: true

--- a/docs/contributing/testing-coverage.md
+++ b/docs/contributing/testing-coverage.md
@@ -1,0 +1,104 @@
+# Code Coverage in Tracee
+
+This document explains how code coverage is configured and used in Tracee.
+
+## Overview
+
+Tracee uses Go's built-in coverage tools combined with Codecov for comprehensive test coverage reporting. Coverage is tracked for multiple test types to ensure quality across all components.
+
+## Coverage Types
+
+### 1. Unit Tests Coverage
+- **Target**: 75% overall, 80% for new code
+- **Scope**: Core Go logic, utilities, and non-eBPF components
+- **Files**: `cmd/`, `pkg/`, `signatures/`
+- **Command**: `make test-unit`
+
+### 2. Integration Tests Coverage
+- **Scope**: eBPF + Go integration, full system testing
+- **Command**: `make test-integration`
+
+## Local Development
+
+### View Coverage Summary
+```bash
+make coverage
+```
+
+### Generate HTML Coverage Reports
+```bash
+make coverage-html
+# Opens coverage.html and types/coverage.html
+```
+
+### Run Individual Coverage Commands
+```bash
+# Unit tests only
+go test ./... -coverprofile=coverage.txt -covermode=atomic
+
+# View coverage percentage
+go tool cover -func=coverage.txt
+
+# Generate HTML report
+go tool cover -html=coverage.txt -o coverage.html
+```
+
+## CI/CD Integration
+
+Coverage is automatically collected and reported on:
+- Every Pull Request
+- Every push to main branch
+- Integration tests (when run)
+
+### Codecov Integration
+
+Coverage reports are uploaded to [Codecov](https://codecov.io) with the following flags:
+- `unit`: Unit test coverage
+- `integration`: Integration test coverage
+
+### Coverage Configuration
+
+Coverage behavior is configured in `codecov.yml`:
+- Project coverage target: 75%
+- Patch coverage target: 80%
+- Automatic PR comments with coverage diff
+- Excludes test files, generated code, and vendor dependencies
+
+## Coverage Files
+
+The following coverage files are generated (and gitignored):
+- `coverage.txt`: Main unit test coverage
+- `integration-coverage.txt`: Integration test coverage
+- `coverage.html`: HTML report for local viewing
+
+## Best Practices
+
+1. **Focus on Critical Paths**: Prioritize coverage for core event processing, filtering, and detection logic
+2. **Test Edge Cases**: Include error handling and boundary conditions
+3. **Integration Coverage**: Ensure eBPF + Go interactions are tested
+4. **Meaningful Tests**: Aim for tests that verify behavior, not just coverage numbers
+
+## Excluded from Coverage
+
+- Generated files (`*.pb.go`)
+- Test files (`*_test.go`)
+- Mock files (`mock_*.go`, `*_mock.go`)
+- Vendor dependencies (`vendor/`, `3rdparty/`)
+- Documentation and build scripts
+- Test utilities and test data
+
+## Troubleshooting
+
+### Coverage Not Generated
+- Ensure you're running tests with `-coverprofile` flag
+- Check that `-covermode=atomic` is set (required for concurrent programs)
+
+### Low Coverage Warnings
+- Review which functions/lines are not covered
+- Consider if uncovered code represents important paths
+- Add tests for critical uncovered functionality
+
+### Codecov Upload Failures
+- Verify `CODECOV_TOKEN` is set in repository secrets
+- Check that coverage files exist before upload
+- Review GitHub Actions logs for specific error messages

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -629,6 +629,7 @@ nav:
           - Overview: contributing/overview.md
           - Guidelines: contributing/guidelines.md
           - Adding New Events: contributing/adding-events.md
+          - Code Coverage: contributing/testing-coverage.md
           - Performance: contributing/performance.md
           - Kubernetes: contributing/kubernetes.md
           - Setup Development Machine with Vagrant: contributing/setup-development-machine-with-vagrant.md


### PR DESCRIPTION
### 1. Explain what the PR does

- Add -covermode=atomic to unit and integration tests for concurrent safety
- Configure GitHub Actions to upload coverage reports to Codecov
- Add codecov.yml with appropriate targets (75% project, 80% patch)
- Create new Makefile targets: 'coverage' and 'coverage-html' for local development
- Add comprehensive developer documentation for coverage workflows
- Exclude type definitions from coverage (focus on business logic)
- Support separate coverage tracking for unit vs integration tests

Fixes #152


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
