### PR TITLE
docs: fix bullet point formatting in documentation

### DIFF
--- a/docs/docs/detectors/datastore-api.md
+++ b/docs/docs/detectors/datastore-api.md
@@ -166,6 +166,7 @@ type Registry interface {
 **Nil-Safety Guarantee:**
 
 Accessor methods (`Processes()`, `Containers()`, etc.) **never return nil**. If a store is not registered or unavailable, they return a null object that:
+
 - Implements the store interface
 - Returns `ErrStoreUnhealthy` for all operations
 - Has health status set to `HealthUnhealthy`

--- a/docs/docs/detectors/index.md
+++ b/docs/docs/detectors/index.md
@@ -100,6 +100,7 @@ Perfect for: Detectors that need to query system state and context
 | [DataStore API](datastore-api.md) | Complete datastore API docs | Advanced Go developers |
 
 **Total reading time to first detector**:
+
 - **YAML**: ~15 minutes
 - **Go**: ~30 minutes (Quick Start only)
 

--- a/docs/docs/events/builtin/man/misc/vfs_read.md
+++ b/docs/docs/events/builtin/man/misc/vfs_read.md
@@ -62,6 +62,7 @@ The event hooks into the inner implementation of `read` and other buffer read sy
 ## LIMITATIONS
 
 This event does not capture:
+
 - Memory-mapped file access
 - Direct I/O operations that bypass VFS
 - Other read methods like `vfs_readv` (vectorized reads)

--- a/docs/docs/events/builtin/man/network/net_packet_icmp.md
+++ b/docs/docs/events/builtin/man/network/net_packet_icmp.md
@@ -76,12 +76,14 @@ Common ICMP message types captured:
 Each ICMP type has specific codes providing additional context:
 
 **Destination Unreachable (Type 3)**:
+
 - Code 0: Network unreachable
 - Code 1: Host unreachable
 - Code 2: Protocol unreachable
 - Code 3: Port unreachable
 
 **Time Exceeded (Type 11)**:
+
 - Code 0: TTL exceeded in transit
 - Code 1: Fragment reassembly time exceeded
 

--- a/docs/docs/events/builtin/man/security/ftrace_hook.md
+++ b/docs/docs/events/builtin/man/security/ftrace_hook.md
@@ -37,6 +37,7 @@ This event monitors the function tracing infrastructure to detect when functions
 
 **flags** (*string*)
 : Ftrace flags indicating hook behavior:
+
 - **R**: Registers are passed to the callback
 - **I**: Callback can change the RIP register value
 - **D**: Direct call to the function

--- a/docs/docs/events/builtin/man/security/kernel_module_loading.md
+++ b/docs/docs/events/builtin/man/security/kernel_module_loading.md
@@ -65,12 +65,14 @@ The signature monitors for:
 ## LEGITIMATE VS. MALICIOUS LOADING
 
 **Legitimate scenarios**:
+
 - Hardware driver installation
 - System feature activation (e.g., VPN, virtualization)
 - Administrative tools requiring kernel access
 - Security software components
 
 **Suspicious indicators**:
+
 - Loading from unusual locations
 - Unsigned or unknown modules
 - Loading during suspicious timeframes

--- a/docs/docs/events/builtin/man/security/stack_pivot.md
+++ b/docs/docs/events/builtin/man/security/stack_pivot.md
@@ -62,6 +62,7 @@ This event detects stack pivoting by checking the stack pointer at selected sysc
 The kernel manages the stack for each process's main thread, but additional threads must create and manage their own stacks. Since the kernel has no direct notion of thread stacks, Tracee tracks thread stacks by storing the memory region pointed to by the stack pointer when new threads are created.
 
 Limitations:
+
 - Threads created before Tracee starts are not tracked
 - For untracked threads, anonymous memory regions are ignored to avoid false positives
 - This may result in false negatives for legitimate thread stacks created before Tracee started

--- a/docs/docs/events/builtin/syscall-events.md
+++ b/docs/docs/events/builtin/syscall-events.md
@@ -16,6 +16,7 @@ For broad syscall analysis, Tracee provides comprehensive monitoring events:
 - **sys_exit**: Captures all system call exits using raw tracepoints
 
 These events are ideal for:
+
 - Security auditing across all syscalls
 - System-wide syscall pattern analysis
 - Performance monitoring of syscall frequency

--- a/docs/docs/events/custom/overview.md
+++ b/docs/docs/events/custom/overview.md
@@ -9,6 +9,7 @@ Tracee comes with many built-in events, but you can extend its capabilities by c
 **📖 See the [Detector Documentation](../../detectors/index.md) for complete guide and examples.**
 
 Key benefits:
+
 - Type-safe protobuf access
 - Rich data extraction helpers
 - System state access (process trees, containers, DNS)

--- a/docs/docs/flags/stores.1.md
+++ b/docs/docs/flags/stores.1.md
@@ -106,6 +106,7 @@ The **\-\-stores** flag allows you to configure data stores for DNS cache and pr
    Note: All process options automatically enable process, and `dns.max-entries` automatically enables DNS, so you don't need `--stores dns` or `--stores process`.
 
 Please refer to the [DataStore API documentation](../detectors/datastore-api.md) for information about using these stores in detectors:
+
 - [DNSStore](../detectors/datastore-api.md#dnsstore) - DNS cache access
 - [ProcessStore](../detectors/datastore-api.md#processstore) - Process tree and ancestry
 

--- a/docs/docs/outputs/event-structure.md
+++ b/docs/docs/outputs/event-structure.md
@@ -247,6 +247,7 @@ The `.data` array contains `EventValue` messages with typed union fields:
 ## Protobuf Definition
 
 For the complete and authoritative event structure, see:
+
 - [event.proto](https://github.com/aquasecurity/tracee/blob/main/api/v1beta1/event.proto) - Main event structure
 - [event_data.proto](https://github.com/aquasecurity/tracee/blob/main/api/v1beta1/event_data.proto) - EventValue types
 - [workload.proto](https://github.com/aquasecurity/tracee/blob/main/api/v1beta1/workload.proto) - Workload/process context

--- a/docs/docs/outputs/output-formats.md
+++ b/docs/docs/outputs/output-formats.md
@@ -218,6 +218,7 @@ When authoring a Go template, the data source is Tracee's `v1beta1.Event` protob
 - `.threat` - Threat information for signature detections
 
 **Note:** For signature events, additional fields are available:
+
 - `.threat.name` - Threat/signature name
 - `.threat.description` - Threat description
 - `.threat.properties.signatureID` - Signature ID

--- a/docs/docs/policies/rules.md
+++ b/docs/docs/policies/rules.md
@@ -3,6 +3,7 @@
 Rules are part of the Tracee Policy, `rules` let you define which events to trace.
 
 `rules` have 2 sections: 
+
 - events: let you define which events you want to trace.
 - filters: enable you to refine the policy's scope.
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -56,6 +56,7 @@ ERRO permission denied loading eBPF program
 **Problem**: Unsupported kernel version errors
 
 **Solution**: 
+
 - Check supported kernels: [Prerequisites](install/prerequisites.md#kernel-version)
 - Tracee requires kernel 5.4 or newer (4.18 for RHEL 8)
 - Consider upgrading to a supported kernel version

--- a/docs/man/ftrace_hook.1
+++ b/docs/man/ftrace_hook.1
@@ -33,11 +33,17 @@ The callback offset inside the function
 The owner of the callback (kernel module name if applicable)
 .TP
 \f[B]flags\f[R] (\f[I]string\f[R])
-Ftrace flags indicating hook behavior: \- \f[B]R\f[R]: Registers are
-passed to the callback \- \f[B]I\f[R]: Callback can change the RIP
-register value \- \f[B]D\f[R]: Direct call to the function \-
-\f[B]O\f[R]: Callsite\-specific operations \- \f[B]M\f[R]: Function has
-I or D flags
+Ftrace flags indicating hook behavior:
+.IP \[bu] 2
+\f[B]R\f[R]: Registers are passed to the callback
+.IP \[bu] 2
+\f[B]I\f[R]: Callback can change the RIP register value
+.IP \[bu] 2
+\f[B]D\f[R]: Direct call to the function
+.IP \[bu] 2
+\f[B]O\f[R]: Callsite\-specific operations
+.IP \[bu] 2
+\f[B]M\f[R]: Function has I or D flags
 .TP
 \f[B]count\f[R] (\f[I]integer\f[R])
 The number of callbacks registered with the symbol

--- a/docs/man/kernel_module_loading.1
+++ b/docs/man/kernel_module_loading.1
@@ -72,14 +72,27 @@ are loaded
 \f[B]Forensic analysis\f[R]: Analyze kernel\-level persistence
 techniques
 .SS LEGITIMATE VS. MALICIOUS LOADING
-\f[B]Legitimate scenarios\f[R]: \- Hardware driver installation \-
-System feature activation (e.g., VPN, virtualization) \- Administrative
-tools requiring kernel access \- Security software components
+\f[B]Legitimate scenarios\f[R]:
+.IP \[bu] 2
+Hardware driver installation
+.IP \[bu] 2
+System feature activation (e.g., VPN, virtualization)
+.IP \[bu] 2
+Administrative tools requiring kernel access
+.IP \[bu] 2
+Security software components
 .PP
-\f[B]Suspicious indicators\f[R]: \- Loading from unusual locations \-
-Unsigned or unknown modules \- Loading during suspicious timeframes \-
-Modules with obfuscated names \- Concurrent with other suspicious
-activities
+\f[B]Suspicious indicators\f[R]:
+.IP \[bu] 2
+Loading from unusual locations
+.IP \[bu] 2
+Unsigned or unknown modules
+.IP \[bu] 2
+Loading during suspicious timeframes
+.IP \[bu] 2
+Modules with obfuscated names
+.IP \[bu] 2
+Concurrent with other suspicious activities
 .SS DETECTION CHALLENGES
 .IP \[bu] 2
 \f[B]False positives\f[R]: Legitimate administrative activities

--- a/docs/man/net_packet_icmp.1
+++ b/docs/man/net_packet_icmp.1
@@ -76,11 +76,20 @@ unreachable
 .SS ICMP CODES
 Each ICMP type has specific codes providing additional context:
 .PP
-\f[B]Destination Unreachable (Type 3)\f[R]: \- Code 0: Network
-unreachable \- Code 1: Host unreachable \- Code 2: Protocol unreachable
-\- Code 3: Port unreachable
+\f[B]Destination Unreachable (Type 3)\f[R]:
+.IP \[bu] 2
+Code 0: Network unreachable
+.IP \[bu] 2
+Code 1: Host unreachable
+.IP \[bu] 2
+Code 2: Protocol unreachable
+.IP \[bu] 2
+Code 3: Port unreachable
 .PP
-\f[B]Time Exceeded (Type 11)\f[R]: \- Code 0: TTL exceeded in transit \-
+\f[B]Time Exceeded (Type 11)\f[R]:
+.IP \[bu] 2
+Code 0: TTL exceeded in transit
+.IP \[bu] 2
 Code 1: Fragment reassembly time exceeded
 .SS SECURITY CONSIDERATIONS
 Monitor for malicious ICMP usage:

--- a/docs/man/stack_pivot.1
+++ b/docs/man/stack_pivot.1
@@ -76,10 +76,15 @@ Since the kernel has no direct notion of thread stacks, Tracee tracks
 thread stacks by storing the memory region pointed to by the stack
 pointer when new threads are created.
 .PP
-Limitations: \- Threads created before Tracee starts are not tracked \-
+Limitations:
+.IP \[bu] 2
+Threads created before Tracee starts are not tracked
+.IP \[bu] 2
 For untracked threads, anonymous memory regions are ignored to avoid
-false positives \- This may result in false negatives for legitimate
-thread stacks created before Tracee started
+false positives
+.IP \[bu] 2
+This may result in false negatives for legitimate thread stacks created
+before Tracee started
 .SS EXAMPLE USAGE
 Monitor specific syscalls for stack pivoting:
 .IP

--- a/docs/man/stores.1
+++ b/docs/man/stores.1
@@ -180,5 +180,8 @@ need \f[CR]\-\-stores dns\f[R] or \f[CR]\-\-stores process\f[R].
 .RE
 .PP
 Please refer to the DataStore API documentation for information about
-using these stores in detectors: \- DNSStore \- DNS cache access \-
+using these stores in detectors:
+.IP \[bu] 2
+DNSStore \- DNS cache access
+.IP \[bu] 2
 ProcessStore \- Process tree and ancestry

--- a/docs/man/vfs_read.1
+++ b/docs/man/vfs_read.1
@@ -61,9 +61,13 @@ resolution
 \f[B]Alternative methods\f[R]: Note that files can be read through other
 methods like \f[CR]vfs_readv\f[R], memory mapping, and direct I/O
 .SS LIMITATIONS
-This event does not capture: \- Memory\-mapped file access \- Direct I/O
-operations that bypass VFS \- Other read methods like
-\f[CR]vfs_readv\f[R] (vectorized reads)
+This event does not capture:
+.IP \[bu] 2
+Memory\-mapped file access
+.IP \[bu] 2
+Direct I/O operations that bypass VFS
+.IP \[bu] 2
+Other read methods like \f[CR]vfs_readv\f[R] (vectorized reads)
 .SS RELATED EVENTS
 .IP \[bu] 2
 \f[B]vfs_write\f[R]: Virtual filesystem write operations


### PR DESCRIPTION
- Add blank lines before bullet lists after colons
- Convert subsection headers from bullets to paragraphs
- Fix spacing in security-model.md and other docs
- Regenerate affected man pages