### PR TITLE
fix(events/sorting): prevent deadlock in concurrent event sending

### DIFF
--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -172,7 +172,7 @@ func (sorter *EventsChronologicalSorter) Start(in <-chan *trace.Event, out chan<
 			if len(sorter.extractionSavedTimestamps) > sorter.intervalsAmountThresholdForDelay {
 				extractionTimestamp := sorter.extractionSavedTimestamps[0]
 				sorter.extractionSavedTimestamps = sorter.extractionSavedTimestamps[1:]
-				go sorter.sendEvents(out, extractionTimestamp)
+				sorter.sendEvents(out, extractionTimestamp)
 			}
 
 		case <-ctx.Done():


### PR DESCRIPTION
Close: #4656

### 1. Explain what the PR does

7ff234794 **fix(events/sorting): prevent deadlock in concurrent event sending**

```
Remove goroutine spawn that caused deadlock when holding
outputChanMutex while blocking on channel send.
The mutex already serializes sends, making async calls unnecessary.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
