### PR TITLE
style: fix linter warnings

### DIFF
--- a/cmd/tracee-bench/main.go
+++ b/cmd/tracee-bench/main.go
@@ -32,7 +32,7 @@ type measurement struct {
 }
 
 func (m measurement) Print() {
-	log.Printf("\n")
+	log.Print("\n")
 	fmt.Printf("Events/Sec:     %f\n", m.AvgEbpfRate)
 	fmt.Printf("EventsLost/Sec: %f\n", m.AvgLostEventsRate)
 	fmt.Printf("Events Lost:    %d\n", m.LostEvents)

--- a/cmd/tracee/cmd/root.go
+++ b/cmd/tracee/cmd/root.go
@@ -34,7 +34,7 @@ access to hundreds of events that help you understand how your system behaves.`,
 				// parse all flags
 				if err := cmd.Flags().Parse(args); err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-					fmt.Fprintf(os.Stderr, "Run 'tracee --help' or 'tracee man' for usage.\n")
+					fmt.Fprint(os.Stderr, "Run 'tracee --help' or 'tracee man' for usage.\n")
 					os.Exit(1)
 				}
 

--- a/common/bitwise/bitwise_test.go
+++ b/common/bitwise/bitwise_test.go
@@ -335,10 +335,10 @@ func TestBitwiseOperationsCombined(t *testing.T) {
 
 		// Check each bit
 		if !HasBit(n, 0) || !HasBit(n, 2) || !HasBit(n, 4) {
-			t.Errorf("Bits 0, 2, 4 should be set")
+			t.Error("Bits 0, 2, 4 should be set")
 		}
 		if HasBit(n, 1) || HasBit(n, 3) || HasBit(n, 5) {
-			t.Errorf("Bits 1, 3, 5 should not be set")
+			t.Error("Bits 1, 3, 5 should not be set")
 		}
 
 		// Clear using mask (clear bits 0 and 4)
@@ -349,10 +349,10 @@ func TestBitwiseOperationsCombined(t *testing.T) {
 			t.Errorf("Expected value 4, got %d", n)
 		}
 		if !HasBit(n, 2) {
-			t.Errorf("Bit 2 should still be set")
+			t.Error("Bit 2 should still be set")
 		}
 		if HasBit(n, 0) || HasBit(n, 4) {
-			t.Errorf("Bits 0 and 4 should be cleared")
+			t.Error("Bits 0 and 4 should be cleared")
 		}
 	})
 }

--- a/common/digest/hash_test.go
+++ b/common/digest/hash_test.go
@@ -34,7 +34,6 @@ func TestCurrentHashCompatibility(t *testing.T) {
 	}
 
 	for _, filePath := range files {
-
 		file, err := os.Open(filePath)
 		if err != nil {
 			t.Fatal(err)

--- a/common/environment/amount_test.go
+++ b/common/environment/amount_test.go
@@ -147,7 +147,7 @@ func TestGetMEMAmountInMBs(t *testing.T) {
 			t.Logf("System memory: %d MB", result)
 		} else {
 			// On some systems the file might not exist or be inaccessible
-			t.Logf("GetMEMAmountInMBs returned 0 (expected on some systems)")
+			t.Log("GetMEMAmountInMBs returned 0 (expected on some systems)")
 		}
 	})
 

--- a/common/environment/kernel_config.go
+++ b/common/environment/kernel_config.go
@@ -365,9 +365,7 @@ func (k *KernelConfig) ExistsValue(option KernelConfigOption, value interface{})
 	if cfg, ok := k.configs[option]; ok {
 		switch v := cfg.(type) {
 		case KernelConfigOptionValue:
-			if value == ANY {
-				return true
-			} else if v == value {
+			if value == ANY || v == value {
 				return true
 			}
 		case string:

--- a/common/proc/status_test.go
+++ b/common/proc/status_test.go
@@ -199,7 +199,7 @@ func Test_parsePidNSField(t *testing.T) {
 
 			if tc.expectedErr {
 				if err == nil {
-					t.Errorf("Expected error but got none")
+					t.Error("Expected error but got none")
 				}
 			} else {
 				if err != nil {

--- a/common/set/set_test.go
+++ b/common/set/set_test.go
@@ -11,7 +11,7 @@ func TestNewSimpleSet(t *testing.T) {
 	t.Run("empty set", func(t *testing.T) {
 		s := NewSimpleSet[int]()
 		if !s.Empty() {
-			t.Errorf("Expected empty set")
+			t.Error("Expected empty set")
 		}
 		if s.Length() != 0 {
 			t.Errorf("Expected length 0, got %d", s.Length())
@@ -21,7 +21,7 @@ func TestNewSimpleSet(t *testing.T) {
 	t.Run("set with initial items", func(t *testing.T) {
 		s := NewSimpleSet(1, 2, 3)
 		if s.Empty() {
-			t.Errorf("Expected non-empty set")
+			t.Error("Expected non-empty set")
 		}
 		if s.Length() != 3 {
 			t.Errorf("Expected length 3, got %d", s.Length())
@@ -61,7 +61,7 @@ func TestNewSimpleSet(t *testing.T) {
 		}
 
 		if !s.Has("hello") || !s.Has("world") {
-			t.Errorf("Expected set to contain 'hello' and 'world'")
+			t.Error("Expected set to contain 'hello' and 'world'")
 		}
 	})
 }
@@ -90,10 +90,10 @@ func TestNewSimpleSetWithHash(t *testing.T) {
 		}
 
 		if !s.Has(Person{"Alice", 99}) { // Any age should work for Alice
-			t.Errorf("Expected set to contain Alice (regardless of age)")
+			t.Error("Expected set to contain Alice (regardless of age)")
 		}
 		if !s.Has(Person{"Bob", 99}) { // Any age should work for Bob
-			t.Errorf("Expected set to contain Bob (regardless of age)")
+			t.Error("Expected set to contain Bob (regardless of age)")
 		}
 	})
 
@@ -119,23 +119,23 @@ func TestSimpleSet_BasicOperations(t *testing.T) {
 
 	t.Run("empty set operations", func(t *testing.T) {
 		if !s.Empty() {
-			t.Errorf("New set should be empty")
+			t.Error("New set should be empty")
 		}
 		if s.Length() != 0 {
-			t.Errorf("Empty set length should be 0")
+			t.Error("Empty set length should be 0")
 		}
 		if s.Has(42) {
-			t.Errorf("Empty set should not contain any items")
+			t.Error("Empty set should not contain any items")
 		}
 		if len(s.Items()) != 0 {
-			t.Errorf("Empty set items should be empty slice")
+			t.Error("Empty set items should be empty slice")
 		}
 	})
 
 	t.Run("append items", func(t *testing.T) {
 		s.Append(1, 2, 3)
 		if s.Empty() {
-			t.Errorf("Set should not be empty after append")
+			t.Error("Set should not be empty after append")
 		}
 		if s.Length() != 3 {
 			t.Errorf("Expected length 3, got %d", s.Length())
@@ -162,10 +162,10 @@ func TestSimpleSet_BasicOperations(t *testing.T) {
 	t.Run("clear set", func(t *testing.T) {
 		s.Clear()
 		if !s.Empty() {
-			t.Errorf("Set should be empty after clear")
+			t.Error("Set should be empty after clear")
 		}
 		if s.Length() != 0 {
-			t.Errorf("Cleared set length should be 0")
+			t.Error("Cleared set length should be 0")
 		}
 	})
 }
@@ -209,7 +209,7 @@ func TestSimpleSet_ItemsVsMutable(t *testing.T) {
 
 		// Original set should be unchanged
 		if s.Items()[0] == 999 {
-			t.Errorf("Items() should return a copy, not reference")
+			t.Error("Items() should return a copy, not reference")
 		}
 	})
 
@@ -219,13 +219,13 @@ func TestSimpleSet_ItemsVsMutable(t *testing.T) {
 
 		// They should be the same slice
 		if &mutable[0] != &original[0] {
-			t.Errorf("ItemsMutable() should return same reference")
+			t.Error("ItemsMutable() should return same reference")
 		}
 
 		// Modifying one affects the other
 		mutable[0] = 999
 		if original[0] != 999 {
-			t.Errorf("ItemsMutable() should return mutable reference")
+			t.Error("ItemsMutable() should return mutable reference")
 		}
 	})
 }
@@ -264,13 +264,13 @@ func TestSet_ThreadSafe(t *testing.T) {
 		s := New(1, 2, 3)
 
 		if s.Empty() {
-			t.Errorf("Set with items should not be empty")
+			t.Error("Set with items should not be empty")
 		}
 		if s.Length() != 3 {
 			t.Errorf("Expected length 3, got %d", s.Length())
 		}
 		if !s.Has(2) {
-			t.Errorf("Set should contain 2")
+			t.Error("Set should contain 2")
 		}
 
 		items := s.Items()
@@ -299,7 +299,7 @@ func TestSet_ThreadSafe(t *testing.T) {
 		s.Clear()
 
 		if !s.Empty() {
-			t.Errorf("Set should be empty after clear")
+			t.Error("Set should be empty after clear")
 		}
 	})
 
@@ -341,18 +341,18 @@ func TestSet_WithHash(t *testing.T) {
 		// We can't predict which of "hello"/"world" will be kept, so check both possibilities
 		hasLength5 := s.Has("hello") || s.Has("world")
 		if !hasLength5 {
-			t.Errorf("Should contain either 'hello' or 'world' (length 5)")
+			t.Error("Should contain either 'hello' or 'world' (length 5)")
 		}
 		if !s.Has("hi") {
-			t.Errorf("Should contain 'hi' (length 2)")
+			t.Error("Should contain 'hi' (length 2)")
 		}
 
 		// Test that any other string with same length is recognized
 		if !s.Has("abcde") { // Any 5-char string should match "hello"/"world"
-			t.Errorf("Should contain string of length 5")
+			t.Error("Should contain string of length 5")
 		}
 		if !s.Has("xy") { // Any 2-char string should match "hi"
-			t.Errorf("Should contain string of length 2")
+			t.Error("Should contain string of length 2")
 		}
 	})
 }
@@ -375,7 +375,7 @@ func TestSimpleSet_EdgeCases(t *testing.T) {
 
 		// Check some random items
 		if !s.Has(500) || !s.Has(999) || !s.Has(0) {
-			t.Errorf("Large set should contain test items")
+			t.Error("Large set should contain test items")
 		}
 	})
 
@@ -388,7 +388,7 @@ func TestSimpleSet_EdgeCases(t *testing.T) {
 		s.Clear()
 
 		if !s.Empty() {
-			t.Errorf("Set should remain empty")
+			t.Error("Set should remain empty")
 		}
 	})
 
@@ -399,10 +399,10 @@ func TestSimpleSet_EdgeCases(t *testing.T) {
 		s.Append(nilPtr)
 
 		if s.Length() != 1 {
-			t.Errorf("Should be able to store nil pointers")
+			t.Error("Should be able to store nil pointers")
 		}
 		if !s.Has(nilPtr) {
-			t.Errorf("Should find nil pointer")
+			t.Error("Should find nil pointer")
 		}
 	})
 }
@@ -472,7 +472,7 @@ func TestSet_DifferentTypes(t *testing.T) {
 		}
 
 		if !s.Has(Point{1, 2}) {
-			t.Errorf("Should contain Point{1, 2}")
+			t.Error("Should contain Point{1, 2}")
 		}
 	})
 }

--- a/common/system/monitor_test.go
+++ b/common/system/monitor_test.go
@@ -233,7 +233,7 @@ func TestGetRSSMemoryIntegration(t *testing.T) {
 			t.Errorf("RSS seems too small: %d bytes", stats.RSS)
 		}
 	} else {
-		t.Logf("RSS is 0, possibly /proc/self/status is not readable")
+		t.Log("RSS is 0, possibly /proc/self/status is not readable")
 	}
 }
 

--- a/common/tests/helpers_test.go
+++ b/common/tests/helpers_test.go
@@ -341,7 +341,7 @@ And unicode: 🚀 ñ 中文`
 		}
 
 		if string(readContent) != content {
-			t.Errorf("Content mismatch for large file")
+			t.Error("Content mismatch for large file")
 		}
 	})
 
