### PR TITLE
bugfix(lsm): support quotes in CONFIG_LSM

### DIFF
--- a/common/environment/lsm_test.go
+++ b/common/environment/lsm_test.go
@@ -389,6 +389,14 @@ func TestCheckBPFInKernelConfigLSM(t *testing.T) {
 			expectedError:  false,
 		},
 		{
+			name: "CONFIG_LSM contains bpf with quotes",
+			kernelConfig: map[KernelConfigOption]interface{}{
+				CONFIG_LSM: "\"lockdown,yama,apparmor,bpf\"",
+			},
+			expectedResult: true,
+			expectedError:  false,
+		},
+		{
 			name: "CONFIG_LSM does not contain bpf",
 			kernelConfig: map[KernelConfigOption]interface{}{
 				CONFIG_LSM: "lockdown,yama,apparmor",
@@ -528,6 +536,13 @@ func TestCheckBPFInBootParams(t *testing.T) {
 		{
 			name:               "LSM parameter with BPF in middle",
 			bootCmdline:        "root=/dev/sda1 lsm=lockdown,bpf,yama quiet",
+			expectedBPFEnabled: true,
+			expectedParamFound: true,
+			expectedError:      false,
+		},
+		{
+			name:               "LSM parameter with BPF and quotes",
+			bootCmdline:        "root=/dev/sda1 lsm=\"lockdown,yama,bpf\" quiet",
 			expectedBPFEnabled: true,
 			expectedParamFound: true,
 			expectedError:      false,


### PR DESCRIPTION
### 1. Explain what the PR does

Add support for quotes in LSM supported features.
For example: CONFIG_LSM="lockdown,yama,apparmor,bpf"

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
