### PR TITLE
fix: capture BPF objects when bpf_attach event is not selected

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -3951,13 +3951,11 @@ int BPF_KPROBE(trace_security_bpf)
         events_perf_submit(&p, 0);
     }
 
-    if (!reset_event(p.event, BPF_ATTACH))
-        return 0;
-
     union bpf_attr *attr = (union bpf_attr *) PT_REGS_PARM2(ctx);
 
-    // send bpf_attach event if filters match
-    if (evaluate_scope_filters(&p))
+    // send bpf_attach event if event is selected and filters match
+    bool event_reset = reset_event(p.event, BPF_ATTACH);
+    if (event_reset && evaluate_scope_filters(&p))
         check_bpf_link(&p, attr, cmd);
 
     // Capture BPF object loaded


### PR DESCRIPTION
### 1. Explain what the PR does

Previously, `trace_security_bpf` returned early when `reset_event(BPF_ATTACH)` returned false, which prevented BPF object capture when users enabled capture bpf without selecting the bpf_attach event.

This change gates only the bpf_attach event emission on selection (no early return) while always allowing the capture path to execute, ensuring BPF objects are captured on BPF_PROG_LOAD when capture bpf is set.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
