### PR TITLE
fix(types): correct TIMESPEC_T ArgMeta type from float64 to time.Time

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -7,9 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aquasecurity/tracee/types/protocol"
 )
@@ -218,6 +220,16 @@ func (arg *Argument) UnmarshalJSON(b []byte) error {
 				return err
 			}
 			arg.Value = tmp
+		case "time.Time":
+			// Parse time.Time from float64 seconds since epoch
+			tmp, err := num.Float64()
+			if err != nil {
+				return err
+			}
+			// Extract seconds and nanoseconds with proper precision using math.Modf
+			seconds, frac := math.Modf(tmp)
+			nanoseconds := int64(frac * 1e9)
+			arg.Value = time.Unix(int64(seconds), nanoseconds)
 		case "uint16":
 			tmp, err := strconv.ParseUint(num.String(), 10, 16)
 			if err != nil {


### PR DESCRIPTION
### 1. Explain what the PR does

Fix type mismatch where TIMESPEC_T arguments were decoded as time.Time but had ArgMeta.Type='float64', causing issues for JSON consumers.

- Add time.Time JSON unmarshaling support with nanosecond precision
- Add comprehensive tests with floating-point precision handling

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
