### PR TITLE
filters: fix container!=new and pid!=new filter parsing

### DIFF
--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -164,7 +164,7 @@ func parseScopeFilters(p *policy.Policy, scopeFlags []scopeFlag) error {
 				if err := p.ContFilter.Parse(scopeFlag.scopeName); err != nil {
 					return err
 				}
-				if err := p.NewContFilter.Parse("!new"); err != nil {
+				if err := p.NewContFilter.Parse("not-new"); err != nil {
 					return err
 				}
 			case scopeFlag.operator == "=":
@@ -205,7 +205,7 @@ func parseScopeFilters(p *policy.Policy, scopeFlags []scopeFlag) error {
 					return err
 				}
 			case "!=new":
-				if err := p.NewPidFilter.Parse("!new"); err != nil {
+				if err := p.NewPidFilter.Parse("not-new"); err != nil {
 					return err
 				}
 			default:

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -2297,6 +2297,38 @@ func TestParseScopeFilters(t *testing.T) {
 			},
 		},
 		{
+			name:   "container!=new should set NewContFilter to not-new",
+			policy: policy.NewPolicy(),
+			scopeFlags: []scopeFlag{{
+				full:              "container!=new",
+				scopeName:         "container",
+				operator:          "!=",
+				operatorAndValues: "!=new",
+			}},
+			validate: func(t *testing.T, p *policy.Policy) {
+				assert.NotNil(t, p.NewContFilter)
+				assert.True(t, p.NewContFilter.Enabled())
+				// With the fix, Value() should return false (filter out new containers)
+				assert.False(t, p.NewContFilter.Value(), "NewContFilter should be false to exclude new containers")
+			},
+		},
+		{
+			name:   "pid!=new should set NewPidFilter to not-new",
+			policy: policy.NewPolicy(),
+			scopeFlags: []scopeFlag{{
+				full:              "pid!=new",
+				scopeName:         "pid",
+				operator:          "!=",
+				operatorAndValues: "!=new",
+			}},
+			validate: func(t *testing.T, p *policy.Policy) {
+				assert.NotNil(t, p.NewPidFilter)
+				assert.True(t, p.NewPidFilter.Enabled())
+				// With the fix, Value() should return false (filter out new pids)
+				assert.False(t, p.NewPidFilter.Value(), "NewPidFilter should be false to exclude new pids")
+			},
+		},
+		{
 			name:   "invalid scope filter",
 			policy: policy.NewPolicy(),
 			scopeFlags: []scopeFlag{{


### PR DESCRIPTION
Fix BoolFilter.Parse() to use 'not-new' instead of '!new'. The '!' prefix is not recognized by BoolFilter, causing these filters to incorrectly match new containers/processes instead of excluding them.