### PR TITLE
Refactor stores names

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -190,7 +190,7 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 		return runner, err
 	}
 
-	cfg.ProcTree = stores.GetProcTreeConfig()
+	cfg.ProcessStore = stores.GetProcessStoreConfig()
 	cfg.DNSStore = stores.GetDNSStoreConfig()
 
 	// Artifacts command line flags - via viper

--- a/pkg/cmd/flags/stores.go
+++ b/pkg/cmd/flags/stores.go
@@ -81,8 +81,8 @@ func (s *StoresConfig) flags() []string {
 	return flags
 }
 
-// GetProcTreeConfig returns the process tree config
-func (s *StoresConfig) GetProcTreeConfig() process.ProcTreeConfig {
+// GetProcessStoreConfig returns the process store config
+func (s *StoresConfig) GetProcessStoreConfig() process.ProcTreeConfig {
 	// Default to SourceSignals if process is enabled but no source is specified
 	source := process.SourceSignals
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	Capture           *CaptureConfig
 	Capabilities      *CapabilitiesConfig
 	Output            *OutputConfig
-	ProcTree          process.ProcTreeConfig
+	ProcessStore      process.ProcTreeConfig
 	Buffers           BuffersConfig
 	MaxPidsCache      int // maximum number of pids to cache per mnt ns (in Tracee.pidsInMntns)
 	BTFObjPath        string

--- a/pkg/ebpf/processor.go
+++ b/pkg/ebpf/processor.go
@@ -87,14 +87,14 @@ func (t *Tracee) registerEventProcessors() {
 	//
 
 	// Processors registered when proctree source "events" is enabled.
-	switch t.config.ProcTree.Source {
+	switch t.config.ProcessStore.Source {
 	case process.SourceEvents, process.SourceBoth:
 		t.RegisterEventProcessor(events.SchedProcessFork, t.procTreeForkProcessor)
 		t.RegisterEventProcessor(events.SchedProcessExec, t.procTreeExecProcessor)
 		t.RegisterEventProcessor(events.SchedProcessExit, t.procTreeExitProcessor)
 	}
 	// Processors enriching process tree with regular pipeline events.
-	if t.config.ProcTree.Source != process.SourceNone {
+	if t.config.ProcessStore.Source != process.SourceNone {
 		t.RegisterEventProcessor(events.All, t.procTreeAddBinInfo)
 	}
 

--- a/pkg/ebpf/signature_engine.go
+++ b/pkg/ebpf/signature_engine.go
@@ -167,7 +167,7 @@ func (t *Tracee) PrepareBuiltinDataSources() []detect.DataSource {
 	}
 
 	// Process Tree Data Source
-	switch t.config.ProcTree.Source {
+	switch t.config.ProcessStore.Source {
 	case process.SourceNone:
 	default:
 		datasources = append(datasources, process.NewDataSource(t.dataStoreRegistry.GetProcessTree()))

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -271,10 +271,10 @@ func New(cfg config.Config) (*Tracee, error) {
 	}
 
 	pmCfg := policy.ManagerConfig{
-		HeartbeatEnabled: cfg.HealthzEnabled,
-		DNSStore:         cfg.DNSStore,
-		ProcTreeConfig:   cfg.ProcTree,
-		CaptureConfig:    getNewCaptureConfig(),
+		HeartbeatEnabled:   cfg.HealthzEnabled,
+		DNSStoreConfig:     cfg.DNSStore,
+		ProcessStoreConfig: cfg.ProcessStore,
+		CaptureConfig:      getNewCaptureConfig(),
 	}
 	pm, err := policy.NewManager(pmCfg, depsManager, initialPolicies...)
 	if err != nil {
@@ -533,11 +533,11 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	// Initialize Process Tree (if enabled)
 
 	var processTree *process.ProcessTree
-	if t.config.ProcTree.Source != process.SourceNone {
+	if t.config.ProcessStore.Source != process.SourceNone {
 		// Procfs enrichment is now supported with both CLOCK_BOOTTIME and CLOCK_MONOTONIC.
 		// The timeutil.ProcfsStartTimeToEpochNS() function handles the conversion from
 		// procfs values (always BOOTTIME) to the BPF clock base (MONOTONIC or BOOTTIME).
-		processTree, err = process.NewProcessTree(ctx, t.config.ProcTree)
+		processTree, err = process.NewProcessTree(ctx, t.config.ProcessStore)
 		if err != nil {
 			return errfmt.WrapError(err)
 		}
@@ -990,7 +990,7 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	if t.config.Output.ParseArgumentsFDs {
 		cOptVal = cOptVal | optTranslateFDFilePath
 	}
-	switch t.config.ProcTree.Source {
+	switch t.config.ProcessStore.Source {
 	case process.SourceBoth, process.SourceEvents:
 		cOptVal = cOptVal | optForkProcTree // tell sched_process_fork to be prolix
 	}

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -20,10 +20,10 @@ import (
 )
 
 type ManagerConfig struct {
-	DNSStore         dns.Config
-	ProcTreeConfig   process.ProcTreeConfig
-	CaptureConfig    config.CaptureConfig
-	HeartbeatEnabled bool
+	DNSStoreConfig     dns.Config
+	ProcessStoreConfig process.ProcTreeConfig
+	CaptureConfig      config.CaptureConfig
+	HeartbeatEnabled   bool
 }
 
 // Manager is a thread-safe struct that manages the enabled policies for each rule
@@ -197,7 +197,7 @@ func (m *Manager) selectConfiguredEvents() {
 		m.selectEvent(events.SignalSchedProcessExit, newEventFlags(eventFlagsWithSubmit(PolicyAll)))
 	}
 
-	switch m.cfg.ProcTreeConfig.Source {
+	switch m.cfg.ProcessStoreConfig.Source {
 	case process.SourceBoth:
 		pipeEvts()
 		signalEvts()
@@ -209,7 +209,7 @@ func (m *Manager) selectConfiguredEvents() {
 
 	// DNS Cache events
 
-	if m.cfg.DNSStore.Enable {
+	if m.cfg.DNSStoreConfig.Enable {
 		m.selectEvent(events.NetPacketDNS, newEventFlags(eventFlagsWithSubmit(PolicyAll)))
 	}
 

--- a/tests/testutils/tracee_integrated.go
+++ b/tests/testutils/tracee_integrated.go
@@ -106,7 +106,7 @@ func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 	}
 
 	// No process tree in the integration tests
-	cfg.ProcTree = process.ProcTreeConfig{
+	cfg.ProcessStore = process.ProcTreeConfig{
 		Source: process.SourceNone,
 	}
 


### PR DESCRIPTION
This PR refactors tracee config fields, to match recent changes so the internal code matches the new concepts:

- `DNSCacheConfig` becomes `DNSStore` 
- `ProcTree` becomes `ProcessStore`
