### PR TITLE
fix(ebpf): use u32 for read_size in save_bytes_to_buf

### DIFF
--- a/pkg/ebpf/c/common/buffer.h
+++ b/pkg/ebpf/c/common/buffer.h
@@ -143,7 +143,7 @@ statfunc int save_bytes_to_buf(args_buffer_t *buf, void *ptr, u32 size, u8 index
     if (buf->offset > ARGS_BUF_SIZE - (MAX_BYTES_ARR_SIZE + 1 + sizeof(int)))
         return 0;
 
-    size_t read_size = size;
+    u32 read_size = size;
     if (read_size >= MAX_BYTES_ARR_SIZE)
         read_size = MAX_BYTES_ARR_SIZE - 1;
 


### PR DESCRIPTION
### 1. Explain what the PR does

d6f648727 **fix(ebpf): use u32 for read_size in save_bytes_to_buf**

```
The save_bytes_to_buf function expects a u32 size parameter to match
bpf_probe_read's signature, but was using size_t internally which creates
a type mismatch on 64-bit systems (size_t: 8 bytes vs u32: 4 bytes).

This ensures consistent 32-bit sizing throughout the storing operation.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
