### PR TITLE
feat(policy): add IsEventFilteredByScope API with ...

### DIFF
--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -122,7 +122,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "uid>=1000",
-							scopeName:         "uid",
+							scopeName:         string(filters.ScopeUID),
 							operator:          ">=",
 							values:            "1000",
 							operatorAndValues: ">=1000",
@@ -159,7 +159,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "pid<=10",
-							scopeName:         "pid",
+							scopeName:         string(filters.ScopePID),
 							operator:          "<=",
 							values:            "10",
 							operatorAndValues: "<=10",
@@ -196,7 +196,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "mntns=4026531840",
-							scopeName:         "mntns",
+							scopeName:         string(filters.ScopeMntNS),
 							operator:          "=",
 							values:            "4026531840",
 							operatorAndValues: "=4026531840",
@@ -233,7 +233,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "pidns!=4026531836",
-							scopeName:         "pidns",
+							scopeName:         string(filters.ScopePidNS),
 							operator:          "!=",
 							values:            "4026531836",
 							operatorAndValues: "!=4026531836",
@@ -307,7 +307,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "comm=bash",
-							scopeName:         "comm",
+							scopeName:         string(filters.ScopeComm),
 							operator:          "=",
 							values:            "bash",
 							operatorAndValues: "=bash",
@@ -344,7 +344,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "container=new",
-							scopeName:         "container",
+							scopeName:         string(filters.ScopeContainer),
 							operator:          "=",
 							values:            "new",
 							operatorAndValues: "=new",
@@ -381,7 +381,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "not-container",
-							scopeName:         "container",
+							scopeName:         string(filters.ScopeContainer),
 							operator:          "not",
 							values:            "",
 							operatorAndValues: "",
@@ -418,7 +418,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "container",
-							scopeName:         "container",
+							scopeName:         string(filters.ScopeContainer),
 							operator:          "",
 							values:            "",
 							operatorAndValues: "",
