### PR TITLE
filters: add container=started filter with eBPF support

### DIFF
--- a/docs/docs/flags/scope.1.md
+++ b/docs/docs/flags/scope.1.md
@@ -68,6 +68,7 @@ Available for the following boolean field:
 The following special filters can be used within the scope filter expressions:
 
 - new: Select newly created containers or process IDs.
+- started: Select events from containers that have completed initialization and started running (post-entrypoint execution). Only available for container scope (e.g., `container=started`). Note: The negation `container!=started` is not supported due to race conditions with early container event recognition.
 - follow: Select events from the processes that match the criteria and their descendants.
 
 ## EXAMPLES
@@ -94,6 +95,12 @@ The following special filters can be used within the scope filter expressions:
 
   ```console
   --scope container=new
+  ```
+
+- To trace only events from containers that have started running (post-entrypoint execution), use the following flag:
+
+  ```console
+  --scope container=started
   ```
 
 - To trace only events from the container with ID 'ab356bc4dd554', use the following flag:

--- a/docs/docs/policies/scopes.md
+++ b/docs/docs/policies/scopes.md
@@ -117,6 +117,24 @@ scope:
     - container
 ```
 
+You can also filter for containers based on their state:
+
+- **container=new**: Events are collected only from newly created containers (during container initialization):
+
+```yaml
+scope:
+    - container=new
+```
+
+- **container=started**: Events are collected only from containers that have completed initialization and started running (post-entrypoint execution):
+
+```yaml
+scope:
+    - container=started
+```
+
+Note: The negation `container!=started` is not supported due to race conditions with early container event recognition.
+
 ### not-container
 
 Events are collected from everything but containers:

--- a/docs/man/scope.1
+++ b/docs/man/scope.1
@@ -71,6 +71,12 @@ expressions:
 .IP \[bu] 2
 new: Select newly created containers or process IDs.
 .IP \[bu] 2
+started: Select events from containers that have completed
+initialization and started running (post\-entrypoint execution).
+Only available for container scope (e.g., \f[CR]container=started\f[R]).
+Note: The negation \f[CR]container!=started\f[R] is not supported due to
+race conditions with early container event recognition.
+.IP \[bu] 2
 follow: Select events from the processes that match the criteria and
 their descendants.
 .SS EXAMPLES
@@ -106,6 +112,15 @@ flag:
 .IP
 .EX
 \-\-scope container=new
+.EE
+.RE
+.IP \[bu] 2
+To trace only events from containers that have started running
+(post\-entrypoint execution), use the following flag:
+.RS 2
+.IP
+.EX
+\-\-scope container=started
 .EE
 .RE
 .IP \[bu] 2

--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -167,6 +167,14 @@ func parseScopeFilters(p *policy.Policy, scopeFlags []scopeFlag) error {
 				if err := p.NewContFilter.Parse("!new"); err != nil {
 					return err
 				}
+			case scopeFlag.operatorAndValues == "=started":
+				// Container started state filter: container=started (only started containers)
+				if err := p.ContFilter.Parse(scopeFlag.scopeName); err != nil {
+					return err
+				}
+				if err := p.ContStartedFilter.Parse("started"); err != nil {
+					return err
+				}
 			case scopeFlag.operator == "=":
 				if err := p.ContIDFilter.Parse(scopeFlag.operatorAndValues); err != nil {
 					return err

--- a/pkg/ebpf/c/common/filtering.h
+++ b/pkg/ebpf/c/common/filtering.h
@@ -220,6 +220,16 @@ statfunc u64 match_scope_filters(program_data_t *p)
         res &= bool_filter_matches(match_bitmap, is_new_container) | mask;
     }
 
+    if (policies_cfg->cont_started_filter_enabled) {
+        bool is_started = false;
+        if (p->event->context.task.flags & CONTAINER_STARTED_FLAG)
+            is_started = true;
+        u64 match_bitmap = policies_cfg->cont_started_filter_match_if_key_missing;
+        u64 mask = ~policies_cfg->cont_started_filter_enabled;
+
+        res &= bool_filter_matches(match_bitmap, is_started) | mask;
+    }
+
     if (policies_cfg->new_pid_filter_enabled) {
         u64 match_bitmap = policies_cfg->new_pid_filter_match_if_key_missing;
         u64 mask = ~policies_cfg->new_pid_filter_enabled;

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -400,6 +400,7 @@ typedef struct policies_config {
     u64 cgroup_id_filter_enabled;
     u64 cont_filter_enabled;
     u64 new_cont_filter_enabled;
+    u64 cont_started_filter_enabled;
     u64 new_pid_filter_enabled;
     u64 proc_tree_filter_enabled;
     u64 bin_path_filter_enabled;
@@ -414,6 +415,7 @@ typedef struct policies_config {
     u64 cgroup_id_filter_match_if_key_missing;
     u64 cont_filter_match_if_key_missing;
     u64 new_cont_filter_match_if_key_missing;
+    u64 cont_started_filter_match_if_key_missing;
     u64 new_pid_filter_match_if_key_missing;
     u64 proc_tree_filter_match_if_key_missing;
     u64 bin_path_filter_match_if_key_missing;

--- a/pkg/filters/scope_test.go
+++ b/pkg/filters/scope_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/tracee/pkg/filters/sets"
+	"github.com/aquasecurity/tracee/types/trace"
 )
 
 func TestScopeFilterClone(t *testing.T) {
@@ -37,5 +39,126 @@ func TestScopeFilterClone(t *testing.T) {
 	require.NoError(t, err)
 	if cmp.Equal(filter, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
+	}
+}
+
+func TestScopeFilter_ContainerStarted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		field          string
+		operatorValues string
+		event          trace.Event
+		expectedMatch  bool
+		expectedErrStr string
+	}{
+		{
+			name:           "container - matches any container",
+			field:          "container",
+			operatorValues: "",
+			event: trace.Event{
+				Container:    trace.Container{ID: "abc123"},
+				ContextFlags: trace.ContextFlags{ContainerStarted: false},
+			},
+			expectedMatch: true,
+		},
+		{
+			name:           "container - matches started container",
+			field:          "container",
+			operatorValues: "",
+			event: trace.Event{
+				Container:    trace.Container{ID: "abc123"},
+				ContextFlags: trace.ContextFlags{ContainerStarted: true},
+			},
+			expectedMatch: true,
+		},
+		{
+			name:           "container - does not match host",
+			field:          "container",
+			operatorValues: "",
+			event: trace.Event{
+				Container:    trace.Container{ID: ""},
+				ContextFlags: trace.ContextFlags{ContainerStarted: false},
+			},
+			expectedMatch: false,
+		},
+		{
+			name:           "container=started - matches started container",
+			field:          "container",
+			operatorValues: "=started",
+			event: trace.Event{
+				Container:    trace.Container{ID: "abc123"},
+				ContextFlags: trace.ContextFlags{ContainerStarted: true},
+			},
+			expectedMatch: true,
+		},
+		{
+			name:           "container=started - does not match init container",
+			field:          "container",
+			operatorValues: "=started",
+			event: trace.Event{
+				Container:    trace.Container{ID: "abc123"},
+				ContextFlags: trace.ContextFlags{ContainerStarted: false},
+			},
+			expectedMatch: false,
+		},
+		{
+			name:           "container=started - does not match host",
+			field:          "container",
+			operatorValues: "=started",
+			event: trace.Event{
+				Container:    trace.Container{ID: ""},
+				ContextFlags: trace.ContextFlags{ContainerStarted: false},
+			},
+			expectedMatch: false,
+		},
+		{
+			name:           "host - matches host events",
+			field:          "host",
+			operatorValues: "",
+			event: trace.Event{
+				Container:    trace.Container{ID: ""},
+				ContextFlags: trace.ContextFlags{ContainerStarted: false},
+			},
+			expectedMatch: true,
+		},
+		{
+			name:           "host - does not match container",
+			field:          "host",
+			operatorValues: "",
+			event: trace.Event{
+				Container:    trace.Container{ID: "abc123"},
+				ContextFlags: trace.ContextFlags{ContainerStarted: false},
+			},
+			expectedMatch: false,
+		},
+		{
+			name:           "container=invalid - returns error",
+			field:          "container",
+			operatorValues: "=invalid",
+			event:          trace.Event{},
+			expectedMatch:  false,
+			expectedErrStr: "invalid filter expression",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := NewScopeFilter()
+			err := filter.Parse(tt.field, tt.operatorValues)
+
+			if tt.expectedErrStr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrStr)
+				return
+			}
+
+			require.NoError(t, err)
+			match := filter.Filter(tt.event)
+			assert.Equal(t, tt.expectedMatch, match, "Event should match=%v, got=%v", tt.expectedMatch, match)
+		})
 	}
 }

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -841,32 +841,34 @@ func (ps *policies) createNewPoliciesConfigMap(bpfModule *bpf.Module) error {
 // Order of fields is important, as it is used as a value for
 // the PoliciesConfigMap BPF map.
 type PoliciesConfig struct {
-	UIDFilterEnabled      uint64
-	PIDFilterEnabled      uint64
-	MntNsFilterEnabled    uint64
-	PidNsFilterEnabled    uint64
-	UtsNsFilterEnabled    uint64
-	CommFilterEnabled     uint64
-	CgroupIdFilterEnabled uint64
-	ContFilterEnabled     uint64
-	NewContFilterEnabled  uint64
-	NewPidFilterEnabled   uint64
-	ProcTreeFilterEnabled uint64
-	BinPathFilterEnabled  uint64
-	FollowFilterEnabled   uint64
+	UIDFilterEnabled         uint64
+	PIDFilterEnabled         uint64
+	MntNsFilterEnabled       uint64
+	PidNsFilterEnabled       uint64
+	UtsNsFilterEnabled       uint64
+	CommFilterEnabled        uint64
+	CgroupIdFilterEnabled    uint64
+	ContFilterEnabled        uint64
+	NewContFilterEnabled     uint64
+	ContStartedFilterEnabled uint64
+	NewPidFilterEnabled      uint64
+	ProcTreeFilterEnabled    uint64
+	BinPathFilterEnabled     uint64
+	FollowFilterEnabled      uint64
 
-	UIDFilterMatchIfKeyMissing      uint64
-	PIDFilterMatchIfKeyMissing      uint64
-	MntNsFilterMatchIfKeyMissing    uint64
-	PidNsFilterMatchIfKeyMissing    uint64
-	UtsNsFilterMatchIfKeyMissing    uint64
-	CommFilterMatchIfKeyMissing     uint64
-	CgroupIdFilterMatchIfKeyMissing uint64
-	ContFilterMatchIfKeyMissing     uint64
-	NewContFilterMatchIfKeyMissing  uint64
-	NewPidFilterMatchIfKeyMissing   uint64
-	ProcTreeFilterMatchIfKeyMissing uint64
-	BinPathFilterMatchIfKeyMissing  uint64
+	UIDFilterMatchIfKeyMissing         uint64
+	PIDFilterMatchIfKeyMissing         uint64
+	MntNsFilterMatchIfKeyMissing       uint64
+	PidNsFilterMatchIfKeyMissing       uint64
+	UtsNsFilterMatchIfKeyMissing       uint64
+	CommFilterMatchIfKeyMissing        uint64
+	CgroupIdFilterMatchIfKeyMissing    uint64
+	ContFilterMatchIfKeyMissing        uint64
+	NewContFilterMatchIfKeyMissing     uint64
+	ContStartedFilterMatchIfKeyMissing uint64
+	NewPidFilterMatchIfKeyMissing      uint64
+	ProcTreeFilterMatchIfKeyMissing    uint64
+	BinPathFilterMatchIfKeyMissing     uint64
 
 	EnabledPolicies uint64
 
@@ -924,6 +926,9 @@ func (ps *policies) computePoliciesConfig() *PoliciesConfig {
 		if p.NewContFilter.Enabled() {
 			cfg.NewContFilterEnabled |= 1 << offset
 		}
+		if p.ContStartedFilter.Enabled() {
+			cfg.ContStartedFilterEnabled |= 1 << offset
+		}
 		if p.NewPidFilter.Enabled() {
 			cfg.NewPidFilterEnabled |= 1 << offset
 		}
@@ -963,6 +968,9 @@ func (ps *policies) computePoliciesConfig() *PoliciesConfig {
 		}
 		if p.NewContFilter.MatchIfKeyMissing() {
 			cfg.NewContFilterMatchIfKeyMissing |= 1 << offset
+		}
+		if p.ContStartedFilter.MatchIfKeyMissing() {
+			cfg.ContStartedFilterMatchIfKeyMissing |= 1 << offset
 		}
 		if p.NewPidFilter.MatchIfKeyMissing() {
 			cfg.NewPidFilterMatchIfKeyMissing |= 1 << offset

--- a/pkg/policy/policy.go
+++ b/pkg/policy/policy.go
@@ -19,6 +19,7 @@ type Policy struct {
 	ContFilter        *filters.BoolFilter
 	NewContFilter     *filters.BoolFilter
 	ContIDFilter      *filters.StringFilter
+	ContStartedFilter *filters.BoolFilter
 	ProcessTreeFilter *filters.ProcessTreeFilter
 	BinaryFilter      *filters.BinaryFilter
 	Follow            bool
@@ -49,6 +50,7 @@ func NewPolicy() *Policy {
 		ContFilter:        filters.NewBoolFilter(),
 		NewContFilter:     filters.NewBoolFilter(),
 		ContIDFilter:      filters.NewStringFilter(nil),
+		ContStartedFilter: filters.NewBoolFilter(),
 		ProcessTreeFilter: filters.NewProcessTreeFilter(),
 		BinaryFilter:      filters.NewBinaryFilter(),
 		Follow:            false,
@@ -60,7 +62,8 @@ func NewPolicy() *Policy {
 func (p *Policy) ContainerFilterEnabled() bool {
 	return (p.ContFilter.Enabled() && p.ContFilter.Value()) ||
 		(p.NewContFilter.Enabled() && p.NewContFilter.Value()) ||
-		p.ContIDFilter.Enabled()
+		p.ContIDFilter.Enabled() ||
+		p.ContStartedFilter.Enabled()
 }
 
 func (p *Policy) Clone() *Policy {
@@ -82,6 +85,7 @@ func (p *Policy) Clone() *Policy {
 	n.ContFilter = p.ContFilter.Clone()
 	n.NewContFilter = p.NewContFilter.Clone()
 	n.ContIDFilter = p.ContIDFilter.Clone()
+	n.ContStartedFilter = p.ContStartedFilter.Clone()
 	n.ProcessTreeFilter = p.ProcessTreeFilter.Clone()
 	n.BinaryFilter = p.BinaryFilter.Clone()
 	n.Follow = p.Follow


### PR DESCRIPTION
Add filtering for containers by started state (post-entrypoint execution).

- Add ContStartedFilter to Policy and eBPF config
- Check CONTAINER_STARTED_FLAG in eBPF filtering
- Parse 'container=started' scope filter
- Update tests (removed container=init, now only container=started)

Note: container!=started not supported due to race conditions with early container event recognition.
