### PR TITLE
[v0.24.1] chore(k8s): prepare v0.24.1 release

### DIFF
--- a/deploy/helm/tracee/Chart.yaml
+++ b/deploy/helm/tracee/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: tracee
 description: Linux Runtime Security and Forensics using eBPF
-home: https://aquasecurity.github.io/tracee/v0.24.0/
+home: https://aquasecurity.github.io/tracee/v0.24.1/
 sources:
   - https://github.com/aquasecurity/tracee
 
@@ -18,10 +18,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.24.0"
+version: "0.24.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.24.0"
+appVersion: "0.24.1"

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: tracee
   labels:
-    helm.sh/chart: tracee-0.24.0
+    helm.sh/chart: tracee-0.24.1
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.24.0"
+    app.kubernetes.io/version: "0.24.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: tracee/templates/serviceaccount.yaml
@@ -17,10 +17,10 @@ kind: ServiceAccount
 metadata:
   name: tracee-operator
   labels:
-    helm.sh/chart: tracee-0.24.0
+    helm.sh/chart: tracee-0.24.1
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.24.0"
+    app.kubernetes.io/version: "0.24.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: tracee/templates/tracee-config.yaml
@@ -29,10 +29,10 @@ kind: ConfigMap
 metadata:
   name: tracee-config
   labels:
-    helm.sh/chart: tracee-0.24.0
+    helm.sh/chart: tracee-0.24.1
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.24.0"
+    app.kubernetes.io/version: "0.24.1"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |-
@@ -117,10 +117,10 @@ kind: DaemonSet
 metadata:
   name: tracee
   labels:
-    helm.sh/chart: tracee-0.24.0
+    helm.sh/chart: tracee-0.24.1
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.24.0"
+    app.kubernetes.io/version: "0.24.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -139,7 +139,7 @@ spec:
         {}
       containers:
         - name: tracee
-          image: "docker.io/aquasec/tracee:0.24.0"
+          image: "docker.io/aquasec/tracee:0.24.1"
           imagePullPolicy: IfNotPresent
           command:
             - /tracee/tracee
@@ -217,10 +217,10 @@ kind: Deployment
 metadata:
   name: tracee-operator
   labels:
-    helm.sh/chart: tracee-0.24.0
+    helm.sh/chart: tracee-0.24.1
     app.kubernetes.io/name: tracee
     app.kubernetes.io/instance: tracee
-    app.kubernetes.io/version: "0.24.0"
+    app.kubernetes.io/version: "0.24.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -237,7 +237,7 @@ spec:
         {}
       containers:
       - name: tracee-operator
-        image: "docker.io/aquasec/tracee:0.24.0"
+        image: "docker.io/aquasec/tracee:0.24.1"
         imagePullPolicy: IfNotPresent
         command:
           - /tracee/tracee-operator


### PR DESCRIPTION
Backport of #5059 

### 1. Explain what the PR does

257f09e6c **chore(k8s): prepare v0.24.1 release**

```
(cherry picked from commit 89deb74ac39c89f03cc60a8ba231dad10dc5bfa7)
```

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
