### PR TITLE
docs: add detector and datastore developer documentation

### DIFF
--- a/docs/docs/detectors/api-reference.md
+++ b/docs/docs/detectors/api-reference.md
@@ -1,0 +1,1978 @@
+# Detector API Reference
+
+Complete reference documentation for the Tracee Detector API. This guide documents all interfaces, structures, and features for writing custom detectors.
+
+**New to detectors?** Start with the [Quick Start Guide](quickstart.md) first.
+
+## Table of Contents
+
+1. [Core Interfaces](#core-interfaces)
+2. [DetectorDefinition](#detectordefinition)
+3. [Detector Requirements](#detector-requirements)
+4. [DetectorOutput](#detectoroutput)
+5. [Auto-Population](#auto-population)
+6. [Lifecycle Management](#lifecycle-management)
+7. [Testing](#testing)
+8. [Best Practices](#best-practices)
+
+---
+
+## Core Interfaces
+
+### EventDetector Interface
+
+All detectors must implement this interface:
+
+{% raw %}
+```go
+type EventDetector interface {
+    // GetDefinition returns the detector's metadata and requirements
+    // Called once during registration - result is cached
+    GetDefinition() DetectorDefinition
+
+    // Init is called once at startup with shared resources
+    // Use this to store logger, datastores, and initialize state
+    Init(params DetectorParams) error
+
+    // OnEvent processes each matching event
+    // Return one or more DetectorOutput, nil for no detection, or error
+    OnEvent(ctx context.Context, event *v1beta1.Event) ([]DetectorOutput, error)
+}
+```
+{% endraw %}
+
+### DetectorParams
+
+Provided to `Init()` with shared resources:
+
+{% raw %}
+```go
+type DetectorParams struct {
+    Logger     Logger                 // Structured logger (zap-based)
+    DataStores datastores.Registry    // Access to all datastores
+    Config     DetectorConfig         // Detector-specific configuration
+}
+```
+{% endraw %}
+
+**Example**:
+{% raw %}
+```go
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+    d.logger = params.Logger
+    d.dataStores = params.DataStores
+
+    // Check required datastore availability
+    if !params.DataStores.IsAvailable("process") {
+        return errors.New("process store required but unavailable")
+    }
+
+    d.logger.Debugw("Detector initialized", "id", d.GetDefinition().ID)
+    return nil
+}
+```
+{% endraw %}
+
+---
+
+## DetectorDefinition
+
+### Complete Structure
+
+{% raw %}
+```go
+type DetectorDefinition struct {
+    // Unique identifier (required)
+    ID string
+
+    // Event and datastore requirements (required)
+    Requirements DetectorRequirements
+
+    // Output event specification (required)
+    ProducedEvent v1beta1.EventDefinition
+
+    // Default threat metadata (optional, recommended for threats)
+    ThreatMetadata *v1beta1.Threat
+
+    // Auto-population configuration (optional, recommended)
+    AutoPopulate AutoPopulateFields
+}
+```
+{% endraw %}
+
+### Detector ID Conventions
+
+Choose an appropriate ID format:
+
+**Threat Detectors** (TRC-XXX):
+{% raw %}
+```go
+ID: "TRC-001"  // Sensitive file access
+ID: "TRC-014"  // Process injection detection
+```
+{% endraw %}
+
+**Derived Events** (DRV-XXX):
+{% raw %}
+```go
+ID: "DRV-001"  // Container lifecycle events
+ID: "DRV-003"  // Hooked syscall detector
+```
+{% endraw %}
+
+**Custom/Vendor** (VENDOR-XXX):
+{% raw %}
+```go
+ID: "ACME-001"  // Custom company detection
+```
+{% endraw %}
+
+### ProducedEvent: Event Definition
+
+Defines the event your detector produces:
+
+{% raw %}
+```go
+ProducedEvent: v1beta1.EventDefinition{
+    Name:        "my_detection",           // Required: unique snake_case name
+    Description: "Detailed description",    // Required: clear explanation
+    Version:     &v1beta1.Version{         // Required: semantic version
+        Major: 1,
+        Minor: 0,
+        Patch: 0,
+    },
+    Fields: []*v1beta1.EventField{         // Required: output fields schema
+        {
+            Name: "field_name",
+            Type: "const char*",            // Type for display/docs
+        },
+    },
+    Tags: []string{"security", "file"},    // Optional: categorization
+}
+```
+{% endraw %}
+
+**Field Types** (documentation only):
+
+- `const char*` - String
+- `int`, `u32`, `u64` - Integers
+- `bool` - Boolean
+- Custom types for complex data
+
+**Example with all fields**:
+{% raw %}
+```go
+ProducedEvent: v1beta1.EventDefinition{
+    Name:        "suspicious_shell_execution",
+    Description: "Detects suspicious shell command execution patterns",
+    Version:     &v1beta1.Version{Major: 1, Minor: 2, Patch: 0},
+    Fields: []*v1beta1.EventField{
+        {Name: "command", Type: "const char*"},
+        {Name: "shell_type", Type: "const char*"},
+        {Name: "risk_score", Type: "int"},
+        {Name: "indicators", Type: "const char*[]"},
+    },
+    Tags: []string{"execution", "defense-evasion"},
+}
+```
+{% endraw %}
+
+### ThreatMetadata: Threat Template
+
+Default threat information, copied to outputs when `AutoPopulate.Threat=true`:
+
+{% raw %}
+```go
+ThreatMetadata: &v1beta1.Threat{
+    Name:        "Short threat name",
+    Description: "Detailed threat description",
+    Severity:    v1beta1.Severity_MEDIUM,
+    Signature: &v1beta1.ThreatSignature{
+        ID:   "MITRE T1055",
+        Name: "Process Injection",
+    },
+    Mitre: &v1beta1.MitreAttack{
+        Tactic:     []string{"Defense Evasion", "Privilege Escalation"},
+        Technique:  []string{"T1055"},
+        SubTechnique: []string{"T1055.001"},
+    },
+}
+```
+{% endraw %}
+
+**Severity Levels**:
+
+- `Severity_INFO` - Informational events
+- `Severity_LOW` - Low-risk threats
+- `Severity_MEDIUM` - Moderate threats (default for most detections)
+- `Severity_HIGH` - Serious threats requiring immediate attention
+- `Severity_CRITICAL` - Critical threats (data exfiltration, rootkits)
+
+**Override per detection**:
+{% raw %}
+```go
+return []detection.DetectorOutput{{
+    Data: data,
+    Threat: &v1beta1.Threat{
+        Name:     "Critical System Compromise",
+        Severity: v1beta1.Severity_CRITICAL,  // Override default MEDIUM
+    },
+}}, nil
+```
+{% endraw %}
+
+---
+
+## Detector Requirements
+
+### DetectorRequirements Structure
+
+Declare what your detector needs:
+
+{% raw %}
+```go
+type DetectorRequirements struct {
+    // Events lists the events this detector needs to receive
+    Events []EventRequirement
+
+    // DataStores lists required datastores with their dependency types
+    DataStores []DataStoreRequirement
+
+    // Enrichments lists required event enrichment options
+    Enrichments []EnrichmentRequirement
+
+    // Architectures lists supported CPU architectures (empty = all)
+    Architectures []string
+
+    // MinTraceeVersion specifies minimum Tracee version (optional, inclusive)
+    MinTraceeVersion *v1beta1.Version
+
+    // MaxTraceeVersion specifies maximum Tracee version (optional, exclusive)
+    MaxTraceeVersion *v1beta1.Version
+}
+```
+{% endraw %}
+
+### EventRequirement Structure
+
+Declare which events your detector needs:
+
+{% raw %}
+```go
+type EventRequirement struct {
+    Name             string            // Event name (required)
+    DataFilters      []string          // Filter by event data (optional)
+    ScopeFilters     []string          // Filter by origin (optional)
+    MinVersion       *v1beta1.Version  // Minimum event version (optional)
+    MaxVersion       *v1beta1.Version  // Maximum event version (optional, exclusive)
+    Dependency       DependencyType    // Required vs optional (optional, default Required)
+}
+```
+{% endraw %}
+
+### Basic Requirements
+
+{% raw %}
+```go
+Requirements: detection.DetectorRequirements{
+    Events: []detection.EventRequirement{
+        {Name: "security_file_open"},
+        {Name: "security_inode_unlink"},
+    },
+}
+```
+{% endraw %}
+
+### DataFilters: Filtering Event Data
+
+Engine-level filtering - only matching events reach your detector:
+
+{% raw %}
+```go
+{
+    Name: "security_file_open",
+    DataFilters: []string{
+        "pathname=/etc/shadow",          // Exact match
+        "pathname=/etc/sudoers",          // OR condition
+    },
+}
+```
+{% endraw %}
+
+**Filter operators**:
+{% raw %}
+```go
+"field=value"       // Exact match
+"field=/path/*"     // Glob pattern (*, ?)
+"field!=value"      // Not equal
+"field>100"         // Greater than (numeric)
+"field<100"         // Less than (numeric)
+"field>=100"        // Greater or equal
+"field<=100"        // Less or equal
+```
+{% endraw %}
+
+**Multiple filters** (AND logic):
+{% raw %}
+```go
+DataFilters: []string{
+    "pathname=/tmp/*",       // Must match /tmp/*
+    "flags>0",               // AND flags > 0
+}
+```
+{% endraw %}
+
+**Common patterns**:
+{% raw %}
+```go
+// Sensitive paths
+DataFilters: []string{
+    "pathname=/etc/shadow",
+    "pathname=/etc/passwd",
+    "pathname=/root/.ssh/*",
+}
+
+// Specific flags
+DataFilters: []string{
+    "flags=0x80000",  // O_CLOEXEC
+}
+
+// Suspicious syscalls
+DataFilters: []string{
+    "syscall=ptrace",
+    "syscall=process_vm_writev",
+}
+```
+{% endraw %}
+
+### ScopeFilters: Filtering by Origin
+
+Filter by where events originated:
+
+{% raw %}
+```go
+{
+    Name: "security_file_open",
+    ScopeFilters: []string{
+        "container=started",  // Only containers
+    },
+}
+```
+{% endraw %}
+
+**Scope options**:
+{% raw %}
+```go
+"container=started"      // Only from containers
+"not-container"          // Only from host (not containers)
+"pid=1000"              // Specific PID
+"pid!=1"                // Exclude init process
+```
+{% endraw %}
+
+### Event Version Constraints
+
+Require minimum event version:
+
+{% raw %}
+```go
+{
+    Name: "security_bprm_check",
+    MinVersion: &v1beta1.Version{
+        Major: 2,
+        Minor: 1,
+    },
+}
+```
+{% endraw %}
+
+### Required vs Optional Events
+
+{% raw %}
+```go
+type DependencyType int
+
+const (
+    DependencyRequired DependencyType = iota  // Detector fails if event unavailable
+    DependencyOptional                         // Detector works without event
+)
+```
+{% endraw %}
+
+**Example**:
+{% raw %}
+```go
+Events: []detection.EventRequirement{
+    {
+        Name:       "security_file_open",
+        Dependency: detection.DependencyRequired,  // Must have
+    },
+    {
+        Name:       "hooked_syscalls",
+        Dependency: detection.DependencyOptional,  // Nice to have
+    },
+}
+```
+{% endraw %}
+
+### DataStore Requirements
+
+Declare datastore dependencies:
+
+{% raw %}
+```go
+type DataStoreRequirement struct {
+    Name       string          // Datastore name
+    Dependency DependencyType  // Required vs optional
+}
+```
+{% endraw %}
+
+**Available datastores**:
+
+- `process` - Process tree and ancestry
+- `container` - Container metadata
+- `dns` - DNS cache
+- `system` - System information
+- `syscall` - Syscall mappings
+- `symbol` - Kernel symbols
+
+**Example**:
+{% raw %}
+```go
+Requirements: detection.DetectorRequirements{
+    Events: []detection.EventRequirement{
+        {Name: "security_file_open"},
+    },
+    DataStores: []detection.DataStoreRequirement{
+        {Name: "process", Dependency: detection.DependencyRequired},
+        {Name: "container", Dependency: detection.DependencyOptional},
+    },
+}
+```
+{% endraw %}
+
+### Enrichment Requirements
+
+Request specific data enrichments on input events:
+
+{% raw %}
+```go
+type EnrichmentRequirement struct {
+    Name       string          // Enrichment option name
+    Dependency DependencyType  // Required vs optional
+    Config     string          // Enrichment-specific config (optional)
+}
+```
+{% endraw %}
+
+**Available enrichments**:
+
+- `exec-env` - Execution environment variables
+- `exec-hash` - Executable file hashes (Config: "inode", "dev-inode", "digest-inode")
+
+**Example**:
+{% raw %}
+```go
+DetectorDefinition{
+    ID: "TRC-001",
+    Requirements: detection.DetectorRequirements{
+        Enrichments: []detection.EnrichmentRequirement{
+            {
+                Name:       "exec-hash",
+                Config:     "digest-inode",
+                Dependency: detection.DependencyRequired,
+            },
+        },
+    },
+}
+```
+{% endraw %}
+
+### Architecture Filtering
+
+Restrict detector to specific CPU architectures (rarely needed):
+
+{% raw %}
+```go
+DetectorDefinition{
+    ID: "TRC-X86-001",
+    Requirements: detection.DetectorRequirements{
+        Architectures: []string{"amd64"},  // Only x86-64
+        // ... rest of requirements
+    },
+}
+```
+{% endraw %}
+
+**Supported architectures**:
+
+- `amd64` (x86-64)
+- `arm64` (AArch64)
+
+**Default**: Empty slice (or omit field) means the detector supports all architectures.
+
+**When to use**: Only when your detector uses architecture-specific logic or syscalls that don't exist on all platforms.
+
+### Tracee Version Constraints
+
+Require minimum/maximum Tracee version:
+
+{% raw %}
+```go
+DetectorDefinition{
+    ID: "TRC-NEW-001",
+    Requirements: detection.DetectorRequirements{
+        MinTraceeVersion: &v1beta1.Version{
+            Major: 0,
+            Minor: 20,
+            Patch: 0,
+        },
+        // MaxTraceeVersion is optional (exclusive)
+    },
+}
+```
+{% endraw %}
+
+**When to use**: Your detector relies on features introduced in specific Tracee versions.
+
+### Complete Requirements Example
+
+Putting it all together - a detector with all requirement types:
+
+{% raw %}
+```go
+DetectorDefinition{
+    ID: "TRC-COMPREHENSIVE-001",
+
+    Requirements: detection.DetectorRequirements{
+        // Event requirements with filters
+        Events: []detection.EventRequirement{
+            {
+                Name: "security_file_open",
+                DataFilters: []string{
+                    "pathname=/etc/shadow",
+                    "pathname=/etc/sudoers",
+                    "pathname=/root/.ssh/*",
+                },
+                ScopeFilters: []string{
+                    "container=started",  // Containers only
+                },
+                MinVersion:  &v1beta1.Version{Major: 1, Minor: 5},
+                Dependency:  detection.DependencyRequired,
+            },
+            {
+                Name:       "security_inode_unlink",
+                DataFilters: []string{"pathname=/var/log/*"},
+                Dependency:  detection.DependencyOptional,
+            },
+        },
+
+        // Datastore requirements
+        DataStores: []detection.DataStoreRequirement{
+            {Name: "process", Dependency: detection.DependencyRequired},
+            {Name: "container", Dependency: detection.DependencyOptional},
+        },
+
+        // Enrichment requirements
+        Enrichments: []detection.EnrichmentRequirement{
+            {
+                Name:       "exec-hash",
+                Config:     "digest-inode",
+                Dependency: detection.DependencyRequired,
+            },
+            {
+                Name:       "exec-env",
+                Dependency: detection.DependencyOptional,
+            },
+        },
+
+        // Architecture constraints (rarely needed)
+        Architectures: []string{"amd64", "arm64"},
+
+        // Version constraints (if detector uses new features)
+        MinTraceeVersion: &v1beta1.Version{
+            Major: 0,
+            Minor: 20,
+            Patch: 0,
+        },
+        // MaxTraceeVersion is optional (exclusive upper bound)
+    },
+
+    // ... rest of definition (ProducedEvent, ThreatMetadata, etc.)
+}
+```
+{% endraw %}
+
+---
+
+## DetectorOutput
+
+### Structure
+
+What your `OnEvent()` returns:
+
+{% raw %}
+```go
+type DetectorOutput struct {
+    // Event data fields (required) - corresponds to ProducedEvent.Fields
+    Data []*v1beta1.EventValue
+
+    // Override auto-population settings for this output (optional)
+    // If nil, uses Definition.AutoPopulate
+    AutoPopulate *AutoPopulateFields
+
+    // Override threat metadata (optional) - overrides Definition.ThreatMetadata
+    Threat *v1beta1.Threat
+
+    // Override ancestry depth (optional) - overrides AutoPopulate.ProcessAncestry
+    AncestryDepth *uint32
+}
+```
+{% endraw %}
+
+### Creating Event Data
+
+Use helper functions to create type-safe event values:
+
+{% raw %}
+```go
+// String values
+v1beta1.NewStringValue("field_name", "value")
+
+// Integer values
+v1beta1.NewInt32Value("count", int32(42))
+v1beta1.NewInt64Value("count", int64(42))
+v1beta1.NewUInt32Value("flags", uint32(0x1234))
+v1beta1.NewUInt64Value("flags", uint64(0x1234))
+
+// Boolean values
+v1beta1.NewBoolValue("is_suspicious", true)
+
+// Byte array values
+v1beta1.NewBytesValue("data", []byte{0x01, 0x02})
+
+// Complex example
+return []detection.DetectorOutput{{
+    Data: []*v1beta1.EventValue{
+        v1beta1.NewStringValue("command", "/bin/bash -c 'curl evil.com'"),
+        v1beta1.NewStringValue("shell", "bash"),
+        v1beta1.NewInt32Value("risk_score", int32(85)),
+        v1beta1.NewBoolValue("known_ioc", true),
+    },
+}}, nil
+```
+{% endraw %}
+
+### Multiple Outputs
+
+Return multiple detections from a single input:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    var outputs []detection.DetectorOutput
+
+    if condition1 {
+        outputs = append(outputs, detection.DetectorOutput{
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("type", "pattern_a"),
+            },
+        })
+    }
+
+    if condition2 {
+        outputs = append(outputs, detection.DetectorOutput{
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("type", "pattern_b"),
+            },
+            Threat: &v1beta1.Threat{
+                Severity: v1beta1.Severity_HIGH,  // Different severity
+            },
+        })
+    }
+
+    return outputs, nil
+}
+```
+{% endraw %}
+
+### No Detection
+
+Return `nil, nil` when no detection occurred:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    value, found := v1beta1.GetData[string](event, "field")
+    if !found || !d.isSuspicious(value) {
+        return nil, nil  // No detection
+    }
+
+    return []detection.DetectorOutput{{...}}, nil
+}
+```
+{% endraw %}
+
+---
+
+## Auto-Population
+
+Declaratively specify automatic field enrichment:
+
+{% raw %}
+```go
+type AutoPopulateFields struct {
+    Threat          bool  // Copy ThreatMetadata to output
+    DetectedFrom    bool  // Link to triggering event
+    ProcessAncestry bool  // Fetch 5 levels of process ancestry
+}
+```
+{% endraw %}
+
+### Threat: Automatic Threat Metadata
+
+{% raw %}
+```go
+AutoPopulate: detection.AutoPopulateFields{
+    Threat: true,
+}
+```
+{% endraw %}
+
+**Behavior**:
+
+- If `output.Threat` is nil, engine copies `Definition.ThreatMetadata`
+- If `output.Threat` is set, that takes precedence
+- `Definition.ThreatMetadata` acts as a template/default
+
+**Example**:
+{% raw %}
+```go
+// In definition
+ThreatMetadata: &v1beta1.Threat{
+    Name:     "Suspicious File Access",
+    Severity: v1beta1.Severity_MEDIUM,
+}
+
+// In OnEvent - uses default
+return []detection.DetectorOutput{{
+    Data: data,
+    // Threat: nil - engine copies ThreatMetadata above
+}}, nil
+
+// In OnEvent - overrides default
+return []detection.DetectorOutput{{
+    Data: data,
+    Threat: &v1beta1.Threat{
+        Name:     "Critical System File Access",
+        Severity: v1beta1.Severity_CRITICAL,  // Higher severity
+    },
+}}, nil
+```
+{% endraw %}
+
+### DetectedFrom: Provenance Tracking
+
+{% raw %}
+```go
+AutoPopulate: detection.AutoPopulateFields{
+    DetectedFrom: true,
+}
+```
+{% endraw %}
+
+**Behavior**: Engine sets `output.DetectedFrom` with:
+
+- `event_id` - Triggering event's ID
+- `event_name` - Triggering event's name
+- `stack_addresses` - Stack trace (if available)
+
+**Output structure**:
+```json
+{
+  "detected_from": {
+    "event_id": 257,
+    "event_name": "security_file_open",
+    "stack_addresses": [...]
+  }
+}
+```
+
+### ProcessAncestry: Automatic Ancestry Enrichment
+
+{% raw %}
+```go
+AutoPopulate: detection.AutoPopulateFields{
+    ProcessAncestry: true,  // Default: 5 levels
+}
+```
+{% endraw %}
+
+**Requirements**:
+
+- Tracee must run with `--stores process.source=both`
+- Process must be in the process tree
+- Default depth: 5 levels (parent → grandparent → great-grandparent → ...)
+
+**Ancestry structure**:
+```json
+{
+  "workload": {
+    "process": {
+      "entity_id": 12345,
+      "pid": 67890,
+      "executable": {"path": "/bin/cat"},
+      "ancestors": [
+        {"entity_id": 12344, "pid": 67889, "executable": {"path": "/bin/bash"}},
+        {"entity_id": 12343, "pid": 67888, "thread": {"name": "sshd"}},
+        {"entity_id": 1, "pid": 1, "thread": {"name": "systemd"}}
+      ]
+    }
+  }
+}
+```
+
+**Per-detection ancestry depth control**:
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    severity := d.analyzeThreat(event)
+
+    if severity == "critical" {
+        // Deep ancestry for forensics
+        depth := uint32(10)
+        return []detection.DetectorOutput{{
+            Data:          data,
+            AncestryDepth: &depth,
+        }}, nil
+    }
+
+    if severity == "low" {
+        // Disable ancestry for performance
+        depth := uint32(0)
+        return []detection.DetectorOutput{{
+            Data:          data,
+            AncestryDepth: &depth,
+        }}, nil
+    }
+
+    // Use default (ProcessAncestry=true → 5 levels)
+    return []detection.DetectorOutput{{
+        Data: data,
+        // AncestryDepth: nil
+    }}, nil
+}
+```
+{% endraw %}
+
+### Complete Auto-Population Example
+
+{% raw %}
+```go
+DetectorDefinition{
+    ID: "TRC-001",
+
+    ThreatMetadata: &v1beta1.Threat{
+        Name:     "Sensitive File Access",
+        Severity: v1beta1.Severity_MEDIUM,
+    },
+
+    AutoPopulate: detection.AutoPopulateFields{
+        Threat:          true,  // Copy ThreatMetadata
+        DetectedFrom:    true,  // Add provenance
+        ProcessAncestry: true,  // Add 5-level ancestry
+    },
+}
+
+// OnEvent just returns data - engine enriches everything else
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    return []detection.DetectorOutput{{
+        Data: []*v1beta1.EventValue{
+            v1beta1.NewStringValue("file", "/etc/shadow"),
+        },
+        // Engine automatically adds:
+        // - Threat (from ThreatMetadata)
+        // - DetectedFrom (provenance)
+        // - Workload.Process.Ancestors (5 levels)
+    }}, nil
+}
+```
+{% endraw %}
+
+### Overriding Auto-Population Per Output
+
+You can override auto-population settings for specific outputs using the `AutoPopulate` field in `DetectorOutput`:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    severity := d.analyzeThreat(event)
+
+    if severity == "critical" {
+        // Enable all enrichment for critical threats
+        return []detection.DetectorOutput{{
+            Data: data,
+            AutoPopulate: &detection.AutoPopulateFields{
+                Threat:          true,
+                DetectedFrom:    true,
+                ProcessAncestry: true,
+            },
+        }}, nil
+    }
+
+    if severity == "low" {
+        // Disable enrichment for low-severity detections (performance)
+        return []detection.DetectorOutput{{
+            Data: data,
+            AutoPopulate: &detection.AutoPopulateFields{
+                Threat:          true,
+                DetectedFrom:    false,  // Skip provenance
+                ProcessAncestry: false,  // Skip ancestry
+            },
+        }}, nil
+    }
+
+    // Use default from Definition.AutoPopulate
+    return []detection.DetectorOutput{{
+        Data: data,
+        // AutoPopulate: nil - uses Definition.AutoPopulate
+    }}, nil
+}
+```
+{% endraw %}
+
+**Use cases for per-output overrides**:
+
+- Vary enrichment based on threat severity
+- Skip expensive enrichment for low-confidence detections
+- Add extra context for high-priority alerts
+
+---
+
+## Lifecycle Management
+
+### Init() Best Practices
+
+Called once at startup - use for initialization:
+
+{% raw %}
+```go
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+    // 1. Store logger (always do this)
+    d.logger = params.Logger
+
+    // 2. Store datastores if needed
+    d.dataStores = params.DataStores
+
+    // 3. Validate required datastores
+    if !params.DataStores.IsAvailable("process") {
+        return errors.New("process store required but unavailable")
+    }
+
+    // 4. Initialize detector state
+    d.cache = make(map[string]int)
+
+    // 5. Log initialization
+    d.logger.Debugw("Detector initialized",
+        "id", d.GetDefinition().ID,
+        "version", d.GetDefinition().ProducedEvent.Version,
+    )
+
+    return nil
+}
+```
+{% endraw %}
+
+**Don't do in Init()**:
+
+- Heavy computation (blocks startup)
+- Network requests
+- File I/O (except small config files)
+
+### OnEvent() Guidelines
+
+Called for every matching event - must be fast:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    // 1. Respect context cancellation
+    select {
+    case <-ctx.Done():
+        return nil, ctx.Err()
+    default:
+    }
+
+    // 2. Extract required data early
+    value, found := v1beta1.GetData[string](event, "field")
+    if !found {
+        return nil, nil  // Skip silently
+    }
+
+    // 3. Fast-path rejection
+    if !d.couldBeSuspicious(value) {
+        return nil, nil
+    }
+
+    // 4. Detailed analysis
+    if d.isSuspicious(value) {
+        return []detection.DetectorOutput{{
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("field", value),
+            },
+        }}, nil
+    }
+
+    return nil, nil
+}
+```
+{% endraw %}
+
+**Performance tips**:
+
+- Check cheapest conditions first
+- Use datastores judiciously (they're fast but not free)
+- Avoid allocations in hot path
+- Consider caching expensive computations
+
+### Error Handling Guidelines
+
+**Transient errors** - Return error, engine may retry:
+{% raw %}
+```go
+proc, err := d.dataStores.Processes().GetProcess(entityId)
+if err != nil && !errors.Is(err, datastores.ErrNotFound) {
+    return nil, fmt.Errorf("failed to get process: %w", err)
+}
+```
+{% endraw %}
+
+**Expected conditions** - Return nil detection:
+{% raw %}
+```go
+// Data not found - this is normal
+if errors.Is(err, datastores.ErrNotFound) {
+    return nil, nil
+}
+
+// Optional field missing - expected
+value, found := v1beta1.GetData[string](event, "optional_field")
+if !found {
+    return nil, nil
+}
+```
+{% endraw %}
+
+**Critical errors** - Log and return error:
+{% raw %}
+```go
+if err := d.criticalOperation(); err != nil {
+    d.logger.Errorw("Critical operation failed",
+        "error", err,
+        "event", event.Name,
+    )
+    return nil, fmt.Errorf("critical failure: %w", err)
+}
+```
+{% endraw %}
+
+**Error wrapping**:
+{% raw %}
+```go
+// Good - provides context
+return nil, fmt.Errorf("failed to analyze process %d: %w", pid, err)
+
+// Bad - loses context
+return nil, err
+```
+{% endraw %}
+
+---
+
+## Testing
+
+### Unit Testing Patterns
+
+Test detectors with mock events:
+
+{% raw %}
+```go
+package detectors
+
+import (
+    "context"
+    "testing"
+
+    "github.com/aquasecurity/tracee/api/v1beta1"
+    "github.com/aquasecurity/tracee/api/v1beta1/detection"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestSensitiveFileAccess_OnEvent(t *testing.T) {
+    detector := &SensitiveFileAccess{}
+
+    // Initialize with test params
+    err := detector.Init(detection.DetectorParams{
+        Logger: &mockLogger{},  // Use your mock logger implementation
+        Config: detection.NewEmptyDetectorConfig(),
+    })
+    require.NoError(t, err)
+
+    t.Run("detects_shadow_access", func(t *testing.T) {
+        event := &v1beta1.Event{
+            Id:   257,
+            Name: "security_file_open",
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("pathname", "/etc/shadow"),
+            },
+        }
+
+        outputs, err := detector.OnEvent(context.Background(), event)
+
+        require.NoError(t, err)
+        require.Len(t, outputs, 1)
+
+        // Verify output data
+        data := outputs[0].Data
+        require.Len(t, data, 2)
+        assert.Equal(t, "file_path", data[0].Name)
+        assert.Equal(t, "/etc/shadow", data[0].GetValue().GetStringValue())
+    })
+
+    t.Run("ignores_normal_files", func(t *testing.T) {
+        event := &v1beta1.Event{
+            Id:   257,
+            Name: "security_file_open",
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("pathname", "/tmp/normal.txt"),
+            },
+        }
+
+        outputs, err := detector.OnEvent(context.Background(), event)
+
+        require.NoError(t, err)
+        assert.Empty(t, outputs)  // No detection expected
+    })
+}
+```
+{% endraw %}
+
+### Mock Logger and DataStores
+
+Create mock implementations for testing:
+
+{% raw %}
+```go
+// Mock logger for testing
+type mockLogger struct{}
+
+func (m *mockLogger) Debugw(msg string, keysAndValues ...any) {}
+func (m *mockLogger) Infow(msg string, keysAndValues ...any)  {}
+func (m *mockLogger) Warnw(msg string, keysAndValues ...any)  {}
+func (m *mockLogger) Errorw(msg string, keysAndValues ...any) {}
+
+// Mock process store
+type mockProcessStore struct {
+    processes map[uint32]*datastores.ProcessInfo
+}
+
+func (m *mockProcessStore) GetProcess(entityId uint32) (*datastores.ProcessInfo, error) {
+    proc, ok := m.processes[entityId]
+    if !ok {
+        return nil, datastores.ErrNotFound
+    }
+    return proc, nil
+}
+
+// Mock datastore registry
+type mockRegistry struct {
+    processStore datastores.ProcessStore
+}
+
+func (m *mockRegistry) Processes() datastores.ProcessStore {
+    return m.processStore
+}
+
+func (m *mockRegistry) IsAvailable(name string) bool {
+    if name == "process" && m.processStore != nil {
+        return true
+    }
+    return false
+}
+
+func TestDetectorWithDataStore(t *testing.T) {
+    // Create mock store with test data
+    mockStore := &mockProcessStore{
+        processes: map[uint32]*datastores.ProcessInfo{
+            12345: {
+                EntityID: 12345,
+                Executable: &v1beta1.Executable{Path: "/bin/bash"},
+            },
+        },
+    }
+
+    // Create mock registry
+    registry := &mockRegistry{processStore: mockStore}
+
+    // Initialize detector with mocks
+    detector := &MyDetector{}
+    err := detector.Init(detection.DetectorParams{
+        Logger:     &mockLogger{},
+        DataStores: registry,
+        Config:     detection.NewEmptyDetectorConfig(),
+    })
+    require.NoError(t, err)
+
+    // Test with mock data
+    // ...
+}
+```
+{% endraw %}
+
+### Test Helpers
+
+Use built-in type-safe helpers for data extraction:
+
+{% raw %}
+```go
+// Type-safe data extraction with assertion
+pathname, found := v1beta1.GetData[string](event, "pathname")
+require.True(t, found, "pathname field should exist")
+assert.Equal(t, "/etc/shadow", pathname)
+```
+{% endraw %}
+
+---
+
+## Best Practices
+
+### Detector Design Principles
+
+**1. Single Responsibility**
+Each detector should focus on one threat pattern or derived event type.
+
+**Good**:
+{% raw %}
+```go
+// Focused on one threat
+type ContainerEscapeDetector struct {}
+
+// Focused on one derived event type
+type ContainerLifecycleDetector struct {}
+```
+{% endraw %}
+
+**Bad**:
+{% raw %}
+```go
+// Too broad
+type AllContainerThreatsDetector struct {}  // Don't do this!
+```
+{% endraw %}
+
+**2. Fail Fast**
+Reject events as early as possible:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    // 1. Check required fields first
+    pathname, found := v1beta1.GetData[string](event, "pathname")
+    if !found {
+        return nil, nil
+    }
+
+    // 2. Quick pattern checks
+    if !strings.HasPrefix(pathname, "/etc/") {
+        return nil, nil
+    }
+
+    // 3. Expensive checks last
+    if d.isKnownMaliciousPattern(pathname) {
+        // Create detection
+    }
+
+    return nil, nil
+}
+```
+{% endraw %}
+
+**3. Leverage Engine Filtering**
+Use `DataFilters` instead of logic in `OnEvent()`:
+
+**Good**:
+{% raw %}
+```go
+DataFilters: []string{
+    "pathname=/etc/*",
+    "flags>0",
+}
+
+func (d *MyDetector) OnEvent(...) {
+    // Events already filtered - just detection logic
+}
+```
+{% endraw %}
+
+**Bad**:
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(...) {
+    pathname, _ := v1beta1.GetData[string](event, "pathname")
+    if !strings.HasPrefix(pathname, "/etc/") {  // Should be in DataFilters!
+        return nil, nil
+    }
+}
+```
+{% endraw %}
+
+**4. Use Auto-Population**
+Let the engine handle enrichment:
+
+**Good**:
+{% raw %}
+```go
+AutoPopulate: detection.AutoPopulateFields{
+    Threat:          true,
+    DetectedFrom:    true,
+    ProcessAncestry: true,
+}
+
+func (d *MyDetector) OnEvent(...) {
+    return []detection.DetectorOutput{{
+        Data: simpleData,  // Just the data fields
+    }}, nil
+}
+```
+{% endraw %}
+
+**Bad**:
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(...) {
+    // Don't manually query ancestry if you can auto-populate!
+    ancestry, _ := d.dataStores.Processes().GetAncestry(entityId, 5)
+    // Manual enrichment is error-prone and slower
+}
+```
+{% endraw %}
+
+**5. Graceful Degradation**
+Handle missing datastores gracefully:
+
+{% raw %}
+```go
+// In Init - validate required stores
+if !params.DataStores.IsAvailable("process") {
+    return errors.New("process store required")
+}
+
+// In OnEvent - handle optional stores
+if params.DataStores.IsAvailable("container") {
+    containerInfo, _ := d.dataStores.Containers().GetContainer(id)
+    // Use if available
+}
+```
+{% endraw %}
+
+### Performance Considerations
+
+**1. Minimize DataStore Queries**
+{% raw %}
+```go
+// Good - single query
+proc, err := d.dataStores.Processes().GetProcess(entityId)
+
+// Bad - unnecessary queries
+proc, _ := d.dataStores.Processes().GetProcess(entityId)
+ancestors, _ := d.dataStores.Processes().GetAncestry(entityId, 5)
+// Could use AutoPopulate.ProcessAncestry instead!
+```
+{% endraw %}
+
+**2. Cache Expensive Computations**
+{% raw %}
+```go
+type MyDetector struct {
+    mu    sync.RWMutex
+    cache map[string]result
+}
+
+func (d *MyDetector) expensiveCheck(key string) result {
+    // Check cache (read lock)
+    d.mu.RLock()
+    if cached, ok := d.cache[key]; ok {
+        d.mu.RUnlock()
+        return cached
+    }
+    d.mu.RUnlock()
+
+    // Compute (write lock)
+    d.mu.Lock()
+    defer d.mu.Unlock()
+
+    // Double-check after acquiring write lock
+    if cached, ok := d.cache[key]; ok {
+        return cached
+    }
+
+    result := d.compute(key)
+    d.cache[key] = result
+    return result
+}
+```
+{% endraw %}
+
+**3. Batch Operations**
+If checking multiple conditions, batch them:
+
+{% raw %}
+```go
+// Good - batch check
+if d.isSuspiciousPath(pathname) &&
+   d.isSuspiciousFlags(flags) &&
+   d.isSuspiciousProcess(proc) {
+    // All checks passed
+}
+
+// Bad - create intermediary slices
+var checks []bool
+checks = append(checks, d.isSuspiciousPath(pathname))
+checks = append(checks, d.isSuspiciousFlags(flags))
+// Unnecessary allocations
+```
+{% endraw %}
+
+**4. Use Appropriate Data Structures**
+{% raw %}
+```go
+// Good - fast lookup
+type MyDetector struct {
+    suspiciousPaths map[string]bool  // O(1) lookup
+}
+
+// Bad - linear search
+type MyDetector struct {
+    suspiciousPaths []string  // O(n) lookup
+}
+```
+{% endraw %}
+
+### Code Organization
+
+**File structure**:
+```
+detectors/
+├── my_detector.go           # Detector implementation
+├── my_detector_test.go      # Unit tests
+└── my_detector_patterns.go  # Optional: complex pattern logic
+```
+
+**Detector file template**:
+{% raw %}
+```go
+package detectors
+
+// 1. Imports
+import (
+    "context"
+    "github.com/aquasecurity/tracee/api/v1beta1"
+    "github.com/aquasecurity/tracee/api/v1beta1/detection"
+)
+
+// 2. Auto-registration
+func init() {
+    register(&MyDetector{})
+}
+
+// 3. Detector struct
+type MyDetector struct {
+    logger     detection.Logger
+    dataStores datastores.Registry
+    // ... other state
+}
+
+// 4. GetDefinition
+func (d *MyDetector) GetDefinition() detection.DetectorDefinition {
+    // ...
+}
+
+// 5. Init
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+    // ...
+}
+
+// 6. OnEvent
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    // ...
+}
+
+// 7. Private helper methods
+func (d *MyDetector) helperMethod() {
+    // ...
+}
+```
+{% endraw %}
+
+---
+
+## Data Access Helpers
+
+### Type-Safe Event Data Extraction
+
+Use generic `GetData[T]` for compile-time type safety:
+
+{% raw %}
+```go
+// String extraction
+pathname, found := v1beta1.GetData[string](event, "pathname")
+if !found {
+    return nil, nil
+}
+
+// Integer extraction
+flags, found := v1beta1.GetData[int64](event, "flags")
+
+// Unsigned integer
+uid, found := v1beta1.GetData[uint64](event, "uid")
+
+// Boolean
+success, found := v1beta1.GetData[bool](event, "success")
+
+// Byte array
+data, found := v1beta1.GetData[[]byte](event, "data")
+```
+{% endraw %}
+
+### Null-Safe Accessors
+
+Use protobuf's generated `Get*()` methods - they're nil-safe:
+
+{% raw %}
+```go
+// Safe - returns empty string if any field is nil
+processPath := event.GetWorkload().GetProcess().GetExecutable().GetPath()
+
+// Safe - returns 0 if nil
+entityId := event.GetWorkload().GetProcess().GetEntityId()
+
+// Safe - returns empty slice if nil
+ancestors := event.GetWorkload().GetProcess().GetAncestors()
+```
+{% endraw %}
+
+**Never do this**:
+{% raw %}
+```go
+// UNSAFE - panics if any field is nil!
+if event.Workload != nil && event.Workload.Process != nil {
+    path := event.Workload.Process.Executable.Path  // Can still panic!
+}
+```
+{% endraw %}
+
+### Common Access Patterns
+
+{% raw %}
+```go
+// Process information
+entityId := event.GetWorkload().GetProcess().GetEntityId()
+pid := event.GetWorkload().GetProcess().GetPid()
+executable := event.GetWorkload().GetProcess().GetExecutable().GetPath()
+commandLine := event.GetWorkload().GetProcess().GetCommandLine()
+
+// Container information (if in container)
+containerId := event.GetWorkload().GetContainer().GetId()
+containerName := event.GetWorkload().GetContainer().GetName()
+containerImage := event.GetWorkload().GetContainer().GetImage().GetName()
+
+// Kubernetes information (if available)
+namespace := event.GetWorkload().GetK8s().GetNamespace()
+podName := event.GetWorkload().GetK8s().GetPod().GetName()
+
+// User information
+uid := event.GetWorkload().GetProcess().GetRealUser().GetId()
+username := event.GetWorkload().GetProcess().GetRealUser().GetName()
+```
+{% endraw %}
+
+---
+
+### Next Steps
+
+- **[Quick Start](quickstart.md)**: Write your first detector
+- **[DataStore API](datastore-api.md)**: Complete datastore reference
+- **Real Examples**: Browse `detectors/` directory
+
+### Getting Help
+
+- **GitHub Issues**: https://github.com/aquasecurity/tracee/issues
+- **Discussions**: https://github.com/aquasecurity/tracee/discussions
+- **API Definitions**: `api/v1beta1/detection/detector.go`
+
+---
+
+## Migration from Signatures
+
+This section helps you migrate existing signatures to the new detector API.
+
+### Quick Comparison
+
+| Feature | Old Signature API | New Detector API |
+|---------|-------------------|------------------|
+| Package | `package main` (plugin) | `package detectors` (compiled-in) |
+| Interface | `detect.Signature` | `detection.EventDetector` |
+| Event Access | `protocol.Event` (runtime casting) | `*v1beta1.Event` (direct protobuf) |
+| Data Extraction | Manual loop through `Args` | `GetData[T]` (type-safe) |
+| Event Filtering | `GetSelectedEvents()` (name only) | `EventRequirement` (data + scope filters) |
+| Output | Async `ctx.Callback()` | Synchronous return `[]detection.DetectorOutput` |
+| Metadata | `GetMetadata()` separate | `GetDefinition()` unified |
+| State Management | Manual | LRU caches + datastore access |
+| Context Access | Limited | Full datastore access (process, container, etc.) |
+| Auto-enrichment | Manual | Declarative (`AutoPopulateFields`) |
+| Testing | Callback mocking | Direct function calls |
+| Registration | `ExportedSignatures` list | `init()` auto-registration |
+
+### Step-by-Step Migration
+
+**Before** (old signature):
+
+{% raw %}
+```go
+package main
+
+import (
+	"github.com/aquasecurity/tracee/types/detect"
+	"github.com/aquasecurity/tracee/types/protocol"
+)
+
+type MySignature struct {
+	cb detect.SignatureHandler
+}
+
+func (s *MySignature) GetMetadata() detect.SignatureMetadata {
+	return detect.SignatureMetadata{
+		ID:          "TRC-001",
+		Name:        "Sensitive File Access",
+		Description: "Detects access to sensitive files",
+		Version:     "1.0.0",
+		Severity:    detect.SeverityMedium,
+	}
+}
+
+func (s *MySignature) GetSelectedEvents() []detect.SignatureEventSelector {
+	return []detect.SignatureEventSelector{
+		{Source: "tracee", Name: "security_file_open"},
+	}
+}
+
+func (s *MySignature) Init(ctx detect.SignatureContext) error {
+	s.cb = ctx.Callback
+	return nil
+}
+
+func (s *MySignature) OnEvent(event protocol.Event) error {
+	traceEvent, ok := event.Payload.(trace.Event)
+	if !ok {
+		return fmt.Errorf("unexpected event type")
+	}
+
+	var pathname string
+	for _, arg := range traceEvent.Args {
+		if arg.Name == "pathname" {
+			pathname = arg.Value.(string)
+			break
+		}
+	}
+
+	if !strings.HasPrefix(pathname, "/etc/") {
+		return nil
+	}
+
+	s.cb(&detect.Finding{
+		SigMetadata: s.GetMetadata(),
+		Event:       event,
+		Data: map[string]interface{}{
+			"file": pathname,
+		},
+	})
+
+	return nil
+}
+
+func (s *MySignature) Close() {}
+```
+{% endraw %}
+
+**After** (new detector):
+
+{% raw %}
+```go
+package detectors
+
+import (
+	"context"
+	"strings"
+
+	"github.com/aquasecurity/tracee/api/v1beta1"
+	"github.com/aquasecurity/tracee/api/v1beta1/detection"
+)
+
+func init() {
+	register(&SensitiveFileAccess{})
+}
+
+type SensitiveFileAccess struct {
+	logger detection.Logger
+}
+
+func (d *SensitiveFileAccess) GetDefinition() detection.DetectorDefinition {
+	return detection.DetectorDefinition{
+		ID: "TRC-001",
+		Requirements: detection.DetectorRequirements{
+			Events: []detection.EventRequirement{
+				{
+					Name: "security_file_open",
+					DataFilters: []string{"pathname=/etc/*"},  // Engine filters
+				},
+			},
+		},
+		ProducedEvent: v1beta1.EventDefinition{
+			Name:        "sensitive_file_access",
+			Description: "Detects access to sensitive files",
+			Version:     &v1beta1.Version{Major: 1, Minor: 0, Patch: 0},
+			Fields: []*v1beta1.EventField{
+				{Name: "file", Type: "const char*"},
+			},
+		},
+		ThreatMetadata: &v1beta1.Threat{
+			Name:        "Sensitive File Access",
+			Description: "Access to sensitive system files detected",
+			Severity:    v1beta1.Severity_MEDIUM,
+		},
+		AutoPopulate: detection.AutoPopulateFields{
+			Threat:          true,
+			DetectedFrom:    true,
+			ProcessAncestry: true,
+		},
+	}
+}
+
+func (d *SensitiveFileAccess) Init(params detection.DetectorParams) error {
+	d.logger = params.Logger
+	return nil
+}
+
+func (d *SensitiveFileAccess) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+	// Type-safe extraction (no casting)
+	pathname, found := v1beta1.GetData[string](event, "pathname")
+	if !found {
+		return nil, nil
+	}
+
+	// No need to filter by /etc/* - engine already did it
+
+	return []detection.DetectorOutput{{
+		Data: []*v1beta1.EventValue{
+			v1beta1.NewStringValue("file", pathname),
+		},
+		// Threat, DetectedFrom, ProcessAncestry auto-populated by engine
+	}}, nil
+}
+
+// Close() is optional - only implement if you need cleanup
+```
+{% endraw %}
+
+### Migration Checklist
+
+- [ ] Change package from `main` to `detectors`
+- [ ] Add `init() { register(&YourDetector{}) }`
+- [ ] Update imports to `api/v1beta1` packages
+- [ ] Replace `detect.Signature` with `detection.EventDetector`
+- [ ] Combine `GetMetadata()` + `GetSelectedEvents()` → `GetDefinition()`
+- [ ] Move data filters from `OnEvent()` to `EventRequirement.DataFilters`
+- [ ] Replace `protocol.Event` casting with `*v1beta1.Event` parameter
+- [ ] Replace manual `Args` loop with `GetData[T]()`
+- [ ] Replace `ctx.Callback()` with synchronous `return []detection.DetectorOutput{}`
+- [ ] Return `DetectorOutput` with `Data` fields instead of full `v1beta1.Event`
+- [ ] Add `AutoPopulateFields` for automatic enrichment
+- [ ] Update tests to call `OnEvent()` directly and verify `DetectorOutput`
+- [ ] Remove `Close()` if empty (optional interface)
+
+### Common Pattern Translations
+
+**Pattern: Event Selection**
+{% raw %}
+```go
+// Before
+GetSelectedEvents() []detect.SignatureEventSelector {
+	return []detect.SignatureEventSelector{
+		{Source: "tracee", Name: "openat"},
+	}
+}
+
+// After
+Requirements: detection.DetectorRequirements{
+	Events: []detection.EventRequirement{
+		{Name: "openat"},
+	},
+},
+```
+{% endraw %}
+
+**Pattern: Data Extraction**
+{% raw %}
+```go
+// Before
+var pathname string
+for _, arg := range traceEvent.Args {
+	if arg.Name == "pathname" {
+		pathname = arg.Value.(string)  // Runtime casting
+		break
+	}
+}
+
+// After
+pathname, found := v1beta1.GetData[string](event, "pathname")  // Compile-time safety
+if !found {
+	return nil, nil
+}
+```
+{% endraw %}
+
+**Pattern: Filtering**
+{% raw %}
+```go
+// Before (in OnEvent)
+if !strings.HasPrefix(pathname, "/etc/") {
+	return nil  // Manual filter
+}
+
+// After (in EventRequirement)
+DataFilters: []string{"pathname=/etc/*"},  // Engine filters before dispatch
+```
+{% endraw %}
+
+**Pattern: Callback → Return**
+{% raw %}
+```go
+// Before
+s.cb(&detect.Finding{
+	SigMetadata: s.GetMetadata(),
+	Event:       event,
+	Data:        map[string]interface{}{"file": pathname},
+})
+return nil
+
+// After
+return []detection.DetectorOutput{{
+	Data: []*v1beta1.EventValue{
+		v1beta1.NewStringValue("file", pathname),
+	},
+}}, nil
+```
+{% endraw %}
+
+---
+
+## Troubleshooting
+
+### Problem: Detector Not Running
+
+**Symptoms**: Detector code exists but never triggers
+
+**Diagnosis**:
+```bash
+# Check if detector is registered
+sudo ./dist/tracee list | grep detectors
+
+# Check Tracee logs
+sudo ./dist/tracee --logging debug
+```
+
+**Solutions**:
+1. Verify `init() { register(&YourDetector{}) }` exists
+2. Rebuild Tracee: `make clean && make tracee`
+3. Check for panics in `Init()` (blocks registration)
+
+### Problem: No Events Received
+
+**Symptoms**: `OnEvent()` never called
+
+**Diagnosis**:
+1. Check event name: `sudo ./dist/tracee list | grep event_name`
+2. Temporarily remove `DataFilters` to see if they're too restrictive
+3. Add debug logging in `OnEvent()`
+
+**Solutions**:
+1. Fix event name typo in `EventRequirement.Name`
+2. Adjust `DataFilters` - they might be filtering everything out
+3. Check `ScopeFilters` - ensure they match your test environment
+
+### Problem: DataStore Returns ErrNotFound
+
+**Symptoms**: `GetProcess()`, `GetContainer()` return `ErrNotFound`
+
+**Possible causes**:
+1. Process tree not enabled: `--stores process.source=both`
+2. Process exited before query
+3. Container not tracked yet
+
+**Solutions**:
+{% raw %}
+```go
+// Always handle ErrNotFound gracefully
+proc, err := d.dataStores.Processes().GetProcess(entityId)
+if errors.Is(err, datastores.ErrNotFound) {
+    // This is normal - process might have exited
+    return nil, nil
+}
+if err != nil {
+    return nil, fmt.Errorf("unexpected error: %w", err)
+}
+```
+{% endraw %}
+
+### Problem: High CPU Usage
+
+**Symptoms**: Tracee consuming excessive CPU
+
+**Diagnosis**:
+1. Check if detector receives too many events
+2. Profile detector logic
+
+**Solutions**:
+1. Add more restrictive `DataFilters`
+2. Optimize detector logic - avoid expensive operations in `OnEvent()`
+3. Use caching for repeated computations
+4. Consider batching if doing aggregations
+
+### Problem: Memory Leaks
+
+**Symptoms**: Memory usage grows over time
+
+**Causes**:
+1. Unbounded maps/slices in detector state
+2. Not cleaning up old entries
+
+**Solutions**:
+{% raw %}
+```go
+// Use LRU cache with TTL instead of unbounded maps
+import "github.com/hashicorp/golang-lru/v2/expirable"
+
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+    // Bounded cache with expiration
+    d.cache = expirable.NewLRU[string, *data](
+        1000,          // Max entries
+        nil,           // No eviction callback
+        5*time.Minute, // TTL
+    )
+    return nil
+}
+```
+{% endraw %}
+

