### PR TITLE
detectors: add container enrichment requirement support

### DIFF
--- a/api/v1beta1/detection/constants.go
+++ b/api/v1beta1/detection/constants.go
@@ -1,0 +1,18 @@
+package detection
+
+// Enrichment names for use in EnrichmentRequirement
+const (
+	EnrichmentExecEnv   = "exec-env"  // Capture exec environment variables
+	EnrichmentExecHash  = "exec-hash" // Calculate executable hashes
+	EnrichmentContainer = "container" // Enrich container metadata fields
+)
+
+// DataStore names for use in DataStoreRequirement
+const (
+	DataStoreProcess   = "process"   // Process tree datastore
+	DataStoreContainer = "container" // Container metadata datastore
+	DataStoreSymbol    = "symbol"    // Symbol resolution datastore
+	DataStoreDNS       = "dns"       // DNS query datastore
+	DataStoreSystem    = "system"    // System information datastore
+	DataStoreSyscall   = "syscall"   // Syscall information datastore
+)

--- a/docs/docs/detectors/api-reference.md
+++ b/docs/docs/detectors/api-reference.md
@@ -470,6 +470,7 @@ type EnrichmentRequirement struct {
 
 - `exec-env` - Execution environment variables
 - `exec-hash` - Executable file hashes (Config: "inode", "dev-inode", "digest-inode")
+- `container` - Container metadata fields in Event struct (Name, Image, Pod info)
 
 **Example**:
 {% raw %}
@@ -488,6 +489,29 @@ DetectorDefinition{
 }
 ```
 {% endraw %}
+
+**Container enrichment example**:
+
+{% raw %}
+```go
+DetectorDefinition{
+    ID: "TRC-CONTAINER-001",
+    Requirements: detection.DetectorRequirements{
+        Events: []detection.EventRequirement{
+            {Name: "security_file_open"},
+        },
+        Enrichments: []detection.EnrichmentRequirement{
+            {
+                Name:       detection.EnrichmentContainer,
+                Dependency: detection.DependencyRequired,
+            },
+        },
+    },
+}
+```
+{% endraw %}
+
+This detector requires container fields to be pre-populated in the Event struct. Without `--enrichment container`, registration will fail.
 
 ### Architecture Filtering
 

--- a/docs/docs/detectors/datastore-api.md
+++ b/docs/docs/detectors/datastore-api.md
@@ -487,6 +487,28 @@ type ContainerStore interface {
 ```
 {% endraw %}
 
+**Important:** Container enrichment (`--enrichment container`) is required for container metadata:
+
+When `--enrichment container` is enabled, Tracee:
+1. Queries container runtimes (Docker, containerd, CRI-O, Podman) at userspace
+2. Populates the container datastore with Name, Image, Pod info, etc.
+3. Attaches this metadata to Event.Workload.Container fields
+
+**Without `--enrichment container`:**
+- Only `Event.Workload.Container.Id` is available (from cgroup context)
+- Container datastore queries will NOT return Name, Image, or Pod information
+- Both Event fields and datastore will lack enriched metadata
+
+**With `--enrichment container`:**
+- `Event.Workload.Container.Name`, `.Image`, `.Pod` are populated in events
+- Container datastore can return full metadata when queried
+- Detectors can choose: read from Event fields directly OR query datastore
+
+**Why use datastore queries if enrichment is required anyway?**
+- More flexible error handling (e.g., handle not-found containers)
+- Access to additional methods like `GetContainerByName()`
+- Useful when container info is needed conditionally in detection logic
+
 ### ContainerInfo Structure
 
 {% raw %}

--- a/docs/docs/detectors/yaml-detectors.md
+++ b/docs/docs/detectors/yaml-detectors.md
@@ -123,6 +123,8 @@ requirements:
       dependency: required      # required or optional
     - name: exec-hash
       config: digest-inode      # Enrichment-specific config
+    - name: container           # Container enrichment
+      dependency: required
 ```
 
 **Event Filters:**

--- a/pkg/detectors/registry_test.go
+++ b/pkg/detectors/registry_test.go
@@ -812,6 +812,49 @@ func TestRegistry_EnrichmentValidation(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name: "container enrichment required and enabled",
+			enrichments: []detection.EnrichmentRequirement{
+				{Name: "container", Dependency: detection.DependencyRequired},
+			},
+			enrichOpts: &EnrichmentOptions{
+				Container: true,
+			},
+			expectErr: false,
+		},
+		{
+			name: "container enrichment required but not enabled",
+			enrichments: []detection.EnrichmentRequirement{
+				{Name: "container", Dependency: detection.DependencyRequired},
+			},
+			enrichOpts: &EnrichmentOptions{
+				Container: false,
+			},
+			expectErr: true,
+			errMsg:    "requires enrichment \"container\" which is not enabled",
+		},
+		{
+			name: "container enrichment optional and not enabled",
+			enrichments: []detection.EnrichmentRequirement{
+				{Name: "container", Dependency: detection.DependencyOptional},
+			},
+			enrichOpts: &EnrichmentOptions{
+				Container: false,
+			},
+			expectErr: false,
+		},
+		{
+			name: "mixed enrichments: container required, exec-env optional",
+			enrichments: []detection.EnrichmentRequirement{
+				{Name: "container", Dependency: detection.DependencyRequired},
+				{Name: "exec-env", Dependency: detection.DependencyOptional},
+			},
+			enrichOpts: &EnrichmentOptions{
+				Container: true,
+				ExecEnv:   false,
+			},
+			expectErr: false,
+		},
+		{
 			name: "multiple enrichments - one missing",
 			enrichments: []detection.EnrichmentRequirement{
 				{Name: "exec-env", Dependency: detection.DependencyRequired},

--- a/pkg/detectors/yaml/validator.go
+++ b/pkg/detectors/yaml/validator.go
@@ -219,7 +219,7 @@ func validateEnrichmentRequirement(spec EnrichmentRequirementSpec, filePath stri
 
 	// Validate known enrichment names
 	if !isValidEnrichmentName(spec.Name) {
-		return errfmt.Errorf("%s: unknown enrichment '%s': must be one of exec-env, exec-hash", filePath, spec.Name)
+		return errfmt.Errorf("%s: unknown enrichment '%s': must be one of exec-env, exec-hash, container", filePath, spec.Name)
 	}
 
 	return nil
@@ -376,7 +376,11 @@ func isValidArchitecture(arch string) bool {
 
 // isValidEnrichmentName checks if an enrichment name is known
 func isValidEnrichmentName(name string) bool {
-	validEnrichments := []string{"exec-env", "exec-hash"}
+	validEnrichments := []string{
+		detection.EnrichmentExecEnv,
+		detection.EnrichmentExecHash,
+		detection.EnrichmentContainer,
+	}
 	for _, valid := range validEnrichments {
 		if name == valid {
 			return true

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -467,6 +467,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 	enrichOpts := &detectors.EnrichmentOptions{
 		ExecEnv:      t.config.Output.ExecEnv,
 		ExecHashMode: t.config.Output.CalcHashes,
+		Container:    t.config.EnrichmentEnabled,
 	}
 	t.detectorEngine = detectors.NewEngine(t.policyManager, enrichOpts)
 


### PR DESCRIPTION
Add container enrichment as a detector requirement option, allowing detectors to declare when they need container metadata fields.

- Add Container bool to EnrichmentOptions struct
- Validate 'container' enrichment during detector registration
- Add test cases for required/optional container enrichment
- Update documentation: API reference, YAML syntax, quickstart guide
- Clarify that enrichment is required for both Event fields and datastore

Both Event.Workload.Container fields and datastore queries require --enrichment container to populate Name/Image/Pod metadata.
