### PR TITLE
fix(grpc): correct event field mappings in protobuf conversion

### DIFF
--- a/pkg/server/grpc/tracee.go
+++ b/pkg/server/grpc/tracee.go
@@ -815,7 +815,7 @@ func getProcess(e trace.Event) *pb.Process {
 			HostTid:        wrapperspb.UInt32(uint32(e.HostThreadID)),
 			Tid:            wrapperspb.UInt32(uint32(e.ThreadID)),
 			Syscall:        sanitizeStringForProtobuf(e.Syscall),
-			Compat:         e.ContextFlags.ContainerStarted,
+			Compat:         e.ContextFlags.IsCompat,
 			UserStackTrace: userStackTrace,
 		},
 		Ancestors: ancestors,
@@ -840,8 +840,9 @@ func getContainer(e trace.Event) *pb.Container {
 	}
 
 	container := &pb.Container{
-		Id:   sanitizeStringForProtobuf(e.Container.ID),
-		Name: sanitizeStringForProtobuf(e.Container.Name),
+		Id:        sanitizeStringForProtobuf(e.Container.ID),
+		Name:      sanitizeStringForProtobuf(e.Container.Name),
+		IsRunning: e.ContextFlags.ContainerStarted,
 	}
 
 	if e.Container.ImageName != "" {

--- a/pkg/server/grpc/tracee_test.go
+++ b/pkg/server/grpc/tracee_test.go
@@ -31,7 +31,7 @@ func Test_convertEventWithProcessWorkload(t *testing.T) {
 		EventName:           "eventTest",
 		MatchedPolicies:     []string{"policyTest"},
 		Syscall:             "syscall",
-		ContextFlags:        trace.ContextFlags{ContainerStarted: true},
+		ContextFlags:        trace.ContextFlags{ContainerStarted: true, IsCompat: true},
 		ThreadEntityId:      9,
 		ProcessEntityId:     10,
 		ParentEntityId:      11,


### PR DESCRIPTION
Fix two bugs in trace.Event to protobuf conversion:

1. Thread.Compat now correctly maps to IsCompat (compat syscall mode)
   - Was incorrectly using ContainerStarted
   - Compat refers to 32-bit syscalls on 64-bit systems

2. Container.IsRunning now populated from ContainerStarted flag
   - Field was previously never set