### PR TITLE
feat(detectors): add AncestryDepth field for per-detection ancestry control

### DIFF
--- a/api/v1beta1/detection/detector.go
+++ b/api/v1beta1/detection/detector.go
@@ -43,6 +43,12 @@ type DetectorOutput struct {
 	// If nil and AutoPopulate.Threat=true, engine uses Definition.ThreatMetadata
 	Threat *v1beta1.Threat
 
+	// AncestryDepth overrides the process ancestry depth for this detection.
+	// Priority: output.AncestryDepth > definition.ProcessAncestry (default 5).
+	// Values: nil (use ProcessAncestry boolean), 0 (disable), 1+ (fetch N levels)
+	// Use case: request deep ancestry for high-severity detections, or disable for performance
+	AncestryDepth *uint32
+
 	// Future extensibility (commented for documentation):
 	// Timestamp *timestamppb.Timestamp  // Override input timestamp (rare)
 	// Workload  *v1beta1.Workload       // Override input workload (rare)


### PR DESCRIPTION
Add optional AncestryDepth field to DetectorOutput enabling fine-grained control over process ancestry fetching depth on a per-detection basis.

Changes:
- Add AncestryDepth *uint32 to DetectorOutput struct
- Implement priority: output.AncestryDepth > ProcessAncestry bool (default 5)
- Update dispatch logic to use explicit depth when provided

The ProcessAncestry boolean remains as simple fallback (default 5 levels). Detectors can now override depth per detection: nil (use boolean), 0 (disable), or N (fetch N levels).