### PR TITLE
feat(ebpf): add helpers to get socket from a fd

### DIFF
--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -23,6 +23,8 @@ statfunc struct path get_path_from_file(struct file *);
 statfunc struct file *get_struct_file_from_fd(u64);
 statfunc unsigned short get_inode_mode_from_fd(u64);
 statfunc int check_fd_type(u64, u16);
+statfunc int is_file_type(struct file *, u16);
+statfunc int is_socket_file(struct file *);
 statfunc unsigned long get_inode_nr_from_dentry(struct dentry *);
 statfunc dev_t get_dev_from_dentry(struct dentry *);
 statfunc u64 get_ctime_nanosec_from_dentry(struct dentry *);
@@ -157,6 +159,21 @@ statfunc int check_fd_type(u64 fd, u16 type)
     }
 
     return 0;
+}
+
+statfunc int is_file_type(struct file *file, u16 type)
+{
+    unsigned short i_mode = get_inode_mode_from_file(file);
+
+    if ((i_mode & S_IFMT) == type)
+        return 1;
+
+    return 0;
+}
+
+statfunc int is_socket_file(struct file *file)
+{
+    return is_file_type(file, S_IFSOCK);
 }
 
 statfunc unsigned long get_inode_nr_from_dentry(struct dentry *dentry)


### PR DESCRIPTION
### 1. Explain what the PR does

eb27cb69b **feat(ebpf): add helpers to get socket from a fd**

```
- is_file_type() check file types
- is_socket_file() check if a file is a socket
- get_socket_from_fd() retrieve a socket from a file descriptor
```


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
