### PR TITLE
fix(healthz): healthz flags enables heartbeat

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -337,6 +337,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	runner.HTTP = serverRunner.HTTP
 	runner.GRPC = serverRunner.GRPC
 	cfg.MetricsEnabled = runner.HTTP.MetricsEndpointEnabled()
+	cfg.HealthzEnabled = runner.HTTP.HealthzEnabled()
 	runner.TraceeConfig = cfg
 	runner.Printer = p
 	runner.InstallPath = traceeInstallPath

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,8 +36,9 @@ type Config struct {
 	CgroupFSPath        string
 	CgroupFSForce       bool
 	EngineConfig        engine.Config
-	MetricsEnabled      bool
 	DNSCacheConfig      dns.Config
+	MetricsEnabled      bool
+	HealthzEnabled      bool
 }
 
 // Validate does static validation of the configuration

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -258,9 +258,10 @@ func New(cfg config.Config) (*Tracee, error) {
 	}
 
 	pmCfg := policy.ManagerConfig{
-		DNSCacheConfig: cfg.DNSCacheConfig,
-		ProcTreeConfig: cfg.ProcTree,
-		CaptureConfig:  getNewCaptureConfig(),
+		HeartbeatEnabled: cfg.HealthzEnabled,
+		DNSCacheConfig:   cfg.DNSCacheConfig,
+		ProcTreeConfig:   cfg.ProcTree,
+		CaptureConfig:    getNewCaptureConfig(),
 	}
 	pm, err := policy.NewManager(pmCfg, depsManager, initialPolicies...)
 	if err != nil {

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -14466,7 +14466,7 @@ var CoreEvents = map[ID]Definition{
 	SignalHeartbeat: {
 		id:       SignalHeartbeat,
 		id32Bit:  Sys32Undefined,
-		name:     "heartbeat_event",
+		name:     "signal_heartbeat",
 		version:  NewVersion(1, 0, 0),
 		internal: true,
 		sets:     []string{"default"},

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -20,9 +20,10 @@ import (
 )
 
 type ManagerConfig struct {
-	DNSCacheConfig dns.Config
-	ProcTreeConfig process.ProcTreeConfig
-	CaptureConfig  config.CaptureConfig
+	DNSCacheConfig   dns.Config
+	ProcTreeConfig   process.ProcTreeConfig
+	CaptureConfig    config.CaptureConfig
+	HeartbeatEnabled bool
 }
 
 // Manager is a thread-safe struct that manages the enabled policies for each rule
@@ -207,6 +208,12 @@ func (m *Manager) selectConfiguredEvents() {
 
 	if m.cfg.DNSCacheConfig.Enable {
 		m.selectEvent(events.NetPacketDNS, newEventFlags(eventFlagsWithSubmit(PolicyAll)))
+	}
+
+	// heartbeat event
+
+	if m.cfg.HeartbeatEnabled {
+		m.selectEvent(events.SignalHeartbeat, newEventFlags(eventFlagsWithSubmit(PolicyAll)))
 	}
 
 	// Pseudo events added by capture (if enabled by the user)

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -24,8 +24,9 @@ const heartbeatAckTimeout = time.Duration(2 * time.Second)
 type Server struct {
 	hs             *http.Server
 	mux            *http.ServeMux // just an exposed copy of hs.Handler
-	metricsEnabled bool
 	pyroProfiler   *pyroscope.Profiler
+	metricsEnabled bool
+	healthzEnabled bool
 }
 
 // New creates a new server
@@ -56,6 +57,7 @@ func (s *Server) EnableHealthzEndpoint() {
 		}
 		fmt.Fprintf(w, "NOT OK")
 	})
+	s.healthzEnabled = true
 }
 
 // Start starts the http server on the listen address
@@ -127,6 +129,15 @@ func (s *Server) MetricsEndpointEnabled() bool {
 	}
 
 	return s.metricsEnabled
+}
+
+// HealthzEnabled returns true if healthz endpoint is enabled
+func (s *Server) HealthzEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return s.healthzEnabled
 }
 
 //go:noinline

--- a/pkg/server/http/server_test.go
+++ b/pkg/server/http/server_test.go
@@ -41,3 +41,38 @@ func TestServer(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthzEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		server         *Server
+		enableHealthz  bool
+		expectedResult bool
+	}{
+		{
+			name:           "server without healthz enabled returns false",
+			server:         New(""),
+			enableHealthz:  false,
+			expectedResult: false,
+		},
+		{
+			name:           "server with healthz enabled returns true",
+			server:         New(""),
+			enableHealthz:  true,
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.enableHealthz && tt.server != nil {
+				tt.server.EnableHealthzEndpoint()
+			}
+
+			result := tt.server.HealthzEnabled()
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/5000

### 1. Explain what the PR does

The change will add `signal_heartbeat` whenever the flag `--healthz` is enabled, so the `/healthz` endpoint works as expected. 

### 2. Explain how to test it

```
./dist/tracee --events anti_debugging --server healthz
```

```
curl http://localhost:3366/healthz
```

### 3. Other comments

**BREAKING CHANGE**: All control  plane signals are named `signal_**` but heartbeat, which is name `heartbeat_event`. I'm changing this here, let me know if anything against it. 

<!--
Links? References? Anything pointing to more context about the change.
-->
