### PR TITLE
fix(events): correct TIMESPEC_T decoded as time.Time instead of float64

### DIFF
--- a/pkg/events/data/decode.go
+++ b/pkg/events/data/decode.go
@@ -66,7 +66,7 @@ var decodeAsStringDict = map[DecodeAs]string{
 	STR_ARR_T:    "[]string",
 	SOCK_ADDR_T:  "SockAddr",
 	CRED_T:       "trace.SlimCred",
-	TIMESPEC_T:   "time.Time",
+	TIMESPEC_T:   "float64",
 	ARGS_ARR_T:   "[]string",
 	BOOL_T:       "bool",
 	FLOAT_T:      "float",


### PR DESCRIPTION
### 1. Explain what the PR does

Fix type mismatch where TIMESPEC_T arguments were decoded as time.Time but had ArgMeta.Type='float64', causing issues for JSON consumers.

- Update 20 TIMESPEC_T fields in core.go to use 'time.Time' type
- Add time.Time JSON unmarshaling support with nanosecond precision
- Add comprehensive tests with floating-point precision handling

Affects syscalls: clock_nanosleep, nanosleep, futex, poll, select, etc.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
