### PR TITLE
Load infra/map autocreate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/IBM/fluent-forward-go v0.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/aquasecurity/libbpfgo v0.9.0-libbpf-1.5.1.0.20250716183222-3474da5de8f6
+	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b
 	github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250423143044-dcfcaf219805
 	github.com/aquasecurity/tracee/types v0.0.0-20250624132442-3fa6c15acc67

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/Microsoft/hcsshim v0.12.3 h1:LS9NXqXhMoqNCplK1ApmVSfB4UnVLRDWRapB6EIl
 github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6CtY2Qg/JVQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/aquasecurity/libbpfgo v0.9.0-libbpf-1.5.1.0.20250716183222-3474da5de8f6 h1:/zSaeCq2OR+mW3RsRfoJYmCCaVBj3m+y97tvbZxbpRc=
-github.com/aquasecurity/libbpfgo v0.9.0-libbpf-1.5.1.0.20250716183222-3474da5de8f6/go.mod h1:JQNC5NuGwyYC7IZum6JqPNVHarFAuab+h4lO6t0jIhc=
+github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b h1:JCzw7Y3GyoH5CS2iAuebTX8G+CVr65yiLQGSFUQxjAc=
+github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b/go.mod h1:JQNC5NuGwyYC7IZum6JqPNVHarFAuab+h4lO6t0jIhc=
 github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5 h1:zseTkmEkMBo4b2gYzE5dnj6EfEjajipUQLGs+FtTw3M=
 github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5/go.mod h1:fCLvZ7yle7SJoMNFSUCNVZo6Qf6xWXUmP0isGvRrIL8=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250423143044-dcfcaf219805 h1:ZvXdP2rPm+7fTS102MAz/TcW++KalkMVIgQF0x3x5rQ=


### PR DESCRIPTION
### 1. Explain what the PR does

This is a follow-up PR for #4892.
Add a check of bpf maps support in the system before creating them in the bpf module load.
This will allow together with the bpf map compatibility requirement of the probes to use new types of bpf maps in bpf programs while supporting older kernel versions. Together with the fallback mechanism, it will allow to create efficient programs that use new bpf map types in newer kernels and fallback programs for older versions, allowing an event to be both efficient and support all environments.

As the map type and program type compatibility requirements have been merge, this PR resolves #1653

### 2. Explain how to test it

Tested it manually by creating an arena map and seeing the log of failing to create it, while still running Tracee normally.
