### PR TITLE
feat(dependencies): add GetAllEventDependentsOfProbe

### DIFF
--- a/pkg/events/dependencies/manager_events.go
+++ b/pkg/events/dependencies/manager_events.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/aquasecurity/tracee/common/logger"
+	"github.com/aquasecurity/tracee/pkg/ebpf/probes"
 	"github.com/aquasecurity/tracee/pkg/events"
 )
 
@@ -399,4 +400,54 @@ func (m *Manager) handleEventAddError(node *EventNode, err error) error {
 	}
 	// Fallback succeeded, no error to return
 	return nil
+}
+
+// GetAllEventDependentsOfProbe returns all events that transitively depend on the given probe.
+func (m *Manager) GetAllEventDependentsOfProbe(handle probes.Handle) ([]events.ID, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	probeNode := m.getProbe(handle)
+	if probeNode == nil {
+		return nil, ErrNodeNotFound
+	}
+
+	return m.collectAllEventDependents(probeNode.GetDependents()), nil
+}
+
+// collectAllEventDependents performs a depth-first traversal to collect all events
+// that transitively depend on the given starting events.
+func (m *Manager) collectAllEventDependents(startEvents []events.ID) []events.ID {
+	visited := make(map[events.ID]struct{}, len(startEvents))
+	result := make([]events.ID, 0, len(startEvents))
+
+	// Recursive function to collect all dependents
+	var collect func(events.ID)
+	collect = func(id events.ID) {
+		if _, seen := visited[id]; seen {
+			return
+		}
+
+		visited[id] = struct{}{}
+		result = append(result, id)
+
+		node := m.getEventNode(id)
+		if node == nil {
+			// should never happen
+			logger.Debugw("event node not found", "event", id)
+			return
+		}
+
+		// Recursively process all dependents
+		for _, dep := range node.GetDependents() {
+			collect(dep)
+		}
+	}
+
+	// Start collection from each initial event
+	for _, id := range startEvents {
+		collect(id)
+	}
+
+	return result
 }

--- a/pkg/events/dependencies/manager_test.go
+++ b/pkg/events/dependencies/manager_test.go
@@ -2181,3 +2181,563 @@ func TestManager_StateChangeWatcher_TailcallMerge(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []uint32{1, 2, 3, 4}, tailCallNode.GetTailCall().GetIndexes())
 }
