### PR TITLE
docs: fix outdated references and reorganize contributing guides

### DIFF
--- a/docs/contributing/adding-events.md
+++ b/docs/contributing/adding-events.md
@@ -151,7 +151,7 @@ This table maps internal Go event IDs to external protobuf event IDs for gRPC co
 
 ```bash
 # Generate protobuf Go files from proto definitions
-make protoc
+make -f builder/Makefile.protoc
 ```
 
 This command uses `protoc` to generate:
@@ -182,7 +182,7 @@ case *YourCustomType:
 1. Add the type definition to `api/v1beta1/event_data.proto`
 2. Add the field to the `EventValue` oneof
 3. Implement conversion logic in `event_data.go`
-4. Run `make protoc` to regenerate files
+4. Run `make -f builder/Makefile.protoc` to regenerate files
 
 ## Testing Your New Event
 
@@ -273,7 +273,7 @@ After everything is working, create a markdown file in the `docs/` directory to 
 - Verify event IDs don't conflict
 - Check eBPF program section names match probe configuration
 - Ensure all required headers are included
-- Run `make protoc` after modifying proto files
+- Run `make -f builder/Makefile.protoc` after modifying proto files
 
 **Protobuf/gRPC Issues:**
 - Event ID mismatches between Go, eBPF, and protobuf

--- a/docs/contributing/checkpatch.md
+++ b/docs/contributing/checkpatch.md
@@ -1,6 +1,6 @@
-# Checkpatch Script
+# Code Quality Guide
 
-The checkpatch script (`scripts/checkpatch.sh`) is the **comprehensive PR verification tool** for Tracee development. It has been integrated with the existing `make check-pr` command to provide a unified, enhanced experience for all developers.
+This guide covers all code quality tools and checks for Tracee development. The checkpatch script (`scripts/checkpatch.sh`) powers the `make check-pr` command and provides comprehensive PR verification for all developers.
 
 ## Purpose
 
@@ -30,12 +30,30 @@ make check-pr-skip-tests        # Skip unit tests
 ./scripts/checkpatch.sh --help            # Show all options
 ```
 
-### Detailed Usage
+### All Available Commands
 
-The script can be run from the repository root using:
-- **Make targets** (recommended): `make check-pr`, `make check-pr-fast`, etc.
-- **Direct script**: `./scripts/checkpatch.sh [OPTIONS] [commit-ref]`
-- **ARGS approach**: `make check-pr ARGS="--fast --skip-docs HEAD~1"`
+**Primary Make Targets (Recommended):**
+```bash
+make check-pr                   # Full comprehensive checks (recommended for PR submission)
+make check-pr-fast              # Quick checks (skip static analysis + unit tests)
+make check-pr-skip-docs         # Skip documentation verification
+make check-pr-skip-tests        # Skip unit tests
+make format-pr                  # Show what formatting changes are needed
+make fix-fmt                   # Automatically fix code formatting issues
+```
+
+**Individual Check Commands:**
+```bash
+make -f builder/Makefile.checkers fmt-check     # Check code formatting only
+make -f builder/Makefile.checkers fmt-fix       # Fix code formatting automatically
+make -f builder/Makefile.checkers code-check    # Static code analysis only
+```
+
+**Direct Script Usage (Advanced):**
+```bash
+./scripts/checkpatch.sh [OPTIONS] [commit-ref]  # Direct script access
+make check-pr ARGS="--fast --skip-docs HEAD~1"  # Pass arguments through make
+```
 
 ## Test Categories
 
@@ -107,12 +125,17 @@ make check-pr-fast || exit 1
 ### IDE Integration
 Many IDEs can be configured to run external scripts. Configure your IDE to run `make check-pr-fast` or `./scripts/checkpatch.sh` as a build or test step.
 
-### Development Workflow
-Recommended workflow:
-1. Make your changes
-2. Run `make check-pr-fast` for quick validation (or `make check-pr` for full checks)
-3. Fix any issues found
-4. Commit and push with confidence
+### Recommended Development Workflow
+
+1. **Make your changes**
+2. **Quick validation**: Run `make check-pr-fast` for immediate feedback
+3. **Fix any issues**: Use `make fix-fmt` for formatting or address other issues manually
+4. **Full validation**: Run `make check-pr` before PR submission
+5. **Commit and push** with confidence
+
+**Integration Options:**
+- **Pre-commit hook**: Add `make check-pr-fast || exit 1` to `.git/hooks/pre-commit`
+- **IDE integration**: Configure your IDE to run `make check-pr-fast` as a build step
 
 ## Troubleshooting
 
@@ -129,13 +152,19 @@ Recommended workflow:
 ✗ Documentation verification failed
 - tracee.1.md change requires corresponding tracee.1 change
 ```
