### PR TITLE
feat(detectors): add enrichment requirement validation

### DIFF
--- a/api/v1beta1/detection/detector.go
+++ b/api/v1beta1/detection/detector.go
@@ -81,6 +81,9 @@ type DetectorRequirements struct {
 	// DataStores lists required datastores with their dependency types
 	DataStores []DataStoreRequirement `yaml:"datastores,omitempty"`
 
+	// Enrichments lists required event enrichment options
+	Enrichments []EnrichmentRequirement `yaml:"enrichments,omitempty"`
+
 	// Architectures lists supported CPU architectures (e.g., "amd64", "arm64")
 	// Empty slice means the detector supports all architectures
 	// Values should use Go's GOARCH format: "amd64" (x86-64), "arm64" (AArch64), etc.
@@ -135,6 +138,20 @@ type DataStoreRequirement struct {
 	// - Required: Registration fails if datastore unavailable
 	// - Optional: Detector handles absence gracefully
 	Dependency DependencyType `yaml:"dependency,omitempty"`
+}
+
+// EnrichmentRequirement specifies a required event enrichment option.
+type EnrichmentRequirement struct {
+	// Name is the enrichment option name: "exec-env", "exec-hash"
+	Name string `yaml:"name"`
+
+	// Dependency controls whether this enrichment is required or optional
+	// Zero value (0) = DependencyRequired (default)
+	Dependency DependencyType `yaml:"dependency,omitempty"`
+
+	// Config contains enrichment-specific configuration (e.g., exec-hash mode)
+	// For exec-hash: "inode", "dev-inode", "digest-inode"
+	Config string `yaml:"config,omitempty"`
 }
 
 // AutoPopulateFields specifies which output event fields the engine should populate.

--- a/pkg/detectors/dispatch_test.go
+++ b/pkg/detectors/dispatch_test.go
@@ -109,7 +109,7 @@ func TestDispatchToDetectors_WithOutput(t *testing.T) {
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
 	policyMgr := newTestPolicyManager(detEventID)
 
-	engine := NewEngine(policyMgr)
+	engine := NewEngine(policyMgr, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -179,7 +179,7 @@ func TestAutoPopulateFields_Threat(t *testing.T) {
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
 	policyMgr := newTestPolicyManager(detEventID)
 
-	engine := NewEngine(policyMgr)
+	engine := NewEngine(policyMgr, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -247,7 +247,7 @@ func TestAutoPopulateFields_DetectedFrom(t *testing.T) {
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
 	policyMgr := newTestPolicyManager(detEventID)
 
-	engine := NewEngine(policyMgr)
+	engine := NewEngine(policyMgr, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -312,7 +312,7 @@ func TestAutoPopulateFields_Combined(t *testing.T) {
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
 	policyMgr := newTestPolicyManager(detEventID)
 
-	engine := NewEngine(policyMgr)
+	engine := NewEngine(policyMgr, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -442,7 +442,7 @@ func TestDispatchWithScopeFilter(t *testing.T) {
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
 	policyMgr := newTestPolicyManager(detEventID)
 
-	engine := NewEngine(policyMgr)
+	engine := NewEngine(policyMgr, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -554,7 +554,7 @@ func TestAutoPopulateFields_ProcessAncestry(t *testing.T) {
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
 	policyMgr := newTestPolicyManager(detEventID)
 
-	engine := NewEngine(policyMgr)
+	engine := NewEngine(policyMgr, nil)
 
 	// Create a registry with process store for testing
 	reg := newTestDataStoreRegistry()

--- a/pkg/detectors/engine.go
+++ b/pkg/detectors/engine.go
@@ -10,19 +10,21 @@ import (
 
 // Engine is the main detector engine that orchestrates registration and dispatch
 type Engine struct {
-	registry   *registry
-	dispatcher *dispatcher
-	metrics    *Metrics
+	registry          *registry
+	dispatcher        *dispatcher
+	metrics           *Metrics
+	enrichmentOptions *EnrichmentOptions
 }
 
 // NewEngine creates a new detector engine
-func NewEngine(policyManager *policy.Manager) *Engine {
-	registry := newRegistry(policyManager)
+func NewEngine(policyManager *policy.Manager, enrichmentOptions *EnrichmentOptions) *Engine {
+	registry := newRegistry(policyManager, enrichmentOptions)
 	metrics := NewMetrics()
 	return &Engine{
-		registry:   registry,
-		dispatcher: newDispatcher(registry, policyManager, metrics),
-		metrics:    metrics,
+		registry:          registry,
+		dispatcher:        newDispatcher(registry, policyManager, metrics),
+		metrics:           metrics,
+		enrichmentOptions: enrichmentOptions,
 	}
 }
 

--- a/pkg/detectors/engine_test.go
+++ b/pkg/detectors/engine_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewEngine(t *testing.T) {
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	require.NotNil(t, engine)
 	assert.NotNil(t, engine.registry)
 	assert.NotNil(t, engine.dispatcher)
@@ -34,7 +34,7 @@ func TestEngine_RegisterDetector(t *testing.T) {
 	_, err := CreateEventsFromDetectors(events.StartDetectorID+10000, []detection.EventDetector{testDetector})
 	require.NoError(t, err)
 
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -45,7 +45,7 @@ func TestEngine_RegisterDetector(t *testing.T) {
 }
 
 func TestEngine_GetDetectorCount(t *testing.T) {
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	assert.Equal(t, 0, engine.GetDetectorCount())
 
 	// Register first detector
@@ -100,7 +100,7 @@ func TestEngine_UnregisterDetector(t *testing.T) {
 	_, err := CreateEventsFromDetectors(events.StartDetectorID+10003, []detection.EventDetector{testDetector})
 	require.NoError(t, err)
 
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -121,7 +121,7 @@ func TestEngine_UnregisterDetector(t *testing.T) {
 }
 
 func TestEngine_ListDetectors(t *testing.T) {
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	assert.Empty(t, engine.ListDetectors())
 
 	// Register detectors
@@ -175,7 +175,7 @@ func TestEngine_GetDetector(t *testing.T) {
 	_, err := CreateEventsFromDetectors(events.StartDetectorID+10006, []detection.EventDetector{testDetector})
 	require.NoError(t, err)
 
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -207,7 +207,7 @@ func TestEngine_EnableDisableDetector(t *testing.T) {
 	_, err := CreateEventsFromDetectors(events.StartDetectorID+10007, []detection.EventDetector{testDetector})
 	require.NoError(t, err)
 
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -246,7 +246,7 @@ func TestEngine_DispatchToDetectors(t *testing.T) {
 	_, err := CreateEventsFromDetectors(events.StartDetectorID+10008, []detection.EventDetector{producingDetector})
 	require.NoError(t, err)
 
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	params := detection.DetectorParams{
 		Config: detection.NewEmptyDetectorConfig(),
 	}
@@ -270,7 +270,7 @@ func TestEngine_DispatchToDetectors(t *testing.T) {
 }
 
 func TestEngine_GetMetrics(t *testing.T) {
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	metrics := engine.GetMetrics()
 	assert.NotNil(t, metrics)
 	assert.NotNil(t, metrics.EventsProcessed)
@@ -280,7 +280,7 @@ func TestEngine_GetMetrics(t *testing.T) {
 }
 
 func TestEngine_RegisterPrometheusMetrics(t *testing.T) {
-	engine := NewEngine(nil)
+	engine := NewEngine(nil, nil)
 	// Just test that it doesn't panic - actual Prometheus registration
 	// might fail in test environment but shouldn't crash
 	err := engine.RegisterPrometheusMetrics()

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -463,7 +463,11 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	}
 
 	// Initialize Detector Engine
-	t.detectorEngine = detectors.NewEngine(t.policyManager)
+	enrichOpts := &detectors.EnrichmentOptions{
+		ExecEnv:      t.config.Output.ExecEnv,
+		ExecHashMode: t.config.Output.CalcHashes,
+	}
+	t.detectorEngine = detectors.NewEngine(t.policyManager, enrichOpts)
 
 	// Register detector metrics if metrics are enabled
 	if t.MetricsEnabled() {


### PR DESCRIPTION
Allow detectors to declare dependencies on enrichment options (exec-env,
exec-hash) via EnrichmentRequirement in their requirements. Registration
fails if required enrichments are not enabled in Tracee's OutputConfig.

Features:
- New EnrichmentRequirement in DetectorRequirements API
- Mode-specific validation for exec-hash (inode, dev-inode, digest-inode)
- Required vs. optional dependency support