### PR TITLE
feat(probes): add map type compatibility requirement

### DIFF
--- a/pkg/errfmt/errfmt.go
+++ b/pkg/errfmt/errfmt.go
@@ -25,6 +25,14 @@ func prefixFunc(msg string, skip int) error {
 	return fmt.Errorf("%v: %v", fName, msg)
 }
 
+// prefixFuncError prefixes a given error with the name of the function that
+// called it based on the skip value, preserving the error chain.
+func prefixFuncError(err error, skip int) error {
+	fName := funcName(skip + 1)
+
+	return fmt.Errorf("%v: %w", fName, err)
+}
+
 // Errorf returns an error prefixed by the current (caller) function name
 // and formatted with the given arguments.
 func Errorf(format string, a ...interface{}) error {
@@ -37,11 +45,11 @@ func Errorf(format string, a ...interface{}) error {
 }
 
 // WrapError returns the given error prefixed by the current (caller) function
-// name.
+// name while preserving the error chain.
 func WrapError(e error) error {
 	if e == nil {
 		return nil
 	}
 
-	return prefixFunc(e.Error(), 1)
+	return prefixFuncError(e, 1)
 }


### PR DESCRIPTION
### 1. Explain what the PR does

Support map type requirement in probes compatibilities.
This allow the usage of a map of a type which is not supported in all kernel versions by a program.
Currently, unsupported maps will still fail to be created upon bpf module load, but I will address it in a follow-up PR.

This PR is a simpler version of #4892

### 2. Explain how to test it

I have tested it manually by creating a requirement of an arena map which my system doesn't support, and seeing the debug logs of failure.
It will be easier to test once we have events that use this feature.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
