### PR TITLE
fix: adjust code coverage targets to realistic baseline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,13 +5,13 @@ coverage:
   status:
     project:
       default:
-        target: 75%           # Overall project coverage target
-        threshold: 1%         # Allow 1% decrease without failing
-        if_ci_failed: error   # Fail if CI failed
+        target: auto         # Start with current coverage as baseline
+        threshold: 1%        # Allow 1% decrease without failing
+        if_ci_failed: error  # Fail if CI failed
     patch:
       default:
-        target: 80%           # New code should have higher coverage
-        threshold: 5%         # Allow some flexibility for new features
+        target: 60%          # New code should have reasonable coverage
+        threshold: 10%       # More flexibility for initial adoption
         if_ci_failed: error
 
   ignore:

--- a/docs/contributing/testing-coverage.md
+++ b/docs/contributing/testing-coverage.md
@@ -9,7 +9,7 @@ Tracee uses Go's built-in coverage tools combined with Codecov for comprehensive
 ## Coverage Types
 
 ### 1. Unit Tests Coverage
-- **Target**: 75% overall, 80% for new code
+- **Target**: Maintain current baseline, 60% for new code
 - **Scope**: Core Go logic, utilities, and non-eBPF components
 - **Files**: `cmd/`, `pkg/`, `signatures/`
 - **Command**: `make test-unit`
@@ -59,8 +59,8 @@ Coverage reports are uploaded to [Codecov](https://codecov.io) with the followin
 ### Coverage Configuration
 
 Coverage behavior is configured in `codecov.yml`:
-- Project coverage target: 75%
-- Patch coverage target: 80%
+- Project coverage target: Auto (maintains current baseline)
+- Patch coverage target: 60% for new code
 - Automatic PR comments with coverage diff
 - Excludes test files, generated code, and vendor dependencies
 


### PR DESCRIPTION
### 1. Explain what the PR does

- Set project coverage target to 'auto' to use current baseline (~30%)
- Reduce new code coverage target to 60% for initial adoption
- Increase threshold flexibility to 10% for new code
- Update documentation to reflect realistic targets

This prevents immediate CI failures while establishing coverage tracking.
### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
