### PR TITLE
chore(deps): bump types to 7dc44bdb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45
 	github.com/aquasecurity/tracee/api v0.0.0
 	github.com/aquasecurity/tracee/common v0.0.0
-	github.com/aquasecurity/tracee/types v0.0.0-20251124133010-e9e27afbf5b3
+	github.com/aquasecurity/tracee/types v0.0.0-20251205142631-7dc44bdb801c
 	github.com/containerd/containerd v1.7.29
 	github.com/docker/docker v28.1.1+incompatible
 	github.com/google/gopacket v1.1.19

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45 h1:AjGH0Y/gMhFu73Jr37RoBsIAPiaT8Ufm6LptyEiX6rw=
 github.com/aquasecurity/libbpfgo v0.9.2-libbpf-1.5.1.0.20250826165200-6296a7fa0a45/go.mod h1:mKk/RxlMO0K2HqA4dGLBdfUsvwLYtNhPanHXFPYbw38=
-github.com/aquasecurity/tracee/types v0.0.0-20251124133010-e9e27afbf5b3 h1:7voC+8MZ3R3/yYBrGsQ/n4dU9yIh4ukqvyTb8MHaNA4=
-github.com/aquasecurity/tracee/types v0.0.0-20251124133010-e9e27afbf5b3/go.mod h1:xz2jCxstNfq/ETX4bc1AO/vT3lnIv3LFTUGLTNHVrhM=
+github.com/aquasecurity/tracee/types v0.0.0-20251205142631-7dc44bdb801c h1:z5KtKy9rBKP6Wg8Wuok4AkfD5x86GRsw0URDor2Gxig=
+github.com/aquasecurity/tracee/types v0.0.0-20251205142631-7dc44bdb801c/go.mod h1:jnyVhf+0A1J24eD8DlmNv46yWg5I4TJkHnptkWyPOH8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=


### PR DESCRIPTION
Continuing #5098

### 1. Explain what the PR does

de222e197 **chore(deps): bump types to 7dc44bdb**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
