### PR TITLE
feat(datastores): standardize error returns and document nil contract

### DIFF
--- a/api/v1beta1/datastores/interfaces.go
+++ b/api/v1beta1/datastores/interfaces.go
@@ -42,8 +42,8 @@ type ProcessStore interface {
 	DataStore
 
 	// GetProcess retrieves process information by entity ID
-	// Returns nil, false if the process is not found
-	GetProcess(entityId uint32) (*ProcessInfo, bool)
+	// Returns ErrNotFound if the process is not found
+	GetProcess(entityId uint32) (*ProcessInfo, error)
 
 	// GetChildProcesses returns all child processes of the given process
 	// Returns empty slice if no children found
@@ -61,12 +61,12 @@ type ContainerStore interface {
 	DataStore
 
 	// GetContainer retrieves container information by container ID
-	// Returns nil, false if the container is not found
-	GetContainer(id string) (*ContainerInfo, bool)
+	// Returns ErrNotFound if the container is not found
+	GetContainer(id string) (*ContainerInfo, error)
 
 	// GetContainerByName retrieves container information by container name
-	// Returns nil, false if no container with that name is found
-	GetContainerByName(name string) (*ContainerInfo, bool)
+	// Returns ErrNotFound if no container with that name is found
+	GetContainerByName(name string) (*ContainerInfo, error)
 }
 
 // KernelSymbolStore provides access to kernel symbol information
@@ -95,8 +95,8 @@ type DNSStore interface {
 	DataStore
 
 	// GetDNSResponse retrieves cached DNS response for a query
-	// Returns nil, false if no cached response is found
-	GetDNSResponse(query string) (*DNSResponse, bool)
+	// Returns ErrNotFound if no cached response is found
+	GetDNSResponse(query string) (*DNSResponse, error)
 }
 
 // SystemStore provides access to immutable system information
@@ -113,12 +113,12 @@ type SyscallStore interface {
 	DataStore
 
 	// GetSyscallName returns the syscall name for a given ID
-	// Returns empty string and false if the syscall ID is not found
+	// Returns ErrNotFound if the syscall ID is not found
 	// Note: Syscall IDs are architecture-specific (x86 vs ARM)
-	GetSyscallName(id int32) (string, bool)
+	GetSyscallName(id int32) (string, error)
 
 	// GetSyscallID returns the syscall ID for a given name
-	// Returns 0 and false if the syscall name is not found
+	// Returns ErrNotFound if the syscall name is not found
 	// Note: Syscall IDs are architecture-specific (x86 vs ARM)
-	GetSyscallID(name string) (int32, bool)
+	GetSyscallID(name string) (int32, error)
 }

--- a/api/v1beta1/datastores/registry.go
+++ b/api/v1beta1/datastores/registry.go
@@ -1,23 +1,46 @@
 package datastores
 
 // Registry provides unified access to all datastores
+//
+// IMPORTANT: All datastore accessor methods (Processes, Containers, etc.)
+// always return a non-nil store instance, even if the store is unavailable
+// or disabled. Use IsAvailable() or check store.GetHealth() to verify
+// availability before use.
+//
+// Example checking availability:
+//
+//	registry := params.DataStores
+//	if !registry.IsAvailable("process") {
+//	    return errors.New("process store required but unavailable")
+//	}
+//	procStore := registry.Processes()  // Never nil
+//	proc, err := procStore.GetProcess(entityId)
+//	if errors.Is(err, ErrNotFound) {
+//	    // Process not found
+//	}
 type Registry interface {
 	// Processes returns the process datastore
+	// Never returns nil - check IsAvailable("process") for availability
 	Processes() ProcessStore
 
 	// Containers returns the container datastore
+	// Never returns nil - check IsAvailable("container") for availability
 	Containers() ContainerStore
 
 	// KernelSymbols returns the kernel symbol datastore
+	// Never returns nil - check IsAvailable("symbol") for availability
 	KernelSymbols() KernelSymbolStore
 
 	// DNS returns the DNS cache datastore
+	// Never returns nil - check IsAvailable("dns") for availability
 	DNS() DNSStore
 
 	// System returns the system information datastore
+	// Never returns nil - check IsAvailable("system") for availability
 	System() SystemStore
 
 	// Syscalls returns the syscall information datastore
+	// Never returns nil - check IsAvailable("syscall") for availability
 	Syscalls() SyscallStore
 
 	// GetCustom retrieves a custom datastore by name

--- a/pkg/datastores/container/store.go
+++ b/pkg/datastores/container/store.go
@@ -75,7 +75,7 @@ func (m *Manager) GetMetrics() *datastores.DataStoreMetrics {
 // ContainerStore interface implementation
 
 // GetContainer retrieves container information by container ID
-func (m *Manager) GetContainer(id string) (*datastores.ContainerInfo, bool) {
+func (m *Manager) GetContainer(id string) (*datastores.ContainerInfo, error) {
 	m.lastAccessNano.Store(time.Now().UnixNano())
 
 	m.lock.RLock()
@@ -83,14 +83,14 @@ func (m *Manager) GetContainer(id string) (*datastores.ContainerInfo, bool) {
 	m.lock.RUnlock()
 
 	if !ok {
-		return nil, false
+		return nil, datastores.ErrNotFound
 	}
 
-	return convertContainer(&cont), true
+	return convertContainer(&cont), nil
 }
 
 // GetContainerByName retrieves container information by container name
-func (m *Manager) GetContainerByName(name string) (*datastores.ContainerInfo, bool) {
+func (m *Manager) GetContainerByName(name string) (*datastores.ContainerInfo, error) {
 	m.lastAccessNano.Store(time.Now().UnixNano())
 
 	m.lock.RLock()
@@ -107,10 +107,10 @@ func (m *Manager) GetContainerByName(name string) (*datastores.ContainerInfo, bo
 	m.lock.RUnlock()
 
 	if foundCont == nil {
-		return nil, false
+		return nil, datastores.ErrNotFound
 	}
 
-	return convertContainer(foundCont), true
+	return convertContainer(foundCont), nil
 }
 
 // convertContainer converts internal Container to public ContainerInfo

--- a/pkg/datastores/container/store_test.go
+++ b/pkg/datastores/container/store_test.go
@@ -39,14 +39,14 @@ func TestManager_DataStoreInterface(t *testing.T) {
 	})
 
 	t.Run("GetContainer_NotFound", func(t *testing.T) {
-		info, found := mgr.GetContainer("nonexistent")
-		assert.False(t, found)
+		info, err := mgr.GetContainer("nonexistent")
+		assert.ErrorIs(t, err, datastores.ErrNotFound)
 		assert.Nil(t, info)
 	})
 
 	t.Run("GetContainerByName_NotFound", func(t *testing.T) {
-		info, found := mgr.GetContainerByName("nonexistent")
-		assert.False(t, found)
+		info, err := mgr.GetContainerByName("nonexistent")
+		assert.ErrorIs(t, err, datastores.ErrNotFound)
 		assert.Nil(t, info)
 	})
 }

--- a/pkg/datastores/dns/store.go
+++ b/pkg/datastores/dns/store.go
@@ -72,17 +72,17 @@ func (nc *DNSCache) GetMetrics() *datastores.DataStoreMetrics {
 // DNSStore interface implementation
 
 // GetDNSResponse retrieves cached DNS response for a query
-func (nc *DNSCache) GetDNSResponse(query string) (*datastores.DNSResponse, bool) {
+func (nc *DNSCache) GetDNSResponse(query string) (*datastores.DNSResponse, error) {
 	nc.lastAccessNano.Store(time.Now().UnixNano())
 
 	result, err := nc.Get(query)
 	if err != nil {
-		return nil, false
+		return nil, datastores.ErrNotFound
 	}
 
 	return &datastores.DNSResponse{
 		Query:   query,
 		IPs:     result.IPResults(),
 		Domains: result.DNSResults(),
-	}, true
+	}, nil
 }

--- a/pkg/datastores/dns/store_test.go
+++ b/pkg/datastores/dns/store_test.go
@@ -37,8 +37,8 @@ func TestDNSCache_DataStoreInterface(t *testing.T) {
 	})
 
 	t.Run("GetDNSResponse_NotFound", func(t *testing.T) {
-		resp, found := cache.GetDNSResponse("nonexistent.example.com")
-		assert.False(t, found)
+		resp, err := cache.GetDNSResponse("nonexistent.example.com")
+		assert.ErrorIs(t, err, datastores.ErrNotFound)
 		assert.Nil(t, resp)
 	})
 

--- a/pkg/datastores/process/store.go
+++ b/pkg/datastores/process/store.go
@@ -92,13 +92,13 @@ func (pt *ProcessTree) GetMetrics() *datastores.DataStoreMetrics {
 // ProcessStore interface implementation
 
 // GetProcess retrieves process information by entity ID (hash)
-func (pt *ProcessTree) GetProcess(entityId uint32) (*datastores.ProcessInfo, bool) {
+func (pt *ProcessTree) GetProcess(entityId uint32) (*datastores.ProcessInfo, error) {
 	pt.lastAccessNano.Store(time.Now().UnixNano())
 
 	hash := entityId
 	proc, ok := pt.GetProcessByHash(hash)
 	if !ok {
-		return nil, false
+		return nil, datastores.ErrNotFound
 	}
 
 	info := proc.GetInfo()
@@ -119,7 +119,7 @@ func (pt *ProcessTree) GetProcess(entityId uint32) (*datastores.ProcessInfo, boo
 		ExitTime:  info.GetExitTime(),
 		UID:       info.GetUid(),
 		GID:       info.GetGid(),
-	}, true
+	}, nil
 }
 
 // GetChildProcesses returns all child processes of the given process
@@ -139,7 +139,7 @@ func (pt *ProcessTree) GetChildProcesses(entityId uint32) ([]*datastores.Process
 
 	children := make([]*datastores.ProcessInfo, 0, len(childrenMap))
 	for childHash := range childrenMap {
-		if childInfo, ok := pt.GetProcess(childHash); ok {
+		if childInfo, err := pt.GetProcess(childHash); err == nil {
 			children = append(children, childInfo)
 		}
 	}

--- a/pkg/datastores/process/store_test.go
+++ b/pkg/datastores/process/store_test.go
@@ -40,8 +40,8 @@ func TestProcessTree_DataStoreInterface(t *testing.T) {
 	})
 
 	t.Run("GetProcess_NotFound", func(t *testing.T) {
-		info, found := pt.GetProcess(999999)
-		assert.False(t, found)
+		info, err := pt.GetProcess(999999)
+		assert.ErrorIs(t, err, datastores.ErrNotFound)
 		assert.Nil(t, info)
 	})
 
@@ -170,8 +170,8 @@ func TestProcessStore_GetAncestry(t *testing.T) {
 		}
 		proc.GetInfo().SetFeed(feed)
 
-		info, ok := pt.GetProcess(uint32(999))
-		require.True(t, ok)
+		info, err := pt.GetProcess(uint32(999))
+		require.NoError(t, err)
 		assert.NotZero(t, info.ExitTime, "ExitTime should be populated")
 	})
 }

--- a/pkg/datastores/registry_test.go
+++ b/pkg/datastores/registry_test.go
@@ -26,8 +26,8 @@ type mockProcessStore struct {
 	mockDataStore
 }
 
-func (m *mockProcessStore) GetProcess(entityId uint32) (*datastores.ProcessInfo, bool) {
-	return nil, false
+func (m *mockProcessStore) GetProcess(entityId uint32) (*datastores.ProcessInfo, error) {
+	return nil, datastores.ErrNotFound
 }
 
 func (m *mockProcessStore) GetChildProcesses(entityId uint32) ([]*datastores.ProcessInfo, error) {
@@ -43,12 +43,12 @@ type mockContainerStore struct {
 	mockDataStore
 }
 
-func (m *mockContainerStore) GetContainer(id string) (*datastores.ContainerInfo, bool) {
-	return nil, false
+func (m *mockContainerStore) GetContainer(id string) (*datastores.ContainerInfo, error) {
+	return nil, datastores.ErrNotFound
 }
 
-func (m *mockContainerStore) GetContainerByName(name string) (*datastores.ContainerInfo, bool) {
-	return nil, false
+func (m *mockContainerStore) GetContainerByName(name string) (*datastores.ContainerInfo, error) {
+	return nil, datastores.ErrNotFound
 }
 
 func TestRegistry_RegisterStore(t *testing.T) {

--- a/pkg/datastores/syscall/store.go
+++ b/pkg/datastores/syscall/store.go
@@ -48,36 +48,36 @@ func (s *Store) GetMetrics() *datastores.DataStoreMetrics {
 }
 
 // GetSyscallName returns the syscall name for a given ID
-// Returns empty string and false if the syscall ID is not found or is not a syscall
-func (s *Store) GetSyscallName(id int32) (string, bool) {
+// Returns ErrNotFound if the syscall ID is not found or is not a syscall
+func (s *Store) GetSyscallName(id int32) (string, error) {
 	def := s.eventCore.GetDefinitionByID(events.ID(id))
 
 	// Check if definition was found (Undefined means not found)
 	if def.GetID() == events.Undefined {
-		return "", false
+		return "", datastores.ErrNotFound
 	}
 
 	// Only return name if this is actually a syscall
 	if !def.IsSyscall() {
-		return "", false
+		return "", datastores.ErrNotFound
 	}
 
-	return def.GetName(), true
+	return def.GetName(), nil
 }
 
 // GetSyscallID returns the syscall ID for a given name
-// Returns 0 and false if the syscall name is not found or is not a syscall
-func (s *Store) GetSyscallID(name string) (int32, bool) {
+// Returns ErrNotFound if the syscall name is not found or is not a syscall
+func (s *Store) GetSyscallID(name string) (int32, error) {
 	id, found := s.eventCore.GetDefinitionIDByName(name)
 	if !found {
-		return 0, false
+		return 0, datastores.ErrNotFound
 	}
 
 	// Verify this is actually a syscall
 	def := s.eventCore.GetDefinitionByID(id)
 	if def.GetID() == events.Undefined || !def.IsSyscall() {
-		return 0, false
+		return 0, datastores.ErrNotFound
 	}
 
-	return int32(id), true
+	return int32(id), nil
 }


### PR DESCRIPTION
- Change all datastore query methods to return (value, error) pattern
- Return datastores.ErrNotFound instead of (nil, false)
- Document that Registry accessors never return nil stores
- Update all datastore implementations and tests
