### PR TITLE
feat(datastores): add process ancestry retrieval and auto-population

### DIFF
--- a/api/v1beta1/datastores/interfaces.go
+++ b/api/v1beta1/datastores/interfaces.go
@@ -43,17 +43,17 @@ type ProcessStore interface {
 
 	// GetProcess retrieves process information by entity ID
 	// Returns nil, false if the process is not found
-	GetProcess(entityId uint64) (*ProcessInfo, bool)
+	GetProcess(entityId uint32) (*ProcessInfo, bool)
 
 	// GetChildProcesses returns all child processes of the given process
 	// Returns empty slice if no children found
-	GetChildProcesses(entityId uint64) ([]*ProcessInfo, error)
+	GetChildProcesses(entityId uint32) ([]*ProcessInfo, error)
 
 	// GetAncestry retrieves the process ancestry chain up to maxDepth levels
 	// Returns slice of ProcessInfo with [0] = process itself, [1] = parent, [2] = grandparent, etc.
 	// If a parent is not found in the tree, the chain stops there
 	// Returns empty slice if maxDepth <= 0 or process not found
-	GetAncestry(entityId uint64, maxDepth int) ([]*ProcessInfo, error)
+	GetAncestry(entityId uint32, maxDepth int) ([]*ProcessInfo, error)
 }
 
 // ContainerStore provides access to container information

--- a/api/v1beta1/datastores/types.go
+++ b/api/v1beta1/datastores/types.go
@@ -4,14 +4,25 @@ import "time"
 
 // ProcessInfo contains information about a process
 type ProcessInfo struct {
-	EntityID  uint64    // Primary key (hash from ProcessTree) - matches Event.Process.EntityId
-	PID       uint32    // OS process ID (for display/logging)
-	PPID      uint32    // OS parent PID (for display/logging)
+	// Unique identifiers (hashes)
+	UniqueId       uint32 // Process unique ID (hash) - matches protobuf unique_id
+	ParentUniqueId uint32 // Parent process unique ID (hash) - efficient ancestry
+
+	// Process IDs
+	HostPid  uint32 // Host namespace PID (root namespace) - matches protobuf host_pid
+	Pid      uint32 // Process namespace PID (container if containerized) - matches protobuf pid
+	HostPpid uint32 // Host namespace parent PID
+	Ppid     uint32 // Process namespace parent PID
+
+	// Process metadata
 	Name      string    // Binary name only: "bash"
 	Exe       string    // Full path: "/usr/bin/bash"
 	StartTime time.Time // Process start time
-	UID       uint32    // User ID
-	GID       uint32    // Group ID
+	ExitTime  time.Time // Process exit time (zero if still running)
+
+	// User/Group
+	UID uint32 // User ID - matches protobuf real_user.id
+	GID uint32 // Group ID
 	// Phase 2: CmdLine/Args (memory impact)
 }
 

--- a/pkg/datastores/registry_test.go
+++ b/pkg/datastores/registry_test.go
@@ -23,15 +23,15 @@ type mockProcessStore struct {
 	mockDataStore
 }
 
-func (m *mockProcessStore) GetProcess(entityId uint64) (*datastores.ProcessInfo, bool) {
+func (m *mockProcessStore) GetProcess(entityId uint32) (*datastores.ProcessInfo, bool) {
 	return nil, false
 }
 
-func (m *mockProcessStore) GetChildProcesses(entityId uint64) ([]*datastores.ProcessInfo, error) {
+func (m *mockProcessStore) GetChildProcesses(entityId uint32) ([]*datastores.ProcessInfo, error) {
 	return nil, nil
 }
 
-func (m *mockProcessStore) GetAncestry(entityId uint64, maxDepth int) ([]*datastores.ProcessInfo, error) {
+func (m *mockProcessStore) GetAncestry(entityId uint32, maxDepth int) ([]*datastores.ProcessInfo, error) {
 	return nil, nil
 }
 

--- a/pkg/detectors/dispatch.go
+++ b/pkg/detectors/dispatch.go
@@ -233,7 +233,7 @@ func (d *dispatcher) autoPopulateFields(output, input *v1beta1.Event, detector *
 		return // Already populated by detector
 	}
 
-	entityId := uint64(output.Workload.Process.UniqueId.GetValue())
+	entityId := output.Workload.Process.UniqueId.GetValue()
 	if entityId == 0 || detector.params.DataStores == nil {
 		return
 	}
@@ -249,9 +249,9 @@ func (d *dispatcher) autoPopulateFields(output, input *v1beta1.Event, detector *
 	output.Workload.Process.Ancestors = make([]*v1beta1.Process, 0, len(ancestry)-1)
 	for _, ancestor := range ancestry[1:] {
 		proc := &v1beta1.Process{
-			UniqueId: &wrapperspb.UInt32Value{Value: uint32(ancestor.EntityID)},
-			HostPid:  &wrapperspb.UInt32Value{Value: ancestor.PID},
-			Pid:      &wrapperspb.UInt32Value{Value: ancestor.PID},
+			UniqueId: &wrapperspb.UInt32Value{Value: ancestor.UniqueId},
+			HostPid:  &wrapperspb.UInt32Value{Value: ancestor.HostPid},
+			Pid:      &wrapperspb.UInt32Value{Value: ancestor.Pid},
 		}
 
 		// Populate thread with process name (comm)


### PR DESCRIPTION
Add GetAncestry() method to ProcessStore interface for retrieving process
ancestry chains up to a specified depth. Integrate with detector engine's
auto-population framework to automatically populate ancestor information.

**Commit 1: datastores: add GetAncestry() method to ProcessStore**
- Add GetAncestry(entityId, maxDepth) to ProcessStore interface
- Implementation walks parent chain with circular reference detection
- Returns [0]=self, [1]=parent, [2]=grandparent, etc.
- Gracefully handles missing parents and bounded depth
- Comprehensive unit tests (72 lines)

**Commit 2: detectors: wire GetAncestry() into auto-population**
- Implement ProcessAncestry auto-population in dispatcher
- Queries up to 5 ancestor levels when AutoPopulate.ProcessAncestry = true
- Converts datastores.ProcessInfo to v1beta1.Process format
- Respects manual overrides (only populates if Ancestors empty)
- End-to-end integration test

**Benefits:**
- Enables detectors to analyze process lineage for threat detection
- Opt-in design minimizes performance impact
- Bounded depth (5 levels) prevents resource exhaustion
- Fail-safe: errors don't break detection pipeline