### PR TITLE
tests: Add automated VM testing environment with QEMU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ compile_commands.json
 .vagrant
 goenv.mk
 
+# VM test logs
+tests/vm-test-logs/
+
 # binaries and build files
 dist
 *.o

--- a/docs/contributing/setup-development-machine-with-vagrant.md
+++ b/docs/contributing/setup-development-machine-with-vagrant.md
@@ -17,12 +17,13 @@ This allows developers involved in the project to check out the code, run `vagra
 
 ## Prerequisites
 
-- [HashiCorp Vagrant]
-- [QEMU] with hardware acceleration support:
-  - **Linux**: KVM acceleration (recommended for optimal performance)
-  - **macOS**: HVF (Hypervisor Framework) acceleration on Intel/Apple Silicon
-  - **Fallback**: TCG software emulation (slower but works on all systems)
-- [vagrant-qemu plugin]: Install with `vagrant plugin install vagrant-qemu`
+- [Vagrant] (2.2+)
+- [QEMU] - Cross-platform virtualization (recommended)
+  - **Linux**: `sudo pacman -S qemu-full` (Arch) or `sudo apt install qemu-system-x86` (Ubuntu)
+  - **macOS**: `brew install qemu`
+- [vagrant-qemu plugin] - Install with: `vagrant plugin install vagrant-qemu`
+
+**Note**: The Vagrantfile uses QEMU for better cross-platform compatibility and performance. Hardware acceleration (KVM on Linux, HVF on macOS) is automatically detected and used when available.
 
 ## Clone the Tracee Repository
 
@@ -185,6 +186,46 @@ The VM uses a sophisticated shared folder system that varies by host OS:
 You can now build Tracee within the VM using the provided Makefile. Consult the Tracee documentation for specific build instructions.
 [Building Tracee Documentation](./building/building.md)
 
+## Running Tests in the VM
+
+Tracee's integration and e2e tests require root privileges and can affect your system. The recommended approach is to run them in an isolated VM environment.
+
+### Quick Start
+
+Run all tests automatically in an isolated VM:
+
+```bash
+./tests/run-vm-tests.sh
+```
+
+This will:
+- Start a test VM (`VM_TYPE=test`)
+- Build Tracee and run all test suites
+- Show results and clean up automatically
+
+**Run specific tests:**
+
+```bash
+# Run only integration tests
+./tests/run-vm-tests.sh --integration
+
+# Run only unit tests
+./tests/run-vm-tests.sh --unit
+
+# Combine test suites
+./tests/run-vm-tests.sh --integration --e2e-inst
+```
+
+### Detailed Testing Guide
+
+For comprehensive information including:
+- Prerequisites and installation
+- Manual testing workflows
+- Troubleshooting and debugging
+- Advanced usage examples
+
+See: **[VM Testing Guide](vm-testing.md)**
+
 ## Stopping the VM
 
 To stop the VM, use:
@@ -203,16 +244,13 @@ To completely remove the VM, use:
 
 ## Troubleshooting
 
-### Hardware Acceleration Issues
+- **QEMU Installation Issues**: Ensure QEMU is properly installed and the vagrant-qemu plugin is active. Run `vagrant plugin list` to verify.
 
-**KVM not available (Linux):**
-```bash
-# Check if KVM is supported
-ls /dev/kvm
-# If missing, enable virtualization in BIOS/UEFI
-# Install KVM packages:
-sudo apt install qemu-kvm libvirt-daemon-system
-```
+- **Shared Folder Issues**: QEMU uses 9p filesystem for sharing. If sync issues occur, try reloading the VM with `vagrant reload`.
+
+- **Networking Issues**: If you have trouble accessing forwarded ports, check your firewall settings on both the host and guest machines.
+
+- **Performance**: For best performance, ensure hardware acceleration is available (KVM on Linux, HVF on macOS). Check with `egrep -c '(vmx|svm)' /proc/cpuinfo` on Linux.
 
 **HVF not available (macOS):**
 ```bash

