### PR TITLE
fix: Add binutils-gold package to Alpine dependencies

### DIFF
--- a/scripts/installation/install-deps-alpine.sh
+++ b/scripts/installation/install-deps-alpine.sh
@@ -42,7 +42,8 @@ install_base_packages() {
         zstd-static \
         libc6-compat \
         tar \
-        ca-certificates
+        ca-certificates \
+        binutils-gold
 
     # Create symlinks for compatibility with tests expecting binaries in /usr/bin
     # BusyBox applets - link directly to busybox so applet name is detected correctly


### PR DESCRIPTION
### 1. Explain what the PR does

Fixes aarch64 release snapshot build failure:
- Error: clang: error: invalid linker name in argument '-fuse-ld=gold'
- Root cause: Missing gold linker binary (/usr/bin/ld.gold)
- Solution: Install binutils-gold package in Alpine script

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
