### PR TITLE
feat(datastores): Implement null object pattern for registry accessors

### DIFF
--- a/docs/docs/detectors/datastore-api.md
+++ b/docs/docs/detectors/datastore-api.md
@@ -163,6 +163,26 @@ type Registry interface {
 ```
 {% endraw %}
 
+**Nil-Safety Guarantee:**
+
+Accessor methods (`Processes()`, `Containers()`, etc.) **never return nil**. If a store is not registered or unavailable, they return a null object that:
+- Implements the store interface
+- Returns `ErrStoreUnhealthy` for all operations
+- Has health status set to `HealthUnhealthy`
+
+This eliminates nil checks and allows safe method chaining:
+
+```go
+// Always safe - no nil check needed
+proc, err := datastores.Processes().GetProcess(entityID)
+if errors.Is(err, datastores.ErrStoreUnhealthy) {
+    // Store not available
+}
+if errors.Is(err, datastores.ErrNotFound) {
+    // Process not found
+}
+```
+
 ### Usage Examples
 
 **Basic access**:

--- a/pkg/datastores/null_stores.go
+++ b/pkg/datastores/null_stores.go
@@ -1,0 +1,178 @@
+package datastores
+
+import (
+	"time"
+
+	"github.com/aquasecurity/tracee/api/v1beta1/datastores"
+)
+
+// Null object implementations for datastores
+// These are returned when a store is not registered, ensuring accessor methods never return nil
+
+// nullProcessStore implements ProcessStore with all operations returning ErrStoreUnhealthy
+type nullProcessStore struct{}
+
+func (n *nullProcessStore) Name() string { return "null_process" }
+
+func (n *nullProcessStore) GetHealth() *datastores.HealthInfo {
+	return &datastores.HealthInfo{
+		Status:    datastores.HealthUnhealthy,
+		Message:   "process store not available",
+		LastCheck: time.Now(),
+	}
+}
+
+func (n *nullProcessStore) GetMetrics() *datastores.DataStoreMetrics {
+	return &datastores.DataStoreMetrics{
+		ItemCount:  0,
+		LastAccess: time.Now(),
+	}
+}
+
+func (n *nullProcessStore) GetProcess(entityId uint32) (*datastores.ProcessInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+func (n *nullProcessStore) GetChildProcesses(entityId uint32) ([]*datastores.ProcessInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+func (n *nullProcessStore) GetAncestry(entityId uint32, maxDepth int) ([]*datastores.ProcessInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+// nullContainerStore implements ContainerStore with all operations returning ErrStoreUnhealthy
+type nullContainerStore struct{}
+
+func (n *nullContainerStore) Name() string { return "null_container" }
+
+func (n *nullContainerStore) GetHealth() *datastores.HealthInfo {
+	return &datastores.HealthInfo{
+		Status:    datastores.HealthUnhealthy,
+		Message:   "container store not available",
+		LastCheck: time.Now(),
+	}
+}
+
+func (n *nullContainerStore) GetMetrics() *datastores.DataStoreMetrics {
+	return &datastores.DataStoreMetrics{
+		ItemCount:  0,
+		LastAccess: time.Now(),
+	}
+}
+
+func (n *nullContainerStore) GetContainer(id string) (*datastores.ContainerInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+func (n *nullContainerStore) GetContainerByName(name string) (*datastores.ContainerInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+// nullKernelSymbolStore implements KernelSymbolStore with all operations returning ErrStoreUnhealthy
+type nullKernelSymbolStore struct{}
+
+func (n *nullKernelSymbolStore) Name() string { return "null_symbol" }
+
+func (n *nullKernelSymbolStore) GetHealth() *datastores.HealthInfo {
+	return &datastores.HealthInfo{
+		Status:    datastores.HealthUnhealthy,
+		Message:   "kernel symbol store not available",
+		LastCheck: time.Now(),
+	}
+}
+
+func (n *nullKernelSymbolStore) GetMetrics() *datastores.DataStoreMetrics {
+	return &datastores.DataStoreMetrics{
+		ItemCount:  0,
+		LastAccess: time.Now(),
+	}
+}
+
+func (n *nullKernelSymbolStore) ResolveSymbolByAddress(addr uint64) ([]*datastores.SymbolInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+func (n *nullKernelSymbolStore) GetSymbolAddress(name string) (uint64, error) {
+	return 0, datastores.ErrStoreUnhealthy
+}
+
+func (n *nullKernelSymbolStore) ResolveSymbolsBatch(addrs []uint64) (map[uint64][]*datastores.SymbolInfo, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+// nullDNSStore implements DNSStore with all operations returning ErrStoreUnhealthy
+type nullDNSStore struct{}
+
+func (n *nullDNSStore) Name() string { return "null_dns" }
+
+func (n *nullDNSStore) GetHealth() *datastores.HealthInfo {
+	return &datastores.HealthInfo{
+		Status:    datastores.HealthUnhealthy,
+		Message:   "DNS store not available",
+		LastCheck: time.Now(),
+	}
+}
+
+func (n *nullDNSStore) GetMetrics() *datastores.DataStoreMetrics {
+	return &datastores.DataStoreMetrics{
+		ItemCount:  0,
+		LastAccess: time.Now(),
+	}
+}
+
+func (n *nullDNSStore) GetDNSResponse(query string) (*datastores.DNSResponse, error) {
+	return nil, datastores.ErrStoreUnhealthy
+}
+
+// nullSystemStore implements SystemStore with all operations returning ErrStoreUnhealthy
+type nullSystemStore struct{}
+
+func (n *nullSystemStore) Name() string { return "null_system" }
+
+func (n *nullSystemStore) GetHealth() *datastores.HealthInfo {
+	return &datastores.HealthInfo{
+		Status:    datastores.HealthUnhealthy,
+		Message:   "system store not available",
+		LastCheck: time.Now(),
+	}
+}
+
+func (n *nullSystemStore) GetMetrics() *datastores.DataStoreMetrics {
+	return &datastores.DataStoreMetrics{
+		ItemCount:  0,
+		LastAccess: time.Now(),
+	}
+}
+
+func (n *nullSystemStore) GetSystemInfo() *datastores.SystemInfo {
+	return &datastores.SystemInfo{}
+}
+
+// nullSyscallStore implements SyscallStore with all operations returning ErrStoreUnhealthy
+type nullSyscallStore struct{}
+
+func (n *nullSyscallStore) Name() string { return "null_syscall" }
+
+func (n *nullSyscallStore) GetHealth() *datastores.HealthInfo {
+	return &datastores.HealthInfo{
+		Status:    datastores.HealthUnhealthy,
+		Message:   "syscall store not available",
+		LastCheck: time.Now(),
+	}
+}
+
+func (n *nullSyscallStore) GetMetrics() *datastores.DataStoreMetrics {
+	return &datastores.DataStoreMetrics{
+		ItemCount:  0,
+		LastAccess: time.Now(),
+	}
+}
+
+func (n *nullSyscallStore) GetSyscallName(id int32) (string, error) {
+	return "", datastores.ErrStoreUnhealthy
+}
+
+func (n *nullSyscallStore) GetSyscallID(name string) (int32, error) {
+	return 0, datastores.ErrStoreUnhealthy
+}

--- a/pkg/datastores/null_stores_test.go
+++ b/pkg/datastores/null_stores_test.go
@@ -1,0 +1,366 @@
+package datastores
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aquasecurity/tracee/api/v1beta1/datastores"
+)
+
+func TestNullProcessStore(t *testing.T) {
+	store := &nullProcessStore{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "null_process", store.Name())
+	})
+
+	t.Run("GetHealth", func(t *testing.T) {
+		health := store.GetHealth()
+		assert.NotNil(t, health)
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+		assert.Equal(t, "process store not available", health.Message)
+		assert.False(t, health.LastCheck.IsZero())
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		metrics := store.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.ItemCount)
+		assert.False(t, metrics.LastAccess.IsZero())
+	})
+
+	t.Run("GetProcess", func(t *testing.T) {
+		proc, err := store.GetProcess(1)
+		assert.Nil(t, proc)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("GetChildProcesses", func(t *testing.T) {
+		children, err := store.GetChildProcesses(1)
+		assert.Nil(t, children)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("GetAncestry", func(t *testing.T) {
+		ancestry, err := store.GetAncestry(1, 10)
+		assert.Nil(t, ancestry)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+}
+
+func TestNullContainerStore(t *testing.T) {
+	store := &nullContainerStore{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "null_container", store.Name())
+	})
+
+	t.Run("GetHealth", func(t *testing.T) {
+		health := store.GetHealth()
+		assert.NotNil(t, health)
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+		assert.Equal(t, "container store not available", health.Message)
+		assert.False(t, health.LastCheck.IsZero())
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		metrics := store.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.ItemCount)
+		assert.False(t, metrics.LastAccess.IsZero())
+	})
+
+	t.Run("GetContainer", func(t *testing.T) {
+		container, err := store.GetContainer("test-id")
+		assert.Nil(t, container)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("GetContainerByName", func(t *testing.T) {
+		container, err := store.GetContainerByName("test-name")
+		assert.Nil(t, container)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+}
+
+func TestNullKernelSymbolStore(t *testing.T) {
+	store := &nullKernelSymbolStore{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "null_symbol", store.Name())
+	})
+
+	t.Run("GetHealth", func(t *testing.T) {
+		health := store.GetHealth()
+		assert.NotNil(t, health)
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+		assert.Equal(t, "kernel symbol store not available", health.Message)
+		assert.False(t, health.LastCheck.IsZero())
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		metrics := store.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.ItemCount)
+		assert.False(t, metrics.LastAccess.IsZero())
+	})
+
+	t.Run("ResolveSymbolByAddress", func(t *testing.T) {
+		symbols, err := store.ResolveSymbolByAddress(0x12345678)
+		assert.Nil(t, symbols)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("GetSymbolAddress", func(t *testing.T) {
+		addr, err := store.GetSymbolAddress("test_symbol")
+		assert.Equal(t, uint64(0), addr)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("ResolveSymbolsBatch", func(t *testing.T) {
+		addrs := []uint64{0x1000, 0x2000, 0x3000}
+		result, err := store.ResolveSymbolsBatch(addrs)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+}
+
+func TestNullDNSStore(t *testing.T) {
+	store := &nullDNSStore{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "null_dns", store.Name())
+	})
+
+	t.Run("GetHealth", func(t *testing.T) {
+		health := store.GetHealth()
+		assert.NotNil(t, health)
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+		assert.Equal(t, "DNS store not available", health.Message)
+		assert.False(t, health.LastCheck.IsZero())
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		metrics := store.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.ItemCount)
+		assert.False(t, metrics.LastAccess.IsZero())
+	})
+
+	t.Run("GetDNSResponse", func(t *testing.T) {
+		response, err := store.GetDNSResponse("example.com")
+		assert.Nil(t, response)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+}
+
+func TestNullSystemStore(t *testing.T) {
+	store := &nullSystemStore{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "null_system", store.Name())
+	})
+
+	t.Run("GetHealth", func(t *testing.T) {
+		health := store.GetHealth()
+		assert.NotNil(t, health)
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+		assert.Equal(t, "system store not available", health.Message)
+		assert.False(t, health.LastCheck.IsZero())
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		metrics := store.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.ItemCount)
+		assert.False(t, metrics.LastAccess.IsZero())
+	})
+
+	t.Run("GetSystemInfo", func(t *testing.T) {
+		info := store.GetSystemInfo()
+		assert.NotNil(t, info)
+		// Verify it returns an empty SystemInfo struct
+		assert.Equal(t, &datastores.SystemInfo{}, info)
+	})
+}
+
+func TestNullSyscallStore(t *testing.T) {
+	store := &nullSyscallStore{}
+
+	t.Run("Name", func(t *testing.T) {
+		assert.Equal(t, "null_syscall", store.Name())
+	})
+
+	t.Run("GetHealth", func(t *testing.T) {
+		health := store.GetHealth()
+		assert.NotNil(t, health)
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+		assert.Equal(t, "syscall store not available", health.Message)
+		assert.False(t, health.LastCheck.IsZero())
+	})
+
+	t.Run("GetMetrics", func(t *testing.T) {
+		metrics := store.GetMetrics()
+		assert.NotNil(t, metrics)
+		assert.Equal(t, int64(0), metrics.ItemCount)
+		assert.False(t, metrics.LastAccess.IsZero())
+	})
+
+	t.Run("GetSyscallName", func(t *testing.T) {
+		name, err := store.GetSyscallName(1)
+		assert.Equal(t, "", name)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("GetSyscallID", func(t *testing.T) {
+		id, err := store.GetSyscallID("read")
+		assert.Equal(t, int32(0), id)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+}
+
+// TestNullStores_RegistryIntegration tests that null stores are properly returned by the registry
+func TestNullStores_RegistryIntegration(t *testing.T) {
+	t.Run("Processes returns null store when not registered", func(t *testing.T) {
+		reg := NewRegistry()
+		store := reg.Processes()
+
+		assert.NotNil(t, store)
+		assert.Equal(t, "null_process", store.Name())
+
+		health := store.GetHealth()
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+
+		_, err := store.GetProcess(1)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("Containers returns null store when not registered", func(t *testing.T) {
+		reg := NewRegistry()
+		store := reg.Containers()
+
+		assert.NotNil(t, store)
+		assert.Equal(t, "null_container", store.Name())
+
+		health := store.GetHealth()
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+
+		_, err := store.GetContainer("test")
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("KernelSymbols returns null store when not registered", func(t *testing.T) {
+		reg := NewRegistry()
+		store := reg.KernelSymbols()
+
+		assert.NotNil(t, store)
+		assert.Equal(t, "null_symbol", store.Name())
+
+		health := store.GetHealth()
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+
+		_, err := store.GetSymbolAddress("test")
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("DNS returns null store when not registered", func(t *testing.T) {
+		reg := NewRegistry()
+		store := reg.DNS()
+
+		assert.NotNil(t, store)
+		assert.Equal(t, "null_dns", store.Name())
+
+		health := store.GetHealth()
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+
+		_, err := store.GetDNSResponse("example.com")
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+
+	t.Run("System returns null store when not registered", func(t *testing.T) {
+		reg := NewRegistry()
+		store := reg.System()
+
+		assert.NotNil(t, store)
+		assert.Equal(t, "null_system", store.Name())
+
+		health := store.GetHealth()
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+
+		info := store.GetSystemInfo()
+		assert.NotNil(t, info)
+	})
+
+	t.Run("Syscalls returns null store when not registered", func(t *testing.T) {
+		reg := NewRegistry()
+		store := reg.Syscalls()
+
+		assert.NotNil(t, store)
+		assert.Equal(t, "null_syscall", store.Name())
+
+		health := store.GetHealth()
+		assert.Equal(t, datastores.HealthUnhealthy, health.Status)
+
+		_, err := store.GetSyscallName(1)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
+	})
+}
+
+// TestNullStores_SafeMethodChaining verifies that null stores enable safe method chaining
+func TestNullStores_SafeMethodChaining(t *testing.T) {
+	reg := NewRegistry()
+
+	// All these chains should work without nil checks
+	t.Run("Process store chaining", func(t *testing.T) {
+		// This would panic with nil, but works with null object
+		name := reg.Processes().Name()
+		assert.Equal(t, "null_process", name)
+
+		status := reg.Processes().GetHealth().Status
+		assert.Equal(t, datastores.HealthUnhealthy, status)
+
+		count := reg.Processes().GetMetrics().ItemCount
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("Container store chaining", func(t *testing.T) {
+		name := reg.Containers().Name()
+		assert.Equal(t, "null_container", name)
+
+		status := reg.Containers().GetHealth().Status
+		assert.Equal(t, datastores.HealthUnhealthy, status)
+	})
+
+	t.Run("KernelSymbol store chaining", func(t *testing.T) {
+		name := reg.KernelSymbols().Name()
+		assert.Equal(t, "null_symbol", name)
+
+		status := reg.KernelSymbols().GetHealth().Status
+		assert.Equal(t, datastores.HealthUnhealthy, status)
+	})
+
+	t.Run("DNS store chaining", func(t *testing.T) {
+		name := reg.DNS().Name()
+		assert.Equal(t, "null_dns", name)
+
+		status := reg.DNS().GetHealth().Status
+		assert.Equal(t, datastores.HealthUnhealthy, status)
+	})
+
+	t.Run("System store chaining", func(t *testing.T) {
+		name := reg.System().Name()
+		assert.Equal(t, "null_system", name)
+
+		status := reg.System().GetHealth().Status
+		assert.Equal(t, datastores.HealthUnhealthy, status)
+	})
+
+	t.Run("Syscall store chaining", func(t *testing.T) {
+		name := reg.Syscalls().Name()
+		assert.Equal(t, "null_syscall", name)
+
+		status := reg.Syscalls().GetHealth().Status
+		assert.Equal(t, datastores.HealthUnhealthy, status)
+	})
+}

--- a/pkg/datastores/registry.go
+++ b/pkg/datastores/registry.go
@@ -37,6 +37,13 @@ func NewRegistry() *Registry {
 	return &Registry{
 		stores:      make(map[string]datastores.DataStore),
 		initialized: make(map[string]bool),
+		// Initialize with null objects to ensure accessor methods never return nil
+		processStore:      &nullProcessStore{},
+		containerStore:    &nullContainerStore{},
+		kernelSymbolStore: &nullKernelSymbolStore{},
+		dnsStore:          &nullDNSStore{},
+		systemStore:       &nullSystemStore{},
+		syscallStore:      &nullSyscallStore{},
 	}
 }
 

--- a/pkg/datastores/registry_test.go
+++ b/pkg/datastores/registry_test.go
@@ -107,7 +107,12 @@ func TestRegistry_Processes(t *testing.T) {
 		reg := NewRegistry()
 
 		result := reg.Processes()
-		assert.Nil(t, result)
+		assert.NotNil(t, result, "accessor methods must never return nil")
+		assert.Equal(t, "null_process", result.Name())
+
+		// Null store should return ErrStoreUnhealthy
+		_, err := result.GetProcess(1)
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
 	})
 
 	t.Run("Processes_WrongType", func(t *testing.T) {
@@ -118,7 +123,8 @@ func TestRegistry_Processes(t *testing.T) {
 		require.NoError(t, err)
 
 		result := reg.Processes()
-		assert.Nil(t, result, "should return nil when store doesn't implement ProcessStore")
+		assert.NotNil(t, result, "accessor methods must never return nil")
+		assert.Equal(t, "null_process", result.Name(), "should return null object when store doesn't implement ProcessStore")
 	})
 }
 
@@ -139,7 +145,12 @@ func TestRegistry_Containers(t *testing.T) {
 		reg := NewRegistry()
 
 		result := reg.Containers()
-		assert.Nil(t, result)
+		assert.NotNil(t, result, "accessor methods must never return nil")
+		assert.Equal(t, "null_container", result.Name())
+
+		// Null store should return ErrStoreUnhealthy
+		_, err := result.GetContainer("test")
+		assert.ErrorIs(t, err, datastores.ErrStoreUnhealthy)
 	})
 }
 


### PR DESCRIPTION
Ensure Registry accessor methods never return nil for safety and consistency.

- Add null object implementations for all store types
- Initialize Registry with null objects by default
- Null stores return ErrStoreUnhealthy for all operations
- Update tests to verify nil-safety guarantee
- Document nil-safety guarantee in API docs

Benefits:
- Eliminates need for nil checks in detector code
- Enables safe method chaining
- Clear error signals (ErrStoreUnhealthy vs ErrNotFound)
- Graceful degradation when stores unavailable
