### PR TITLE
Fix sig engine close chan

### DIFF
--- a/pkg/signatures/engine/engine.go
+++ b/pkg/signatures/engine/engine.go
@@ -215,7 +215,6 @@ func (engine *Engine) consumeSources(ctx context.Context) {
 				}
 				engine.inputs.Tracee = nil
 				if engine.checkCompletion() {
-					close(engine.output)
 					return
 				}
 


### PR DESCRIPTION
```
    fix(engine): remove duplicate channel close causing panic
    
    The signature engine was closing the output channel twice:
    1. In signature_engine.go via 'defer close(engineOutput)'
    2. In engine.go via 'close(engine.output)'
    
    Since engineOutput and engine.output are the same channel, this caused
    a 'close of closed channel' panic during shutdown.
    
    The fix follows Go channel ownership principle: only the creator
    (signature_engine.go) should close the channel.
    
    Fixes panic: close of closed channel at engine.go:218
```

```
    fix(engine): prevent send-on-closed-channel race in matchHandler
    
    Uses context-based protection to prevent 'send on closed channel' panics
    during shutdown. Works regardless of signature Close() implementations.
```

Fix: #4679 