### PR TITLE
fix(detectors): data filters bypassed due to kernel filtering optimiz…

### DIFF
--- a/pkg/detectors/registry.go
+++ b/pkg/detectors/registry.go
@@ -369,7 +369,7 @@ func (r *registry) RegisterDetector(
 			// Get or create data filter for this event ID
 			dataFilter, exists := dataFilters[reqEventID]
 			if !exists {
-				dataFilter = filters.NewDataFilter()
+				dataFilter = filters.NewDetectorDataFilter() // Use detector-specific filter
 				dataFilters[reqEventID] = dataFilter
 			}
 


### PR DESCRIPTION
…ation

Detector data filters were skipped when DataFilter enabled kernel filtering mode for pathname fields. Detectors lack kernel-side filtering, so userspace filtering must always run.

Add skipKernelFilter flag to DataFilter and NewDetectorDataFilter() constructor. Detector registry now uses NewDetectorDataFilter() to ensure filters are always applied in userspace.
