### PR TITLE
fix(flags): add DetectorsFlag to GetFlagsFromViper switch

### DIFF
--- a/pkg/cmd/flags/config.go
+++ b/pkg/cmd/flags/config.go
@@ -27,6 +27,8 @@ func GetFlagsFromViper(key string) ([]string, error) {
 		flagger = &CapabilitiesConfig{}
 	case "containers":
 		flagger = &ContainerConfig{}
+	case DetectorsFlag:
+		flagger = &DetectorsConfig{}
 	case LoggingFlag:
 		flagger = &LogConfig{}
 	case "output":


### PR DESCRIPTION
Add DetectorsFlag case to GetFlagsFromViper to enable CLI flag parsing for --detectors flag. Without this, the flag would fail with 'unrecognized key: detectors' error.

This completes the detectors flag implementation alongside the existing config file support (detectors.yaml-dir) added in previous commits.