@@ -678,7 +678,7 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 					scopeFlags: []scopeFlag{
 						{
 							full:              "comm=bash",
-							scopeName:         "comm",
+							scopeName:         string(filters.ScopeComm),
 							operator:          "=",
 							values:            "bash",
 							operatorAndValues: "=bash",
@@ -692,14 +692,14 @@ func TestPrepareFilterMapsFromPolicies(t *testing.T) {
 						},
 						{
 							full:              "not-container",
-							scopeName:         "container",
+							scopeName:         string(filters.ScopeContainer),
 							operator:          "not",
 							values:            "",
 							operatorAndValues: "",
 						},
 						{
 							full:              "uid=1000",
-							scopeName:         "uid",
+							scopeName:         string(filters.ScopeUID),
 							operator:          "=",
 							values:            "1000",
 							operatorAndValues: "=1000",
@@ -2147,7 +2147,7 @@ func TestCreateSinglePolicy(t *testing.T) {
 				policyName: "test-policy",
 				scopeFlags: []scopeFlag{{
 					full:              "comm=bash",
-					scopeName:         "comm",
+					scopeName:         string(filters.ScopeComm),
 					operator:          "=",
 					operatorAndValues: "=bash",
 				}},
@@ -2182,13 +2182,13 @@ func TestCreateSinglePolicy(t *testing.T) {
 				scopeFlags: []scopeFlag{
 					{
 						full:              "uid=1000",
-						scopeName:         "uid",
+						scopeName:         string(filters.ScopeUID),
 						operator:          "=",
 						operatorAndValues: "=1000",
 					},
 					{
 						full:      "container",
-						scopeName: "container",
+						scopeName: string(filters.ScopeContainer),
 					},
 				},
 			},
@@ -2270,7 +2270,7 @@ func TestParseScopeFilters(t *testing.T) {
 			policy: policy.NewPolicy(),
 			scopeFlags: []scopeFlag{{
 				full:              "comm=bash",
-				scopeName:         "comm",
+				scopeName:         string(filters.ScopeComm),
 				operator:          "=",
 				operatorAndValues: "=bash",
 			}},
@@ -2284,11 +2284,11 @@ func TestParseScopeFilters(t *testing.T) {
 			scopeFlags: []scopeFlag{
 				{
 					full:      "container",
-					scopeName: "container",
+					scopeName: string(filters.ScopeContainer),
 				},
 				{
 					full:              "container=new",
-					scopeName:         "container",
+					scopeName:         string(filters.ScopeContainer),
 					operator:          "=",
 					operatorAndValues: "=new",
 				},

--- a/pkg/filters/binary.go
+++ b/pkg/filters/binary.go
@@ -131,6 +131,10 @@ func (f *BinaryFilter) Disable() {
 }
 
 func (f *BinaryFilter) Enabled() bool {
+	if f == nil {
+		return false
+	}
+
 	return f.enabled
 }
 

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -144,6 +144,14 @@ func (f *BoolFilter) Value() bool {
 	return f.trueEnabled
 }
 
+func (f *BoolFilter) IsTrueEnabled() bool {
+	return f.trueEnabled
+}
+
+func (f *BoolFilter) IsFalseEnabled() bool {
+	return f.falseEnabled
+}
+
 func (f *BoolFilter) MatchIfKeyMissing() bool {
 	return !f.Value()
 }

--- a/pkg/filters/data.go
+++ b/pkg/filters/data.go
@@ -314,6 +314,10 @@ func (f *DataFilter) Disable() {
 }
 
 func (f *DataFilter) Enabled() bool {
+	if f == nil {
+		return false
+	}
+
 	return f.enabled
 }
 

--- a/pkg/filters/errors.go
+++ b/pkg/filters/errors.go
@@ -37,7 +37,7 @@ func InvalidEventField(data string) error {
 	return fmt.Errorf("invalid event data field: %s", data)
 }
 
-func InvalidScopeField(field string) error {
+func InvalidScopeField(field ScopeName) error {
 	return fmt.Errorf("invalid event scope field: %s", field)
 }
 

--- a/pkg/filters/numeric.go
+++ b/pkg/filters/numeric.go
@@ -127,6 +127,10 @@ func (f *NumericFilter[T]) Disable() {
 }
 
 func (f *NumericFilter[T]) Enabled() bool {
+	if f == nil {
+		return false
+	}
+
 	return f.enabled
 }
 

--- a/pkg/filters/processtree.go
+++ b/pkg/filters/processtree.go
@@ -36,6 +36,10 @@ func (f *ProcessTreeFilter) Disable() {
 }
 
 func (f *ProcessTreeFilter) Enabled() bool {
+	if f == nil {
+		return false
+	}
+
 	return f.enabled
 }
 

--- a/pkg/filters/scope_test.go
+++ b/pkg/filters/scope_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/tracee/pkg/filters/sets"
@@ -13,7 +14,7 @@ func TestScopeFilterClone(t *testing.T) {
 	t.Parallel()
 
 	filter := NewScopeFilter()
-	err := filter.Parse("processorId", "=0")
+	err := filter.Parse(ScopeProcessorID, "=0")
 	require.NoError(t, err)
 
 	copy := filter.Clone()
@@ -33,9 +34,588 @@ func TestScopeFilterClone(t *testing.T) {
 	}
 
 	// ensure that changes to the copy do not affect the original
-	err = copy.Parse("pid", "=1")
+	err = copy.Parse(ScopePID, "=1")
 	require.NoError(t, err)
 	if cmp.Equal(filter, copy, opt1) {
 		t.Errorf("Changes to copied filter affected the original")
+	}
+}
+
+func TestScopeFilterHasScopeFiltering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		setupFilter    func(*ScopeFilter) error
+		scopeToCheck   ScopeName
+		expectedResult bool
+	}{
+		// ========================================
+		// Cases expecting TRUE (scope is filtered)
+		// ========================================
+
+		// Boolean scope filters
+		{
+			name: "container scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainer, "")
+			},
+			scopeToCheck:   ScopeContainer,
+			expectedResult: true,
+		},
+		{
+			name: "host scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeHost, "")
+			},
+			scopeToCheck:   ScopeHost,
+			expectedResult: true,
+		},
+
+		// Process ID scope filters
+		{
+			name: "pid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePID, "=1234")
+			},
+			scopeToCheck:   ScopePID,
+			expectedResult: true,
+		},
+		{
+			name: "pid alias 'p' enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeP, "=5678")
+			},
+			scopeToCheck:   ScopeP,
+			expectedResult: true,
+		},
+		{
+			name: "pid alias 'processId' enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeProcessID, "=9999")
+			},
+			scopeToCheck:   ScopeProcessID,
+			expectedResult: true,
+		},
+		{
+			name: "tid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeTID, "=5678")
+			},
+			scopeToCheck:   ScopeTID,
+			expectedResult: true,
+		},
+		{
+			name: "tid alias 'threadId' enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeThreadID, "=1111")
+			},
+			scopeToCheck:   ScopeThreadID,
+			expectedResult: true,
+		},
+		{
+			name: "ppid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePPID, "=1")
+			},
+			scopeToCheck:   ScopePPID,
+			expectedResult: true,
+		},
+		{
+			name: "hostPid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeHostPID, "=12345")
+			},
+			scopeToCheck:   ScopeHostPID,
+			expectedResult: true,
+		},
+		{
+			name: "hostTid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeHostTID, "=54321")
+			},
+			scopeToCheck:   ScopeHostTID,
+			expectedResult: true,
+		},
+		{
+			name: "hostPpid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeHostPPID, "=1")
+			},
+			scopeToCheck:   ScopeHostPPID,
+			expectedResult: true,
+		},
+
+		// User scope filters
+		{
+			name: "uid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeUID, "=1000")
+			},
+			scopeToCheck:   ScopeUID,
+			expectedResult: true,
+		},
+		{
+			name: "uid alias 'userId' enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeUserID, "=1001")
+			},
+			scopeToCheck:   ScopeUserID,
+			expectedResult: true,
+		},
+
+		// Namespace scope filters
+		{
+			name: "mntns scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeMntNS, "=4026531840")
+			},
+			scopeToCheck:   ScopeMntNS,
+			expectedResult: true,
+		},
+		{
+			name: "mntns alias 'mountNamespace' enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeMountNamespace, "=4026531841")
+			},
+			scopeToCheck:   ScopeMountNamespace,
+			expectedResult: true,
+		},
+		{
+			name: "pidns scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePidNS, "=4026531836")
+			},
+			scopeToCheck:   ScopePidNS,
+			expectedResult: true,
+		},
+		{
+			name: "pidns alias 'pidNamespace' enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePidNamespace, "=4026531837")
+			},
+			scopeToCheck:   ScopePidNamespace,
+			expectedResult: true,
+		},
+
+		// Process name scope filters
+		{
+			name: "comm scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeComm, "=bash")
+			},
+			scopeToCheck:   ScopeComm,
+			expectedResult: true,
+		},
+		{
+			name: "processName alias for comm",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeProcessName, "=zsh")
+			},
+			scopeToCheck:   ScopeProcessName,
+			expectedResult: true,
+		},
+
+		// Host scope filter
+		{
+			name: "hostName scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeHostName, "=myhost")
+			},
+			scopeToCheck:   ScopeHostName,
+			expectedResult: true,
+		},
+
+		// Cgroup scope filter
+		{
+			name: "cgroupId scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeCgroupID, "=123456")
+			},
+			scopeToCheck:   ScopeCgroupID,
+			expectedResult: true,
+		},
+
+		// Container attribute scope filters
+		{
+			name: "containerId scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainerID, "=abc123def456")
+			},
+			scopeToCheck:   ScopeContainerID,
+			expectedResult: true,
+		},
+		{
+			name: "containerImage scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainerImage, "=nginx:latest")
+			},
+			scopeToCheck:   ScopeContainerImage,
+			expectedResult: true,
+		},
+		{
+			name: "containerName scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainerName, "=my-container")
+			},
+			scopeToCheck:   ScopeContainerName,
+			expectedResult: true,
+		},
+		{
+			name: "containerImageDigest scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainerImageDigest, "=sha256:abc123")
+			},
+			scopeToCheck:   ScopeContainerImageDigest,
+			expectedResult: true,
+		},
+
+		// Kubernetes pod scope filters
+		{
+			name: "podName scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePodName, "=my-pod")
+			},
+			scopeToCheck:   ScopePodName,
+			expectedResult: true,
+		},
+		{
+			name: "podNamespace scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePodNamespace, "=default")
+			},
+			scopeToCheck:   ScopePodNamespace,
+			expectedResult: true,
+		},
+		{
+			name: "podNs alias for podNamespace enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePodNs, "=kube-system")
+			},
+			scopeToCheck:   ScopePodNs,
+			expectedResult: true,
+		},
+		{
+			name: "podUid scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePodUID, "=abc-123-def-456")
+			},
+			scopeToCheck:   ScopePodUID,
+			expectedResult: true,
+		},
+		{
+			name: "podSandbox scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePodSandbox, "=true")
+			},
+			scopeToCheck:   ScopePodSandbox,
+			expectedResult: true,
+		},
+
+		// Other scope filters
+		{
+			name: "syscall scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeSyscall, "=openat")
+			},
+			scopeToCheck:   ScopeSyscall,
+			expectedResult: true,
+		},
+		{
+			name: "timestamp scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeTimestamp, ">1234567890")
+			},
+			scopeToCheck:   ScopeTimestamp,
+			expectedResult: true,
+		},
+		{
+			name: "processorId scope enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeProcessorID, "=0")
+			},
+			scopeToCheck:   ScopeProcessorID,
+			expectedResult: true,
+		},
+
+		// Multiple scopes enabled
+		{
+			name: "multiple scopes enabled - check first",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopePID, "=1234"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeUID, "=1000"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeComm, "=bash")
+			},
+			scopeToCheck:   ScopePID,
+			expectedResult: true,
+		},
+		{
+			name: "multiple scopes enabled - check middle",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopePID, "=1234"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeUID, "=1000"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeComm, "=bash")
+			},
+			scopeToCheck:   ScopeUID,
+			expectedResult: true,
+		},
+		{
+			name: "multiple scopes enabled - check last",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopePID, "=1234"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeUID, "=1000"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeComm, "=bash")
+			},
+			scopeToCheck:   ScopeComm,
+			expectedResult: true,
+		},
+
+		// ========================================
+		// Cases expecting FALSE (scope is NOT filtered)
+		// ========================================
+
+		{
+			name: "scope not enabled - checking uid when only pid enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePID, "=1234")
+			},
+			scopeToCheck:   ScopeUID,
+			expectedResult: false,
+		},
+		{
+			name: "scope not enabled - checking container when only host enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeHost, "")
+			},
+			scopeToCheck:   ScopeContainer,
+			expectedResult: false,
+		},
+		{
+			name: "scope not enabled - checking comm when only pid enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePID, "=1234")
+			},
+			scopeToCheck:   ScopeComm,
+			expectedResult: false,
+		},
+		{
+			name: "scope not enabled - checking syscall when only uid enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeUID, "=1000")
+			},
+			scopeToCheck:   ScopeSyscall,
+			expectedResult: false,
+		},
+		{
+			name: "scope not enabled - checking podName when only containerId enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainerID, "=abc123")
+			},
+			scopeToCheck:   ScopePodName,
+			expectedResult: false,
+		},
+		{
+			name: "unknown scope name",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopePID, "=1234")
+			},
+			scopeToCheck:   ScopeName("unknownScope"),
+			expectedResult: false,
+		},
+		{
+			name: "invalid scope name",
+			setupFilter: func(f *ScopeFilter) error {
+				return f.Parse(ScopeContainer, "")
+			},
+			scopeToCheck:   ScopeName("invalidScopeName"),
+			expectedResult: false,
+		},
+		{
+			name: "filter not enabled - no scopes parsed",
+			setupFilter: func(f *ScopeFilter) error {
+				// Don't parse anything, filter remains disabled
+				return nil
+			},
+			scopeToCheck:   ScopePID,
+			expectedResult: false,
+		},
+		{
+			name: "filter not enabled - checking any scope on empty filter",
+			setupFilter: func(f *ScopeFilter) error {
+				return nil
+			},
+			scopeToCheck:   ScopeContainer,
+			expectedResult: false,
+		},
+		{
+			name: "filter not enabled - checking uid on empty filter",
+			setupFilter: func(f *ScopeFilter) error {
+				return nil
+			},
+			scopeToCheck:   ScopeUID,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (comm)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeContainer, ""); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopePID, "=1234"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeUID, "=1000")
+			},
+			scopeToCheck:   ScopeComm,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (syscall)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeHost, ""); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeTID, "=5678"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeMntNS, "=4026531840")
+			},
+			scopeToCheck:   ScopeSyscall,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (podName)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeContainer, ""); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopePID, "=1234"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeUID, "=1000"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeComm, "=bash")
+			},
+			scopeToCheck:   ScopePodName,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (timestamp)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeContainerID, "=abc123"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeContainerImage, "=nginx"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeContainerName, "=my-container")
+			},
+			scopeToCheck:   ScopeTimestamp,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (hostPpid)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopePID, "=1234"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopePPID, "=1"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeHostPID, "=5678")
+			},
+			scopeToCheck:   ScopeHostPPID,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (cgroupId)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopePodName, "=my-pod"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopePodNamespace, "=default"); err != nil {
+					return err
+				}
+				return f.Parse(ScopePodUID, "=abc-123")
+			},
+			scopeToCheck:   ScopeCgroupID,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (processorId)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeUID, "=1000"); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopeComm, "=bash"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeHostName, "=myhost")
+			},
+			scopeToCheck:   ScopeProcessorID,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking non-enabled scope (mntns)",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeContainer, ""); err != nil {
+					return err
+				}
+				if err := f.Parse(ScopePidNS, "=4026531836"); err != nil {
+					return err
+				}
+				return f.Parse(ScopeSyscall, "=openat")
+			},
+			scopeToCheck:   ScopeMntNS,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking container when only host and pid enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeHost, ""); err != nil {
+					return err
+				}
+				return f.Parse(ScopePID, "=1234")
+			},
+			scopeToCheck:   ScopeContainer,
+			expectedResult: false,
+		},
+		{
+			name: "multiple scopes enabled - checking host when only container and uid enabled",
+			setupFilter: func(f *ScopeFilter) error {
+				if err := f.Parse(ScopeContainer, ""); err != nil {
+					return err
+				}
+				return f.Parse(ScopeUID, "=1000")
+			},
+			scopeToCheck:   ScopeHost,
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := NewScopeFilter()
+			err := tt.setupFilter(filter)
+			assert.NoError(t, err)
+
+			result := filter.HasScopeFiltering(tt.scopeToCheck)
+			assert.Equal(t, tt.expectedResult, result)
+		})
 	}
 }

