### PR TITLE
Remove obsolete tracee.pid readiness file

### DIFF
--- a/scripts/tracee_common.sh
+++ b/scripts/tracee_common.sh
@@ -32,89 +32,13 @@ setup_tracee_paths() {
     TRACEE_WORKDIR=$(realpath "${TRACEE_WORKDIR}" 2> /dev/null \
         || printf "%s" "${TRACEE_WORKDIR}")
 
-    TRACEE_PIDFILE="${TRACEE_WORKDIR}/tracee.pid"
-
-    export TRACEE_WORKDIR TRACEE_PIDFILE
+    export TRACEE_WORKDIR
 }
 
 # Default error handler - scripts can override this
 handle_tracee_error() {
     error_msg="$1"
     die "${error_msg:-Tracee operation failed}"
-}
-
-# get_tracee_pid_from_pidfile [must_fail]
-#
-# Attempts to read and validate the tracee PID from the PID file.
-#
-# Parameters:
-#   must_fail - Controls error handling behavior:
-#     "nofail"   - Silent mode: return 0 on any error, no output, no script exit
-#     <anything> - Strict mode: log errors and call error handler on any error
-#
-# Return behavior:
-#   Success: Prints the PID to stdout and returns 0
-#   Error in "nofail" mode: Returns 0 silently
-#   Error in strict mode: Calls handle_tracee_error() and exits script
-#
-# Validation checks performed:
-#   - PID file exists
-#   - PID file is readable
-#   - PID file contains non-empty content
-#   - Process with that PID is actually running
-get_tracee_pid_from_pidfile() {
-    must_fail="${1:-fail}"
-
-    if [ ! -f "${TRACEE_PIDFILE}" ]; then
-        if [ "${must_fail}" = "nofail" ]; then
-            return 0
-        fi
-
-        error "Tracee PID file ${TRACEE_PIDFILE} not found"
-        handle_tracee_error "PID file not found"
-    fi
-
-    if ! get_tracee_pid_from_pidfile_pid=$(cat "${TRACEE_PIDFILE}" 2> /dev/null); then
-        if [ "${must_fail}" = "nofail" ]; then
-            return 0
-        fi
-
-        error "Failed to read Tracee PID from ${TRACEE_PIDFILE}"
-        handle_tracee_error "Cannot read PID file"
-    fi
-
-    if [ -z "${get_tracee_pid_from_pidfile_pid}" ]; then
-        if [ "${must_fail}" = "nofail" ]; then
-            return 0
-        fi
-
-        error "Tracee PID file ${TRACEE_PIDFILE} is empty"
-        handle_tracee_error "Invalid PID file"
-    fi
-
-    if ! kill -0 "${get_tracee_pid_from_pidfile_pid}" 2> /dev/null; then
-        if [ "${must_fail}" = "nofail" ]; then
-            return 0
-        fi
-
-        error "Tracee process with PID ${get_tracee_pid_from_pidfile_pid} not found"
-        handle_tracee_error "Tracee process is not running"
-    fi
-
-    printf "%s" "${get_tracee_pid_from_pidfile_pid}"
-}
-
-# cleanup_tracee_pid_file - Remove the PID file
-cleanup_tracee_pid_file() {
-    if [ -f "${TRACEE_PIDFILE}" ]; then
-        info "Removing PID file ${TRACEE_PIDFILE}"
-        rm -f "${TRACEE_PIDFILE}" || {
-            error "Failed to remove PID file ${TRACEE_PIDFILE}"
-            return 1
-        }
-    fi
-
-    return 0
 }
 
 # get_running_tracee_pids - Find all running processes named "tracee"

--- a/tests/e2e-kernel-test.sh
+++ b/tests/e2e-kernel-test.sh
@@ -77,6 +77,7 @@ tracee_command="./dist/tracee \
     --runtime workdir=$TRACEE_TMP_DIR \
     --output json:$outputfile \
     --logging file=$logfile \
+    --server healthz \
     --policy ./tests/policies/kernel/kernel.yaml 2>&1 \
     | tee $SCRIPT_TMP_DIR/build-$$"
 
@@ -88,7 +89,7 @@ timedout=0
 while true; do
     times=$(($times + 1))
     sleep 1
-    if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
+    if curl -s -o /dev/null -w "%{http_code}" http://localhost:3366/healthz 2>/dev/null | grep -q "200"; then
         info
         info "UP AND RUNNING"
         info

--- a/tests/e2e-net-test.sh
+++ b/tests/e2e-net-test.sh
@@ -87,6 +87,7 @@ tracee_command="./dist/tracee \
     --runtime workdir=$TRACEE_TMP_DIR \
     --output json:$outputfile \
     --logging file=$logfile \
+    --server healthz \
     --policy ./tests/policies/net/ \
     --signatures-dir ./dist/e2e-net-signatures/"
 
@@ -98,7 +99,7 @@ timedout=0
 while true; do
     times=$(($times + 1))
     sleep 1
-    if [[ -f $TRACEE_TMP_DIR/tracee.pid ]]; then
+    if curl -s -o /dev/null -w "%{http_code}" http://localhost:3366/healthz 2>/dev/null | grep -q "200"; then
         info
         info "UP AND RUNNING"
         info


### PR DESCRIPTION
The tracee.pid file was written too early in the startup sequence (after t.Init() but before event processing begins) and was not a reliable readiness indicator. This change removes the PID file mechanism entirely and migrates all consumers to use the /healthz HTTP endpoint, which properly indicates readiness after the ready callback fires.

Changes:
- pkg/cmd/tracee.go: Remove PID file creation/cleanup logic
- tests/e2e-kernel-test.sh: Poll /healthz endpoint for readiness
- tests/e2e-net-test.sh: Poll /healthz endpoint for readiness
- scripts/tracee_common.sh: Remove PID file helper functions

Benefits:
- Readiness checks now accurately reflect when Tracee is ready to process events
- Consistent readiness mechanism across all environments (K8s, tests, production)
- Follows Cloud Native best practices with /healthz endpoint
- Simplified codebase with ~90 lines of code removed

Fixes: #1548