### PR TITLE
[v0.24.2] fix(container): strip conmon prefix from CRI-O container IDs

### DIFF
--- a/pkg/datastores/container/containers.go
+++ b/pkg/datastores/container/containers.go
@@ -291,8 +291,12 @@ func parseContainerIdFromCgroupPath(cgroupPath string) (string, runtime.RuntimeI
 			contRuntime = runtime.Docker
 			id = strings.TrimPrefix(id, "docker-")
 		case strings.HasPrefix(id, "crio-"):
-			contRuntime = runtime.Crio
 			id = strings.TrimPrefix(id, "crio-")
+			// Skip conmon cgroups - conmon is a monitoring process, not a container
+			if strings.HasPrefix(id, "conmon-") {
+				continue
+			}
+			contRuntime = runtime.Crio
 		case strings.HasPrefix(id, "cri-containerd-"):
 			contRuntime = runtime.Containerd
 			id = strings.TrimPrefix(id, "cri-containerd-")

--- a/pkg/datastores/container/containers_test.go
+++ b/pkg/datastores/container/containers_test.go
@@ -1,0 +1,100 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/tracee/pkg/datastores/container/runtime"
+)
+
+func TestParseContainerIdFromCgroupPath(t *testing.T) {
+	tests := []struct {
+		name                string
+		cgroupPath          string
+		expectedContainerId string
+		expectedRuntime     runtime.RuntimeId
+		expectedIsRoot      bool
+	}{
+		{
+			name:                "docker systemd format",
+			cgroupPath:          "/kubepods/besteffort/pod123/docker-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.scope",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Docker,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "crio systemd format without conmon",
+			cgroupPath:          "/kubepods/besteffort/pod123/crio-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.scope",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Crio,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "crio systemd format with conmon prefix (should be skipped)",
+			cgroupPath:          "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podb13213a6_d47e_4bd1_bc00_f175d1ad3b6e.slice/crio-conmon-eb5a56051cf7c5e9e588d0dca94d6673d67d43604686e1485984732b18701057.scope",
+			expectedContainerId: "",
+			expectedRuntime:     runtime.Unknown,
+			expectedIsRoot:      false,
+		},
+		{
+			name:                "cri-containerd systemd format",
+			cgroupPath:          "/kubepods/besteffort/pod123/cri-containerd-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.scope",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Containerd,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "containerd with colon separator",
+			cgroupPath:          "/kubepods/besteffort/pod123/some:cri-containerd:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Containerd,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "libpod/podman systemd format",
+			cgroupPath:          "/machine.slice/libpod-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.scope",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Podman,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "docker non-systemd format",
+			cgroupPath:          "/docker/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Docker,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "containerd with pod prefix",
+			cgroupPath:          "/kubepods/besteffort/pod123/1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Containerd,
+			expectedIsRoot:      true,
+		},
+		{
+			name:                "non-container path",
+			cgroupPath:          "/user.slice/user-1000.slice",
+			expectedContainerId: "",
+			expectedRuntime:     runtime.Unknown,
+			expectedIsRoot:      false,
+		},
+		{
+			name:                "nested container (should return outer)",
+			cgroupPath:          "/kubepods/besteffort/pod123/docker-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.scope/system.slice",
+			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			expectedRuntime:     runtime.Docker,
+			expectedIsRoot:      false, // not root because there's more after it
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerId, containerRuntime, isRoot := parseContainerIdFromCgroupPath(tt.cgroupPath)
+
+			assert.Equal(t, tt.expectedContainerId, containerId, "Container ID mismatch")
+			assert.Equal(t, tt.expectedRuntime, containerRuntime, "Runtime mismatch")
+			assert.Equal(t, tt.expectedIsRoot, isRoot, "IsRoot mismatch")
+		})
+	}
+}


### PR DESCRIPTION
Backport of #5087 

### 1. Explain what the PR does

71b958f6c **fix(container): skip CRI-O conmon cgroups**

> CRI-O uses conmon (container monitor) processes that have their own cgroups
> with paths like crio-conmon-<container-id>. These are monitoring processes,
> not containers. Previously, Tracee would incorrectly recognize these as
> containers with ID conmon-<container-id>. Now properly skips conmon cgroups
> entirely, preventing false container identification.
> 
> (cherry picked from commit 63f348f02a1f6c0b9236b9eb25de495108642a1d)

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
