### PR TITLE
fix(go.mod): update api and common deps to v0.0.0

### DIFF
--- a/cmd/traceectl/go.mod
+++ b/cmd/traceectl/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.7
 
 require (
 	github.com/aquasecurity/table v1.10.0
-	github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6
+	github.com/aquasecurity/tracee/api v0.0.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/IBM/fluent-forward-go v0.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45
-	github.com/aquasecurity/tracee/api v0.0.0-20250929201500-3e47b0c6eaf6
-	github.com/aquasecurity/tracee/common v0.0.0-20251021142419-a5944135ac44
+	github.com/aquasecurity/tracee/api v0.0.0
+	github.com/aquasecurity/tracee/common v0.0.0
 	github.com/aquasecurity/tracee/types v0.0.0-20250902170041-945d17d40601
 	github.com/containerd/containerd v1.7.29
 	github.com/docker/docker v28.1.1+incompatible


### PR DESCRIPTION
### 1. Explain what the PR does

a6094f678 **fix(go.mod): update api and common deps to v0.0.0**

```
Replace versioned dependencies for tracee/api and tracee/common in
go.mod and cmd/traceectl/go.mod with stable version v0.0.0 to ensure
consistency across modules.

Both modules are already replaced to use local paths, so this change
does not affect the actual code being used, just aligns the versioning
in the go.mod files.
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
