### PR TITLE
docs: fix mkdocs navigation and macro syntax errors

### DIFF
--- a/docs/docs/outputs/event-structure.md
+++ b/docs/docs/outputs/event-structure.md
@@ -160,6 +160,7 @@ If you're using Go templates, update your field references:
 
 ### Template Examples
 
+{% raw %}
 **Before:**
 ```go
 Event: {{.EventName}}
@@ -205,11 +206,13 @@ Time: {{.timestamp.seconds}}.{{.timestamp.nanos}}
   {{.name}}: {{.value}}
 {{end}}
 ```
+{% endraw %}
 
 ### Accessing Event Data
 
 Event-specific data is in the `.data` array. Each item has a `.name` and a typed `.value` field:
 
+{% raw %}
 ```go
 {{range .data}}
   {{if eq .name "pathname"}}
@@ -221,6 +224,7 @@ Event-specific data is in the `.data` array. Each item has a `.name` and a typed
   {{end}}
 {{end}}
 ```
+{% endraw %}
 
 ## Event Value Types
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,10 +37,13 @@ nav:
                                   - output: docs/flags/output.1.md
                                   - capture: docs/flags/capture.1.md
                                   - config: docs/flags/config.1.md
-                                  - containers: docs/flags/containers.1.md
                                   - capabilities: docs/flags/capabilities.1.md
                                   - logging: docs/flags/logging.1.md
                                   - server: docs/flags/server.1.md
+                                  - buffers: docs/flags/buffers.1.md
+                                  - enrichment: docs/flags/enrichment.1.md
+                                  - runtime: docs/flags/runtime.1.md
+                                  - stores: docs/flags/stores.1.md
           - Events:
                 - Overview: docs/events/index.md
                 - Built-in Events:


### PR DESCRIPTION
- Add missing flag files to navigation: buffers, enrichment, runtime, stores
- Remove reference to non-existent containers.1.md flag file
- Escape Go template examples in event-structure.md using raw blocks to prevent mkdocs-macros plugin from parsing them as Jinja2 templates

Fixes mkdocs build warnings and macro syntax errors.
