### PR TITLE
bugfix(kconfig): return value for string configs as well

### DIFF
--- a/common/environment/kernel_config.go
+++ b/common/environment/kernel_config.go
@@ -318,12 +318,20 @@ func (k *KernelConfig) readConfigFromScanner(reader io.Reader) {
 
 // GetValue will return a KernelConfigOptionValue for a given KernelConfigOption when this is a BUILTIN or a MODULE
 func (k *KernelConfig) GetValue(option KernelConfigOption) KernelConfigOptionValue {
-	value, ok := k.configs[KernelConfigOption(option)].(KernelConfigOptionValue)
-	if ok {
-		return value
+	value, ok := k.configs[KernelConfigOption(option)]
+	if !ok {
+		return UNDEFINED // not an error as the config option might not exist in kconfig file
 	}
 
-	return UNDEFINED // not an error as the config option might not exist in kconfig file
+	switch v := value.(type) {
+	case KernelConfigOptionValue:
+		return v
+	case string:
+		return STRING
+	}
+
+	// unsupported type - should not happen
+	return UNDEFINED
 }
 
 // GetValueString will return a KernelConfigOptionValue for a given KernelConfigOption when this is actually a string


### PR DESCRIPTION
### 1. Explain what the PR does

The GetValue method of the kernel_config returns KernelConfigValue.
As STRING is a valid value, it should support it as well.

"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