--- a/docs/contributing/vm-testing.md
+++ b/docs/contributing/vm-testing.md
@@ -1,0 +1,460 @@
+# Running Tracee Tests in a VM
+
+This guide explains how to run Tracee integration and end-to-end (e2e) tests in an isolated Vagrant VM environment, ensuring your host system remains unaffected by privileged operations, eBPF programs, and Docker containers.
+
+## Why Use a VM for Testing?
+
+Tracee's integration and e2e tests require:
+- **Root privileges** for eBPF operations
+- **Kernel access** for loading eBPF programs
+- **Docker** for container-related tests
+- **System modifications** that could affect your host
+
+Running tests in a VM provides complete isolation, ensuring:
+- No sudo required on your host machine
+- eBPF operations safely contained
+- Docker containers isolated from host
+- No risk of affecting your development environment
+
+## Prerequisites
+
+### Required Software
+
+1. **Vagrant** (2.2+)
+   ```bash
+   # Check if installed
+   vagrant --version
+
+   # Install on various platforms
+   # See: https://www.vagrantup.com/downloads
+   ```
+
+2. **QEMU** (recommended) or VirtualBox
+   ```bash
+   # QEMU (recommended - better performance and compatibility)
+   # Manjaro/Arch
+   sudo pacman -S qemu-full
+
+   # Ubuntu/Debian
+   sudo apt-get install qemu-system-x86
+
+   # macOS
+   brew install qemu
+   ```
+
+3. **Vagrant QEMU Plugin** (if using QEMU)
+   ```bash
+   vagrant plugin install vagrant-qemu
+   ```
+
+### System Requirements
+
+- **CPU**: 4+ cores recommended (VM uses 4 by default)
+- **RAM**: 8GB+ recommended (VM uses 8GB by default)
+- **Disk**: ~20GB free space for VM and build artifacts
+- **Network**: Internet access for downloading VM image and dependencies
+
+## Quick Start
+
+The simplest way to run all tests:
+
+```bash
+cd /path/to/tracee
+./tests/run-vm-tests.sh
+```
+
+This will:
+1. ✓ Check prerequisites (Vagrant, hypervisor)
+2. ✓ Start a test VM (Ubuntu 24.04 with eBPF kernel)
+3. ✓ Install all dependencies automatically
+4. ✓ Build Tracee from source
+5. ✓ Run all test suites (unit, integration, e2e)
+6. ✓ Collect logs to `tests/vm-test-logs/`
+7. ✓ Destroy VM on success (or preserve on failure)
+
+**First run takes 10-15 minutes** (downloads VM image and installs dependencies).
+**Subsequent runs take ~2-3 minutes** (provisioning only runs once).
+
+### Running Specific Tests
+
+You can run specific test suites instead of all tests:
+
+```bash
+# Run only integration tests
+./tests/run-vm-tests.sh --integration
+
+# Run only unit tests
+./tests/run-vm-tests.sh --unit
+
+# Run only e2e instrumentation tests
+./tests/run-vm-tests.sh --e2e-inst
+
+# Run only e2e network tests
+./tests/run-vm-tests.sh --e2e-net
+
+# Combine multiple test suites
+./tests/run-vm-tests.sh --integration --e2e-inst
+```
+
+**Available test options:**
+- `--unit` - Unit tests only (fastest)
+- `--integration` - Integration tests only
+- `--e2e-inst` - E2E instrumentation tests only
+- `--e2e-net` - E2E network tests only
+
+Multiple options can be combined. If no options are specified, all tests run.
+
+## Customizing Resource Allocation
+
+### Using Environment Variables
+
+```bash
+# Use 8 CPUs and 16GB RAM
+VM_CPUS=8 VM_MEM=16 ./tests/run-vm-tests.sh
+
+# Minimal resources (slower but less resource-intensive)
+VM_CPUS=2 VM_MEM=4 ./tests/run-vm-tests.sh
+```
+
+### Using Command-Line Options
+
+```bash
+# Specify resources via flags
+./tests/run-vm-tests.sh --vm-cpus 8 --vm-mem 16
+
+# Keep VM running even after successful tests (for inspection)
+./tests/run-vm-tests.sh --keep-vm
+
+# Combine resource settings with test selection
+./tests/run-vm-tests.sh --vm-cpus 8 --integration
+
+# Run multiple test suites with custom resources
+./tests/run-vm-tests.sh --vm-cpus 4 --vm-mem 8 --integration --e2e-inst
+```
+
+## Manual Testing Workflow
+
+If you want more control over the test process:
+
+### 1. Start the VM
+
+```bash
+cd /path/to/tracee
+
+# Start test VM (lighter than dev VM, no K8s)
+export VM_TYPE=test
+vagrant up
+```
+
+**Note**: The first `vagrant up` takes longer as it:
+- Downloads the Ubuntu 24.04 base image
+- Provisions the VM with all dependencies
+- Installs Go, Clang, Docker, and build tools
+
+### 2. Access the VM
+
+```bash
+vagrant ssh
+```
+
+You'll be in the `/vagrant` directory, which is synced with your Tracee repository.
+
+### 3. Build Tracee
+
+```bash
+# Inside the VM
+cd /vagrant
+make all
+```
+
+### 4. Run Tests Manually
+
+```bash
+# Run unit tests
+make test-unit
+
+# Run integration tests (requires root)
+sudo make test-integration
+
+# Run e2e instrumentation tests
+sudo bash tests/e2e-inst-test.sh
+
+# Run e2e network tests
+sudo bash tests/e2e-net-test.sh
+```
+
+### 5. Exit and Destroy VM
+
+```bash
+# Exit the VM
+exit
+
+# Destroy the VM (frees disk space)
+vagrant destroy -f
+```
+
+## Debugging Failed Tests
+
+When tests fail, the VM is automatically preserved for debugging.
+
+### Accessing the VM After Failure
+
+```bash
+cd /path/to/tracee
+vagrant ssh
+```
+
+### Viewing Test Logs
+
+Test logs are synced to your host machine:
+
+```bash
+# On your host (outside VM)
+ls tests/vm-test-logs/
+
+# View specific test logs
+less tests/vm-test-logs/test-run-YYYYMMDD_HHMMSS.log
+less tests/vm-test-logs/integration-tests-YYYYMMDD_HHMMSS.log
+```
+
+### Re-running Failed Tests
+
+```bash
+# Inside the VM
+vagrant ssh
+
+# Re-run all tests
+sudo /vagrant/tests/run-tests-in-vm.sh
+
+# Or run specific test suites
+sudo make test-integration
+sudo bash tests/e2e-inst-test.sh
+```
+
+### Cleaning Up After Debugging
+
+```bash
+# Exit the VM
+exit
+
+# Destroy the VM
+vagrant destroy -f
+```
+
+## Understanding VM Types
+
+The Tracee Vagrantfile supports two VM types:
+
+### Test VM (`VM_TYPE=test`) - Recommended for Testing
+- Lightweight configuration
+- No Kubernetes (MicroK8s) installed
+- Faster provisioning
+- Designed for test execution
+
+```bash
+export VM_TYPE=test
+vagrant up
+```
+
+### Dev VM (`VM_TYPE=dev`) - For Development
+- Full development environment
+- Includes MicroK8s, kubectl, helm
+- Suitable for K8s-related development
+- Takes longer to provision
+
+```bash
+export VM_TYPE=dev
+vagrant up
+```
+
+**For running tests, always use `VM_TYPE=test`.**
+
+## Troubleshooting
+
+### VM Fails to Start
+
+**Problem**: `vagrant up` fails with hypervisor errors
+
+**Solution**:
+1. Ensure VirtualBox or Parallels is installed
+2. Check virtualization is enabled in BIOS/UEFI
+3. Try destroying and recreating:
+   ```bash
+   vagrant destroy -f
+   vagrant up
+   ```
+
+### Shared Folder Issues
+
+**Problem**: `/vagrant` directory is empty or not mounted
+
+**Solution**:
+1. Ensure Guest Additions are installed (done automatically)
+2. Try reloading the VM:
+   ```bash
+   vagrant reload
+   ```
+
+### Tests Fail with "Permission Denied"
+
+**Problem**: Tests fail due to insufficient privileges
+
+**Solution**:
+- Always run tests with `sudo` inside the VM
+- Use the automated script: `sudo /vagrant/tests/run-tests-in-vm.sh`
+
+### VM is Slow or Unresponsive
+
+**Problem**: VM performance is poor
+
+**Solution**:
+- Increase CPU/RAM allocation:
+  ```bash
+  VM_PROC=8 VM_MEM=16 vagrant up
+  ```
+- Close other resource-intensive applications
+- Check host system has sufficient resources
+
+### Docker Tests Fail
+
+**Problem**: Container-related tests fail
+
+**Solution**:
+1. Ensure Docker is running in the VM:
+   ```bash
+   vagrant ssh
+   sudo systemctl status docker
+   sudo systemctl start docker
+   ```
+
+2. Pull required images manually:
+   ```bash
+   sudo docker pull busybox
+   ```
+
+### Out of Disk Space
+
+**Problem**: VM or host runs out of disk space
+
+**Solution**:
+1. Clean up old VMs:
+   ```bash
+   vagrant global-status --prune
+   vagrant destroy <vm-id>
+   ```
+
+2. Remove unused Vagrant boxes:
+   ```bash
+   vagrant box list
+   vagrant box remove <box-name>
+   ```
+
+3. Force clean provisioning state (rarely needed):
+   ```bash
+   vagrant destroy -f
+   vagrant up --provision
+   ```
+
+### Slow Provisioning / Dependencies Reinstalling
+
+**Problem**: VM reinstalling Go, Clang, etc. on every boot
+
+**Solution**:
+```bash
+# Provisioning should only run once. If it repeats:
+vagrant destroy -f
+vagrant up
+```
+
+After initial setup, `vagrant up` should start in ~30 seconds (not minutes).
+
+## Advanced Usage
+
+### Running Selective Tests
+
+You can modify `tests/run-tests-in-vm.sh` or run specific make targets:
+
+```bash
+# Inside VM - run only integration tests
+sudo make test-integration
+
+# Run only e2e network tests
+sudo bash tests/e2e-net-test.sh
+```
+
+### Preserving VM for Multiple Test Runs
+
+```bash
+# Start VM once
+export VM_TYPE=test
+vagrant up
+
+# Run tests multiple times
+vagrant ssh -c "sudo /vagrant/tests/run-tests-in-vm.sh"
+
+# Make changes, re-run
+vagrant ssh -c "sudo /vagrant/tests/run-tests-in-vm.sh"
+
+# Destroy when done
+vagrant destroy -f
+```
+
+### Using Different Kernel Versions
+
+The Vagrantfile installs kernel `6.2.0-1018-aws` by default. To test with different kernels, modify the `KERNEL_VERSION` variable in the Vagrantfile provisioning section.
+
+## Best Practices
+
+1. **Always use VM for integration/e2e tests** - Never run these directly on your host
+2. **Destroy VMs regularly** - Free up disk space: `vagrant destroy -f`
+3. **Keep VM_TYPE=test for testing** - Faster and lighter than dev VM
+4. **Check logs on failure** - Logs in `tests/vm-test-logs/` are your friend
+5. **Allocate adequate resources** - At least 4 CPUs and 8GB RAM recommended
+
+## CI/CD Integration
+
+This VM testing approach mirrors what CI does, making it easier to debug CI failures locally:
+
+```bash
+# Reproduce CI test failures locally
+./tests/run-vm-tests.sh
+
+# Check the same logs CI would generate
+cat tests/vm-test-logs/test-run-*.log
+```
+
+## Additional Resources
+
+- [Vagrant Documentation](https://www.vagrantup.com/docs)
+- [Tracee Building Guide](../docs/contributing/building/building.md)
+- [Tracee Testing Guide](../.cursor/rules/testing-guide.mdc)
+- [Setup Development Machine with Vagrant](../docs/contributing/setup-development-machine-with-vagrant.md)
+
+## Summary
+
+```bash
+# Quick command reference
+
+# Automated testing (recommended)
+./tests/run-vm-tests.sh
+
+# Custom resources
+VM_PROC=8 VM_MEM=16 ./tests/run-vm-tests.sh
+
+# Manual testing workflow
+export VM_TYPE=test
+vagrant up
+vagrant ssh
+sudo /vagrant/tests/run-tests-in-vm.sh
+exit
+vagrant destroy -f
+
+# Debugging after failure
+vagrant ssh
+# ... debug ...
+exit
+vagrant destroy -f
+```
+
+Happy testing! 🧪
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Tracee Tests
+
+This directory contains various test suites for Tracee.
+
+## Test Types
+
+- **Unit tests**: `make test-unit` - Test individual components
+- **Integration tests**: `make test-integration` - Test system integration (requires root)
+- **E2E tests**: End-to-end testing with real scenarios
+
+## Running Tests in a VM
+
+For safe, isolated testing that won't affect your host system, see:
+
+**[VM Testing Guide](../docs/contributing/vm-testing.md)**
+
+Quick start:
+```bash
+./run-vm-tests.sh
+```
+
+This will run all tests in an isolated VM environment with automatic cleanup.
+

--- a/tests/run-tests-in-vm.sh
+++ b/tests/run-tests-in-vm.sh
@@ -1,0 +1,385 @@
+#!/bin/bash
+#
+# Tracee Test Orchestration Script (runs inside VM)
+#
+# This script runs all Tracee tests inside the Vagrant VM with proper isolation.
+# It should be executed with root privileges from within the VM.
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - One or more tests failed
+#   2 - Build failed
+#   3 - Prerequisites check failed
+
+set -e  # Exit on error (we'll handle specific failures)
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $*"
+}
+
+# Test results tracking
+TESTS_FAILED=0
+TESTS_PASSED=0
+TEST_RESULTS=()
+
+# Test suite flags (default: run all)
+RUN_UNIT=true
+RUN_INTEGRATION=true
+RUN_E2E_INST=true
+RUN_E2E_NET=true
+SELECTIVE_RUN=false  # Set to true if user specifies specific tests
+
+# Log directory
+LOG_DIR="/vagrant/tests/vm-test-logs"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+LOG_FILE="${LOG_DIR}/test-run-${TIMESTAMP}.log"
+
+# Initialize logging
+init_logging() {
+    mkdir -p "${LOG_DIR}"
+    info "Test run started at $(date)" | tee "${LOG_FILE}"
+    info "Logs will be saved to: ${LOG_FILE}"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    info "Checking prerequisites..."
+
+    # Check if running as root
+    if [[ $EUID -ne 0 ]]; then
+        error "This script must be run as root (use sudo)"
+        return 3
+    fi
+
+    # Check if we're in the tracee directory
+    if [[ ! -f "/vagrant/Makefile" ]] && [[ ! -f "$(pwd)/Makefile" ]]; then
+        error "Not in Tracee root directory"
+        return 3
+    fi
+
+    # Change to tracee directory if needed
+    if [[ -f "/vagrant/Makefile" ]]; then
+        cd /vagrant
+    fi
+
+    # Check essential tools
+    local missing_tools=()
+    for tool in make go clang docker; do
+        if ! command -v "$tool" &> /dev/null; then
+            missing_tools+=("$tool")
+        fi
+    done
+
+    if [[ ${#missing_tools[@]} -gt 0 ]]; then
+        error "Missing required tools: ${missing_tools[*]}"
+        return 3
+    fi
+
+    success "Prerequisites check passed"
+    return 0
+}
+
+# Clean previous builds
+clean_builds() {
+    info "Cleaning previous builds..."
+    make clean 2>&1 | tee -a "${LOG_FILE}" || warn "Clean failed (may be first run)"
+    success "Clean completed"
+}
+
+# Build Tracee
+build_tracee() {
+    info "Building Tracee (this may take several minutes)..."
+
+    if make all 2>&1 | tee -a "${LOG_FILE}"; then
+        success "Build completed successfully"
+        return 0
+    else
+        error "Build failed"
+        return 2
+    fi
+}
+
+# Run unit tests
+run_unit_tests() {
+    info "Running unit tests..."
+
+    local unit_log="${LOG_DIR}/unit-tests-${TIMESTAMP}.log"
+
+    make test-unit 2>&1 | tee "${unit_log}" | tee -a "${LOG_FILE}"
+    local exit_code=${PIPESTATUS[0]}
+
+    if [[ $exit_code -eq 0 ]]; then
+        success "Unit tests passed"
+        TEST_RESULTS+=("✓ Unit tests: PASSED")
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "Unit tests failed (exit code: $exit_code)"
+        TEST_RESULTS+=("✗ Unit tests: FAILED (see ${unit_log})")
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# Run integration tests
+run_integration_tests() {
+    info "Running integration tests (requires root and eBPF support)..."
+
+    local integration_log="${LOG_DIR}/integration-tests-${TIMESTAMP}.log"
+
+    # Integration tests require root and eBPF
+    # The Makefile tries to write coverage to ./integration-coverage.txt
+    # which fails on 9p mounts with permission denied
+    # We override the go test command to skip coverage for VM testing
+
+    info "Building syscaller binary..."
+    if ! make embedded-dirs ./dist/syscaller 2>&1 | tee -a "${LOG_FILE}"; then
+        error "Failed to build syscaller"
+        TEST_RESULTS+=("✗ Integration tests: FAILED (build error)")
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    info "Running go test (without coverage to avoid 9p permission issues)..."
+    # Run the same test command as the Makefile but without -coverprofile
+    GOOS=linux CC=clang GOARCH=amd64 GOFIPS140=off \
+        CGO_CFLAGS="-I/vagrant/dist/libbpf/include" \
+        CGO_LDFLAGS="-L/vagrant/dist/libbpf/obj -lbpf" \
+        go test \
+        -tags core,ebpf,lsmsupport \
+        -ldflags="-s=false -w=false -extldflags \"-lelf -lz\" -X main.version=\"$(cat /vagrant/VERSION)\"" \
+        -shuffle on \
+        -timeout 20m \
+        -race \
+        -v \
+        -p 1 \
+        -count=1 \
+        ./tests/integration/... 2>&1 | tee "${integration_log}" | tee -a "${LOG_FILE}"
+
+    local exit_code=${PIPESTATUS[0]}
+
+    if [[ $exit_code -eq 0 ]]; then
+        success "Integration tests passed"
+        TEST_RESULTS+=("✓ Integration tests: PASSED")
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "Integration tests failed (exit code: $exit_code)"
+        TEST_RESULTS+=("✗ Integration tests: FAILED (see ${integration_log})")
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# Run e2e instrumentation tests
+run_e2e_inst_tests() {
+    info "Running e2e instrumentation tests..."
+
+    local e2e_inst_log="${LOG_DIR}/e2e-inst-tests-${TIMESTAMP}.log"
+
+    # Check if e2e test script exists
+    if [[ ! -f "tests/e2e-inst-test.sh" ]]; then
+        warn "e2e instrumentation test script not found, skipping"
+        TEST_RESULTS+=("⊘ E2E instrumentation tests: SKIPPED")
+        return 0
+    fi
+
+    bash tests/e2e-inst-test.sh 2>&1 | tee "${e2e_inst_log}" | tee -a "${LOG_FILE}"
+    local exit_code=${PIPESTATUS[0]}
+
+    if [[ $exit_code -eq 0 ]]; then
+        success "E2E instrumentation tests passed"
+        TEST_RESULTS+=("✓ E2E instrumentation tests: PASSED")
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "E2E instrumentation tests failed (exit code: $exit_code)"
+        TEST_RESULTS+=("✗ E2E instrumentation tests: FAILED (see ${e2e_inst_log})")
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# Run e2e network tests
+run_e2e_net_tests() {
+    info "Running e2e network tests..."
+
+    local e2e_net_log="${LOG_DIR}/e2e-net-tests-${TIMESTAMP}.log"
+
+    # Check if e2e test script exists
+    if [[ ! -f "tests/e2e-net-test.sh" ]]; then
+        warn "e2e network test script not found, skipping"
+        TEST_RESULTS+=("⊘ E2E network tests: SKIPPED")
+        return 0
+    fi
+
+    bash tests/e2e-net-test.sh 2>&1 | tee "${e2e_net_log}" | tee -a "${LOG_FILE}"
+    local exit_code=${PIPESTATUS[0]}
+
+    if [[ $exit_code -eq 0 ]]; then
+        success "E2E network tests passed"
+        TEST_RESULTS+=("✓ E2E network tests: PASSED")
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        error "E2E network tests failed (exit code: $exit_code)"
+        TEST_RESULTS+=("✗ E2E network tests: FAILED (see ${e2e_net_log})")
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# Print test summary
+print_summary() {
+    echo ""
+    echo "========================================"
+    echo "         TEST RESULTS SUMMARY           "
+    echo "========================================"
+    echo ""
+
+    for result in "${TEST_RESULTS[@]}"; do
+        echo "  $result"
+    done
+
+    echo ""
+    echo "----------------------------------------"
+    echo "Total: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+    echo "----------------------------------------"
+    echo ""
+
+    if [[ ${TESTS_FAILED} -eq 0 ]]; then
+        success "All tests passed! 🎉"
+        return 0
+    else
+        error "${TESTS_FAILED} test suite(s) failed"
+        return 1
+    fi
+}
+
+# Main execution
+main() {
+    echo "========================================"
+    echo "   Tracee Test Suite (VM Environment)  "
+    echo "========================================"
+    echo ""
+
+    init_logging
+
+    # Check prerequisites
+    if ! check_prerequisites; then
+        exit 3
+    fi
+
+    # Clean previous builds
+    clean_builds
+
+    # Build Tracee
+    if ! build_tracee; then
+        error "Cannot proceed with tests due to build failure"
+        exit 2
+    fi
+
+    # Run tests (continue even if some fail to get complete picture)
+    set +e  # Don't exit on individual test failures
+
+    if [[ "$SELECTIVE_RUN" == "true" ]]; then
+        info "Running selected test suites..."
+    else
+        info "Running all test suites..."
+    fi
+
+    [[ "$RUN_UNIT" == "true" ]] && run_unit_tests
+    [[ "$RUN_INTEGRATION" == "true" ]] && run_integration_tests
+    [[ "$RUN_E2E_INST" == "true" ]] && run_e2e_inst_tests
+    [[ "$RUN_E2E_NET" == "true" ]] && run_e2e_net_tests
+
+    # Print summary and exit with appropriate code
+    print_summary | tee -a "${LOG_FILE}"
+    local summary_exit=${PIPESTATUS[0]}
+
+    info "Test run completed at $(date)" | tee -a "${LOG_FILE}"
+
+    exit $summary_exit
+}
+
+# Handle script arguments
+case "${1:-}" in
+    --help|-h)
+        echo "Usage: $0 [OPTIONS]"
+        echo ""
+        echo "Run Tracee test suite inside VM (requires root)"
+        echo ""
+        echo "Options:"
+        echo "  --unit              Run only unit tests"
+        echo "  --integration       Run only integration tests"
+        echo "  --e2e-inst          Run only e2e instrumentation tests"
+        echo "  --e2e-net           Run only e2e network tests"
+        echo "  --help, -h          Show this help message"
+        echo ""
+        echo "Multiple options can be combined to run specific test suites."
+        echo "If no test options are specified, all tests will run."
+        echo ""
+        echo "Examples:"
+        echo "  sudo $0                           # Run all tests"
+        echo "  sudo $0 --unit                    # Run only unit tests"
+        echo "  sudo $0 --integration --e2e-inst  # Run integration and e2e inst tests"
+        echo ""
+        exit 0
+        ;;
+    *)
+        # Parse test selection arguments
+        if [[ $# -gt 0 ]]; then
+            # User specified specific tests, so disable all by default
+            RUN_UNIT=false
+            RUN_INTEGRATION=false
+            RUN_E2E_INST=false
+            RUN_E2E_NET=false
+            SELECTIVE_RUN=true
+
+            # Enable only the requested tests
+            for arg in "$@"; do
+                case "$arg" in
+                    --unit)
+                        RUN_UNIT=true
+                        ;;
+                    --integration)
+                        RUN_INTEGRATION=true
+                        ;;
+                    --e2e-inst)
+                        RUN_E2E_INST=true
+                        ;;
+                    --e2e-net)
+                        RUN_E2E_NET=true
+                        ;;
+                    *)
+                        echo "Unknown option: $arg"
+                        echo "Run '$0 --help' for usage information"
+                        exit 1
+                        ;;
+                esac
+            done
+        fi
+        main "$@"
+        ;;
+esac
+

--- a/tests/run-vm-tests.sh
+++ b/tests/run-vm-tests.sh
@@ -1,0 +1,366 @@
+#!/bin/bash
+#
+# Tracee VM Test Wrapper (runs on host)
+#
+# This script orchestrates the complete test execution lifecycle:
+# 1. Validates prerequisites (Vagrant, hypervisor)
+# 2. Starts a test VM using VM_TYPE=test
+# 3. Executes tests inside the VM
+# 4. Handles cleanup (destroy on success, preserve on failure)
+#
+# Usage: ./tests/run-vm-tests.sh [OPTIONS]
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRACEE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+VM_NAME="tracee-test-vm"
+
+# Default configuration (can be overridden by env vars)
+: "${VM_TYPE:=test}"
+: "${VM_CPUS:=4}"
+: "${VM_MEM:=8}"
+: "${KEEP_VM_ON_SUCCESS:=false}"
+
+# Test selection flags (will be passed to in-VM script)
+TEST_ARGS=()
+
+# Logging functions
+info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $*"
+}
+
+# Show usage
+show_usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Run Tracee tests in an isolated Vagrant VM environment.
+
+Options:
+  --keep-vm         Keep VM running even on success (for debugging)
+  --vm-cpus NUM     Number of CPU cores (default: 4)
+  --vm-mem GB       Memory in GB (default: 8)
+  --unit            Run only unit tests
+  --integration     Run only integration tests
+  --e2e-inst        Run only e2e instrumentation tests
+  --e2e-net         Run only e2e network tests
+  --help, -h        Show this help message
+
+Environment Variables:
+  VM_CPUS           Number of CPU cores (default: 4)
+  VM_MEM            Memory in GB (default: 8)
+  KEEP_VM_ON_SUCCESS Keep VM even on success (default: false)
+
+Test Selection:
+  Multiple test options can be combined. If no test options are specified,
+  all tests will run.
+
+Examples:
+  # Run with defaults (4 CPUs, 8GB RAM, all tests)
+  ./tests/run-vm-tests.sh
+
+  # Use more resources
+  VM_CPUS=8 VM_MEM=16 ./tests/run-vm-tests.sh
+
+  # Keep VM for debugging even on success
+  ./tests/run-vm-tests.sh --keep-vm
+
+  # Run only integration tests
+  ./tests/run-vm-tests.sh --integration
+
+  # Run unit and integration tests only
+  ./tests/run-vm-tests.sh --unit --integration
+
+EOF
+}
+
+# Parse command line arguments
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --keep-vm)
+                KEEP_VM_ON_SUCCESS=true
+                shift
+                ;;
+            --vm-cpus)
+                VM_CPUS="$2"
+                shift 2
+                ;;
+            --vm-mem)
+                VM_MEM="$2"
+                shift 2
+                ;;
+            --unit|--integration|--e2e-inst|--e2e-net)
+                # Collect test selection flags
+                TEST_ARGS+=("$1")
+                shift
+                ;;
+            --help|-h)
+                show_usage
+                exit 0
+                ;;
+            *)
+                error "Unknown option: $1"
+                show_usage
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# Check prerequisites
+check_prerequisites() {
+    info "Checking prerequisites..."
+
+    # Check if vagrant is installed
+    if ! command -v vagrant &> /dev/null; then
+        error "Vagrant is not installed"
+        error "Please install Vagrant: https://www.vagrantup.com/downloads"
+        return 1
+    fi
+
+    # Check if we're in the tracee directory
+    if [[ ! -f "${TRACEE_ROOT}/Vagrantfile" ]]; then
+        error "Vagrantfile not found in ${TRACEE_ROOT}"
+        error "Please run this script from the Tracee repository"
+        return 1
+    fi
+
+    # Check for VirtualBox or Parallels
+    local has_hypervisor=false
+    if command -v VBoxManage &> /dev/null; then
+        info "Found VirtualBox"
+        has_hypervisor=true
+    elif command -v prlctl &> /dev/null; then
+        info "Found Parallels"
+        has_hypervisor=true
+    fi
+
+    if [[ "$has_hypervisor" == "false" ]]; then
+        warn "No hypervisor detected (VirtualBox or Parallels)"
+        warn "Please ensure you have a Vagrant-compatible hypervisor installed"
+    fi
+
+    success "Prerequisites check passed"
+    return 0
+}
+
+# Start the VM
+start_vm() {
+    info "Starting VM: ${VM_NAME}"
+    info "Configuration: ${VM_CPUS} CPUs, ${VM_MEM}GB RAM"
+
+    cd "${TRACEE_ROOT}"
+
+    # Check if any other Tracee VM is running
+    if vagrant status 2>/dev/null | grep -E "tracee-(dev|test)-vm.*running" | grep -v "${VM_NAME}" > /dev/null; then
+        warn "Another Tracee VM is running. Stopping it first..."
+        vagrant halt
+        sleep 2
+    fi
+
+    # Export configuration
+    export VM_TYPE="${VM_TYPE}"
+    export VM_CPUS="${VM_CPUS}"
+    export VM_MEM="${VM_MEM}"
+
+    # Start the VM
+    info "Running: vagrant up..."
+    info "(This may take several minutes on first run)"
+
+    if vagrant up; then
+        success "VM started successfully"
+        return 0
+    else
+        error "Failed to start VM"
+        return 1
+    fi
+}
+
+# Check if VM is running
+is_vm_running() {
+    cd "${TRACEE_ROOT}"
+    vagrant status "${VM_NAME}" 2>/dev/null | grep -q "running"
+}
+
+# Run tests in the VM
+run_tests_in_vm() {
+    info "Executing tests inside VM..."
+
+    cd "${TRACEE_ROOT}"
+
+    # Copy script to /tmp to avoid 9p filesystem and ssh.extra_args issues
+    info "Copying test script to VM..."
+    if ! vagrant ssh <<'EOSSH'
+cp /vagrant/tests/run-tests-in-vm.sh /tmp/run-tests-in-vm.sh
+chmod +x /tmp/run-tests-in-vm.sh
+EOSSH
+    then
+        error "Failed to copy test script"
+        return 1
+    fi
+
+    # Execute the test script from /tmp with test selection arguments
+    local test_cmd="/tmp/run-tests-in-vm.sh"
+    if [[ ${#TEST_ARGS[@]} -gt 0 ]]; then
+        test_cmd="$test_cmd ${TEST_ARGS[*]}"
+        info "Running selected tests: ${TEST_ARGS[*]}"
+    fi
+
+    # Use heredoc but explicitly exit with the command's exit code
+    vagrant ssh <<EOSSH
+sudo $test_cmd
+exit \$?
+EOSSH
+    local exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        success "Tests completed successfully"
+        return 0
+    else
+        error "Tests failed (exit code: $exit_code)"
+        return 1
+    fi
+}
+
+# Destroy the VM
+destroy_vm() {
+    local force="${1:-false}"
+
+    cd "${TRACEE_ROOT}"
+
+    if [[ "$force" == "true" ]]; then
+        info "Destroying VM..."
+        vagrant destroy -f
+        success "VM destroyed"
+    else
+        info "Halting VM..."
+        vagrant halt
+        info "VM halted (use 'vagrant destroy' to remove completely)"
+    fi
+}
+
+# Show debugging instructions
+show_debug_instructions() {
+    echo ""
+    echo "========================================"
+    echo "   VM Debugging Instructions"
+    echo "========================================"
+    echo ""
+    echo "The VM has been preserved for debugging."
+    echo ""
+    echo "To access the VM:"
+    echo "  cd ${TRACEE_ROOT}"
+    echo "  vagrant ssh"
+    echo ""
+    echo "Test logs are available at:"
+    echo "  ${TRACEE_ROOT}/tests/vm-test-logs/"
+    echo ""
+    echo "To re-run tests manually inside the VM:"
+    echo "  vagrant ssh"
+    echo "  sudo /vagrant/tests/run-tests-in-vm.sh"
+    echo ""
+    echo "When done debugging, destroy the VM:"
+    echo "  cd ${TRACEE_ROOT}"
+    echo "  vagrant destroy -f"
+    echo ""
+    echo "========================================"
+    echo ""
+}
+
+# Main execution
+main() {
+    echo "========================================"
+    echo "  Tracee VM Test Environment"
+    echo "========================================"
+    echo ""
+
+    # Parse arguments
+    parse_args "$@"
+
+    # Check prerequisites
+    if ! check_prerequisites; then
+        exit 1
+    fi
+
+    # Change to tracee root
+    cd "${TRACEE_ROOT}"
+
+    # Start VM
+    if ! start_vm; then
+        error "Failed to start VM, cannot proceed with tests"
+        exit 1
+    fi
+
+    # Run tests
+    local test_exit_code=0
+    if ! run_tests_in_vm; then
+        test_exit_code=1
+    fi
+
+    # Handle VM cleanup based on test results
+    echo ""
+    if [[ ${test_exit_code} -eq 0 ]]; then
+        success "All tests passed!"
+        echo ""
+
+        if [[ "${KEEP_VM_ON_SUCCESS}" == "true" ]]; then
+            warn "VM preserved for inspection (--keep-vm specified)"
+            show_debug_instructions
+        else
+            info "Cleaning up VM..."
+            destroy_vm true
+            success "VM destroyed"
+        fi
+
+        echo ""
+        success "Test run completed successfully 🎉"
+        exit 0
+    else
+        error "Some tests failed"
+        echo ""
+        warn "VM preserved for debugging"
+        show_debug_instructions
+        exit 1
+    fi
+}
+
+# Trap cleanup on script exit
+cleanup_on_interrupt() {
+    echo ""
+    warn "Script interrupted"
+
+    if is_vm_running; then
+        warn "VM is still running"
+        show_debug_instructions
+    fi
+
+    exit 130
+}
+
+trap cleanup_on_interrupt INT TERM
+
+# Run main
+main "$@"
+


### PR DESCRIPTION
Add automated VM testing infrastructure for running Tracee integration and e2e tests in isolated Vagrant VMs using QEMU/KVM.

Key features:
- Automated VM lifecycle management (start, test, cleanup)
- Selective test execution (--unit, --integration, --e2e-inst, --e2e-net)
- Automatic VM conflict detection and resolution
- Log collection and VM preservation on failure
- Provisioning optimization: first run 10-15min, subsequent runs ~2-3min

Scripts:
- tests/run-vm-tests.sh: Host-side orchestration
- tests/run-tests-in-vm.sh: In-VM test execution

Documentation:
- docs/contributing/vm-testing.md: Comprehensive guide
- docs/contributing/setup-development-machine-with-vagrant.md: Updated
- tests/README.md: Quick reference