### PR TITLE
fix(tests): silence BPF probe autoload errors in integration tests

### DIFF
--- a/pkg/ebpf/probes/probe_group.go
+++ b/pkg/ebpf/probes/probe_group.go
@@ -163,7 +163,15 @@ func (p *ProbeGroup) DetachAll() error {
 	return nil
 }
 
-// Autoload disables autoload feature for a given handle's program.
+// Autoload enables or disables the autoload feature for a given handle's program.
+//
+// Autoload failures are non-fatal and can occur when:
+// - The BPF program doesn't exist in the object file (e.g., uprobes in test binaries)
+// - The program is incompatible with the current kernel version
+// - The program has already been loaded or is in an unexpected state
+//
+// Callers should typically log failures at DEBUG level and continue, as probes that
+// fail to autoload will simply not be used, which is the correct behavior.
 func (p *ProbeGroup) Autoload(handle Handle, autoload bool) error {
 	p.probesLock.Lock()
 	defer p.probesLock.Unlock()

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -1154,7 +1154,7 @@ func (t *Tracee) setProgramsAutoload() {
 	for _, probeHandle := range t.eventsDependencies.GetProbes() {
 		err := t.defaultProbes.Autoload(probeHandle, true)
 		if err != nil {
-			logger.Errorw("Failed to autoload program", "handle", probeHandle, "error", err)
+			logger.Debugw("Failed to autoload program", "handle", probeHandle, "error", err)
 		}
 	}
 
@@ -1169,7 +1169,7 @@ func (t *Tracee) setProgramsAutoload() {
 			}
 			err := t.defaultProbes.Autoload(probeNode.GetHandle(), true)
 			if err != nil {
-				logger.Errorw("Failed to autoload program", "handle", probeNode.GetHandle(), "error", err)
+				logger.Debugw("Failed to autoload program", "handle", probeNode.GetHandle(), "error", err)
 			}
 			return nil
 		})
@@ -1185,7 +1185,7 @@ func (t *Tracee) setProgramsAutoload() {
 			}
 			err := t.defaultProbes.Autoload(probeNode.GetHandle(), false)
 			if err != nil {
-				logger.Errorw("Failed to autoload program", "handle", probeNode.GetHandle(), "error", err)
+				logger.Debugw("Failed to autoload program", "handle", probeNode.GetHandle(), "error", err)
 			}
 			return nil
 		})

--- a/tests/testutils/tracee_integrated.go
+++ b/tests/testutils/tracee_integrated.go
@@ -105,6 +105,11 @@ func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 		Source: process.SourceNone,
 	}
 
+	// Disable healthz/heartbeat in integration tests
+	// The SignalHeartbeat probe is a uprobe that doesn't work properly when
+	// tracee runs as a library in test binaries
+	cfg.HealthzEnabled = false
+
 	errChan := make(chan error)
 
 	go func() {


### PR DESCRIPTION
### 1. Explain what the PR does

757ed9d60 **fix(tests): silence BPF probe autoload errors in integration tests**

> Integration tests were emitting ERROR logs for probe handle 115
> (SignalHeartbeat) failing to autoload. This is a uprobe that attaches
> to github.com/aquasecurity/tracee/pkg/server/http.invokeHeartbeat,
> which doesn't exist when tracee runs as a library in test binaries.
> 
> Changes:
> - Enforce HealthzEnabled as disabled in integration test setup to prevent
>   SignalHeartbeat event from being selected
> - Change autoload failure logging from ERROR to DEBUG level, as these
>   failures are expected and non-fatal (probes may not exist in all
>   environments or kernel versions)
> - Add comprehensive documentation to Autoload() method explaining when
>   failures occur and how callers should handle them
> - Fix Autoload() documentation to correctly state it both enables and
>   disables autoload (was incorrectly documented as only disabling)
> 
> Autoload failures are non-fatal by design - probes that fail to
> autoload are simply not used, which is the correct behavior. The
> system continues to work normally.
> 
> Fixes spurious ERROR logs in integration tests while maintaining
> debuggability through DEBUG-level logging.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