@@ -475,7 +475,7 @@ func TestHelperIntegration(t *testing.T) {
 		}
 
 		if !strings.Contains(string(content), "TestStruct") {
-			t.Errorf("Expected temp file to contain struct analysis")
+			t.Error("Expected temp file to contain struct analysis")
 		}
 	})
 }

--- a/common/timeutil/time_test.go
+++ b/common/timeutil/time_test.go
@@ -302,7 +302,7 @@ func TestSystemDependentFunctions(t *testing.T) {
 			now := time.Now().UnixNano()
 			assert.Less(t, bootTime, now, "Boot time should be before current time")
 		} else {
-			t.Logf("Boot time is 0 (likely containerized environment)")
+			t.Log("Boot time is 0 (likely containerized environment)")
 		}
 	})
 
@@ -331,7 +331,7 @@ func TestSystemDependentFunctions(t *testing.T) {
 			now := time.Now().UnixNano()
 			assert.Less(t, bootTime, now, "Boot time should be before current time")
 		} else {
-			t.Logf("Boot time is 0 (likely containerized environment)")
+			t.Log("Boot time is 0 (likely containerized environment)")
 		}
 	})
 }
@@ -356,7 +356,7 @@ func TestErrorConditions(t *testing.T) {
 		if err != nil {
 			t.Logf("Init with invalid clock returned expected error: %v", err)
 		} else {
-			t.Logf("Init with invalid clock did not return error (system-dependent behavior)")
+			t.Log("Init with invalid clock did not return error (system-dependent behavior)")
 		}
 
 		// Should not panic or crash - just calling the function is the test

--- a/pkg/cmd/flags/stores.go
+++ b/pkg/cmd/flags/stores.go
@@ -90,12 +90,10 @@ func (s *StoresConfig) GetProcessStoreConfig() process.ProcTreeConfig {
 		switch s.Process.Source {
 		case processSourceEvents:
 			source = process.SourceEvents
-		case processSourceSignals:
-			source = process.SourceSignals
 		case processSourceBoth:
 			source = process.SourceBoth
 		default:
-			// If source is empty or invalid, default to signals
+			// If source is empty, invalid, or signals, default to signals
 			source = process.SourceSignals
 		}
 	} else {

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -53,7 +53,7 @@ func PrintEventList(includeSigs bool, wideOutput bool) {
 		}
 	}
 
-	fmt.Printf("Tracee supports the following events (use --wide for wider output):\n")
+	fmt.Println("Tracee supports the following events (use --wide for wider output):")
 	table := newTable()
 
 	// Signature Events

--- a/pkg/cmd/printer/printer.go
+++ b/pkg/cmd/printer/printer.go
@@ -352,7 +352,7 @@ func (p tableEventPrinter) Print(event *pb.Event) {
 // Epilogue prints the epilogue for the table format.
 func (p tableEventPrinter) Epilogue(stats metrics.Stats) {
 	fmt.Println()
-	fmt.Fprintf(p.out, "End of events stream\n")
+	fmt.Fprint(p.out, "End of events stream\n")
 
 	jsonStats, err := stats.MarshalJSON()
 	if err != nil {
@@ -414,7 +414,7 @@ func (p templateEventPrinter) Print(event *pb.Event) {
 			logger.Errorw("Error executing template", "error", err)
 		}
 	} else {
-		fmt.Fprintf(p.out, "Template Obj is nil")
+		fmt.Fprint(p.out, "Template Obj is nil")
 	}
 }
 

--- a/pkg/cmd/printer/printer_test.go
+++ b/pkg/cmd/printer/printer_test.go
@@ -433,5 +433,4 @@ func TestPrinterCreation(t *testing.T) {
 			assert.Equal(t, tc.expectedKind, printer.Kind())
 		})
 	}
