### PR TITLE
chore: update tracee/api to 3e47b0c6

### DIFF
--- a/cmd/traceectl/go.mod
+++ b/cmd/traceectl/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/aquasecurity/table v1.10.0
-	github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5
+	github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0

--- a/cmd/traceectl/go.sum
+++ b/cmd/traceectl/go.sum
@@ -1,7 +1,7 @@
 github.com/aquasecurity/table v1.10.0 h1:gPWV28qp9XSlvXdT3ku8yKQoZE6II0vsmegKpW+dB08=
 github.com/aquasecurity/table v1.10.0/go.mod h1:eqOmvjjB7AhXFgFqpJUEE/ietg7RrMSJZXyTN8E/wZw=
-github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5 h1:zseTkmEkMBo4b2gYzE5dnj6EfEjajipUQLGs+FtTw3M=
-github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5/go.mod h1:fCLvZ7yle7SJoMNFSUCNVZo6Qf6xWXUmP0isGvRrIL8=
+github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6 h1:Zs/wx/VJRL+spJSfoST8oyGvSUy/Enpg7x15LBhEWTg=
+github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6/go.mod h1:fCLvZ7yle7SJoMNFSUCNVZo6Qf6xWXUmP0isGvRrIL8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/IBM/fluent-forward-go v0.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45
-	github.com/aquasecurity/tracee/api v0.0.0-20250423121028-213b81a1b8f5
+	github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6
 	github.com/aquasecurity/tracee/common v0.0.0-20250902170041-945d17d40601
 	github.com/aquasecurity/tracee/types v0.0.0-20250902170041-945d17d40601
 	github.com/containerd/containerd v1.7.27
@@ -169,5 +169,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.76 // indirect
 )
-
-replace github.com/aquasecurity/tracee/api => ./api

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45 h1:AjGH0Y/gMhFu73Jr37RoBsIAPiaT8Ufm6LptyEiX6rw=
 github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45/go.mod h1:mKk/RxlMO0K2HqA4dGLBdfUsvwLYtNhPanHXFPYbw38=
+github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6 h1:Zs/wx/VJRL+spJSfoST8oyGvSUy/Enpg7x15LBhEWTg=
+github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6/go.mod h1:fCLvZ7yle7SJoMNFSUCNVZo6Qf6xWXUmP0isGvRrIL8=
 github.com/aquasecurity/tracee/common v0.0.0-20250902170041-945d17d40601 h1:MNICZTArUHlqBuWbdsdHCu8/fZsTmpnA9ls2FJKrdZY=
 github.com/aquasecurity/tracee/common v0.0.0-20250902170041-945d17d40601/go.mod h1:U21mnx78I0v2g1VVrCi1ZGSlvx2YbmYcfz/cMQsEIc0=
 github.com/aquasecurity/tracee/types v0.0.0-20250902170041-945d17d40601 h1:kh3aJSemoJakSVgZI1/dv49zU5WgSPyMB43vzEpl8k8=


### PR DESCRIPTION
### 1. Explain what the PR does

29537cec0 **chore: update tracee/api to 3e47b0c6**

```
This is sequential of 3e47b0c.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