--- a/docs/docs/detectors/datastore-api.md
+++ b/docs/docs/detectors/datastore-api.md
@@ -1,0 +1,1351 @@
+# DataStore API Reference
+
+Complete API reference for Tracee's DataStore system. This provides read-only access to system state information for detectors.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Core Concepts](#core-concepts)
+3. [Registry Interface](#registry-interface)
+4. [ProcessStore](#processstore)
+5. [ContainerStore](#containerstore)
+6. [SystemStore](#systemstore)
+7. [SyscallStore](#syscallstore)
+8. [KernelSymbolStore](#kernelsymbolstore)
+9. [DNSStore](#dnsstore)
+10. [Health and Metrics](#health-and-metrics)
+11. [Error Handling](#error-handling)
+12. [Advanced Usage](#advanced-usage)
+
+---
+
+## Overview
+
+### What DataStores Provide
+
+DataStores give detectors read-only access to system state information collected by Tracee:
+
+- **Process Tree**: Process information, ancestry, and relationships
+- **Container Registry**: Container metadata, Kubernetes pod information
+- **System Information**: Immutable system details (architecture, kernel, OS)
+- **Syscall Mapping**: Syscall ID ↔ name conversion
+- **Kernel Symbols**: Symbol resolution for addresses
+- **DNS Cache**: DNS query responses
+
+### Registry Pattern
+
+All datastores are accessed through a single `Registry` interface provided to detectors via `DetectorParams`:
+
+{% raw %}
+```go
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+    d.dataStores = params.DataStores  // Registry interface
+
+    // Access individual stores
+    processStore := d.dataStores.Processes()
+    containerStore := d.dataStores.Containers()
+
+    return nil
+}
+```
+{% endraw %}
+
+### Read-Only Access Model
+
+DataStores are **read-only** from the detector perspective:
+
+- ✅ Query existing data
+- ✅ Iterate over collections
+- ✅ Check health and metrics
+- ❌ No writes or modifications
+- ❌ No data deletion
+
+The engine manages datastore lifecycle (initialization, updates, shutdown).
+
+### Thread Safety Guarantees
+
+All datastores are **thread-safe** for concurrent access:
+
+- Multiple detectors can query the same store simultaneously
+- No locking required in detector code
+- Internal RWMutex protects shared state
+
+---
+
+## Core Concepts
+
+### DataStore Base Interface
+
+All datastores implement this base interface:
+
+{% raw %}
+```go
+type DataStore interface {
+    // Name returns the name of this datastore
+    Name() string
+
+    // GetHealth returns the current health status
+    GetHealth() *HealthInfo
+
+    // GetMetrics returns operational metrics
+    GetMetrics() *DataStoreMetrics
+}
+```
+{% endraw %}
+
+### Common Errors
+
+Sentinel errors for standard error cases:
+
+{% raw %}
+```go
+var (
+    ErrNotFound        = errors.New("entity not found")
+    ErrStoreUnhealthy  = errors.New("datastore is unhealthy")
+    ErrNotImplemented  = errors.New("operation not implemented")
+    ErrInvalidArgument = errors.New("invalid argument")
+)
+```
+{% endraw %}
+
+**StoreError** wraps errors with context:
+
+{% raw %}
+```go
+type StoreError struct {
+    StoreName string  // Which store
+    Operation string  // Which operation
+    Err       error   // Underlying error
+}
+```
+{% endraw %}
+
+### Health Status
+
+{% raw %}
+```go
+type HealthStatus int
+
+const (
+    HealthUnknown   HealthStatus = iota  // 0: Unknown state
+    HealthHealthy                        // 1: Operating normally
+    HealthUnhealthy                      // 2: Degraded or unavailable
+)
+```
+{% endraw %}
+
+---
+
+## Registry Interface
+
+### Registry Methods
+
+{% raw %}
+```go
+type Registry interface {
+    // Core stores (always return non-nil, but may be unavailable)
+    Processes() ProcessStore
+    Containers() ContainerStore
+    KernelSymbols() KernelSymbolStore
+    DNS() DNSStore
+    System() SystemStore
+    Syscalls() SyscallStore
+
+    // Custom stores (returns error if not found)
+    GetCustom(name string) (DataStore, error)
+
+    // Introspection
+    List() []string
+    IsAvailable(name string) bool
+    GetMetadata(name string) (*DataStoreMetadata, error)
+    GetMetrics(name string) (*DataStoreMetrics, error)
+}
+```
+{% endraw %}
+
+### Usage Examples
+
+**Basic access**:
+{% raw %}
+```go
+// Direct access to core stores
+processStore := d.dataStores.Processes()
+containerStore := d.dataStores.Containers()
+
+// Use immediately
+proc, err := processStore.GetProcess(entityId)
+if errors.Is(err, datastores.ErrNotFound) {
+    // Process not found
+}
+```
+{% endraw %}
+
+**Check availability**:
+{% raw %}
+```go
+// Check if optional store is available
+if d.dataStores.IsAvailable("system") {
+    systemStore := d.dataStores.System()
+    sysInfo := systemStore.GetSystemInfo()
+    // Use system info
+}
+```
+{% endraw %}
+
+**List all stores**:
+{% raw %}
+```go
+stores := d.dataStores.List()
+d.logger.Infow("Available datastores", "stores", stores)
+// Output: ["process", "container", "symbol", "dns", "system", "syscall"]
+```
+{% endraw %}
+
+**Get store metadata**:
+{% raw %}
+```go
+metadata, err := d.dataStores.GetMetadata("process")
+if err == nil {
+    d.logger.Infow("Process store info",
+        "name", metadata.Name,
+        "description", metadata.Description)
+}
+```
+{% endraw %}
+
+---
+
+## ProcessStore
+
+### Interface
+
+{% raw %}
+```go
+type ProcessStore interface {
+    DataStore
+
+    // GetProcess retrieves process information by entity ID
+    // Returns ErrNotFound if not found
+    GetProcess(entityId uint32) (*ProcessInfo, error)
+
+    // GetChildProcesses returns all child processes
+    // Returns empty slice if no children
+    GetChildProcesses(entityId uint32) ([]*ProcessInfo, error)
+
+    // GetAncestry retrieves the ancestry chain up to maxDepth levels
+    // [0] = process itself, [1] = parent, [2] = grandparent, etc.
+    // Returns empty slice if maxDepth <= 0 or process not found
+    GetAncestry(entityId uint32, maxDepth int) ([]*ProcessInfo, error)
+}
+```
+{% endraw %}
+
+### ProcessInfo Structure
+
+{% raw %}
+```go
+type ProcessInfo struct {
+    EntityID  uint32    // Primary key (hash) - matches Event.Process.EntityId
+    PID       uint32    // OS process ID (for display/logging)
+    PPID      uint32    // OS parent PID (for display/logging)
+    Name      string    // Binary name: "bash"
+    Exe       string    // Full executable path: "/usr/bin/bash"
+    StartTime time.Time // Process start time
+    UID       uint32    // User ID
+    GID       uint32    // Group ID
+}
+```
+{% endraw %}
+
+### Methods
+
+#### GetProcess
+
+Retrieve process information by entity ID.
+
+**Signature**:
+{% raw %}
+```go
+GetProcess(entityId uint32) (*ProcessInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `entityId`: Process entity ID (hash from ProcessTree, matches `event.Workload.Process.EntityId`)
+
+**Returns**:
+
+- `*ProcessInfo`: Process information if found
+- `error`: `ErrNotFound` if not found, `nil` on success
+
+**Example**:
+{% raw %}
+```go
+entityId := event.Workload.Process.EntityId.Value
+proc, err := d.dataStores.Processes().GetProcess(entityId)
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Warnw("Process not found", "entity_id", entityId)
+    return nil, nil
+}
+if err != nil {
+    return nil, fmt.Errorf("failed to get process: %w", err)
+}
+
+d.logger.Infow("Found process",
+    "pid", proc.PID,           // OS PID for logging
+    "name", proc.Name,         // "bash"
+    "exe", proc.Exe,           // "/usr/bin/bash"
+    "uid", proc.UID,
+    "start_time", proc.StartTime)
+```
+{% endraw %}
+
+#### GetAncestry
+
+Retrieve process ancestry chain up to specified depth.
+
+**Signature**:
+{% raw %}
+```go
+GetAncestry(entityId uint32, maxDepth int) ([]*ProcessInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `entityId`: Process entity ID
+- `maxDepth`: Maximum ancestry depth (typically 5)
+
+**Returns**:
+
+- `[]*ProcessInfo`: Ancestry chain where `[0]` = process itself, `[1]` = parent, `[2]` = grandparent, etc.
+- `error`: Error if query fails
+
+**Behavior**:
+
+- Returns empty slice if `maxDepth <= 0`
+- Returns empty slice if process not found
+- Stops if parent not found in tree
+- Stops if circular reference detected
+
+**Example**:
+{% raw %}
+```go
+ancestry, err := d.dataStores.Processes().GetAncestry(entityId, 5)
+if err != nil {
+    return nil, fmt.Errorf("failed to get ancestry: %w", err)
+}
+
+if len(ancestry) == 0 {
+    d.logger.Debugw("No ancestry found")
+    return nil, nil
+}
+
+// ancestry[0] is the process itself
+// ancestry[1] is the parent
+// ancestry[2] is the grandparent, etc.
+
+for i, ancestor := range ancestry {
+    d.logger.Debugw("Ancestor",
+        "level", i,
+        "pid", ancestor.PID,
+        "name", ancestor.Name,
+        "exe", ancestor.Exe)
+}
+
+// Check if parent is suspicious
+if len(ancestry) > 1 {
+    parent := ancestry[1]
+    if strings.Contains(parent.Exe, "suspicious") {
+        // Trigger detection
+    }
+}
+```
+{% endraw %}
+
+#### GetChildProcesses
+
+Retrieve all child processes of a given process.
+
+**Signature**:
+{% raw %}
+```go
+GetChildProcesses(entityId uint32) ([]*ProcessInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `entityId`: Parent process entity ID
+
+**Returns**:
+
+- `[]*ProcessInfo`: List of child processes (empty if no children)
+- `error`: Error if query fails
+
+**Example**:
+{% raw %}
+```go
+children, err := d.dataStores.Processes().GetChildProcesses(entityId)
+if err != nil {
+    return nil, err
+}
+
+d.logger.Infow("Process has children", "count", len(children))
+for _, child := range children {
+    d.logger.Debugw("Child process",
+        "pid", child.PID,
+        "name", child.Name,
+        "exe", child.Exe)
+}
+```
+{% endraw %}
+
+### EntityID vs PID
+
+!!! Important "Always Use EntityID for Lookups"
+    **EntityID** is the primary key for process lookups, not PID.
+
+    **Why?**
+
+    - PIDs can be reused after a process exits
+    - EntityID is unique for the lifetime of the process
+    - EntityID matches `event.Workload.Process.EntityId`
+
+    **Usage**:
+
+    - **EntityID**: For all datastore lookups (`GetProcess`, `GetAncestry`, etc.)
+    - **PID**: Only for display, logging, and debugging
+
+**Correct**:
+{% raw %}
+```go
+// Get EntityID from event
+entityId := event.Workload.Process.EntityId.Value
+
+// Use EntityID for lookup
+proc, err := d.dataStores.Processes().GetProcess(entityId)
+if errors.Is(err, datastores.ErrNotFound) {
+    return nil, nil
+}
+
+// Use PID for logging only
+d.logger.Infow("Process found", "pid", proc.PID, "name", proc.Name)
+```
+{% endraw %}
+
+**Incorrect**:
+{% raw %}
+```go
+// ❌ Don't use PID for lookups
+pid := event.Workload.Process.Pid.Value
+proc, err := d.dataStores.Processes().GetProcess(uint32(pid))  // Wrong!
+```
+{% endraw %}
+
+---
+
+## ContainerStore
+
+### Interface
+
+{% raw %}
+```go
+type ContainerStore interface {
+    DataStore
+
+    // GetContainer retrieves container by ID
+    // Returns ErrNotFound if not found
+    GetContainer(id string) (*ContainerInfo, error)
+
+    // GetContainerByName retrieves container by name
+    // Returns ErrNotFound if not found
+    GetContainerByName(name string) (*ContainerInfo, error)
+}
+```
+{% endraw %}
+
+### ContainerInfo Structure
+
+{% raw %}
+```go
+type ContainerInfo struct {
+    ID          string      // Container ID
+    Name        string      // Container name
+    Image       string      // Container image
+    ImageDigest string      // Image digest (SHA256)
+    Runtime     string      // Runtime: "docker", "containerd", "crio"
+    StartTime   time.Time   // Container start time
+    Pod         *K8sPodInfo // Kubernetes pod info (nil for non-K8s)
+}
+
+type K8sPodInfo struct {
+    Name      string // Pod name
+    UID       string // Pod UID
+    Namespace string // Pod namespace
+    Sandbox   bool   // Whether this is a sandbox container
+}
+```
+{% endraw %}
+
+### Methods
+
+#### GetContainer
+
+Retrieve container information by container ID.
+
+**Signature**:
+{% raw %}
+```go
+GetContainer(id string) (*ContainerInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `id`: Container ID (full ID or short form)
+
+**Returns**:
+
+- `*ContainerInfo`: Container information if found
+- `error`: `ErrNotFound` if not found, `nil` on success
+
+**Example**:
+{% raw %}
+```go
+containerID := v1beta1.GetContainerID(event)
+if containerID == "" {
+    // Not a container event
+    return nil, nil
+}
+
+container, err := d.dataStores.Containers().GetContainer(containerID)
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Warnw("Container not found", "id", containerID)
+    return nil, nil
+}
+if err != nil {
+    return nil, fmt.Errorf("failed to get container: %w", err)
+}
+
+d.logger.Infow("Container info",
+    "id", container.ID,
+    "name", container.Name,
+    "image", container.Image,
+    "runtime", container.Runtime,
+    "start_time", container.StartTime)
+
+// Access Kubernetes pod information
+if container.Pod != nil {
+    d.logger.Infow("Pod info",
+        "name", container.Pod.Name,
+        "namespace", container.Pod.Namespace,
+        "uid", container.Pod.UID,
+        "sandbox", container.Pod.Sandbox)
+}
+```
+{% endraw %}
+
+#### GetContainerByName
+
+Retrieve container information by container name.
+
+**Signature**:
+{% raw %}
+```go
+GetContainerByName(name string) (*ContainerInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `name`: Container name
+
+**Returns**:
+
+- `*ContainerInfo`: Container information if found
+- `error`: `ErrNotFound` if not found, `nil` on success
+
+**Example**:
+{% raw %}
+```go
+container, err := d.dataStores.Containers().GetContainerByName("web-server")
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Debugw("Container not found", "name", "web-server")
+    return nil, nil
+}
+if err != nil {
+    return nil, fmt.Errorf("failed to get container: %w", err)
+}
+
+d.logger.Infow("Found container by name",
+    "name", container.Name,
+    "id", container.ID,
+    "image", container.Image)
+```
+{% endraw %}
+
+---
+
+## SystemStore
+
+### Interface
+
+{% raw %}
+```go
+type SystemStore interface {
+    DataStore
+
+    // GetSystemInfo returns immutable system information
+    // Collected at Tracee startup, never changes
+    GetSystemInfo() *SystemInfo
+}
+```
+{% endraw %}
+
+### SystemInfo Structure
+
+{% raw %}
+```go
+type SystemInfo struct {
+    Architecture    string            // CPU architecture: "x86_64", "aarch64"
+    KernelRelease   string            // Kernel version: "5.15.0-generic"
+    Hostname        string            // System hostname
+    BootTime        time.Time         // System boot time
+    TraceeStartTime time.Time         // When Tracee started
+    OSName          string            // OS name: "Ubuntu"
+    OSVersion       string            // OS version: "22.04"
+    OSPrettyName    string            // Full OS name: "Ubuntu 22.04 LTS"
+    TraceeVersion   string            // Tracee version string
+    InitNamespaces  map[string]uint32 // Init process namespaces
+}
+```
+{% endraw %}
+
+### Methods
+
+#### GetSystemInfo
+
+Retrieve immutable system information.
+
+**Signature**:
+{% raw %}
+```go
+GetSystemInfo() *SystemInfo
+```
+{% endraw %}
+
+**Returns**:
+
+- `*SystemInfo`: System information (never nil if store available)
+
+**Characteristics**:
+
+- **Immutable**: Data never changes during Tracee lifetime
+- **Fast**: No lookup, just returns cached data
+- **Always available**: Returns immediately with no errors
+
+**Example**:
+{% raw %}
+```go
+// System store always returns non-nil (per registry contract)
+// Check IsAvailable() if you need to verify store is ready
+systemStore := d.dataStores.System()
+sysInfo := systemStore.GetSystemInfo()
+
+d.logger.Infow("System information",
+    "arch", sysInfo.Architecture,
+    "kernel", sysInfo.KernelRelease,
+    "os", sysInfo.OSPrettyName,
+    "hostname", sysInfo.Hostname,
+    "tracee_version", sysInfo.TraceeVersion,
+    "boot_time", sysInfo.BootTime,
+    "tracee_start", sysInfo.TraceeStartTime)
+
+// Check architecture for platform-specific logic
+if sysInfo.Architecture == "x86_64" {
+    // x86-specific detection logic
+} else if sysInfo.Architecture == "aarch64" {
+    // ARM-specific detection logic
+}
+
+// Add to detection metadata
+detection.Data = append(detection.Data,
+    v1beta1.NewStringValue("system_arch", sysInfo.Architecture),
+    v1beta1.NewStringValue("kernel_version", sysInfo.KernelRelease),
+    v1beta1.NewStringValue("os", sysInfo.OSPrettyName))
+```
+{% endraw %}
+
+---
+
+## SyscallStore
+
+### Interface
+
+{% raw %}
+```go
+type SyscallStore interface {
+    DataStore
+
+    // GetSyscallName returns syscall name for given ID
+    // Returns ErrNotFound if not found
+    GetSyscallName(id int32) (string, error)
+
+    // GetSyscallID returns syscall ID for given name
+    // Returns ErrNotFound if not found
+    GetSyscallID(name string) (int32, error)
+}
+```
+{% endraw %}
+
+### Methods
+
+#### GetSyscallName
+
+Get syscall name from syscall ID.
+
+**Signature**:
+{% raw %}
+```go
+GetSyscallName(id int32) (string, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `id`: Syscall ID (architecture-specific)
+
+**Returns**:
+
+- `string`: Syscall name if found
+- `error`: `ErrNotFound` if not found, `nil` on success
+
+**Example**:
+{% raw %}
+```go
+syscallID, found := v1beta1.GetData[int32](event, "syscall_id")
+if !found {
+    return nil, nil
+}
+
+name, err := d.dataStores.Syscalls().GetSyscallName(syscallID)
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Debugw("Unknown syscall", "id", syscallID)
+    name = fmt.Sprintf("syscall_%d", syscallID)
+}
+if err != nil && !errors.Is(err, datastores.ErrNotFound) {
+    return nil, fmt.Errorf("failed to get syscall name: %w", err)
+}
+
+d.logger.Infow("Syscall detected", "name", name, "id", syscallID)
+```
+{% endraw %}
+
+#### GetSyscallID
+
+Get syscall ID from syscall name.
+
+**Signature**:
+{% raw %}
+```go
+GetSyscallID(name string) (int32, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `name`: Syscall name (e.g., "execve", "openat")
+
+**Returns**:
+
+- `int32`: Syscall ID if found
+- `error`: `ErrNotFound` if not found, `nil` on success
+
+**Example**:
+{% raw %}
+```go
+id, err := d.dataStores.Syscalls().GetSyscallID("execve")
+if err == nil {
+    d.logger.Infow("Syscall", "name", "execve", "id", id)
+    // ID = 59 on x86_64
+}
+```
+{% endraw %}
+
+!!! Warning "Architecture-Specific"
+    Syscall IDs are **architecture-specific**:
+
+    - ID 59 = `execve` on x86_64
+    - ID 221 = `execve` on ARM64
+
+    The store returns IDs for the **current architecture** only.
+
+---
+
+## KernelSymbolStore
+
+### Interface
+
+{% raw %}
+```go
+type KernelSymbolStore interface {
+    DataStore
+
+    // ResolveSymbolByAddress resolves address to symbols
+    // Returns multiple symbols if aliases exist
+    // Returns ErrNotFound if address cannot be resolved
+    ResolveSymbolByAddress(addr uint64) ([]*SymbolInfo, error)
+
+    // GetSymbolAddress returns address of named symbol
+    // If multiple symbols exist, returns first one found
+    // Returns ErrNotFound if symbol not found
+    GetSymbolAddress(name string) (uint64, error)
+
+    // ResolveSymbolsBatch resolves multiple addresses at once
+    // Returns map of address -> symbols for found addresses
+    // Missing addresses are not included in result
+    ResolveSymbolsBatch(addrs []uint64) (map[uint64][]*SymbolInfo, error)
+}
+```
+{% endraw %}
+
+### SymbolInfo Structure
+
+{% raw %}
+```go
+type SymbolInfo struct {
+    Name    string // Symbol name: "do_sys_open"
+    Address uint64 // Symbol address: 0xffffffff81234567
+    Module  string // Module name: "system" for kernel, or module name
+}
+```
+{% endraw %}
+
+### Methods
+
+#### ResolveSymbolByAddress
+
+Resolve kernel address to symbol information.
+
+**Signature**:
+{% raw %}
+```go
+ResolveSymbolByAddress(addr uint64) ([]*SymbolInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `addr`: Kernel address to resolve
+
+**Returns**:
+
+- `[]*SymbolInfo`: List of symbols at this address (usually one, but aliases possible)
+- `error`: `ErrNotFound` if address cannot be resolved
+
+**Example**:
+{% raw %}
+```go
+address, found := v1beta1.GetData[uint64](event, "address")
+if !found {
+    return nil, nil
+}
+
+symbols, err := d.dataStores.KernelSymbols().ResolveSymbolByAddress(address)
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Warnw("Unknown address", "addr", fmt.Sprintf("0x%x", address))
+    return nil, nil
+}
+if err != nil {
+    return nil, err
+}
+
+for _, symbol := range symbols {
+    d.logger.Infow("Symbol",
+        "name", symbol.Name,
+        "address", fmt.Sprintf("0x%x", symbol.Address),
+        "module", symbol.Module)
+
+    // Check if this is a kernel module (rootkit detection)
+    if symbol.Module != "system" {
+        // Potential hook detected
+        return []detection.DetectorOutput{{
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("symbol", symbol.Name),
+                v1beta1.NewStringValue("module", symbol.Module),
+            },
+        }}, nil
+    }
+}
+```
+{% endraw %}
+
+#### GetSymbolAddress
+
+Get the address of a named kernel symbol.
+
+**Signature**:
+{% raw %}
+```go
+GetSymbolAddress(name string) (uint64, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `name`: Symbol name (e.g., "do_sys_open")
+
+**Returns**:
+
+- `uint64`: Symbol address
+- `error`: `ErrNotFound` if symbol not found
+
+**Example**:
+{% raw %}
+```go
+addr, err := d.dataStores.KernelSymbols().GetSymbolAddress("do_sys_open")
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Warnw("Symbol not found", "name", "do_sys_open")
+    return nil, nil
+}
+if err != nil {
+    return nil, err
+}
+
+d.logger.Infow("Symbol address",
+    "name", "do_sys_open",
+    "address", fmt.Sprintf("0x%x", addr))
+```
+{% endraw %}
+
+#### ResolveSymbolsBatch
+
+Resolve multiple addresses in a single call (more efficient).
+
+**Signature**:
+{% raw %}
+```go
+ResolveSymbolsBatch(addrs []uint64) (map[uint64][]*SymbolInfo, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `addrs`: List of addresses to resolve
+
+**Returns**:
+
+- `map[uint64][]*SymbolInfo`: Map of address to symbols (only includes found addresses)
+- `error`: Error if batch operation fails
+
+**Example**:
+{% raw %}
+```go
+// Get syscall table addresses from event
+addresses := []uint64{0xffffffff81234567, 0xffffffff81abcdef, ...}
+
+// Batch resolve (more efficient than individual lookups)
+symbols, err := d.dataStores.KernelSymbols().ResolveSymbolsBatch(addresses)
+if err != nil {
+    return nil, err
+}
+
+// Process results
+for addr, symbolList := range symbols {
+    for _, symbol := range symbolList {
+        d.logger.Infow("Resolved",
+            "address", fmt.Sprintf("0x%x", addr),
+            "symbol", symbol.Name,
+            "module", symbol.Module)
+
+        // Detect hooks by checking module
+        if symbol.Module != "system" {
+            // Hook detected
+        }
+    }
+}
+
+// Check for addresses that couldn't be resolved
+for _, addr := range addresses {
+    if _, found := symbols[addr]; !found {
+        d.logger.Warnw("Address not resolved", "addr", fmt.Sprintf("0x%x", addr))
+    }
+}
+```
+{% endraw %}
+
+---
+
+## DNSStore
+
+### Interface
+
+{% raw %}
+```go
+type DNSStore interface {
+    DataStore
+
+    // GetDNSResponse retrieves cached DNS response
+    // Returns ErrNotFound if no cached response found
+    GetDNSResponse(query string) (*DNSResponse, error)
+}
+```
+{% endraw %}
+
+### DNSResponse Structure
+
+{% raw %}
+```go
+type DNSResponse struct {
+    Query   string   // DNS query (domain name)
+    IPs     []string // Resolved IP addresses
+    Domains []string // Resolved domains (for reverse lookups)
+}
+```
+{% endraw %}
+
+### Methods
+
+#### GetDNSResponse
+
+Retrieve cached DNS query response.
+
+**Signature**:
+{% raw %}
+```go
+GetDNSResponse(query string) (*DNSResponse, error)
+```
+{% endraw %}
+
+**Parameters**:
+
+- `query`: DNS query (domain name)
+
+**Returns**:
+
+- `*DNSResponse`: DNS response if cached
+- `error`: `ErrNotFound` if not cached, `nil` on success
+
+**Example**:
+{% raw %}
+```go
+domain := "malicious.example.com"
+response, err := d.dataStores.DNS().GetDNSResponse(domain)
+if errors.Is(err, datastores.ErrNotFound) {
+    d.logger.Debugw("No DNS cache entry", "domain", domain)
+    return nil, nil
+}
+if err != nil {
+    return nil, fmt.Errorf("failed to query DNS cache: %w", err)
+}
+
+d.logger.Infow("DNS cache hit",
+    "domain", domain,
+    "ips", response.IPs,
+    "resolved_domains", response.Domains)
+```
+{% endraw %}
+
+!!! Note "Cache Scope"
+    The DNS cache only contains queries observed by Tracee while running.
+    It does **not** contain historical or system-wide DNS data.
+
+---
+
+## Health and Metrics
+
+### Health Information
+
+All datastores expose health status:
+
+{% raw %}
+```go
+type HealthInfo struct {
+    Status    HealthStatus // Current health status
+    Message   string       // Empty if healthy, error details if not
+    LastCheck time.Time    // When health was last checked
+}
+```
+{% endraw %}
+
+**Example**:
+{% raw %}
+```go
+processStore := d.dataStores.Processes()
+health := processStore.GetHealth()
+
+if health.Status != datastores.HealthHealthy {
+    d.logger.Warnw("Process store unhealthy",
+        "status", health.Status.String(),
+        "message", health.Message,
+        "last_check", health.LastCheck)
+
+    // Decide whether to continue or fail
+    if health.Status == datastores.HealthUnhealthy {
+        return nil, fmt.Errorf("process store unhealthy: %s", health.Message)
+    }
+}
+```
+{% endraw %}
+
+### Metrics
+
+Datastores expose operational metrics:
+
+{% raw %}
+```go
+type DataStoreMetrics struct {
+    ItemCount    int64     // Number of items in store
+    SuccessCount uint64    // Successful requests
+    ErrorCount   uint64    // Failed requests
+    CacheHits    uint64    // Cache hits (if applicable)
+    CacheMisses  uint64    // Cache misses (if applicable)
+    LastAccess   time.Time // Last access time
+}
+```
+{% endraw %}
+
+**Example**:
+{% raw %}
+```go
+processStore := d.dataStores.Processes()
+metrics := processStore.GetMetrics()
+
+d.logger.Infow("Process store metrics",
+    "item_count", metrics.ItemCount,
+    "success_count", metrics.SuccessCount,
+    "error_count", metrics.ErrorCount,
+    "cache_hits", metrics.CacheHits,
+    "cache_misses", metrics.CacheMisses,
+    "hit_rate", float64(metrics.CacheHits) / float64(metrics.CacheHits + metrics.CacheMisses),
+    "last_access", metrics.LastAccess)
+
+// Alert if error rate is high
+if metrics.ErrorCount > 0 {
+    errorRate := float64(metrics.ErrorCount) / float64(metrics.SuccessCount + metrics.ErrorCount)
+    if errorRate > 0.01 {
+        d.logger.Warnw("High error rate", "rate", errorRate)
+    }
+}
+```
+{% endraw %}
+
+---
+
+## Error Handling
+
+### Error Classification
+
+**Not Found (common, non-error)**:
+{% raw %}
+```go
+proc, err := d.dataStores.Processes().GetProcess(entityId)
+if errors.Is(err, datastores.ErrNotFound) {
+    // Process not in tree (maybe exited) - this is normal
+    d.logger.Debugw("Process not found", "entity_id", entityId)
+    return nil, nil  // Skip gracefully
+}
+```
+{% endraw %}
+
+**Store Errors (critical)**:
+{% raw %}
+```go
+symbols, err := d.dataStores.KernelSymbols().ResolveSymbolByAddress(addr)
+if err != nil {
+    // Check for specific error types
+    if errors.Is(err, datastores.ErrNotFound) {
+        d.logger.Warnw("Address not in symbol table", "addr", addr)
+        return nil, nil  // Skip gracefully
+    }
+
+    if errors.Is(err, datastores.ErrStoreUnhealthy) {
+        // Store is unhealthy - critical
+        return nil, fmt.Errorf("symbol store unhealthy: %w", err)
+    }
+
+    // Other error - log and return
+    return nil, fmt.Errorf("symbol resolution failed: %w", err)
+}
+```
+{% endraw %}
+
+### Graceful Degradation
+
+Always handle missing/unavailable stores gracefully:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    // Check if optional store is available (use IsAvailable for readiness check)
+    if d.dataStores.IsAvailable("system") {
+        systemStore := d.dataStores.System()
+        sysInfo := systemStore.GetSystemInfo()
+        // Use system info for enrichment
+    } else {
+        d.logger.Debugw("System store unavailable, continuing without system info")
+        // Continue detection without system info
+    }
+
+    // Check for optional data
+    container, err := d.dataStores.Containers().GetContainer(containerID)
+    if errors.Is(err, datastores.ErrNotFound) {
+        d.logger.Debugw("Container not found, continuing without container context")
+        // Continue detection without container info
+    } else if err != nil {
+        return nil, fmt.Errorf("container store error: %w", err)
+    } else {
+        // Use container info for enrichment
+    }
+
+    // Core detection logic...
+}
+```
+{% endraw %}
+
+---
+
+## Advanced Usage
+
+### Combining Multiple Stores
+
+{% raw %}
+```go
+func (d *ContainerEscapeDetector) analyzeEscape(event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    // Get process information
+    entityId := event.Workload.Process.EntityId.Value
+    proc, err := d.dataStores.Processes().GetProcess(entityId)
+    if errors.Is(err, datastores.ErrNotFound) {
+        return nil, nil
+    }
+    if err != nil {
+        return nil, fmt.Errorf("process store error: %w", err)
+    }
+
+    // Get process ancestry
+    ancestry, err := d.dataStores.Processes().GetAncestry(entityId, 5)
+    if err != nil {
+        return nil, err
+    }
+
+    // Get container information
+    containerID := v1beta1.GetContainerID(event)
+    container, err := d.dataStores.Containers().GetContainer(containerID)
+    if errors.Is(err, datastores.ErrNotFound) {
+        return nil, nil
+    }
+    if err != nil {
+        return nil, fmt.Errorf("container store error: %w", err)
+    }
+
+    // Get system information
+    sysInfo := d.dataStores.System().GetSystemInfo()
+
+    // Analyze all together
+    if d.detectEscape(proc, ancestry, container, sysInfo) {
+        return []detection.DetectorOutput{{
+            Data: []*v1beta1.EventValue{
+                v1beta1.NewStringValue("process", proc.Exe),
+                v1beta1.NewStringValue("container", container.Name),
+                v1beta1.NewStringValue("kernel", sysInfo.KernelRelease),
+            },
+        }}, nil
+    }
+
+    return nil, nil
+}
+```
+{% endraw %}
+
+### Caching Store References
+
+Cache store references in Init() for better performance:
+
+{% raw %}
+```go
+type MyDetector struct {
+    logger         detection.Logger
+    processStore   datastores.ProcessStore
+    containerStore datastores.ContainerStore
+    systemStore    datastores.SystemStore
+}
+
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+    d.logger = params.Logger
+
+    // Cache store references (registry always returns non-nil stores)
+    d.processStore = params.DataStores.Processes()
+    d.containerStore = params.DataStores.Containers()
+    d.systemStore = params.DataStores.System()
+
+    // Validate required stores are available
+    if !params.DataStores.IsAvailable("process") {
+        return fmt.Errorf("process store required but not available")
+    }
+
+    // Warn about optional stores
+    if !params.DataStores.IsAvailable("system") {
+        d.logger.Warnw("System store unavailable, some features disabled")
+    }
+
+    return nil
+}
+
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    // Use cached references (no registry lookup)
+    proc, err := d.processStore.GetProcess(entityId)
+    if errors.Is(err, datastores.ErrNotFound) {
+        return nil, nil
+    }
+
+    container, err := d.containerStore.GetContainer(containerID)
+    if errors.Is(err, datastores.ErrNotFound) {
+        return nil, nil
+    }
+
+    // System store always available (cached reference)
+    sysInfo := d.systemStore.GetSystemInfo()
+    // Use system info
+
+    // ...
+}
+```
+{% endraw %}
+
+---
+
+## Summary
+
+### Quick Reference
+
+| Store | Primary Use | Key Methods |
+|-------|-------------|-------------|
+| **ProcessStore** | Process info & ancestry | `GetProcess()`, `GetAncestry()`, `GetChildProcesses()` |
+| **ContainerStore** | Container metadata | `GetContainer()`, `GetContainerByName()` |
+| **SystemStore** | System information | `GetSystemInfo()` |
+| **SyscallStore** | Syscall ID/name mapping | `GetSyscallName()`, `GetSyscallID()` |
+| **KernelSymbolStore** | Symbol resolution | `ResolveSymbolByAddress()`, `ResolveSymbolsBatch()` |
+| **DNSStore** | DNS cache | `GetDNSResponse()` |
+
+### Best Practices
+
+1. **Use EntityID, not PID** for process lookups
+2. **Cache store references** in Init() for performance
+3. **Handle missing data gracefully** (stores may be unavailable)
+4. **Use batch operations** when resolving multiple items
+5. **Check health status** before critical operations
+6. **Monitor metrics** for performance insights
+7. **Fail fast** on critical errors, degrade gracefully on optional failures
+
+### Next Steps
+
+- Read the [Detector API Reference](api-reference.md) for complete detector development
+- Start with the [Quick Start Guide](quickstart.md) to write your first detector
+- Study real detector implementations in `detectors/` directory
+
+---
+
+**API Version**: v1beta1
+**Last Updated**: From implementation commits (60 commits analyzing detector and datastore system)

--- a/docs/docs/detectors/index.md
+++ b/docs/docs/detectors/index.md
@@ -1,0 +1,172 @@
+# Detector Documentation
+
+Detectors are the modern way to write custom threat detection and event derivation logic in Tracee.
+
+## What are Detectors?
+
+Detectors analyze runtime events to identify security threats and derive higher-level events from raw eBPF data. They provide:
+
+- **Type-safe APIs**: Direct protobuf access with compile-time guarantees
+- **Rich context**: Access to process trees, containers, DNS cache, and more
+- **Declarative filtering**: Engine-level event filtering by data, scope, and version
+- **Auto-enrichment**: Automatic population of threat metadata and process ancestry
+- **Built-in observability**: Prometheus metrics and structured logging
+
+## Documentation Guide
+
+### 🚀 For Newcomers
+
+**Start here if you're new to Tracee detectors:**
+
+#### [Quick Start Guide](quickstart.md)
+**Get your first detector running in 30 minutes**
+
+Step-by-step tutorial to build a working detector:
+
+- Create a detector file
+- Build and run Tracee
+- Trigger and observe detections
+- Understand auto-registration, filtering, and enrichment
+
+Perfect for: First-time detector developers, hands-on learners
+
+---
+
+### 📚 For Reference
+
+**Comprehensive API documentation:**
+
+#### [Detector API Reference](api-reference.md)
+**Complete detector API specification**
+
+Everything you need to know about the detector API:
+
+- Core interfaces and structures
+- Event requirements and filtering
+- Auto-population features
+- Advanced features and lifecycle management
+- Testing patterns and best practices
+- Migration from old signatures
+- Troubleshooting common issues
+
+Perfect for: Understanding all capabilities, deep dives, migrating from signatures
+
+#### [DataStore API Reference](datastore-api.md)
+**Complete datastore API specification**
+
+Query system state from your detectors:
+
+- ProcessStore (process information and ancestry)
+- ContainerStore (container and Kubernetes metadata)
+- SystemStore, SyscallStore, KernelSymbolStore, DNSStore
+- Health monitoring and error handling
+
+Perfect for: Detectors that need to query system state and context
+
+---
+
+## Quick Example
+
+Here's a minimal detector to give you a taste:
+
+{% raw %}
+```go
+package detectors
+
+import (
+    "context"
+    "github.com/aquasecurity/tracee/api/v1beta1"
+    "github.com/aquasecurity/tracee/api/v1beta1/detection"
+)
+
+func init() {
+    register(&SensitiveFileAccess{})  // Auto-register
+}
+
+type SensitiveFileAccess struct {
+    logger detection.Logger
+}
+
+func (d *SensitiveFileAccess) GetDefinition() detection.DetectorDefinition {
+    return detection.DetectorDefinition{
+        ID: "TRC-001",
+        Requirements: detection.DetectorRequirements{
+            Events: []detection.EventRequirement{
+                {
+                    Name: "security_file_open",
+                    DataFilters: []string{"pathname=/etc/shadow"},  // Engine filters
+                },
+            },
+        },
+        ProducedEvent: v1beta1.EventDefinition{
+            Name:    "sensitive_file_access",
+            Version: &v1beta1.Version{Major: 1},
+        },
+        ThreatMetadata: &v1beta1.Threat{
+            Severity: v1beta1.Severity_HIGH,
+        },
+        AutoPopulate: detection.AutoPopulateFields{
+            Threat:          true,  // Auto-copy threat metadata
+            ProcessAncestry: true,  // Auto-fetch process tree
+        },
+    }
+}
+
+func (d *SensitiveFileAccess) Init(params detection.DetectorParams) error {
+    d.logger = params.Logger
+    return nil
+}
+
+func (d *SensitiveFileAccess) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+    pathname, _ := v1beta1.GetData[string](event, "pathname")
+    return []detection.DetectorOutput{{
+        Data: []*v1beta1.EventValue{
+            v1beta1.NewStringValue("file", pathname),
+        },
+    }}, nil
+}
+```
+{% endraw %}
+
+**See the [Quick Start Guide](quickstart.md) for a complete walkthrough.**
+
+## Documentation at a Glance
+
+| Document | Purpose | Audience |
+|----------|---------|----------|
+| [Quick Start](quickstart.md) | Hands-on tutorial, first detector | Newcomers |
+| [API Reference](api-reference.md) | Complete detector API + migration + troubleshooting | All developers |
+| [DataStore API](datastore-api.md) | Complete datastore API docs | Developers using datastores |
+
+**Total reading time to first detector**: ~30 minutes (Quick Start only)
+
+## Resources
+
+### Code Examples
+- **Quick Start Example**: [Quick Start Guide](quickstart.md) - complete annotated walkthrough
+- **Real Detectors**: Browse `detectors/` directory for production implementations
+- **Migration Examples**: [API Reference](api-reference.md#migration-from-signatures) - signature → detector
+
+### API Definitions
+- **Detector Interfaces**: `api/v1beta1/detection/detector.go`
+- **DataStore Interfaces**: `api/v1beta1/datastores/interfaces.go`
+- **Event Protobuf**: `api/v1beta1/event.proto`
+
+### Migration from Signatures
+Existing signatures can be migrated to the new detector API. See [Migration Guide](api-reference.md#migration-from-signatures) for:
+
+- Side-by-side API comparison
+- Step-by-step migration instructions
+- Pattern translations and examples
+- Complete migration checklist
+
+## Community and Support
+
+- **Tracee GitHub**: https://github.com/aquasecurity/tracee
+- **Issues**: Report bugs and request features
+- **Discussions**: Ask questions and share detectors
+- **Documentation**: https://aquasecurity.github.io/tracee/
+
+---
+
+**Ready to start?** Jump to the [Quick Start Guide](quickstart.md) for a hands-on tutorial, or dive into the [API Reference](api-reference.md) for complete documentation.

--- a/docs/docs/detectors/quickstart.md
+++ b/docs/docs/detectors/quickstart.md
@@ -1,0 +1,558 @@
+# Detector Quick Start Guide
+
+Get your first Tracee detector running in 30 minutes. This hands-on tutorial assumes basic Go knowledge but no prior Tracee experience.
+
+## What You'll Build
+
+A detector that identifies when processes access sensitive system files like `/etc/shadow` or `/etc/sudoers`, with:
+
+- Automatic threat metadata enrichment
+- Full process ancestry (parent → grandparent → ...)
+- Container context (if applicable)
+
+## Prerequisites
+
+```bash
+# Clone Tracee
+git clone https://github.com/aquasecurity/tracee
+cd tracee
+
+# Verify build environment
+make env
+
+# Required: Linux kernel 4.18+, Go 1.24+, Clang 12+
+```
+
+## Step 1: Create Your Detector File
+
+Create `detectors/sensitive_file_access.go`:
+
+{% raw %}
+```go
+package detectors
+
+import (
+	"context"
+
+	"github.com/aquasecurity/tracee/api/v1beta1"
+	"github.com/aquasecurity/tracee/api/v1beta1/detection"
+)
+
+// Auto-register the detector on startup
+func init() {
+	register(&SensitiveFileAccess{})
+}
+
+// SensitiveFileAccess detects access to sensitive system files
+type SensitiveFileAccess struct {
+	logger detection.Logger
+}
+
+// GetDefinition declares what this detector does and what it needs
+func (d *SensitiveFileAccess) GetDefinition() detection.DetectorDefinition {
+	return detection.DetectorDefinition{
+		ID: "TRC-001",  // Unique identifier
+		
+		Requirements: detection.DetectorRequirements{
+			Events: []detection.EventRequirement{
+				{
+					Name: "security_file_open",
+					// Engine filters - only matching events reach OnEvent()
+					DataFilters: []string{
+						"pathname=/etc/shadow",
+						"pathname=/etc/sudoers",
+					},
+				},
+			},
+		},
+		
+		// Define the output event this detector produces
+		ProducedEvent: v1beta1.EventDefinition{
+			Name:        "sensitive_file_access",
+			Description: "Access to sensitive system files detected",
+			Version: &v1beta1.Version{Major: 1, Minor: 0, Patch: 0},
+			Fields: []*v1beta1.EventField{
+				{Name: "file_path", Type: "const char*"},
+				{Name: "executable", Type: "const char*"},
+			},
+		},
+		
+		// Threat information template (auto-copied to outputs)
+		ThreatMetadata: &v1beta1.Threat{
+			Name:        "Sensitive File Access",
+			Description: "A process attempted to access a sensitive system file",
+			Severity:    v1beta1.Severity_MEDIUM,
+		},
+		
+		// Tell engine to auto-enrich our outputs
+		AutoPopulate: detection.AutoPopulateFields{
+			Threat:          true,  // Copy ThreatMetadata above
+			DetectedFrom:    true,  // Link to triggering event
+			ProcessAncestry: true,  // Add 5 levels of parent processes
+		},
+	}
+}
+
+// Init is called once at startup
+func (d *SensitiveFileAccess) Init(params detection.DetectorParams) error {
+	d.logger = params.Logger
+	d.logger.Infow("SensitiveFileAccess detector initialized")
+	return nil
+}
+
+// OnEvent processes each matching event
+func (d *SensitiveFileAccess) OnEvent(
+	ctx context.Context,
+	event *v1beta1.Event,
+) ([]detection.DetectorOutput, error) {
+	// Type-safe data extraction
+	pathname, found := v1beta1.GetData[string](event, "pathname")
+	if !found {
+		return nil, nil  // Skip if pathname missing
+	}
+
+	// Extract executable path (nil-safe protobuf getters)
+	executablePath := event.GetWorkload().GetProcess().GetExecutable().GetPath()
+
+	// Return output data - engine handles the rest (threat, ancestry, etc.)
+	return []detection.DetectorOutput{{
+		Data: []*v1beta1.EventValue{
+			v1beta1.NewStringValue("file_path", pathname),
+			v1beta1.NewStringValue("executable", executablePath),
+		},
+	}}, nil
+}
+```
+{% endraw %}
+
+## Step 2: Build Tracee
+
+```bash
+# Build with your detector included
+make tracee
+
+# The detector is compiled in - no plugins or manual registration needed!
+```
+
+## Step 3: Run Tracee
+
+```bash
+# Start Tracee with process tree and JSON output
+sudo ./dist/tracee --stores process.source=both --output json | jq
+```
+
+## Step 4: Trigger Your Detector
+
+In a third terminal, access a sensitive file:
+
+```bash
+sudo cat /etc/shadow
+```
+
+## Step 5: See the Detection
+
+You should see output like:
+
+```json
+{
+  "id": 5001,
+  "name": "sensitive_file_access",
+  "version": "1.0.0",
+  "timestamp": "2025-12-16T10:30:45.123Z",
+  "threat": {
+    "name": "Sensitive File Access",
+    "description": "A process attempted to access a sensitive system file",
+    "severity": "MEDIUM"
+  },
+  "data": {
+    "file_path": "/etc/shadow",
+    "executable": "/bin/cat"
+  },
+  "detected_from": {
+    "event_id": 257,
+    "event_name": "security_file_open"
+  },
+  "workload": {
+    "process": {
+      "entity_id": 12345,
+      "pid": 67890,
+      "executable": {"path": "/bin/cat"},
+      "ancestors": [
+        {"entity_id": 12344, "pid": 67889, "executable": {"path": "/bin/bash"}},
+        {"entity_id": 12343, "pid": 67888, "thread": {"name": "sshd"}},
+        {"entity_id": 1, "pid": 1, "thread": {"name": "systemd"}}
+      ]
+    }
+  }
+}
+```
+
+## What Just Happened?
+
+Let's break down the magic:
+
+### 1. Auto-Registration
+
+{% raw %}
+```go
+func init() {
+	register(&SensitiveFileAccess{})
+}
+```
+{% endraw %}
+
+Your detector registered itself automatically. No manual list maintenance!
+
+### 2. Engine Filtering
+
+{% raw %}
+```go
+DataFilters: []string{
+	"pathname=/etc/shadow",
+	"pathname=/etc/sudoers",
+},
+```
+{% endraw %}
+
+Tracee's engine filtered millions of `security_file_open` events. Only those matching your paths reached `OnEvent()`. This happens in the engine - super efficient!
+
+### 3. Type-Safe Extraction
+
+{% raw %}
+```go
+pathname, found := v1beta1.GetData[string](event, "pathname")
+```
+{% endraw %}
+
+Generic type parameter ensures compile-time type safety. No runtime casting errors!
+
+### 4. Auto-Enrichment
+
+{% raw %}
+```go
+AutoPopulate: detection.AutoPopulateFields{
+	Threat:          true,
+	DetectedFrom:    true,
+	ProcessAncestry: true,
+}
+```
+{% endraw %}
+
+The engine automatically:
+
+- ✅ Copied `ThreatMetadata` to `output.Threat`
+- ✅ Set `output.DetectedFrom` pointing to the triggering event
+- ✅ Queried the process tree and populated 5 ancestor levels
+- ✅ Preserved timestamp, workload, and policies from input event
+
+You just returned simple data fields - the engine did the heavy lifting!
+
+## Common Patterns
+
+### Multiple Outputs
+
+A single input can produce multiple detections:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+	var outputs []detection.DetectorOutput
+	
+	// Check condition 1
+	if isSuspicious {
+		outputs = append(outputs, detection.DetectorOutput{
+			Data: []*v1beta1.EventValue{
+				v1beta1.NewStringValue("reason", "suspicious pattern"),
+			},
+		})
+	}
+	
+	// Check condition 2
+	if isMalicious {
+		outputs = append(outputs, detection.DetectorOutput{
+			Data: []*v1beta1.EventValue{
+				v1beta1.NewStringValue("reason", "known malware signature"),
+			},
+		})
+	}
+	
+	return outputs, nil
+}
+```
+{% endraw %}
+
+### Custom Threat Severity
+
+Override the default threat metadata per detection:
+
+{% raw %}
+```go
+return []detection.DetectorOutput{{
+	Data: []*v1beta1.EventValue{
+		v1beta1.NewStringValue("file", pathname),
+	},
+	Threat: &v1beta1.Threat{
+		Name:        "Critical System File Access",
+		Severity:    v1beta1.Severity_CRITICAL,  // Override default MEDIUM
+		Description: "Root accessed critical system file",
+	},
+}}, nil
+```
+{% endraw %}
+
+### Using DataStores
+
+Access system state like process information:
+
+{% raw %}
+```go
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+	entityId := event.GetWorkload().GetProcess().GetEntityId()
+	
+	// Query process store for process details
+	proc, err := d.dataStores.Processes().GetProcess(entityId)
+	if errors.Is(err, datastores.ErrNotFound) {
+		// Process not in tree yet
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	
+	// Use process info in detection logic
+	if proc.GetInterpreter().GetPath() == "/bin/bash" {
+		return []detection.DetectorOutput{{
+			Data: []*v1beta1.EventValue{
+				v1beta1.NewStringValue("shell", "bash"),
+			},
+		}}, nil
+	}
+	
+	return nil, nil
+}
+```
+{% endraw %}
+
+### Filtering by Container
+
+Only detect events from containers:
+
+{% raw %}
+```go
+Requirements: detection.DetectorRequirements{
+	Events: []detection.EventRequirement{
+		{
+			Name: "security_file_open",
+			ScopeFilters: []string{"container=started"},  // Containers only
+		},
+	},
+}
+```
+{% endraw %}
+
+Or only from host:
+
+{% raw %}
+```go
+ScopeFilters: []string{"not-container"},  // Host only
+```
+{% endraw %}
+
+## Debugging Tips
+
+### Enable Debug Logging
+
+```bash
+# Run with debug logs
+sudo ./dist/tracee --logging debug --stores process.source=both
+```
+
+### Check Detector Registration
+
+```bash
+# List detector events
+sudo ./dist/tracee list | grep detectors
+```
+
+### Verify Event Filtering
+
+Check that your event name is correct:
+
+```bash
+# List available events
+sudo ./dist/tracee list | grep security_file_open
+```
+
+### Test Without Filters
+
+Temporarily remove `DataFilters` to see all events:
+
+{% raw %}
+```go
+Requirements: detection.DetectorRequirements{
+	Events: []detection.EventRequirement{
+		{
+			Name: "security_file_open",
+			// DataFilters: []string{...},  // Commented out for testing
+		},
+	},
+}
+```
+{% endraw %}
+
+Add logging in `OnEvent()`:
+
+{% raw %}
+```go
+func (d *SensitiveFileAccess) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+	d.logger.Debugw("Event received", "event", event.Name)
+	// ... rest of logic
+}
+```
+{% endraw %}
+
+## Next Steps
+
+Congratulations! You've written your first Tracee detector. Now explore:
+
+### 📚 Deep Dive into APIs
+- **[API Reference](api-reference.md)**: Complete detector API documentation
+- **[DataStore API](datastore-api.md)**: Query process trees, containers, DNS, and more
+
+### 🔄 Migration and Troubleshooting
+- **[Migration Guide](api-reference.md#migration-from-signatures)**: Migrating from old signatures
+- **[Troubleshooting](api-reference.md#troubleshooting)**: Common issues and solutions
+
+### 🔍 Study Real Examples
+- Browse `detectors/` directory for production implementations
+- See `api/v1beta1/detection/detector.go` for interface definitions
+
+### 🧪 Write Tests
+- Add unit tests in `detectors/sensitive_file_access_test.go`
+- See [Testing Guide](api-reference.md#testing) for patterns
+
+## Troubleshooting
+
+### Detector Not Running
+
+**Problem**: Your detector code changed but behavior didn't
+
+**Solution**: Rebuild Tracee - detectors are compiled in, not dynamically loaded
+```bash
+make tracee
+```
+
+### No Events Received
+
+**Problem**: `OnEvent()` never called
+
+**Possible causes**:
+
+1. Wrong event name - check `tracee list`
+2. Filters too restrictive - temporarily remove them
+3. Event not enabled - Tracee enables events based on requirements automatically
+
+### Process Ancestry Empty
+
+**Problem**: `workload.process.ancestors` is null
+
+**Solution**: Enable process tree:
+```bash
+sudo ./dist/tracee --stores process.source=both
+```
+
+### Build Errors
+
+**Problem**: Compilation fails
+
+**Common fixes**:
+```bash
+# Update dependencies
+make go-tidy
+
+# Clean build
+make clean
+make tracee
+```
+
+## Quick Reference
+
+### Detector Skeleton
+
+{% raw %}
+```go
+package detectors
+
+import (
+	"context"
+
+	"github.com/aquasecurity/tracee/api/v1beta1"
+	"github.com/aquasecurity/tracee/api/v1beta1/datastores"
+	"github.com/aquasecurity/tracee/api/v1beta1/detection"
+)
+
+func init() {
+	register(&MyDetector{})
+}
+
+type MyDetector struct {
+	logger     detection.Logger
+	dataStores datastores.Registry
+}
+
+func (d *MyDetector) GetDefinition() detection.DetectorDefinition {
+	return detection.DetectorDefinition{
+		ID: "TRC-XXX",
+		Requirements: detection.DetectorRequirements{
+			Events: []detection.EventRequirement{{Name: "event_name"}},
+		},
+		ProducedEvent: v1beta1.EventDefinition{
+			Name:    "my_detection",
+			Version: &v1beta1.Version{Major: 1},
+		},
+		AutoPopulate: detection.AutoPopulateFields{
+			Threat:          true,
+			DetectedFrom:    true,
+			ProcessAncestry: true,
+		},
+	}
+}
+
+func (d *MyDetector) Init(params detection.DetectorParams) error {
+	d.logger = params.Logger
+	d.dataStores = params.DataStores
+	return nil
+}
+
+func (d *MyDetector) OnEvent(ctx context.Context, event *v1beta1.Event) ([]detection.DetectorOutput, error) {
+	// Your detection logic
+	return []detection.DetectorOutput{{
+		Data: []*v1beta1.EventValue{},
+	}}, nil
+}
+```
+{% endraw %}
+
+### Essential Commands
+
+```bash
+# Build
+make tracee
+
+# Run with process tree
+sudo ./dist/tracee --stores process.source=both
+
+# View detections in JSON
+sudo ./dist/tracee --output json | jq
+
+# List detector events
+sudo ./dist/tracee list | grep detectors
+
+# Debug mode
+sudo ./dist/tracee --logging debug
+```
+
+---
+
+**Ready for more?** Continue to the [API Reference](api-reference.md) for comprehensive documentation, including migration guides and troubleshooting.
+

--- a/docs/docs/events/custom/overview.md
+++ b/docs/docs/events/custom/overview.md
@@ -2,11 +2,31 @@
 
 Tracee comes with many built-in events, but you can extend its capabilities by creating custom events tailored to your specific needs.
 
-Currently, custom events can be implemented using Go.  Refer to the [Go](./golang.md) documentation for detailed instructions on how to define and integrate your custom events into Tracee.
+## Modern Approach: Detectors
 
-Once you've created your custom event, load it using the `signatures-dir` flag. For example, if your custom event is defined in the directory `/tmp/myevents`, start Tracee with the following command:
+**Recommended**: The modern way to create custom threat detections and derived events is using the **EventDetector API**.
 
-```
+**📖 See the [Detector Documentation](../../detectors/index.md) for complete guide and examples.**
+
+Key benefits:
+- Type-safe protobuf access
+- Rich data extraction helpers
+- System state access (process trees, containers, DNS)
+- Declarative filtering and auto-enrichment
+- Built-in metrics and observability
+- No plugin complexity
+
+## Legacy Approach: Signatures (Plugin System)
+
+The older signature system using `.so` plugins is still supported for backward compatibility, but we recommend migrating to detectors.
+
+Refer to the [Go](./golang.md) documentation for instructions on the legacy plugin-based approach.
+
+### Loading Signatures
+
+Once you've created a signature plugin, load it using the `signatures-dir` flag:
+
+```bash
 tracee --signatures-dir=/tmp/myevents
 ```
 
@@ -15,8 +35,35 @@ tracee --signatures-dir=/tmp/myevents
     for `signatures-dir` you will not load the tracee [signatures](../builtin/security-events.md),
     to avoid such problems, you can either place your own events under the same directory of the tracee custom events,
     or pass multiple directories for example:
-    ```
+    ```bash
     tracee --signatures-dir=/tmp/myevents --signatures-dir=./dist/signatures
     ```
+
+### Migrating from Signatures to Detectors
+
+The [Detector API Reference](../../detectors/api-reference.md#migration-from-signatures) includes complete migration instructions with:
+
+- Step-by-step migration guide
+- Before/after code examples
+- Pattern translations
+- Migration checklist
+
+---
+
+## Choose Your Approach
+
+| Feature | Detectors (Modern) | Signatures (Legacy) |
+|---------|-------------------|---------------------|
+| Type Safety | ✅ Compile-time | ❌ Runtime casting |
+| Data Access | ✅ Type-safe helpers | ❌ Manual parsing |
+| System State | ✅ Full datastore access | ❌ Limited |
+| Event Filtering | ✅ Declarative | ❌ Manual in code |
+| Auto-Enrichment | ✅ Process ancestry, threat metadata | ❌ Manual |
+| Deployment | ✅ Compiled-in | ❌ Separate .so files |
+| Testing | ✅ Direct function calls | ❌ Callback mocking |
+| Observability | ✅ Built-in metrics | ❌ Manual |
+| Documentation | ✅ [Complete guide](../../detectors/index.md) | ✅ [Legacy docs](./golang.md) |
+
+**Recommendation**: Use detectors for all new development. Migrate existing signatures over time.
 
 👈 Please use the side-navigation on the left in order to browse the different topics.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,11 @@ nav:
                 - Custom Events:
                       - Overview: docs/events/custom/overview.md
                       - Go: docs/events/custom/golang.md
+          - Detectors:
+                - Overview: docs/detectors/index.md
+                - Quick Start: docs/detectors/quickstart.md
+                - API Reference: docs/detectors/api-reference.md
+                - DataStore API: docs/detectors/datastore-api.md
           - Policies:
                 - Overview: docs/policies/index.md
                 - Scopes: docs/policies/scopes.md


### PR DESCRIPTION
Add comprehensive documentation for EventDetector API and DataStore system:

- docs/docs/detectors/developer-guide.md - Complete detector development guide with quick start, API reference, testing, migration from signatures, and examples
- docs/docs/detectors/datastore-api.md - DataStore API reference for all stores (Process, Container, System, Syscall, Symbol, DNS) with usage patterns
- docs/docs/detectors/index.md - Landing page with overview and navigation
- docs/docs/events/custom/overview.md - Updated to highlight new detector system and mark signatures as legacy

Covers auto-registration, filters, version validation, enrichment requirements, metrics, process ancestry, and more.