--- a/pkg/filters/string.go
+++ b/pkg/filters/string.go
@@ -197,6 +197,10 @@ func (f *StringFilter) Disable() {
 }
 
 func (f *StringFilter) Enabled() bool {
+	if f == nil {
+		return false
+	}
+
 	return f.enabled
 }
 


### PR DESCRIPTION
### 1. Explain what the PR does

e7b2cc8ce **feat(policy): add IsEventFilteredByScope API with ...**

```
... type-safe scope names

Add Manager.IsEventFilteredByScope() to query if any policy filters a
specific scope dimension for an event. Introduce filters.ScopeName type
with 50+ constants for all supported scope dimensions (container, pid,
uid, mntns, etc.) for compile-time type safety.

New methods:
- Manager.IsEventFilteredByScope(eventID, scope) - query scope filtering
- ScopeFilter.HasScopeFiltering(scope) - check if scope is filtered
- BoolFilter.IsTrueEnabled() / IsFalseEnabled() - boolean filter helpers

Add nil safeguards to Enabled() methods across all filter types
(NumericFilter, StringFilter, BinaryFilter, ProcessTreeFilter, DataFilter,
ScopeFilter). Update Parse() and InvalidScopeField() to accept ScopeName
type. Expand test coverage with additional scope filtering test cases.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
