### PR TITLE
chore: add runtime.KeepAlive for unsafe.Pointer

### DIFF
--- a/common/elf/symbols.go
+++ b/common/elf/symbols.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"syscall"
 	"time"
 	"unsafe"
@@ -298,6 +299,10 @@ func madviseAligned(data []byte, advice int) error {
 		uintptr(alignedLen),
 		uintptr(advice),
 	)
+
+	// Since madvise arguments are derived from an uintptr, it's important
+	// to keep the original object alive until after the syscall.
+	runtime.KeepAlive(data)
 
 	if errno != 0 {
 		return errno


### PR DESCRIPTION
### 1. Explain what the PR does

127078f3f **chore: add runtime.KeepAlive for unsafe.Pointer**

```
Follow Go's recommended pattern for unsafe.Pointer usage in syscalls
by adding runtime.KeepAlive(data) after the madvise call.

While in this case the data is unlikely to be collected, it's good
practice to either convert unsafe.Pointers to uintptr directly in the
syscall.Syscall() call or use runtime.KeepAlive() when the latter is not
so straightforward.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