-*Solution*: Run `make -f builder/Makefile.man man-run` to regenerate man pages.
+*Solution*: Run `make -f builder/Makefile.man` to regenerate man pages.
 
 **Formatting Issues**
 ```
 ✗ Go formatting issues found:
 ```
-*Solution*: Run `gofmt -w .` to fix formatting automatically.
+*Solution*: Run `make fix-fmt` or `make -f builder/Makefile.checkers fmt-fix` to fix formatting automatically.
+
+**Protocol Buffer Issues**
+```
+✗ Protobuf files need regeneration
+```
+*Solution*: Run `make -f builder/Makefile.protoc` to regenerate Go code from `.proto` files.
 
 ### Performance Tips
 

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -59,7 +59,7 @@ Tracee relies on several generated files and has strict formatting requirements.
 2. Protocol Buffer Compilation: If your changes involve modifications to protocol buffer (`.proto`) files, run:
 
     ```bash
-    make -f builder/Makefile.man
+    make -f builder/Makefile.protoc
     ```
 
     This regenerates the corresponding Go code.

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -44,61 +44,22 @@ To contribute to the code:
 
 ### Before You Commit
 
-Tracee relies on several generated files and has strict formatting requirements. Ensure you run the following commands before committing:
+Before submitting code changes, ensure you follow these essential steps:
 
-**`NOTE:`** In order to not depend on the host's library versions, we recommend that you always run make and other project dependencies in a virtual environment so the formatting will be aligned with Tracee guidelines
+1. **Generated Files**: If you've modified certain types of files, regenerate the corresponding outputs:
+   - **Man pages**: Run `make -f builder/Makefile.man` if you changed core code or documentation
+   - **Protocol buffers**: Run `make -f builder/Makefile.protoc` if you modified `.proto` files
 
-1. Man Pages Generation: If you've modified core code or documentation that impacts the man pages, run:
+2. **Code Quality**: Run comprehensive code quality checks:
+   ```bash
+   make check-pr
+   ```
 
-    ```bash
-    make -f builder/Makefile.man
-    ```
+   This verifies formatting, runs linting, performs static analysis, and validates your changes meet project standards.
 
-    This regenerates the man pages to reflect your changes.
+3. **Development Environment**: For consistent results, use a supported [development environment](./building/environment.md) when running checks.
 
-2. Protocol Buffer Compilation: If your changes involve modifications to protocol buffer (`.proto`) files, run:
-
-    ```bash
-    make -f builder/Makefile.protoc
-    ```
-
-    This regenerates the corresponding Go code.
-
-3. Pre-commit checks: Every time you're about to create a pull request, execute:
-
-    **`NOTE:`**  If your host machine dependencies don't align with Tracee dependencies, this command has to run on a supported [environment](./building/environment.md)
-
-    ```bash
-    make check-pr
-    ```
-
-    This command performs essential checks:
-    - `check-fmt`: Verifies code formatting adheres to project standards.
-    - `check-lint`: Runs linting tools (e.g., `golangci-lint`) to catch potential issues.
-    - `check-code`: Performs static code analysis for both Go and C code.
-    - `format-pr`: Displays the commits in your PR in a standardized format.
-
-    **Note:** `check-fmt`,`check-lint`,`check-code`,`format-pr` are individual make command combined under `check-pr`. You can run the following command without any vm using Makefile
-
-    - For `check-fmt`:
-
-        ```bash
-        make -f builder/Makefile.checkers fmt-check
-        ```
-
-    - For `check-code`:
-
-        ```bash
-        make -f builder/Makefile.checkers code-check
-        ```
-
-4. Fixing Code Formatting: If `check-fmt` reports issues, use:
-
-    ```bash
-    make -f builder/Makefile.checkers fmt-fix
-    ```
-
-    This automatically formats your Go and C code to meet project standards. Review the changes with `git status -s` before committing.
+For detailed information about these tools, troubleshooting, and advanced options, see our comprehensive [Code Quality Guide](checkpatch.md).
 
 ### Performance Considerations
 

--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -81,31 +81,6 @@ Development images are built daily from the `main` branch and include the latest
 
 ### Development Workflows
 
-Tracee provides several `make` targets to streamline development:
-
-```bash
-# Quick development checks before committing
-make check-pr              # Run all code quality checks for PR submission
-make format-pr             # Show what formatting changes are needed
-make fix-fmt               # Automatically fix code formatting
-
-# Testing workflows
-make test-unit             # Run unit tests with coverage
-make test-types            # Run tests for the types module
-make test-common           # Run tests for the common module
-make test-integration      # Run integration tests
-
-# Development builds
-make all                   # Build all components (tracee-ebpf, tracee-rules, signatures)
-make tracee                # Build the main tracee binary
-make bpf                   # Build just the eBPF object
-
-# Code analysis and debugging
-make bear                  # Generate compile_commands.json for IDE integration
-DEBUG=1 make              # Build with debug symbols
-METRICS=1 make            # Build with BPF metrics enabled
-```
-
 **Quick Start for Development:**
 ```bash
 # 1. Check your environment
@@ -121,7 +96,21 @@ make test-unit
 make check-pr
 ```
 
