### PR TITLE
refactor: consolidate buffer fields into BuffersConfig

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -121,10 +121,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	// Initialize a tracee config structure
 
 	cfg := config.Config{
-		EventsPerfBufferSize:       buffers.Kernel.Events,
-		ArtifactsPerfBufferSize:    buffers.Kernel.Artifacts,
-		ControlPlanePerfBufferSize: buffers.Kernel.ControlPlane,
-		PipelineChannelSize:        buffers.Pipeline,
+		Buffers: buffers.GetInternalConfig(),
 	}
 
 	// OS release information

--- a/pkg/cmd/flags/buffers.go
+++ b/pkg/cmd/flags/buffers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
+	"github.com/aquasecurity/tracee/pkg/config"
 )
 
 const (
@@ -22,17 +23,30 @@ const (
 	invalidBufferFlagNegativeOrZero  = "invalid buffer flag: %s value can't be negative or zero, use 'trace man buffers' for more info"
 )
 
-// BuffersConfig is a struct containing the buffers sizes
+// BuffersConfig represents CLI buffer configuration that implements cliFlagger interface
 type BuffersConfig struct {
 	Kernel   KernelBuffersConfig `mapstructure:"kernel"`
 	Pipeline int                 `mapstructure:"pipeline"`
 }
 
-// KernelBuffersConfig holds kernel buffer sizes
+// KernelBuffersConfig holds kernel buffer sizes (CLI wrapper for config.KernelBuffersConfig)
 type KernelBuffersConfig struct {
 	Events       int `mapstructure:"events"`
 	Artifacts    int `mapstructure:"artifacts"`
 	ControlPlane int `mapstructure:"control-plane"`
+}
+
+// GetInternalConfig converts the CLI BuffersConfig to the internal config.BuffersConfig
+// This follows the isolation pattern used by other flags (stores, enrichment, etc.)
+func (c *BuffersConfig) GetInternalConfig() config.BuffersConfig {
+	return config.BuffersConfig{
+		Kernel: config.KernelBuffersConfig{
+			Events:       c.Kernel.Events,
+			Artifacts:    c.Kernel.Artifacts,
+			ControlPlane: c.Kernel.ControlPlane,
+		},
+		Pipeline: c.Pipeline,
+	}
 }
 
 // flags returns the flags for the buffers config

--- a/pkg/cmd/flags/buffers_test.go
+++ b/pkg/cmd/flags/buffers_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/pkg/config"
 )
 
 func TestPrepareBuffers(t *testing.T) {
@@ -13,15 +15,15 @@ func TestPrepareBuffers(t *testing.T) {
 	testCases := []struct {
 		testName       string
 		flags          []string
-		expectedReturn BuffersConfig
+		expectedReturn config.BuffersConfig
 		expectedError  string
 	}{
 		// default values (no flags)
 		{
 			testName: "default values",
 			flags:    []string{},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       GetDefaultPerfBufferSize(),
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -33,8 +35,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid kernel.events",
 			flags:    []string{"kernel.events=2048"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       2048,
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -45,8 +47,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid pipeline",
 			flags:    []string{"pipeline=4000"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       GetDefaultPerfBufferSize(),
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -57,8 +59,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid kernel.artifacts",
 			flags:    []string{"kernel.artifacts=512"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       GetDefaultPerfBufferSize(),
 					Artifacts:    512,
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -69,8 +71,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid kernel.control-plane",
 			flags:    []string{"kernel.control-plane=256"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       GetDefaultPerfBufferSize(),
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: 256,
@@ -82,8 +84,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid multiple flags",
 			flags:    []string{"kernel.events=2048", "pipeline=5000"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       2048,
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -94,8 +96,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid all flags",
 			flags:    []string{"kernel.events=2048", "pipeline=4000", "kernel.artifacts=512", "kernel.control-plane=256"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       2048,
 					Artifacts:    512,
 					ControlPlane: 256,
@@ -106,8 +108,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid flags in different order",
 			flags:    []string{"kernel.artifacts=512", "kernel.control-plane=256", "kernel.events=2048", "pipeline=40000"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       2048,
 					Artifacts:    512,
 					ControlPlane: 256,
@@ -119,8 +121,8 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName: "valid duplicate flags",
 			flags:    []string{"kernel.events=2048", "kernel.events=4096"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       4096,
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -132,65 +134,65 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName:       "invalid flag format missing equals",
 			flags:          []string{"kernel.events"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("kernel.events"),
 		},
 		{
 			testName:       "invalid flag format missing equals with value",
 			flags:          []string{"kernel.events2048"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("kernel.events2048"),
 		},
 		{
 			testName:       "invalid flag format empty value",
 			flags:          []string{"kernel.events="},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("kernel.events="),
 		},
 		// invalid flag name
 		{
 			testName:       "invalid flag name",
 			flags:          []string{"invalid-flag=2048"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("invalid-flag"),
 		},
 		{
 			testName:       "invalid flag name with typo",
 			flags:          []string{"kernel.event=2048"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("kernel.event"),
 		},
 		{
 			testName:       "invalid flag name empty",
 			flags:          []string{"=2048"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("=2048"),
 		},
 		// invalid flag value (non-numeric) - note: parseInt returns 0, doesn't error
 		{
 			testName:       "invalid flag value non-numeric",
 			flags:          []string{"kernel.events=invalid"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBufferFlagPositiveIntegerError("kernel.events"),
 		},
 		{
 			testName:       "invalid flag value negative",
 			flags:          []string{"kernel.events=-2048"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBufferFlagNegativeOrZeroError("kernel.events"),
 		},
 		// valid edge cases
 		{
 			testName:       "valid zero value",
 			flags:          []string{"kernel.events=0"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBufferFlagNegativeOrZeroError("kernel.events"),
 		},
 		{
 			testName: "valid large value",
 			flags:    []string{"kernel.events=999999"},
-			expectedReturn: BuffersConfig{
-				Kernel: KernelBuffersConfig{
+			expectedReturn: config.BuffersConfig{
+				Kernel: config.KernelBuffersConfig{
 					Events:       999999,
 					Artifacts:    GetDefaultPerfBufferSize(),
 					ControlPlane: GetDefaultPerfBufferSize(),
@@ -202,13 +204,13 @@ func TestPrepareBuffers(t *testing.T) {
 		{
 			testName:       "mixed valid and invalid flag name",
 			flags:          []string{"kernel.events=2048", "invalid-flag=4096"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("invalid-flag"),
 		},
 		{
 			testName:       "mixed valid and invalid format",
 			flags:          []string{"kernel.events=2048", "pipeline"},
-			expectedReturn: BuffersConfig{},
+			expectedReturn: config.BuffersConfig{},
 			expectedError:  invalidBuffersFlagErrorMsg("pipeline"),
 		},
 	}
@@ -234,7 +236,7 @@ func TestPrepareBuffers(t *testing.T) {
 	}
 }
 
-func TestBuffersConfig_flags(t *testing.T) {
+func TestBuffersFlags(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,39 +18,36 @@ import (
 // NOTE: In the future, Tracee config will be changed at run time and will require
 // proper management.
 type Config struct {
-	InitialPolicies            []interface{} // due to circular dependency, policy.Policy cannot be used here
-	Capture                    *CaptureConfig
-	Capabilities               *CapabilitiesConfig
-	Output                     *OutputConfig
-	ProcTree                   process.ProcTreeConfig
-	EventsPerfBufferSize       int
-	ArtifactsPerfBufferSize    int
-	PipelineChannelSize        int
-	ControlPlanePerfBufferSize int
-	MaxPidsCache               int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
-	BTFObjPath                 string
-	BPFObjBytes                []byte
-	BPFObjPath                 string // path to the BPF object binary for uprobe attachment (defaults to /proc/self/exe)
-	KernelConfig               *environment.KernelConfig
-	OSInfo                     *environment.OSInfo
-	Sockets                    runtime.Sockets
-	EnrichmentEnabled          bool
-	CgroupFSPath               string
-	CgroupFSForce              bool
-	EngineConfig               engine.Config
-	DNSCacheConfig             dns.Config
-	MetricsEnabled             bool
-	HealthzEnabled             bool
-	DetectorConfig             DetectorConfig
+	InitialPolicies   []interface{} // due to circular dependency, policy.Policy cannot be used here
+	Capture           *CaptureConfig
+	Capabilities      *CapabilitiesConfig
+	Output            *OutputConfig
+	ProcTree          process.ProcTreeConfig
+	Buffers           BuffersConfig
+	MaxPidsCache      int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
+	BTFObjPath        string
+	BPFObjBytes       []byte
+	BPFObjPath        string // path to the BPF object binary for uprobe attachment (defaults to /proc/self/exe)
+	KernelConfig      *environment.KernelConfig
+	OSInfo            *environment.OSInfo
+	Sockets           runtime.Sockets
+	EnrichmentEnabled bool
+	CgroupFSPath      string
+	CgroupFSForce     bool
+	EngineConfig      engine.Config
+	DNSCacheConfig    dns.Config
+	MetricsEnabled    bool
+	HealthzEnabled    bool
+	DetectorConfig    DetectorConfig
 }
 
 // Validate does static validation of the configuration
 func (c Config) Validate() error {
 	// Buffer sizes
-	if (c.EventsPerfBufferSize & (c.EventsPerfBufferSize - 1)) != 0 {
+	if (c.Buffers.Kernel.Events & (c.Buffers.Kernel.Events - 1)) != 0 {
 		return errfmt.Errorf("invalid perf buffer size - must be a power of 2")
 	}
-	if (c.ArtifactsPerfBufferSize & (c.ArtifactsPerfBufferSize - 1)) != 0 {
+	if (c.Buffers.Kernel.Artifacts & (c.Buffers.Kernel.Artifacts - 1)) != 0 {
 		return errfmt.Errorf("invalid perf buffer size - must be a power of 2")
 	}
 
@@ -208,4 +205,21 @@ type Stream struct {
 // DetectorConfig manages detector lifecycle
 type DetectorConfig struct {
 	Detectors []detection.EventDetector // All detectors (built-in + extensions)
+}
+
+//
+// Buffers
+//
+
+// BuffersConfig is a struct containing the buffers sizes
+type BuffersConfig struct {
+	Kernel   KernelBuffersConfig `mapstructure:"kernel"`
+	Pipeline int                 `mapstructure:"pipeline"`
+}
+
+// KernelBuffersConfig holds kernel buffer sizes
+type KernelBuffersConfig struct {
+	Events       int `mapstructure:"events"`
+	Artifacts    int `mapstructure:"artifacts"`
+	ControlPlane int `mapstructure:"control-plane"`
 }

--- a/pkg/ebpf/events_enrich.go
+++ b/pkg/ebpf/events_enrich.go
@@ -69,7 +69,7 @@ func (t *Tracee) enrichContainerEvents(ctx gocontext.Context, in <-chan *events.
 	// big lock
 	bLock := sync.RWMutex{}
 	// pipeline channels
-	out := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	out := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	errc := make(chan error, 1)
 	// state machine for enrichment
 	enrichDone := make(map[uint64]bool)

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -46,7 +46,7 @@ func (t *Tracee) handleEvents(ctx context.Context, initialized chan<- struct{}) 
 	// Sort stage: events go through a sorting function.
 
 	if t.config.Output.EventsSorting {
-		eventsChan, errc = t.eventsSorter.StartPipeline(ctx, eventsChan, t.config.ArtifactsPerfBufferSize)
+		eventsChan, errc = t.eventsSorter.StartPipeline(ctx, eventsChan, t.config.Buffers.Kernel.Artifacts)
 		t.stats.Channels["sort"] = eventsChan
 		errcList = append(errcList, errc)
 	}
@@ -104,7 +104,7 @@ func (t *Tracee) handleEvents(ctx context.Context, initialized chan<- struct{}) 
 // through a decoding function that will decode the event from its raw format into a
 // PipelineEvent type.
 func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-chan *events.PipelineEvent, <-chan error) {
-	out := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	out := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	errc := make(chan error, 1)
 
 	// Create local decoder pool for this pipeline stage
@@ -499,7 +499,7 @@ func parseContextFlags(containerId string, flags uint32) trace.ContextFlags {
 func (t *Tracee) processEvents(ctx context.Context, in <-chan *events.PipelineEvent) (
 	<-chan *events.PipelineEvent, <-chan error,
 ) {
-	out := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	out := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	errc := make(chan error, 1)
 
 	// Some "informational" events are started here (TODO: API server?)
@@ -575,7 +575,7 @@ func (t *Tracee) processEvents(ctx context.Context, in <-chan *events.PipelineEv
 func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *events.PipelineEvent) (
 	<-chan *events.PipelineEvent, <-chan error,
 ) {
-	out := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	out := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	errc := make(chan error, 1)
 
 	go func() {
@@ -648,7 +648,7 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *events.PipelineEve
 func (t *Tracee) detectEvents(ctx context.Context, in <-chan *events.PipelineEvent) (
 	<-chan *events.PipelineEvent, <-chan error,
 ) {
-	out := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	out := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	errc := make(chan error, 1)
 
 	// Maximum depth for detector chains (prevents infinite loops)

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -17,12 +17,12 @@ import (
 
 // engineEvents stage in the pipeline allows signatures detection to be executed in the pipeline
 func (t *Tracee) engineEvents(ctx context.Context, in <-chan *events.PipelineEvent) (<-chan *events.PipelineEvent, <-chan error) {
-	out := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	out := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	errc := make(chan error, 1)
 
-	engineOutput := make(chan *detect.Finding, t.config.PipelineChannelSize)
-	engineInput := make(chan protocol.Event, t.config.PipelineChannelSize)
-	engineOutputEvents := make(chan *events.PipelineEvent, t.config.PipelineChannelSize)
+	engineOutput := make(chan *detect.Finding, t.config.Buffers.Pipeline)
+	engineInput := make(chan protocol.Event, t.config.Buffers.Pipeline)
+	engineOutputEvents := make(chan *events.PipelineEvent, t.config.Buffers.Pipeline)
 	source := engine.EventSources{Tracee: engineInput}
 
 	// Prepare built in data sources

--- a/tests/testutils/tracee_integrated.go
+++ b/tests/testutils/tracee_integrated.go
@@ -96,10 +96,14 @@ func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 	cfg.Capture = capture
 
 	defaultBufferPages := (4096 * 1024) / os.Getpagesize() // 4 MB of contiguous pages
-	cfg.EventsPerfBufferSize = defaultBufferPages
-	cfg.ArtifactsPerfBufferSize = defaultBufferPages
-	cfg.ControlPlanePerfBufferSize = defaultBufferPages
-	cfg.PipelineChannelSize = 1000
+	cfg.Buffers = config.BuffersConfig{
+		Kernel: config.KernelBuffersConfig{
+			Events:       defaultBufferPages,
+			Artifacts:    defaultBufferPages,
+			ControlPlane: defaultBufferPages,
+		},
+		Pipeline: 1000,
+	}
 
 	// No process tree in the integration tests
 	cfg.ProcTree = process.ProcTreeConfig{


### PR DESCRIPTION
Replace individual buffer fields in config.Config with a single Buffers field of type BuffersConfig to improve code organization and reduce parameter passing complexity.

- Add BuffersConfig/KernelBuffersConfig types to pkg/config
- Create wrapper type in pkg/cmd/flags for cliFlagger interface
- Update 30+ references across pkg/ebpf and tests

Fixes: #5102
