### PR TITLE
fix:(ebpf): 'and' bitwise bug in save_bytes_to_buf

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -143,12 +143,14 @@ statfunc int save_bytes_to_buf(args_buffer_t *buf, void *ptr, u32 size, u8 index
     if (buf->offset > ARGS_BUF_SIZE - (MAX_BYTES_ARR_SIZE + 1 + sizeof(int)))
         return 0;
 
+    size_t read_size = size;
+    if (read_size >= MAX_BYTES_ARR_SIZE)
+        read_size = MAX_BYTES_ARR_SIZE - 1;
+
     // Read bytes into buffer
-    if (bpf_probe_read(&(buf->args[buf->offset + 1 + sizeof(int)]),
-                       size & (MAX_BYTES_ARR_SIZE - 1),
-                       ptr) == 0) {
+    if (bpf_probe_read(&(buf->args[buf->offset + 1 + sizeof(int)]), read_size, ptr) == 0) {
         // We update offset only if all writes were successful
-        buf->offset += size + 1 + sizeof(int);
+        buf->offset += read_size + 1 + sizeof(int);
         buf->argnum++;
         return 1;
     }


### PR DESCRIPTION
### 1. Explain what the PR does

d2ffc826d **fix:(ebpf): 'and' bitwise bug in save_bytes_to_buf**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