-For a complete list of available targets, run `make help`.
+**Common Development Tasks:**
+```bash
+# Development builds
+make tracee                # Build the main tracee binary
+make bpf                   # Build just the eBPF object
+make all                   # Build all components
+
+# Testing
+make test-unit             # Run unit tests with coverage
+make test-integration      # Run integration tests
+```
+
+For detailed information about code quality checks, dependencies, and troubleshooting, see our [Code Quality Guide](checkpatch.md).
+
+For complete build options and development environment setup, run `make help` or see [Building Documentation](building/building.md).
 
 ## Code
 

--- a/docs/contributing/performance.md
+++ b/docs/contributing/performance.md
@@ -1,9 +1,9 @@
 # Performance Considerations
 
-1. **Profiling Tracee for Performance test** - Tracee integrates with Pyroscope and Pprof for continuous profiling. When running Tracee locally for development or testing, use the `--pyroscope --pprof` command-line option.
+1. **Profiling Tracee for Performance test** - Tracee integrates with Pyroscope and Pprof for continuous profiling. When running Tracee locally for development or testing, use the `--server pyroscope --server pprof` command-line options.
 
     ```bash
-    sudo ./dist/tracee --pyroscope --pprof
+    sudo ./dist/tracee --server pyroscope --server pprof
     ```
 
     This enables profiling data to be sent to a local server. The Tracee repository includes a convenient way to deploy a performance dashboard for analyzing this data. Run the following for more details:

--- a/docs/docs/install/healthz.md
+++ b/docs/docs/install/healthz.md
@@ -5,11 +5,14 @@ Tracee can expose a `/healthz` endpoint that returns `OK` if the everything is h
 Health monitoring endpoint is disabled by default, and can be enabled with the configuration:
 
 ```yaml
-healthz: true
+server:
+  healthz: true
 ```
 
 By default port `3366` is used. It can be customized with the configuration:
 
 ```yaml
-listen-addr: 1234
+server:
+  http-address: :1234
+  healthz: true
 ```

--- a/docs/docs/install/prerequisites.md
+++ b/docs/docs/install/prerequisites.md
@@ -99,7 +99,7 @@ capabilities and justifications:
     - `CAP_BPF`+`CAP_PERFMON` for recent kernels (>=5.8) where the kernel perf paranoid value in `/proc/sys/kernel/perf_event_paranoid` is equal to 2 or less
     - or `CAP_SYS_ADMIN` otherwise
 - `CAP_SYS_PTRACE` (to collect information about processes)
-- `CAP_NET_ADMIN` (to use tc for packets capture)
+- `CAP_NET_ADMIN` (to load cgroup_skb BPF programs for network packet capture)
 - `CAP_SETPCAP` (if given - used to reduce bounding set capabilities)
 - `CAP_SYSLOG` (to access kernel symbols through /proc/kallsyms)
 - On some environments (e.g. Ubuntu) `CAP_IPC_LOCK` might be required as well.

--- a/docs/docs/install/prometheus.md
+++ b/docs/docs/install/prometheus.md
@@ -11,7 +11,7 @@ through the following URLs:
 **tracee** can be scraped through `:3366/metrics`
 
 > Metrics addresses can be changed through **tracee** command line
-> arguments `metrics` and `listen-addr`, check `--help` for more information.
+> arguments `--server metrics` and `--server http-address`, check `--help` for more information.
 
 !!! Tip
     Check [this tutorial] for more information as well.

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -67,9 +67,6 @@ signatures-dir: ""
 
 capabilities:
     bypass: false
-cache:
-    type: mem
-    size: 512
 proctree:
     source: both
     cache:

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -37,13 +37,14 @@ tracee --config ./config.yaml --policy ./policy.yaml && cat /tmp/debug.json
 ```yaml
 install-path: /tmp/tracee
 
-# debugging
+# server configuration
 
-healthz: true
-metrics: false
-pprof: false
-pyroscope: false
-listen-addr: :3366
+server:
+    http-address: ":3366"
+    healthz: true
+    metrics: false
+    pprof: false
+    pyroscope: false
 
 # feature flags
 


### PR DESCRIPTION
Updates documentation to reflect current Tracee architecture and improves contributor experience:

**Technical Updates:**
- Update CAP_NET_ADMIN description from tc programs to cgroup_skb BPF programs
- Fix protoc makefile references (Makefile.man → Makefile.protoc)
- Remove deprecated cache configuration 
- Update to unified server configuration format

**Documentation Reorganization:**
- Streamline contributing guides to eliminate redundancy across 3 pages
- Create clear hierarchy: overview (workflows) → guidelines (standards) → checkpatch (tools)
- Consolidate all development commands and troubleshooting in one place