-
 }

--- a/pkg/datastores/container/runtime/runtime.go
+++ b/pkg/datastores/container/runtime/runtime.go
@@ -61,9 +61,7 @@ func FromString(str string) RuntimeId {
 	switch str {
 	case "docker":
 		return Docker
-	case "crio":
-		return Crio
-	case "cri-o":
+	case "crio", "cri-o":
 		return Crio
 	case "podman":
 		return Podman

--- a/pkg/datastores/dns/dnscache_test.go
+++ b/pkg/datastores/dns/dnscache_test.go
@@ -42,7 +42,6 @@ func init() {
 			eventDump = append(eventDump, e)
 		}
 	}
-
 }
 
 func TestDnsCacheSync(t *testing.T) {

--- a/pkg/datastores/process/proctree_test.go
+++ b/pkg/datastores/process/proctree_test.go
@@ -94,7 +94,7 @@ func TestHashCalculationConsistency(t *testing.T) {
 
 	// Verify that the old approach was different (demonstrating THE BUG)
 	if oldProcfsHash == kernelSignalHash {
-		t.Errorf("Old procfs hash should NOT match kernel signal hash (this demonstrates the bug)")
-		t.Errorf("  If they match, the test conditions don't reproduce the original bug")
+		t.Error("Old procfs hash should NOT match kernel signal hash (this demonstrates the bug)")
+		t.Error("  If they match, the test conditions don't reproduce the original bug")
 	}
 }

--- a/pkg/datastores/symbol/kernel_test.go
+++ b/pkg/datastores/symbol/kernel_test.go
@@ -31,12 +31,12 @@ func TestNewKernelSymbolTable(t *testing.T) {
 	}
 
 	if kst == nil {
-		t.Fatalf("NewKernelSymbolTable() returned nil")
+		t.Fatal("NewKernelSymbolTable() returned nil")
 	}
 
 	// Check if symbols is initialized
 	if kst.symbols == nil {
-		t.Errorf("KernelSymbolTable is not initialized correctly")
+		t.Error("KernelSymbolTable is not initialized correctly")
 	}
 }
 
