### PR TITLE
fix(vagrant): set correct CPU config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -208,7 +208,7 @@ puts "====================="
 provider_settings = lambda do |prov, name|
   if name == "qemu"
     prov.name = vm_name
-    prov.cpus = vm_cpus
+    prov.smp = vm_cpus
     prov.memory = "#{vm_mem}G"  # Use G suffix as shown in the documentation
     # Set QEMU directory (detected earlier based on host OS)
     prov.qemu_dir = qemu_dir if qemu_dir


### PR DESCRIPTION
### 1. Explain what the PR does

1cb753e2fc **fix(vagrant): set correct CPU config**

> Replaced the 'cpus' setting with 'smp' in the Vagrantfile to align with
> QEMU's configuration requirements.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