+
+func TestManager_GetAllEventDependentsOfProbe(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		deps           map[events.ID]events.DependencyStrategy
+		eventsToAdd    []events.ID
+		probeToQuery   probes.Handle
+		expectedEvents []events.ID
+		expectError    error
+	}{
+		// =====================================================================
+		// ERROR CASES
+		// =====================================================================
+		{
+			name:           "error: non-existent probe - empty tree",
+			deps:           map[events.ID]events.DependencyStrategy{},
+			eventsToAdd:    []events.ID{},
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: nil,
+			expectError:    ErrNodeNotFound,
+		},
+		{
+			name: "error: probe doesn't exist - querying different probe",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExit, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(1)},
+			probeToQuery:   probes.SchedProcessExec, // different probe
+			expectedEvents: nil,
+			expectError:    ErrNodeNotFound,
+		},
+		{
+			name: "error: probe at bottom - event doesn't reach probe",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)}, // depends on 1
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)}, // depends on 2
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true), // probe at bottom/leaf
+						},
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(2)}, // add middle event only (Event3 never added)
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: nil, // probe doesn't exist in tree
+			expectError:    ErrNodeNotFound,
+		},
+		{
+			name: "error: probe at very bottom - event doesn't reach probe",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)}, // depends on 1
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)}, // depends on 2
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(3)}, // depends on 3
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(5): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(4)}, // depends on 4
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true), // probe at very bottom/leaf
+						},
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(3)}, // add middle event (3 out of 5) (Event5 never added)
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: nil, // probe doesn't exist in tree
+			expectError:    ErrNodeNotFound,
+		},
+		{
+			name: "error: probe in middle - event added before probe",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true), // probe in middle
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(3)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(5): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(4)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(1)}, // add event right before probe (Event2 never added)
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: nil, // probe doesn't exist in tree
+			expectError:    ErrNodeNotFound,
+		},
+
+		// =====================================================================
+		// SUCCESS CASES - Direct dependents
+		// =====================================================================
+		{
+			name: "success: single direct dependent",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(1)},
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(1)},
+			expectError:    nil,
+		},
+		{
+			name: "success: multiple direct dependents",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(1), events.ID(2), events.ID(3)},
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(1), events.ID(2), events.ID(3)},
+			expectError:    nil,
+		},
+
+		// =====================================================================
+		// SUCCESS CASES - Transitive dependents
+		// =====================================================================
+		{
+			name: "success: transitive dependents - simple chain",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)}, // depends on event 1
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)}, // depends on event 2
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(3)}, // adds 3, which adds 2, which adds 1
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(1), events.ID(2), events.ID(3)}, // all three events
+			expectError:    nil,
+		},
+		{
+			name: "success: transitive dependents - multiple chains",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)}, // depends on 1
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)}, // also depends on 1
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)}, // depends on 2
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(5): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(3)}, // depends on 3
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(4), events.ID(5)},
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(1), events.ID(2), events.ID(3), events.ID(4), events.ID(5)},
+			expectError:    nil,
+		},
+
+		// =====================================================================
+		// SUCCESS CASES - Complex patterns
+		// =====================================================================
+		{
+			name: "success: diamond dependency pattern - deduplication test",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2), events.ID(3)}, // depends on both 2 and 3
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(4)},
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(1), events.ID(2), events.ID(3), events.ID(4)}, // all events, 1 counted once
+			expectError:    nil,
+		},
+		{
+			name: "success: mixed direct and transitive dependents",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true),
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true), // also direct
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)}, // transitive through 1
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)}, // transitive through 2
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(3), events.ID(4)},
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(1), events.ID(2), events.ID(3), events.ID(4)},
+			expectError:    nil,
+		},
+		{
+			name: "success: probe in middle - event added after probe",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true), // probe in middle
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(3)}, // depends on event with probe
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(5): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(4)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(4)}, // add event right after probe
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(3), events.ID(4)}, // Event3 (probe) and Event4 (selected)
+			expectError:    nil,
+		},
+		{
+			name: "success: probe in middle - multiple events spanning probe",
+			deps: map[events.ID]events.DependencyStrategy{
+				events.ID(1): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(2): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(1)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(3): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(2)},
+						nil,
+						[]events.Probe{
+							events.NewProbe(probes.SchedProcessExec, true), // probe in middle
+						},
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(4): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(3)}, // depends on probe event
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(5): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(4)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+				events.ID(6): events.NewDependencyStrategy(
+					events.NewDependencies(
+						[]events.ID{events.ID(5)},
+						nil,
+						nil,
+						nil,
+						events.Capabilities{},
+					)),
+			},
+			eventsToAdd:    []events.ID{events.ID(1), events.ID(2), events.ID(4), events.ID(5)}, // add events before and after probe
+			probeToQuery:   probes.SchedProcessExec,
+			expectedEvents: []events.ID{events.ID(3), events.ID(4), events.ID(5)}, // Only Event3 (probe), Event4, Event5 (depend on probe)
+			expectError:    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create manager
+			m := NewDependenciesManager(getTestDependenciesFunc(tc.deps))
+
+			// Add events
+			for _, eventID := range tc.eventsToAdd {
+				_, err := m.SelectEvent(eventID)
+				assert.NoError(t, err, "Failed to add event %d", eventID)
+			}
+
+			// Query for all events depending on the probe
+			result, err := m.GetAllEventDependentsOfProbe(tc.probeToQuery)
+
+			// Check error expectation
+			assert.ErrorIs(t, err, tc.expectError, "Expected error: %v, got: %v", tc.expectError, err)
+
+			// Verify results contain exactly the expected events (order doesn't matter)
+			assert.ElementsMatch(t, tc.expectedEvents, result,
+				"Expected events: %v, got: %v", tc.expectedEvents, result)
+		})
+	}
+}


### PR DESCRIPTION
### 1. Explain what the PR does

39cf9dd7bc **feat(dependencies): add GetAllEventDependentsOfProbe**

> Add a new method to the Manager that retrieves all events depending on a
> specified probe, including both direct and transitive dependents.
> This functionality is accompanied by comprehensive unit tests to cover
> various success and error scenarios.
> 
> Co-authored-by: Raphael Campos <raphaelcampos.rp@gmail.com>

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