@@ -48,7 +48,7 @@ func getTheOnlySymbol(t *testing.T, kst *KernelSymbolTable) *KernelSymbol {
 		foundSymbol = symbol
 	})
 	if i > 1 {
-		t.Errorf("multiple symbols found")
+		t.Error("multiple symbols found")
 	}
 	return foundSymbol
 }

--- a/pkg/datastores/symbol/table_test.go
+++ b/pkg/datastores/symbol/table_test.go
@@ -35,15 +35,15 @@ func (s testSymbol) Clone() testSymbol {
 func TestNewSymbolTable(t *testing.T) {
 	st := NewSymbolTable[testSymbol](true)
 	if st == nil {
-		t.Fatalf("NewSymbolTable() returned nil")
+		t.Fatal("NewSymbolTable() returned nil")
 	}
 
 	if !st.lazyNameLookup {
-		t.Errorf("lazyNameLookup was not set to true")
+		t.Error("lazyNameLookup was not set to true")
 	}
 
 	if st.sortedSymbols == nil || st.symbolsByName == nil {
-		t.Errorf("data structures are nil")
+		t.Error("data structures are nil")
 	}
 }
 

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -617,9 +617,7 @@ func (t *Tracee) deriveEvents(ctx context.Context, in <-chan *events.PipelineEve
 					// Skip events that dont work with filtering due to missing types
 					// being handled (https://github.com/aquasecurity/tracee/issues/2486)
 					switch events.ID(derivatives[i].EventID) {
-					case events.SymbolsLoaded:
-					case events.SharedObjectLoaded:
-					case events.PrintMemDump:
+					case events.SymbolsLoaded, events.SharedObjectLoaded, events.PrintMemDump:
 					default:
 						// Derived events might need filtering as well
 						if t.matchPolicies(derivativePipelineEvent) == 0 {

--- a/pkg/events/derive/net_packet_helpers.go
+++ b/pkg/events/derive/net_packet_helpers.go
@@ -743,9 +743,7 @@ func getDNSResponseFromProtoDNS(query trace.DnsQueryData, answers []trace.ProtoD
 		var dnsAnswer trace.DnsAnswer
 
 		switch answer.Type {
-		case "A":
-			dnsAnswer.Answer = answer.IP
-		case "AAAA":
+		case "A", "AAAA":
 			dnsAnswer.Answer = answer.IP
 		case "NS":
 			dnsAnswer.Answer = answer.NS

--- a/pkg/filters/bool_test.go
+++ b/pkg/filters/bool_test.go
@@ -129,6 +129,6 @@ func TestBoolFilterClone(t *testing.T) {
 	err = copy.Parse("=true")
 	require.NoError(t, err)
 	if cmp.Equal(filter, copy, opt1) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/numeric_test.go
+++ b/pkg/filters/numeric_test.go
@@ -141,7 +141,7 @@ func testCloneLogic[T NumericConstraint](t *testing.T, filter *NumericFilter[T],
 	err = cloned.Parse("=51")
 	require.NoError(t, err)
 	if cmp.Equal(filter, cloned, opt) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }
 

--- a/pkg/filters/processtree_test.go
+++ b/pkg/filters/processtree_test.go
@@ -165,6 +165,6 @@ func TestProcessTreeFilterClone(t *testing.T) {
 	err = filter.Parse("=2")
 	require.NoError(t, err)
 	if cmp.Equal(filter, copy, opt1) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/scope_test.go
+++ b/pkg/filters/scope_test.go
@@ -38,7 +38,7 @@ func TestScopeFilterClone(t *testing.T) {
 	err = copy.Parse("pid", "=1")
 	require.NoError(t, err)
 	if cmp.Equal(filter, copy, opt1) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }
 

--- a/pkg/filters/sets/sets_test.go
+++ b/pkg/filters/sets/sets_test.go
@@ -84,7 +84,7 @@ func TestPrefixSetClone(t *testing.T) {
 	// ensure that changes to the copy do not affect the original
 	copy.Put("/home")
 	if cmp.Equal(set, copy, opt1) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }
 
@@ -107,6 +107,6 @@ func TestSuffixSetClone(t *testing.T) {
 	// ensure that changes to the copy do not affect the original
 	copy.Put(".ssh")
 	if cmp.Equal(set, copy, opt1) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/filters/string_test.go
+++ b/pkg/filters/string_test.go
@@ -236,6 +236,6 @@ func TestStringFilterClone(t *testing.T) {
 	// ensure that changes to the copy do not affect the original
 	copy.Parse("=xyz")
 	if cmp.Equal(filter, copy, opt1, opt2) {
-		t.Errorf("Changes to copied filter affected the original")
+		t.Error("Changes to copied filter affected the original")
 	}
 }

--- a/pkg/server/grpc/server_test.go
+++ b/pkg/server/grpc/server_test.go
@@ -40,7 +40,7 @@ func TestServer(t *testing.T) {
 			break // Socket exists, server is ready
 		}
 		if i == maxRetries-1 {
-			t.Fatalf("Server did not start within expected time")
+			t.Fatal("Server did not start within expected time")
 		}
 		time.Sleep(10 * time.Millisecond) // Short wait between checks
 	}

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -56,10 +56,10 @@ func (s *Server) EnableMetricsEndpoint() {
 func (s *Server) EnableHealthzEndpoint() {
 	s.mux.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
 		if heartbeat.GetInstance() != nil && heartbeat.GetInstance().IsAlive() {
-			fmt.Fprintf(w, "OK")
+			fmt.Fprint(w, "OK")
 			return
 		}
-		fmt.Fprintf(w, "NOT OK")
+		fmt.Fprint(w, "NOT OK")
 	})
 	s.healthzEnabled = true
 }

--- a/tests/compatibility/compatibility_test.go
+++ b/tests/compatibility/compatibility_test.go
@@ -75,14 +75,14 @@ func TestCompatibility(t *testing.T) {
 	eventBuffer := testutils.NewEventBuffer()
 
 	// Start Tracee
-	t.Logf("  --- started tracee ---")
+	t.Log("  --- started tracee ---")
 	traceeInstance, err := testutils.StartTracee(ctx, t, cfg, nil, nil)
 	require.NoError(t, err, "Failed to start Tracee")
 
 	err = testutils.WaitForTraceeStart(traceeInstance)
 	require.NoError(t, err, "Tracee failed to start")
 
-	t.Logf("  --- tracee started successfully ---")
+	t.Log("  --- tracee started successfully ---")
 
 	// Give time for probes to attach
 	time.Sleep(500 * time.Millisecond)
@@ -111,7 +111,7 @@ func TestCompatibility(t *testing.T) {
 	// Give a moment for the uprobe to fire and event processing to fully initialize
 	time.Sleep(2 * time.Second)
 	// Trigger the features fallback test event multiple times to ensure it fires
-	t.Logf("  --- triggering features fallback test ---")
+	t.Log("  --- triggering features fallback test ---")
 	traceeInstance.TriggerFeaturesFallbackTest()
 
 	err = testutils.WaitForTraceeOutputEvents(t, 10*time.Second, eventBuffer, 1, true)
@@ -153,7 +153,7 @@ func TestCompatibility(t *testing.T) {
 		t.Log(errStop)
 		failed = true
 	} else {
-		t.Logf("  --- stopped tracee ---")
+		t.Log("  --- stopped tracee ---")
 	}
 
 	if failed {
@@ -209,14 +209,14 @@ func getExpectedProbeId(t *testing.T) int {
 // debugProbeAttachments uses reflection to inspect the private defaultProbes field
 // and log the attachment status of the features fallback test probes
 func debugProbeAttachments(t *testing.T, traceeInstance interface{}) {
-	t.Logf("  --- checking probe attachments ---")
+	t.Log("  --- checking probe attachments ---")
 
 	// Use reflection to access the private defaultProbes field
 	traceeValue := reflect.ValueOf(traceeInstance).Elem()
 	defaultProbesField := traceeValue.FieldByName("defaultProbes")
 
 	if !defaultProbesField.IsValid() {
-		t.Logf("  !!! Could not access defaultProbes field")
+		t.Log("  !!! Could not access defaultProbes field")
 		return
 	}
 
@@ -224,7 +224,7 @@ func debugProbeAttachments(t *testing.T, traceeInstance interface{}) {
 	defaultProbesField = reflect.NewAt(defaultProbesField.Type(), defaultProbesField.Addr().UnsafePointer()).Elem()
 
 	if defaultProbesField.IsNil() {
-		t.Logf("  !!! defaultProbes is nil")
+		t.Log("  !!! defaultProbes is nil")
 		return
 	}
 
@@ -242,7 +242,7 @@ func debugProbeAttachments(t *testing.T, traceeInstance interface{}) {
 		// Call GetProbeByHandle method using reflection
 		getProbeMethod := defaultProbesField.MethodByName("GetProbeByHandle")
 		if !getProbeMethod.IsValid() {
-			t.Logf("  !!! Could not find GetProbeByHandle method")
+			t.Log("  !!! Could not find GetProbeByHandle method")
 			continue
 		}
 
@@ -285,20 +285,20 @@ func debugProbeAttachments(t *testing.T, traceeInstance interface{}) {
 		}
 	}
 
-	t.Logf("  --- done checking probe attachments ---")
+	t.Log("  --- done checking probe attachments ---")
 }
 
 // debugEventDependencies uses reflection to inspect the event dependencies
 // and log which probes should be attached for the features fallback test event
 func debugEventDependencies(t *testing.T, traceeInstance interface{}) {
-	t.Logf("  --- checking event dependencies ---")
+	t.Log("  --- checking event dependencies ---")
 
 	// Use reflection to access the private eventsDependencies field
 	traceeValue := reflect.ValueOf(traceeInstance).Elem()
 	eventsDepsField := traceeValue.FieldByName("eventsDependencies")
 
 	if !eventsDepsField.IsValid() {
-		t.Logf("  !!! Could not access eventsDependencies field")
+		t.Log("  !!! Could not access eventsDependencies field")
 		return
 	}
 
@@ -306,34 +306,34 @@ func debugEventDependencies(t *testing.T, traceeInstance interface{}) {
 	eventsDepsField = reflect.NewAt(eventsDepsField.Type(), eventsDepsField.Addr().UnsafePointer()).Elem()
 
 	if eventsDepsField.IsNil() {
-		t.Logf("  !!! eventsDependencies is nil")
+		t.Log("  !!! eventsDependencies is nil")
 		return
 	}
 
 	// Call GetProbes() method to see which probes are registered
 	getProbesMethod := eventsDepsField.MethodByName("GetProbes")
 	if !getProbesMethod.IsValid() {
-		t.Logf("  !!! Could not find GetProbes method")
+		t.Log("  !!! Could not find GetProbes method")
 		return
 	}
 
 	results := getProbesMethod.Call([]reflect.Value{})
 	if len(results) == 0 {
-		t.Logf("  !!! GetProbes returned no results")
+		t.Log("  !!! GetProbes returned no results")
 		return
 	}
 
 	probeHandles := results[0]
 	if !probeHandles.IsValid() || probeHandles.IsNil() {
-		t.Logf("  !!! GetProbes returned invalid/nil slice")
+		t.Log("  !!! GetProbes returned invalid/nil slice")
 		return
 	}
 
 	t.Logf("  Total probe dependencies registered: %d", probeHandles.Len())
-	t.Logf("  Note: Feature fallback probes use compatibility-based selection,")
-	t.Logf("        so only one of the three variants will be attached based on kernel capabilities")
+	t.Log("  Note: Feature fallback probes use compatibility-based selection,")
+	t.Log("        so only one of the three variants will be attached based on kernel capabilities")
 
-	t.Logf("  --- done checking event dependencies ---")
+	t.Log("  --- done checking event dependencies ---")
 }
 
 // TestClockDetection validates that Tracee correctly detects and uses the appropriate
@@ -347,7 +347,7 @@ func TestClockDetection(t *testing.T) {
 	testutils.AssureIsRoot(t)
 
 	// Step 1: Check what the current kernel actually supports
-	t.Logf("  --- detecting kernel BPF clock support ---")
+	t.Log("  --- detecting kernel BPF clock support ---")
 
 	boottimeSupported := handleSupportCheck(
 		t,
@@ -367,15 +367,15 @@ func TestClockDetection(t *testing.T) {
 	if boottimeSupported {
 		expectedClockID = timeutil.CLOCK_BOOTTIME
 		expectedClockName = "CLOCK_BOOTTIME"
-		t.Logf("  ✅ Kernel supports bpf_ktime_get_boot_ns → expecting CLOCK_BOOTTIME")
+		t.Log("  ✅ Kernel supports bpf_ktime_get_boot_ns → expecting CLOCK_BOOTTIME")
 	} else {
 		expectedClockID = timeutil.CLOCK_MONOTONIC
 		expectedClockName = "CLOCK_MONOTONIC"
-		t.Logf("  ⚠️  Kernel does NOT support bpf_ktime_get_boot_ns → expecting CLOCK_MONOTONIC")
+		t.Log("  ⚠️  Kernel does NOT support bpf_ktime_get_boot_ns → expecting CLOCK_MONOTONIC")
 	}
 
 	// Step 3: Initialize Tracee (which triggers clock detection in timeutil.Init)
-	t.Logf("  --- starting tracee to test clock detection ---")
+	t.Log("  --- starting tracee to test clock detection ---")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -401,10 +401,10 @@ func TestClockDetection(t *testing.T) {
 	err = testutils.WaitForTraceeStart(traceeInstance)
 	require.NoError(t, err, "Tracee failed to start")
 
-	t.Logf("  --- tracee started successfully ---")
+	t.Log("  --- tracee started successfully ---")
 
 	// Step 4: Verify Tracee detected and is using the correct clock
-	t.Logf("  --- verifying clock selection ---")
+	t.Log("  --- verifying clock selection ---")
 
 	// The clock is set during Tracee initialization via timeutil.Init()
 	// We can verify this using the public timeutil.GetUsedClockID() API
@@ -434,12 +434,12 @@ func TestClockDetection(t *testing.T) {
 			expectedClockName, actualClockName)
 	}
 
-	t.Logf("  Note: This clock is used for all BPF timestamp conversions and procfs hash calculations")
+	t.Log("  Note: This clock is used for all BPF timestamp conversions and procfs hash calculations")
 
 	// Step 5: Cleanup
 	cancel()
 	err = testutils.WaitForTraceeStop(traceeInstance)
 	assert.NoError(t, err, "Tracee should stop cleanly")
 
-	t.Logf("  --- stopped tracee ---")
+	t.Log("  --- stopped tracee ---")
 }

--- a/tests/e2e-inst-signatures/e2e-set_fs_pwd.go
+++ b/tests/e2e-inst-signatures/e2e-set_fs_pwd.go
@@ -36,11 +36,7 @@ func (sig *e2eSetFsPwd) Init(ctx detect.SignatureContext) error {
 		return err
 	}
 	_, err = ksyms.GetSymbolByName("bpf_probe_read_user_str")
-	if err != nil {
-		sig.hasReadUser = false
-	} else {
-		sig.hasReadUser = true
-	}
+	sig.hasReadUser = err == nil
 
 	return nil
 }

--- a/tests/integration/capture_test.go
+++ b/tests/integration/capture_test.go
@@ -99,7 +99,7 @@ func Test_TraceeCapture(t *testing.T) {
 			r := <-ready // block until tracee is ready (or not)
 			switch r {
 			case testutils.TraceeStarted:
-				t.Logf("  --- started tracee ---")
+				t.Log("  --- started tracee ---")
 			case testutils.TraceeFailed:
 				t.Fatal("tracee failed to start")
 			case testutils.TraceeTimedout:
@@ -129,7 +129,7 @@ func Test_TraceeCapture(t *testing.T) {
 				failed = true
 				t.Logf("failed to stop tracee: %v", cmdErrs)
 			} else {
-				t.Logf("  --- stopped tracee ---")
+				t.Log("  --- stopped tracee ---")
 			}
 
 			if failed {
@@ -164,7 +164,7 @@ func readWriteCaptureTest(t *testing.T, captureDir string, workingDir string) er
 
 	statInfo, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		t.Logf("type assertion failed: expected *syscall.Stat_t")
+		t.Log("type assertion failed: expected *syscall.Stat_t")
 	}
 	inode := statInfo.Ino
 
@@ -207,7 +207,7 @@ func readWritevCaptureTest(t *testing.T, captureDir string, workingDir string) e
 
 	statInfo, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		t.Logf("type assertion failed: expected *syscall.Stat_t")
+		t.Log("type assertion failed: expected *syscall.Stat_t")
 	}
 	inode := statInfo.Ino
 

--- a/tests/integration/container_events_test.go
+++ b/tests/integration/container_events_test.go
@@ -63,7 +63,7 @@ func Test_ContainerCreateRemove(t *testing.T) {
 	cfg.InitialPolicies = initialPolicies
 
 	// Start Tracee
-	t.Logf("  --- started tracee ---")
+	t.Log("  --- started tracee ---")
 	traceeInstance, err := testutils.StartTracee(ctx, t, cfg, nil, nil)
 	require.NoError(t, err, "Failed to start Tracee")
 
@@ -116,7 +116,7 @@ func Test_ContainerCreateRemove(t *testing.T) {
 		switch eventID {
 		case events.ContainerCreate:
 			foundCreate = true
-			t.Logf("Found ContainerCreate event")
+			t.Log("Found ContainerCreate event")
 			// Verify it has container-related arguments
 			assert.NotEmpty(t, evt.Data, "ContainerCreate should have arguments")
 
@@ -155,7 +155,7 @@ func Test_ContainerCreateRemove(t *testing.T) {
 
 		case events.ContainerRemove:
 			foundRemove = true
-			t.Logf("Found ContainerRemove event")
+			t.Log("Found ContainerRemove event")
 			// Verify it has the expected fields
 			assert.NotEmpty(t, evt.Data, "ContainerRemove should have arguments")
 
@@ -189,7 +189,7 @@ func Test_ContainerCreateRemove(t *testing.T) {
 		t.Log(errStop)
 		failed = true
 	} else {
-		t.Logf("  --- stopped tracee ---")
+		t.Log("  --- stopped tracee ---")
 	}
 
 	if failed {
@@ -263,7 +263,7 @@ func Test_ExistingContainers(t *testing.T) {
 	cfg.InitialPolicies = initialPolicies
 
 	// Start Tracee AFTER the container is already running
-	t.Logf("  --- started tracee ---")
+	t.Log("  --- started tracee ---")
 	traceeInstance, err := testutils.StartTracee(ctx, t, cfg, nil, nil)
 	require.NoError(t, err, "Failed to start Tracee")
 
@@ -307,7 +307,7 @@ func Test_ExistingContainers(t *testing.T) {
 		eventID := events.ID(evt.Id)
 		if eventID == events.ExistingContainer {
 			foundExisting = true
-			t.Logf("Found ExistingContainer event")
+			t.Log("Found ExistingContainer event")
 
 			// Verify it has container-related arguments
 			assert.NotEmpty(t, evt.Data, "ExistingContainer should have arguments")
@@ -321,7 +321,7 @@ func Test_ExistingContainers(t *testing.T) {
 				}
 			}
 			if containerName == "" {
-				t.Logf("Failed to get container name")
+				t.Log("Failed to get container name")
 				continue
 			}
 			if containerName != testContainerName {
@@ -371,7 +371,7 @@ func Test_ExistingContainers(t *testing.T) {
 		t.Log(errStop)
 		failed = true
 	} else {
-		t.Logf("  --- stopped tracee ---")
+		t.Log("  --- stopped tracee ---")
 	}
 
 	if failed {

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -274,7 +274,7 @@ func Test_EventsDependencies(t *testing.T) {
 				cancel()
 				t.Fatal(err)
 			}
-			t.Logf("  --- started tracee ---")
+			t.Log("  --- started tracee ---")
 			err = testutils.WaitForTraceeStart(trc)
 			if err != nil {
 				cancel()
@@ -336,7 +336,7 @@ func Test_EventsDependencies(t *testing.T) {
 				t.Log(errStop)
 				failed = true
 			} else {
-				t.Logf("  --- stopped tracee ---")
+				t.Log("  --- stopped tracee ---")
 			}
 
 			if failed {

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -2346,7 +2346,7 @@ func Test_EventFilters(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			t.Logf("  --- started tracee ---")
+			t.Log("  --- started tracee ---")
 			err = testutils.WaitForTraceeStart(trc)
 			if err != nil {
 				t.Fatal(err)
@@ -2385,7 +2385,7 @@ func Test_EventFilters(t *testing.T) {
 				t.Log(errStop)
 				failed = true
 			} else {
-				t.Logf("  --- stopped tracee ---")
+				t.Log("  --- stopped tracee ---")
 			}
 
 			if failed {

--- a/tests/integration/yaml_detector_test.go
+++ b/tests/integration/yaml_detector_test.go
@@ -238,7 +238,7 @@ output:
 	}
 
 	assert.True(t, found, "YAML detector yaml-test-001 should be loaded")
-	t.Logf("Successfully loaded YAML detector yaml-test-001")
+	t.Log("Successfully loaded YAML detector yaml-test-001")
 }
 
 // Test_YAMLDetectorEventGeneration tests that a YAML detector produces events with correct field extraction
@@ -299,7 +299,7 @@ output:
 		}
 	}()
 
-	t.Logf("Tracee started, triggering detection...")
+	t.Log("Tracee started, triggering detection...")
 
 	// Trigger the detector by executing /usr/bin/true
 	cmd := exec.Command("/usr/bin/true")
@@ -419,7 +419,7 @@ output:
 		}
 	}()
 
-	t.Logf("Tracee started with chained detectors, triggering detection...")
+	t.Log("Tracee started with chained detectors, triggering detection...")
 
 	// Trigger the detector chain by executing /usr/bin/id
 	cmd := exec.Command("/usr/bin/id")
@@ -501,13 +501,13 @@ output:
 		}
 	}()
 
-	t.Logf("Tracee started, testing filters...")
+	t.Log("Tracee started, testing filters...")
 
 	// Clear buffer before tests
 	buf.Clear()
 
 	// Test 1: Execute matching pathname - should fire
-	t.Logf("Test 1: Executing /usr/bin/cat (should match filter)")
+	t.Log("Test 1: Executing /usr/bin/cat (should match filter)")
 	cmd := exec.Command("/usr/bin/cat", "/dev/null")
 	err := cmd.Run()
 	require.NoError(t, err, "Failed to execute /usr/bin/cat")
@@ -520,14 +520,14 @@ output:
 	if matchedEvt != nil {
 		matchedPath := getArgValue(matchedEvt, "matched_path")
 		assert.Contains(t, matchedPath, "/usr/bin/cat", "matched_path should contain /usr/bin/cat")
-		t.Logf("✓ Filter matched correctly for /usr/bin/cat")
+		t.Log("✓ Filter matched correctly for /usr/bin/cat")
 	}
 
 	// Clear buffer for next test
 	buf.Clear()
 
 	// Test 2: Execute non-matching pathname - should NOT fire
-	t.Logf("Test 2: Executing /usr/bin/id (should NOT match filter)")
+	t.Log("Test 2: Executing /usr/bin/id (should NOT match filter)")
 	cmd = exec.Command("/usr/bin/id")
 	err = cmd.Run()
 	require.NoError(t, err, "Failed to execute /usr/bin/id")
@@ -536,7 +536,7 @@ output:
 
 	unmatchedEvt := waitForDetectorEvent(buf, "test_filter_match", 2*time.Second)
 	assert.Nil(t, unmatchedEvt, "Detector should NOT fire for non-matching pathname /usr/bin/id")
-	t.Logf("✓ Filter correctly rejected /usr/bin/id")
+	t.Log("✓ Filter correctly rejected /usr/bin/id")
 }
 
 // Test_YAMLDetectorErrorHandling tests graceful handling of invalid YAML and missing fields
@@ -628,7 +628,7 @@ output:
 	assert.False(t, invalidFound, "Invalid syntax detector should NOT be loaded")
 	assert.False(t, missingIDFound, "Missing ID detector should NOT be loaded")
 
-	t.Logf("✓ Error handling verified: valid loaded, invalid rejected")
+	t.Log("✓ Error handling verified: valid loaded, invalid rejected")
 
 	// Test 4: Missing required field during extraction should skip detection gracefully
 	detectorWithRequiredField := `id: yaml-test-required-field
@@ -674,7 +674,7 @@ output:
 		}
 	}()
 
-	t.Logf("Tracee started, testing missing required field...")
+	t.Log("Tracee started, testing missing required field...")
 
 	// Trigger the detector
 	cmd := exec.Command("/bin/hostname")
@@ -687,5 +687,5 @@ output:
 	evt := waitForDetectorEvent(buf, "test_required_field", 2*time.Second)
 	assert.Nil(t, evt, "Detector should skip detection when required field is missing")
 
-	t.Logf("✓ Missing required field handled gracefully (detection skipped)")
+	t.Log("✓ Missing required field handled gracefully (detection skipped)")
 }

--- a/tests/testutils/exec.go
+++ b/tests/testutils/exec.go
@@ -107,7 +107,7 @@ func ExecCmdBgWithSudoAndCtx(ctx context.Context, command string) (int, chan err
 
 	command, args, err := ParseCmd(command)
 	if err != nil {
-		fmt.Printf("Failed to parse command\n")
+		fmt.Println("Failed to parse command")
 		close(cmdStatus)
 		return -1, cmdStatus, &failedToParseCmd{command: command, err: err}
 	}

--- a/tests/testutils/logger.go
+++ b/tests/testutils/logger.go
@@ -18,7 +18,7 @@ import (
 // This function is meant to be used by tests to check logs, and by that test the
 // flow of Tracee from outside.
 func SetTestLogger(t *testing.T, l logger.Level) (loggerOutput <-chan []byte, restoreLogger func()) {
-	t.Logf("  --- setting test logger ---")
+	t.Log("  --- setting test logger ---")
 
 	mw, logChan := newChannelWriter()
 	chanLogger := logger.NewLogger(
@@ -30,7 +30,7 @@ func SetTestLogger(t *testing.T, l logger.Level) (loggerOutput <-chan []byte, re
 	)
 	currentLogger := logger.GetLogger()
 	restoreLogger = func() {
-		t.Logf("  --- restoring default logger ---")
+		t.Log("  --- restoring default logger ---")
 		err := chanLogger.Sync()
 		logger.SetLogger(currentLogger)
 		mw.Close()


### PR DESCRIPTION
Consolidate duplicate branches:
- Merge crio/cri-o, A/AAAA DNS, and duplicate event type cases
- Remove redundant processSourceSignals (covered by default)
- Simplify boolean conditionals to direct assignment

Replace formatted functions with simpler variants:
- Use t.Error/Log/Fatal instead of t.Errorf/Logf/Fatalf when no format specifiers
- Use Print/Fprint instead of Printf/Fprintf when no formatting needed
- Remove extraneous blank lines
