### PR TITLE
fix: add security_file_mprotect probe dependency to capture_mem

### DIFF
--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -13520,6 +13520,9 @@ var CoreEvents = map[ID]Definition{
 		internal: true,
 		dependencies: DependencyStrategy{
 			primary: Dependencies{
+				probes: []Probe{
+					{handle: probes.SecurityFileMProtect, required: true},
+				},
 				tailCalls: []TailCall{
 					{"prog_array", "send_bin", []uint32{TailSendBin}},
 				},


### PR DESCRIPTION
The capture_mem event is triggered from the security_file_mprotect kprobe handler when dynamic code loading is detected (W->X memory protection changes). Without declaring this probe as a dependency, the probe won't be loaded when capture_mem is enabled in isolation via --capture mem, causing memory captures to silently fail.

This fix adds the security_file_mprotect probe as a required dependency and includes an integration test to verify the probe is properly loaded.

Fixes #3813
