### PR TITLE
chore: remove .ONESHELL from recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,6 @@ $(LIBBPF_OBJ): .build_libbpf .build_libbpf_fix
 
 LIBBPF_INCLUDE_UAPI = ./3rdparty/libbpf/include/uapi/linux
 
-.ONESHELL:
 .build_libbpf_fix: .build_libbpf
 # copy all uapi headers to the correct location, since libbpf does not install them fully
 # see: https://github.com/aquasecurity/tracee/pull/4186
@@ -424,7 +423,6 @@ LIBBPF_INCLUDE_UAPI = ./3rdparty/libbpf/include/uapi/linux
 
 TRACEE_EBPF_CFLAGS = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(CMD_PKGCONFIG) $(PKG_CONFIG_FLAG) --cflags $(LIB_BPF))
 
-.ONESHELL:
 .eval_goenv: $(LIBBPF_OBJ)
 #
 	@{
@@ -1161,7 +1159,6 @@ man: clean-man $(MAN_FILES)
 #
 
 .PHONY: clean
-.ONESHELL:
 clean:
 #
 	$(CMD_RM) -rf $(OUTPUT_DIR)

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -29,7 +29,6 @@ CMD_RM ?= rm
 CMD_TAR ?= tar
 CMD_TOUCH ?= touch
 
-.ONESHELL:
 .check_%:
 #
 	@command -v $* >/dev/null


### PR DESCRIPTION
### 1. Explain what the PR does

2dd6a7572 **chore: remove .ONESHELL from recipes**

```
All involved Makefiles already set .ONESHELL in the upper lines.

"If the .ONESHELL special target appears anywhere in the makefile then
all recipe lines for each target will be provided to a single invocation
of the shell." https://www.gnu.org/software/make/manual/html_node/One-Shell.html
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
