### PR TITLE
feat(events): parse mmap flags and setns nstype arguments

### DIFF
--- a/common/parsers/data_parsers_test.go
+++ b/common/parsers/data_parsers_test.go
@@ -1124,3 +1124,70 @@ func TestGetPathFromRawAddr(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNamespaceType(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawValue uint64
+		expected string
+	}{
+		{
+			name:     "Zero (any namespace)",
+			rawValue: 0,
+			expected: "0",
+		},
+		{
+			name:     CLONE_NEWNS.String(),
+			rawValue: CLONE_NEWNS.Value(),
+			expected: CLONE_NEWNS.String(),
+		},
+		{
+			name:     CLONE_NEWUTS.String(),
+			rawValue: CLONE_NEWUTS.Value(),
+			expected: CLONE_NEWUTS.String(),
+		},
+		{
+			name:     CLONE_NEWIPC.String(),
+			rawValue: CLONE_NEWIPC.Value(),
+			expected: CLONE_NEWIPC.String(),
+		},
+		{
+			name:     CLONE_NEWUSER.String(),
+			rawValue: CLONE_NEWUSER.Value(),
+			expected: CLONE_NEWUSER.String(),
+		},
+		{
+			name:     CLONE_NEWPID.String(),
+			rawValue: CLONE_NEWPID.Value(),
+			expected: CLONE_NEWPID.String(),
+		},
+		{
+			name:     CLONE_NEWNET.String(),
+			rawValue: CLONE_NEWNET.Value(),
+			expected: CLONE_NEWNET.String(),
+		},
+		{
+			name:     CLONE_NEWCGROUP.String(),
+			rawValue: CLONE_NEWCGROUP.Value(),
+			expected: CLONE_NEWCGROUP.String(),
+		},
+		{
+			name:     "Multiple namespaces",
+			rawValue: CLONE_NEWNET.Value() | CLONE_NEWNS.Value(),
+			expected: "CLONE_NEWNS|CLONE_NEWNET",
+		},
+		{
+			name:     "All namespace types",
+			rawValue: CLONE_NEWNS.Value() | CLONE_NEWCGROUP.Value() | CLONE_NEWUTS.Value() | CLONE_NEWIPC.Value() | CLONE_NEWUSER.Value() | CLONE_NEWPID.Value() | CLONE_NEWNET.Value(),
+			expected: "CLONE_NEWNS|CLONE_NEWUTS|CLONE_NEWIPC|CLONE_NEWUSER|CLONE_NEWPID|CLONE_NEWNET|CLONE_NEWCGROUP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseNamespaceType(tt.rawValue)
+			assert.Equal(t, tt.expected, result.String())
+			assert.Equal(t, tt.rawValue, result.Value())
+		})
+	}
+}

--- a/pkg/events/parse_args.go
+++ b/pkg/events/parse_args.go
@@ -58,16 +58,35 @@ func ParseDataFields(data []*pb.EventValue, eventID int) error {
 				parseCapability(capField, uint64(capVal.Int32))
 			}
 		}
-	case SecurityMmapFile, DoMmap:
+	case SecurityMmapFile:
 		if protField := GetFieldValue(data, "prot"); protField != nil {
 			if protVal, ok := protField.Value.(*pb.EventValue_UInt64); ok {
 				parseMMapProt(protField, protVal.UInt64)
+			}
+		}
+	case DoMmap:
+		if protField := GetFieldValue(data, "prot"); protField != nil {
+			if protVal, ok := protField.Value.(*pb.EventValue_UInt64); ok {
+				parseMMapProt(protField, protVal.UInt64)
+			}
+		}
+		if mmapFlagsField := GetFieldValue(data, "mmap_flags"); mmapFlagsField != nil {
+			if mmapFlagsVal, ok := mmapFlagsField.Value.(*pb.EventValue_UInt64); ok {
+				parseMmapFlags(mmapFlagsField, mmapFlagsVal.UInt64)
 			}
 		}
 	case Mmap, Mprotect, PkeyMprotect:
 		if protField := GetFieldValue(data, "prot"); protField != nil {
 			if protVal, ok := protField.Value.(*pb.EventValue_Int32); ok {
 				parseMMapProt(protField, uint64(protVal.Int32))
+			}
+		}
+		// Parse mmap flags for Mmap syscall
+		if evtID == Mmap {
+			if flagsField := GetFieldValue(data, "flags"); flagsField != nil {
+				if flagsVal, ok := flagsField.Value.(*pb.EventValue_Int32); ok {
+					parseMmapFlags(flagsField, uint64(flagsVal.Int32))
+				}
 			}
 		}
 	case SecurityFileMprotect:
@@ -249,6 +268,12 @@ func ParseDataFields(data []*pb.EventValue, eventID int) error {
 		if vmaFlagsField := GetFieldValue(data, "vma_flags"); vmaFlagsField != nil {
 			if vmaFlagsVal, ok := vmaFlagsField.Value.(*pb.EventValue_UInt64); ok {
 				vmaFlagsField.Value = &pb.EventValue_Str{Str: parsers.ParseVmFlags(vmaFlagsVal.UInt64).String()}
+			}
+		}
+	case Setns:
+		if nstypeField := GetFieldValue(data, "nstype"); nstypeField != nil {
+			if nstypeVal, ok := nstypeField.Value.(*pb.EventValue_Int32); ok {
+				parseNamespaceType(nstypeField, uint64(nstypeVal.Int32))
 			}
 		}
 	}

--- a/pkg/events/parse_args_helpers.go
+++ b/pkg/events/parse_args_helpers.go
@@ -251,3 +251,13 @@ func parseBpfAttachType(ev *pb.EventValue, attachType int32) {
 
 	ev.Value = &pb.EventValue_Str{Str: attTypeName}
 }
+
+func parseMmapFlags(ev *pb.EventValue, flags uint64) {
+	mmapFlagsArgument := parsers.ParseMmapFlags(flags)
+	ev.Value = &pb.EventValue_Str{Str: mmapFlagsArgument.String()}
+}
+
+func parseNamespaceType(ev *pb.EventValue, nstype uint64) {
+	namespaceTypeArgument := parsers.ParseNamespaceType(nstype)
+	ev.Value = &pb.EventValue_Str{Str: namespaceTypeArgument.String()}
+}


### PR DESCRIPTION
Add ParseNamespaceType function for setns syscall nstype parsing. Wire up mmap flags parsing for mmap syscall and do_mmap event. Add comprehensive unit tests for both parsers.

This displays human-readable strings instead of raw hex values.

Close #2336