### PR TITLE
fix(ebpf): fix compatibility watcher

### DIFF
--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1386,7 +1386,7 @@ func (t *Tracee) validateProbesCompatibility() error {
 				return nil
 			}
 			if !probeCompatibility {
-				return []dependencies.Action{dependencies.CancelNodeAddAction{Reason: errors.New("probe is not compatible with the current environment")}}
+				return []dependencies.Action{dependencies.NewFailNodeAddAction(errors.New("probe is not compatible with the current environment"))}
 			}
 			return nil
 		})


### PR DESCRIPTION
### 1. Explain what the PR does

Fix the wrong use of cancelation action in the compatibility check watcher. This bug caused probes failing the compatibility check to still be added to the manager.

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
