### PR TITLE
fix(ebpf): use sockaddr workaround in arm64

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -2872,19 +2872,15 @@ int BPF_KPROBE(trace_security_socket_connect)
             break;
     }
 
-#if defined(bpf_target_x86)
     if (need_workaround) {
-        // Workaround for sockaddr_un struct length (issue: #1129).
         struct sockaddr_un sockaddr = {0};
         bpf_probe_read(&sockaddr, (u32) addr_len, (void *) address);
         // NOTE(nadav.str): stack allocated, so runtime core size check is avoided
         stsb(args_buf, (void *) &sockaddr, sizeof(struct sockaddr_un), 2);
-    }
-#endif
-
-    // Save the sockaddr struct argument to the event.
-    if (!need_workaround)
+    } else {
+        // Save the sockaddr struct argument to the event.
         stsb(args_buf, (void *) address, sockaddr_len, 2);
+    }
 
     // Submit the event.
     return events_perf_submit(&p, 0);


### PR DESCRIPTION
### 1. Explain what the PR does

f66de1598 **fix(ebpf): use sockaddr workaround in arm64**

```
Workaround was previously limited to x86 due to verifier limitations in ARM64.
These have likely since been fixed, and the workaround therefore works just as well in ARM64.
```

### 2. Explain how to test it

1. Run tracee on arm64 filtering for `security_socket_connect`
2. Connect with ssh to the machine running tracee
3. There should be no event where the value `remote_addr` of is `<nil>`

### 3. Other comments

Compare with #1129
