### PR TITLE
Improve btfhub.sh to download only the required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -583,7 +583,7 @@ TRACEE_PROTOS = ./api/v1beta1/*.proto
 # btfhub (expensive: only run if ebpf obj changed)
 #
 
-SH_BTFHUB = ./3rdparty/btfhub.sh
+SH_BTFHUB = ./scripts/btfhub.sh
 
 .PHONY: btfhub
 btfhub:: \

--- a/scripts/btfhub.sh
+++ b/scripts/btfhub.sh
@@ -13,11 +13,11 @@
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 # shellcheck disable=SC1091
-. "${SCRIPT_DIR}/../scripts/lib.sh"
+. "${SCRIPT_DIR}/lib.sh"
 
 require_cmds git
 
-BASEDIR="${SCRIPT_DIR}/../"
+BASEDIR=$(cd "${SCRIPT_DIR}/../" && pwd)
 cd "${BASEDIR}"
 
 TRACEE_BPF_CORE="${BASEDIR}/dist/tracee.bpf.o"


### PR DESCRIPTION
Close: #4456 

Realized that for Tracee case the sparse clone tool provided in btfhub repo is not enough, then this sparse clones setting the filters manually.

### 1. Explain what the PR does

40b7c10bb **refactor(btfhub): relocate btfhub script**

```
Move the btfhub script to the scripts directory for better organization.
```

7c4f39129 **refactor(btfhub): improve script structure and ...**

```
... add sparse checkout for BTF files

- Implement sparse checkout for efficient BTF file downloads,
  reducing unnecessary data transfer.
- Add logic to handle existing archive directories intelligently,
  ensuring updates are managed correctly.
- Improve user feedback throughout the script (lib.sh).
```

### 2. Explain how to test it

`make btfhub BTFHUB=1`

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
