### PR TITLE
Add internal PipelineEvent structure for pipeline processing

### DIFF
--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -49,7 +49,7 @@ func (t *Tracee) handleNetCaptureEvents(ctx context.Context) {
 	}
 }
 
-func (t *Tracee) processNetCapEvents(ctx context.Context, in <-chan *trace.Event) <-chan error {
+func (t *Tracee) processNetCapEvents(ctx context.Context, in <-chan *events.PipelineEvent) <-chan error {
 	errc := make(chan error, 1)
 
 	go func() {
@@ -58,8 +58,11 @@ func (t *Tracee) processNetCapEvents(ctx context.Context, in <-chan *trace.Event
 		for {
 			select {
 			case event := <-in:
+				if event == nil || event.Event == nil {
+					continue
+				}
 				// TODO: Support captures pipeline in t.processEvent
-				t.processNetCapEvent(event)
+				t.processNetCapEvent(event.Event)
 				_ = t.stats.NetCapCount.Increment()
 				t.eventsPool.Put(event)
 

--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -21,14 +21,18 @@ func init() {
 }
 
 // processEvent processes an event by passing it through all registered event processors.
-func (t *Tracee) processEvent(event *trace.Event) []error {
+func (t *Tracee) processEvent(event *events.PipelineEvent) []error {
+	if event == nil || event.Event == nil {
+		return nil
+	}
+
 	var errs []error
 
 	processors := t.eventProcessor[events.ID(event.EventID)]         // this event processors
 	processors = append(processors, t.eventProcessor[events.All]...) // all events processors
 
 	for _, processor := range processors {
-		err := processor(event)
+		err := processor(event.Event) // processors expect *trace.Event
 		if err != nil {
 			logger.Errorw("Error processing event", "event", event.EventName, "error", err)
 			errs = append(errs, err)

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -604,7 +604,9 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 
 	t.eventsPool = &sync.Pool{
 		New: func() interface{} {
-			return &trace.Event{}
+			return &events.PipelineEvent{
+				Event: &trace.Event{},
+			}
 		},
 	}
 
@@ -1923,7 +1925,7 @@ func (t *Tracee) getSelfLoadedPrograms(kprobesOnly bool) map[string]int {
 // invokeInitEvents emits Tracee events, called Initialization Events, that are generated from the
 // userland process itself, and not from the kernel. These events usually serve as informational
 // events for the signatures engine/logic.
-func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
+func (t *Tracee) invokeInitEvents(out chan *events.PipelineEvent) {
 	var matchedPolicies uint64
 
 	setMatchedPolicies := func(event *trace.Event, matchedPolicies uint64) {
@@ -1943,7 +1945,7 @@ func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
 	if matchedPolicies > 0 {
 		traceeDataEvent := events.TraceeInfoEvent(t.bootTime, t.startTime)
 		setMatchedPolicies(&traceeDataEvent, matchedPolicies)
-		out <- &traceeDataEvent
+		out <- events.NewPipelineEvent(&traceeDataEvent)
 		_ = t.stats.EventCount.Increment()
 	}
 
@@ -1951,7 +1953,7 @@ func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
 	if matchedPolicies > 0 {
 		systemInfoEvent := events.InitNamespacesEvent()
 		setMatchedPolicies(&systemInfoEvent, matchedPolicies)
-		out <- &systemInfoEvent
+		out <- events.NewPipelineEvent(&systemInfoEvent)
 		_ = t.stats.EventCount.Increment()
 	}
 
@@ -1963,7 +1965,7 @@ func (t *Tracee) invokeInitEvents(out chan *trace.Event) {
 		for i := range existingContainerEvents {
 			event := &(existingContainerEvents[i])
 			setMatchedPolicies(event, matchedPolicies)
-			out <- event
+			out <- events.NewPipelineEvent(event)
 			_ = t.stats.EventCount.Increment()
 		}
 	}

--- a/pkg/events/ftrace.go
+++ b/pkg/events/ftrace.go
@@ -60,7 +60,7 @@ func GetFtraceBaseEvent() *trace.Event {
 
 // FtraceHookEvent check for ftrace hooks periodically and reports them.
 // It wakes up every random time to check if there was a change in the hooks.
-func FtraceHookEvent(eventsCounter *counter.Counter, out chan *trace.Event, baseEvent *trace.Event, selfLoadedProgs map[string]int) {
+func FtraceHookEvent(eventsCounter *counter.Counter, out chan *PipelineEvent, baseEvent *trace.Event, selfLoadedProgs map[string]int) {
 	if reportedFtraceHooks == nil { // Failed allocating cache - no point in running
 		return
 	}
@@ -129,7 +129,7 @@ func initFtraceArgs(fields []DataField) []trace.Argument {
 }
 
 // checkFtraceHooks checks for ftrace hooks
-func checkFtraceHooks(eventsCounter *counter.Counter, out chan *trace.Event, baseEvent *trace.Event, ftraceDef *Definition, selfLoadedProgs map[string]int) error {
+func checkFtraceHooks(eventsCounter *counter.Counter, out chan *PipelineEvent, baseEvent *trace.Event, ftraceDef *Definition, selfLoadedProgs map[string]int) error {
 	ftraceHooksBytes, err := getFtraceHooksData()
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func checkFtraceHooks(eventsCounter *counter.Counter, out chan *trace.Event, bas
 		event.Args = args
 		event.ArgsNum = len(args)
 
-		out <- &event
+		out <- NewPipelineEvent(&event)
 		_ = eventsCounter.Increment()
 	}
 

--- a/pkg/events/pipeline_event.go
+++ b/pkg/events/pipeline_event.go
@@ -1,0 +1,59 @@
+package events
+
+import (
+	"github.com/aquasecurity/tracee/types/protocol"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+// PipelineEvent is an internal event structure used throughout the pipeline.
+// It embeds the external types.Event for user-facing data and adds internal
+// fields needed for pipeline processing that should not be exposed to end users.
+type PipelineEvent struct {
+	// User-facing event data
+	*trace.Event
+
+	// Internal pipeline fields
+	// MatchedPoliciesBitmap is a combined bitmap for efficient policy matching.
+	// This replaces the need to expose separate Kernel/User bitmaps to external APIs.
+	MatchedPoliciesBitmap uint64
+}
+
+// NewPipelineEvent creates a new PipelineEvent wrapping the provided trace.Event.
+// The MatchedPoliciesBitmap is initialized from the event's MatchedPoliciesKernel field.
+func NewPipelineEvent(event *trace.Event) *PipelineEvent {
+	if event == nil {
+		return nil
+	}
+	return &PipelineEvent{
+		Event:                 event,
+		MatchedPoliciesBitmap: event.MatchedPoliciesKernel,
+	}
+}
+
+// ToTraceEvent returns the embedded trace.Event for external API use.
+// This method allows extracting the user-facing event data when needed.
+func (pe *PipelineEvent) ToTraceEvent() *trace.Event {
+	if pe == nil {
+		return nil
+	}
+	return pe.Event
+}
+
+// Reset resets the internal fields of PipelineEvent for pool reuse.
+// The embedded Event pointer is not reset here as it will be replaced
+// when getting a new event from the pool.
+func (pe *PipelineEvent) Reset() {
+	if pe == nil {
+		return
+	}
+	pe.MatchedPoliciesBitmap = 0
+}
+
+// ToProtocol converts the PipelineEvent to a protocol.Event for the signature engine.
+// This wraps the embedded trace.Event's ToProtocol method.
+func (pe *PipelineEvent) ToProtocol() protocol.Event {
+	if pe == nil || pe.Event == nil {
+		return protocol.Event{}
+	}
+	return pe.Event.ToProtocol()
+}

--- a/pkg/events/sorting/cpu_queue.go
+++ b/pkg/events/sorting/cpu_queue.go
@@ -2,7 +2,7 @@ package sorting
 
 import (
 	"github.com/aquasecurity/tracee/common/errfmt"
-	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/aquasecurity/tracee/pkg/events"
 )
 
 // Events queue with the ability to follow if it was updated since last check and insertion by time specific for CPU
@@ -13,7 +13,7 @@ type cpuEventsQueue struct {
 }
 
 // InsertByTimestamp insert new event to the queue in the right position according to its timestamp
-func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *trace.Event) error {
+func (cq *cpuEventsQueue) InsertByTimestamp(newEvent *events.PipelineEvent) error {
 	newNode, err := cq.pool.Alloc(newEvent)
 	if err != nil {
 		cq.pool.Reset()

--- a/pkg/events/sorting/pool.go
+++ b/pkg/events/sorting/pool.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
-	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/aquasecurity/tracee/pkg/events"
 )
 
 const poolFreeingPart = 2
@@ -24,7 +24,7 @@ type eventsPool struct {
 // Alloc return an eventNode that contains the event given.
 // The function will try to use stored eventNode if there is one available.
 // If there isn't, it will allocate new one.
-func (p *eventsPool) Alloc(event *trace.Event) (*eventNode, error) {
+func (p *eventsPool) Alloc(event *events.PipelineEvent) (*eventNode, error) {
 	p.poolMutex.Lock()
 	p.allocationsCount++
 	node := p.head

--- a/pkg/events/sorting/queue.go
+++ b/pkg/events/sorting/queue.go
@@ -4,11 +4,11 @@ import (
 	"sync"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
-	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/aquasecurity/tracee/pkg/events"
 )
 
 type eventNode struct {
-	event       *trace.Event
+	event       *events.PipelineEvent
 	previous    *eventNode
 	next        *eventNode
 	isAllocated bool
@@ -23,7 +23,7 @@ type eventsQueue struct {
 }
 
 // Put insert new event to the double linked list
-func (eq *eventsQueue) Put(newEvent *trace.Event) error {
+func (eq *eventsQueue) Put(newEvent *events.PipelineEvent) error {
 	newNode, err := eq.pool.Alloc(newEvent)
 	if err != nil {
 		eq.pool.Reset()
@@ -37,7 +37,7 @@ func (eq *eventsQueue) Put(newEvent *trace.Event) error {
 // Get remove the node at the head of the queue and return it
 // Might return error with a valid event in case of internal pool error, for the user to know that an error occurred
 // but was contained
-func (eq *eventsQueue) Get() (*trace.Event, error) {
+func (eq *eventsQueue) Get() (*events.PipelineEvent, error) {
 	eq.mutex.Lock()
 	defer eq.mutex.Unlock()
 	if eq.head == nil {
@@ -74,7 +74,7 @@ func (eq *eventsQueue) Get() (*trace.Event, error) {
 	return extractedEvent, nil
 }
 
-func (eq *eventsQueue) PeekHead() *trace.Event {
+func (eq *eventsQueue) PeekHead() *events.PipelineEvent {
 	eq.mutex.Lock()
 	defer eq.mutex.Unlock()
 	if eq.head == nil {
@@ -83,7 +83,7 @@ func (eq *eventsQueue) PeekHead() *trace.Event {
 	return eq.head.event
 }
 
-func (eq *eventsQueue) PeekTail() *trace.Event {
+func (eq *eventsQueue) PeekTail() *events.PipelineEvent {
 	eq.mutex.Lock()
 	defer eq.mutex.Unlock()
 	if eq.tail == nil {

--- a/pkg/events/sorting/sorting.go
+++ b/pkg/events/sorting/sorting.go
@@ -108,7 +108,7 @@ import (
 	"github.com/aquasecurity/tracee/common/environment"
 	"github.com/aquasecurity/tracee/common/errfmt"
 	"github.com/aquasecurity/tracee/common/logger"
-	"github.com/aquasecurity/tracee/types/trace"
+	"github.com/aquasecurity/tracee/pkg/events"
 )
 
 // The minimum time of delay before sending events forward.
@@ -142,9 +142,9 @@ func InitEventSorter() (*EventsChronologicalSorter, error) {
 	return &newSorter, nil
 }
 
-func (sorter *EventsChronologicalSorter) StartPipeline(ctx gocontext.Context, in <-chan *trace.Event, outChanSize int) (
-	chan *trace.Event, chan error) {
-	out := make(chan *trace.Event, outChanSize)
+func (sorter *EventsChronologicalSorter) StartPipeline(ctx gocontext.Context, in <-chan *events.PipelineEvent, outChanSize int) (
+	chan *events.PipelineEvent, chan error) {
+	out := make(chan *events.PipelineEvent, outChanSize)
 	errc := make(chan error, 1)
 	go sorter.Start(in, out, ctx, errc)
 	return out, errc
@@ -153,7 +153,7 @@ func (sorter *EventsChronologicalSorter) StartPipeline(ctx gocontext.Context, in
 // Start is the main function of the EventsChronologicalSorter class, which orders input events from events channels
 // and pass forward all ordered events to the output channel after each interval.
 // When exits, the sorter will send forward all buffered events in ordered matter.
-func (sorter *EventsChronologicalSorter) Start(in <-chan *trace.Event, out chan<- *trace.Event,
+func (sorter *EventsChronologicalSorter) Start(in <-chan *events.PipelineEvent, out chan<- *events.PipelineEvent,
 	ctx gocontext.Context, errc chan error) {
 	sorter.errorChan = errc
 	defer close(out)
@@ -183,7 +183,7 @@ func (sorter *EventsChronologicalSorter) Start(in <-chan *trace.Event, out chan<
 }
 
 // addEvent add a new event to the appropriate place in queue according to its timestamp
-func (sorter *EventsChronologicalSorter) addEvent(newEvent *trace.Event) {
+func (sorter *EventsChronologicalSorter) addEvent(newEvent *events.PipelineEvent) {
 	cq := &sorter.cpuEventsQueues[newEvent.ProcessorID]
 	err := cq.InsertByTimestamp(newEvent)
 	if err != nil {
@@ -193,7 +193,7 @@ func (sorter *EventsChronologicalSorter) addEvent(newEvent *trace.Event) {
 }
 
 // sendEvents send to output channel all events up to given timestamp
-func (sorter *EventsChronologicalSorter) sendEvents(outputChan chan<- *trace.Event, extractionMaxTimestamp int) {
+func (sorter *EventsChronologicalSorter) sendEvents(outputChan chan<- *events.PipelineEvent, extractionMaxTimestamp int) {
 	sorter.outputChanMutex.Lock()
 	defer sorter.outputChanMutex.Unlock()
 	for {

--- a/pkg/metrics/stats.go
+++ b/pkg/metrics/stats.go
@@ -14,7 +14,6 @@ import (
 	"github.com/aquasecurity/tracee/common/logger"
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/pkg/version"
-	"github.com/aquasecurity/tracee/types/trace"
 )
 
 // BPFPerfEventCollector is a custom Prometheus collector that reads from BPF maps on-demand
@@ -106,7 +105,7 @@ type Stats struct {
 	// BPF map for on-demand perf event stats collection (METRICS build only)
 	perfEventStatsMap *bpf.BPFMap
 
-	Channels ChannelMetrics[*trace.Event] `json:"ChannelMetrics"`
+	Channels ChannelMetrics[*events.PipelineEvent] `json:"ChannelMetrics"`
 }
 
 func NewStats() *Stats {
@@ -120,7 +119,7 @@ func NewStats() *Stats {
 		LostWrCount:      counter.NewCounter(0),
 		LostNtCapCount:   counter.NewCounter(0),
 		LostBPFLogsCount: counter.NewCounter(0),
-		Channels:         make(ChannelMetrics[*trace.Event]),
+		Channels:         make(ChannelMetrics[*events.PipelineEvent]),
 	}
 
 	return stats


### PR DESCRIPTION
Introduces `PipelineEvent` in `pkg/events` that embeds `*types.Event` and adds internal fields (`MatchedPoliciesBitmap`) for pipeline processing. Separates internal implementation details from the public API while maintaining full backward compatibility.

## Changes

- Created `pkg/events/pipeline_event.go` with `PipelineEvent` structure
- Updated all pipeline stages (decode, sort, process, enrich, derive, engine, sink) to use `PipelineEvent`
- Updated sorting package and metrics to work with `PipelineEvent`
- External APIs continue to receive `types.Event` (extracted in sink stage)

## Backward Compatibility

Fully maintained - External consumers see no changes to event structure.