### PR TITLE
fix(performance): update dashboard detection for new --server flag format

### DIFF
--- a/builder/Makefile.performance
+++ b/builder/Makefile.performance
@@ -82,11 +82,11 @@ dashboard-start: | \
 		echo "tracee is NOT RUNNING"
 		exit 0
 	fi
-	if [ $(shell $(CMD_PS) -axho args | grep -- "-[p]yroscope" | wc -l) -eq 0 ]; then
+	if [ $(shell $(CMD_PS) -axho args | grep -- "--server pyroscope" | wc -l) -eq 0 ]; then
 		echo "tracee is NOT RUNNING with --server pyroscope"
 		exit 0
 	fi
-	if [ $(shell $(CMD_PS) -axho args | grep -- "-[p]prof" | wc -l) -eq 0 ]; then
+	if [ $(shell $(CMD_PS) -axho args | grep -- "--server pprof" | wc -l) -eq 0 ]; then
 		echo "tracee is NOT RUNNING with --server pprof"
 		exit 0
 	fi


### PR DESCRIPTION
The performance dashboard checks were still looking for the old -pyroscope and -pprof flags. Updated to detect the new unified --server flag with pyroscope/pprof values.
