### PR TITLE
fix(printer): resolve data race in TestPrinterFromStream

### DIFF
--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -248,7 +249,10 @@ func TestPrinterFromStream(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		p.FromStream(ctx, stream)
 	}()
 
@@ -264,6 +268,7 @@ func TestPrinterFromStream(t *testing.T) {
 	time.Sleep(time.Millisecond * 10)
 
 	cancel()
+	wg.Wait() // Wait for goroutine to finish before closing
 	p.Close()
 	sm.Close()
 


### PR DESCRIPTION
The test had a data race where Close() was called immediately after cancel() without waiting for the FromStream() goroutine to finish. This caused concurrent access to bufio.Writer from both goroutines.

Fix by adding proper synchronization:
- Use sync.WaitGroup to track the FromStream() goroutine
- Wait for the goroutine to complete before calling Close()

This ensures Close() is never called while Print() is still executing, eliminating the race condition without adding mutex overhead to the hot path (Print() method).

Fixes the race detector warning:
  Read at 0x00c000386128 by goroutine 14 (Close/Flush)
  Previous write at 0x00c000386128 by goroutine 19 (Print/Write)