### PR TITLE
chore(flags): refactor output flags

### DIFF
--- a/pkg/cmd/flags/config.go
+++ b/pkg/cmd/flags/config.go
@@ -1,9 +1,6 @@
 package flags
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/spf13/viper"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
@@ -27,7 +24,7 @@ func GetFlagsFromViper(key string) ([]string, error) {
 		flagger = &CapabilitiesConfig{}
 	case LoggingFlag:
 		flagger = &LogConfig{}
-	case "output":
+	case OutputFlag:
 		flagger = &OutputConfig{}
 	case RuntimeFlag:
 		flagger = &RuntimeConfig{}
@@ -68,127 +65,4 @@ func getConfigFlags(rawValue interface{}, flagger cliFlagger, key string) ([]str
 	default:
 		return nil, errfmt.Errorf("unrecognized type %T for key %s", v, key)
 	}
-}
-
-//
-// output flag
-//
-
-type StreamBufferMode string
-
-const (
-	StreamBufferBlock StreamBufferMode = "block"
-	StreamBufferDrop  StreamBufferMode = "drop"
-)
-
-type StreamFiltersConfig struct {
-	Policies []string `mapstructure:"policies"`
-	Events   []string `mapstructure:"events"`
-}
-
-type StreamBufferConfig struct {
-	Size int              `mapstructure:"size"`
-	Mode StreamBufferMode `mapstructure:"mode"`
-}
-
-type StreamConfig struct {
-	Name         string              `mapstructure:"name"`
-	Destinations []string            `mapstructure:"destinations"`
-	Filters      StreamFiltersConfig `mapstructure:"filters"`
-	Buffer       StreamBufferConfig  `mapstructure:"buffer"`
-}
-
-type DestinationsConfig struct {
-	Name   string `mapstructure:"name"`
-	Type   string `mapstructure:"type"`
-	Format string `mapstructure:"format"`
-	Path   string `mapstructure:"path"`
-	Url    string `mapstructure:"url"`
-}
-
-type OutputOptsConfig struct {
-	None              bool   `mapstructure:"none"`
-	StackAddresses    bool   `mapstructure:"stack-addresses"`
-	ExecEnv           bool   `mapstructure:"exec-env"`
-	ExecHash          string `mapstructure:"exec-hash"`
-	ParseArguments    bool   `mapstructure:"parse-arguments"`
-	ParseArgumentsFDs bool   `mapstructure:"parse-arguments-fds"`
-	SortEvents        bool   `mapstructure:"sort-events"`
-}
-
-type OutputConfig struct {
-	Options      OutputOptsConfig     `mapstructure:"options"`
-	Destinations []DestinationsConfig `mapstructure:"destinations"`
-	Streams      []StreamConfig       `mapstructure:"streams"`
-}
-
-func (c *OutputConfig) flags() []string {
-	flags := []string{}
-
-	// options flags
-	if c.Options.None {
-		flags = append(flags, "none")
-	}
-	if c.Options.StackAddresses {
-		flags = append(flags, "option:stack-addresses")
-	}
-	if c.Options.ExecEnv {
-		flags = append(flags, "option:exec-env")
-	}
-	if c.Options.ExecHash != "" {
-		flags = append(flags, fmt.Sprintf("option:exec-hash=%s", c.Options.ExecHash))
-	}
-	if c.Options.ParseArguments {
-		flags = append(flags, "option:parse-arguments")
-	}
-	if c.Options.ParseArgumentsFDs {
-		flags = append(flags, "option:parse-arguments-fds")
-	}
-	if c.Options.SortEvents {
-		flags = append(flags, "option:sort-events")
-	}
-
-	// destinations
-	for _, destination := range c.Destinations {
-		if destination.Format != "" {
-			flags = append(flags, fmt.Sprintf("destinations.%s.format=%s", destination.Name, destination.Format))
-		}
-
-		if destination.Type != "" {
-			flags = append(flags, fmt.Sprintf("destinations.%s.type=%s", destination.Name, destination.Type))
-		}
-
-		if destination.Path != "" {
-			flags = append(flags, fmt.Sprintf("destinations.%s.path=%s", destination.Name, destination.Path))
-		}
-
-		if destination.Url != "" {
-			flags = append(flags, fmt.Sprintf("destinations.%s.url=%s", destination.Name, destination.Url))
-		}
-	}
-
-	// streams
-	for _, stream := range c.Streams {
-		if stream.Buffer.Mode != "" {
-			flags = append(flags, fmt.Sprintf("streams.%s.buffer.mode=%s", stream.Name, stream.Buffer.Mode))
-		}
-
-		if stream.Buffer.Size >= 0 {
-			flags = append(flags, fmt.Sprintf("streams.%s.buffer.size=%d", stream.Name, stream.Buffer.Size))
-		}
-
-		if len(stream.Destinations) > 0 {
-			flags = append(flags, fmt.Sprintf("streams.%s.destinations=%s", stream.Name, strings.Join(stream.Destinations, ",")))
-		}
-
-		if len(stream.Filters.Events) > 0 {
-			flags = append(flags, fmt.Sprintf("streams.%s.filters.events=%s", stream.Name, strings.Join(stream.Filters.Events, ",")))
-		}
-
-		if len(stream.Filters.Policies) > 0 {
-			flags = append(flags, fmt.Sprintf("streams.%s.filters.policies=%s", stream.Name, strings.Join(stream.Filters.Policies, ",")))
-		}
-	}
-
-	return flags
 }

--- a/pkg/streams/streams.go
+++ b/pkg/streams/streams.go
@@ -47,6 +47,7 @@ func (s *Stream) publish(ctx context.Context, event *pb.Event, policyBitmap uint
 	s.strategyPush(ctx, event)
 }
 
+// blockPublish publishes an event to the stream, blocking if the channel is full.
 func (s *Stream) blockPublish(ctx context.Context, event *pb.Event) {
 	select {
 	case s.events <- event:
@@ -55,6 +56,7 @@ func (s *Stream) blockPublish(ctx context.Context, event *pb.Event) {
 	}
 }
 
+// dropPublish publishes an event to the stream, dropping the event if the channel is full.
 func (s *Stream) dropPublish(ctx context.Context, event *pb.Event) {
 	select {
 	case s.events <- event:


### PR DESCRIPTION
Refactor output flags:

- move config to be with the code (from flags/config.go to flags/output.go)
- extract constants
- add tests to OutpuConfig flags()
- add godoc 