### PR TITLE
Pull Test Images

### DIFF
--- a/.github/actions/pull-test-images/action.yaml
+++ b/.github/actions/pull-test-images/action.yaml
@@ -1,0 +1,54 @@
+name: Pull Test Images
+description: |
+  Pre-pull all container images required for tests to avoid rate limits.
+  Images are cached on the runner for subsequent test steps.
+
+runs:
+  using: composite
+  steps:
+    # - name: Login to Container Registry
+    #   uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+    #   with:
+    #     registry: ghcr.io
+    #     username: ${{ github.actor }}
+    #     password: ${{ github.token }}
+
+    - name: Pull required test images
+      run: |
+        set -eu
+
+        __LIB_DIR="./scripts"
+        # shellcheck disable=SC1091
+        . "${__LIB_DIR}/lib.sh"
+
+        info "Pre-pulling container images for tests..."
+        info "Using ECR Public mirrors to avoid Docker Hub rate limits"
+
+        images="
+        public.ecr.aws/docker/library/busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee
+        public.ecr.aws/docker/library/ubuntu:jammy-20240911.1@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97
+        ghcr.io/aquasecurity/tracee-tester:latest
+        "
+
+        # Pull each image with 1 second delay between pulls to diminish load on registries
+        for image in ${images}; do
+            info "Pulling ${image}..."
+            docker pull "${image}"
+            sleep 1
+        done
+
+        info "All test images pre-pulled and cached"
+      shell: sh
+
+    # - name: Logout from Container Registry
+    #   if: always()
+    #   run: |
+    #     set -eu
+
+    #     __LIB_DIR="./scripts"
+    #     # shellcheck disable=SC1091
+    #     . "${__LIB_DIR}/lib.sh"
+
+    #     # Logout may fail if not logged in, ignore errors
+    #     docker logout ghcr.io || warn "Failed to logout from ghcr.io (may not be logged in)"
+    #   shell: sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -414,6 +414,8 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Setup Tracee
         uses: ./.github/actions/setup-tracee-ubuntu
+      - name: Pull test images
+        uses: ./.github/actions/pull-test-images
       - name: Run Integration Tests
         uses: ./.github/actions/run-integration-tests
         with:
@@ -448,6 +450,8 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Setup Tracee
         uses: ./.github/actions/setup-tracee-ubuntu
+      - name: Pull test images
+        uses: ./.github/actions/pull-test-images
       - name: Run Integration Tests
         uses: ./.github/actions/run-integration-tests
         with:
@@ -531,6 +535,8 @@ jobs:
         continue-on-error: true
       # - name: "Prepare Image (Fix AMIs)"
       #   run: ./tests/e2e-install-deps.sh
+      - name: Pull test images
+        uses: ./.github/actions/pull-test-images
       - name: "Sync System Time"
         run: ./scripts/sync_system_time.sh
         continue-on-error: true

--- a/cmd/evt/cmd/trigger/triggers/common/docker.sh
+++ b/cmd/evt/cmd/trigger/triggers/common/docker.sh
@@ -2,4 +2,4 @@
 
 # common
 
-sh -c 'docker run --rm -it ubuntu /bin/bash'
+sh -c 'docker run --rm busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee echo "Docker container test"'

--- a/performance/benchmark/network/manifests/loadgenerator.yaml
+++ b/performance/benchmark/network/manifests/loadgenerator.yaml
@@ -45,7 +45,7 @@ spec:
               - ALL
           privileged: false
           readOnlyRootFilesystem: true
-        image: busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee
+        image: public.ecr.aws/docker/library/busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee
         env:
         - name: FRONTEND_ADDR
           value: "frontend:80"

--- a/tests/e2e-inst-signatures/scripts/containers_data_source.sh
+++ b/tests/e2e-inst-signatures/scripts/containers_data_source.sh
@@ -11,7 +11,8 @@ info() {
     echo "$@"
 }
 
-BUSYBOX_IMAGE="busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee"
+# Using ECR Public mirror to avoid Docker Hub rate limits
+BUSYBOX_IMAGE="public.ecr.aws/docker/library/busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee"
 wait_container=${E2E_INST_TEST_SLEEP:-5} # time to let container alive
 
 # Parse command line arguments

--- a/tests/integration/common_test.go
+++ b/tests/integration/common_test.go
@@ -4,5 +4,11 @@ package integration
 
 const (
 	// busyboxImage is the pinned busybox image used in integration tests
-	busyboxImage = "busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee"
+	// Using ECR Public mirror to avoid Docker Hub rate limits
+	busyboxImage = "public.ecr.aws/docker/library/busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee"
+
+	// ubuntuJammyPinnedImage is the pinned Ubuntu Jammy image used in integration tests
+	// Fixed version ensures consistent library versions for filter tests
+	// Using ECR Public mirror to avoid Docker Hub rate limits
+	ubuntuJammyPinnedImage = "public.ecr.aws/docker/library/ubuntu:jammy-20240911.1@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97"
 )

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -71,11 +71,11 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"docker run -d --rm hello-world",
+					"docker run -d --rm "+busyboxImage,
 					0,
 					10*time.Second, // give some time for the container to start (possibly downloading the image)
 					[]*pb.Event{
-						expectPbEvent(anyHost, "hello", anyProcessorID, 1, 0, events.SchedProcessExec, orPolNames("container-event")),
+						expectPbEvent(anyHost, "sh", anyProcessorID, 1, 0, events.SchedProcessExec, orPolNames("container-event")),
 					},
 					[]string{}, // no sets
 				),
@@ -772,7 +772,7 @@ func Test_EventFilters(t *testing.T) {
 			},
 			cmdEvents: []cmdEvents{
 				newCmdEvents(
-					"docker run -d --rm hello-world",
+					"docker run -d --rm "+busyboxImage,
 					0,
 					10*time.Second, // give some time for the container to start (possibly downloading the image)
 					[]*pb.Event{
@@ -1836,7 +1836,7 @@ func Test_EventFilters(t *testing.T) {
 					// To test certain "not equal" filters, such as exact, prefix, and suffix,
 					// it was necessary to use a fixed version of Ubuntu to ensure consistent
 					// library versions.
-					"docker run --rm ubuntu:jammy-20240911.1 more /etc/netconfig",
+					"docker run --rm "+ubuntuJammyPinnedImage+" more /etc/netconfig",
 					0,
 					20*time.Second,
 					// Running the commands inside a container caused duplicate
@@ -1920,7 +1920,7 @@ func Test_EventFilters(t *testing.T) {
 					// To test certain "not equal" filters, such as exact, prefix, and suffix,
 					// it was necessary to use a fixed version of Ubuntu to ensure consistent
 					// library versions.
-					"docker run --rm ubuntu:jammy-20240911.1 sh -c 'cat /etc/netconfig > /tmp/netconfig'",
+					"docker run --rm "+ubuntuJammyPinnedImage+" sh -c 'cat /etc/netconfig > /tmp/netconfig'",
 					0,
 					20*time.Second,
 					// Running the commands inside a container caused duplicate


### PR DESCRIPTION
### 1. Explain what the PR does

162fb9de5 **feat(ci): add action to pre-pull container images**

> - Introduce a new GitHub Action to pre-pull required container images
>   for tests, reducing rate limit issues with Docker Hub.
> - Update the workflow files to include the new action in multiple job
>   configurations.
> - Change image references in various scripts and tests to use ECR Public
>   mirrors for consistency and reliability.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
