### PR TITLE
build: remove local common module replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b
 	github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5
-	github.com/aquasecurity/tracee/common v0.0.0-20250828171301-49fe211e2ad6
+	github.com/aquasecurity/tracee/common v0.0.0-20250829165642-afb503dbb342
 	github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250423143044-dcfcaf219805
 	github.com/aquasecurity/tracee/types v0.0.0-20250624132442-3fa6c15acc67
 	github.com/containerd/containerd v1.7.27
@@ -170,5 +170,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.76 // indirect
 )
-
-replace github.com/aquasecurity/tracee/common => ./common

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef2
 github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826130354-1b9ce23ef29b/go.mod h1:JQNC5NuGwyYC7IZum6JqPNVHarFAuab+h4lO6t0jIhc=
 github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5 h1:zseTkmEkMBo4b2gYzE5dnj6EfEjajipUQLGs+FtTw3M=
 github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5/go.mod h1:fCLvZ7yle7SJoMNFSUCNVZo6Qf6xWXUmP0isGvRrIL8=
+github.com/aquasecurity/tracee/common v0.0.0-20250829165642-afb503dbb342 h1:I+Kl5JUzTHzBzSw7g6Nup7tH6/TmsQdWbWl/R9o0r5E=
+github.com/aquasecurity/tracee/common v0.0.0-20250829165642-afb503dbb342/go.mod h1:U21mnx78I0v2g1VVrCi1ZGSlvx2YbmYcfz/cMQsEIc0=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250423143044-dcfcaf219805 h1:ZvXdP2rPm+7fTS102MAz/TcW++KalkMVIgQF0x3x5rQ=
 github.com/aquasecurity/tracee/signatures/helpers v0.0.0-20250423143044-dcfcaf219805/go.mod h1:yftFWA6fBKn0r2gCmO8DYKKSpaZjt/LYK7QgUF9XENo=
 github.com/aquasecurity/tracee/types v0.0.0-20250624132442-3fa6c15acc67 h1:APUSeNvyugFPBMNqDATTPXti5Ry2jiHy72JZD3hvikg=


### PR DESCRIPTION
### 1. Explain what the PR does

The common module has been merged into the main branch and is now available as a published module. Remove the local replace directive to use the official published version.


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
