### PR TITLE
bpf: fix const-init warnings with newer Clang

### DIFF
--- a/pkg/ebpf/c/common/ksymbols.h
+++ b/pkg/ebpf/c/common/ksymbols.h
@@ -42,7 +42,8 @@ statfunc struct pipe_inode_info *get_file_pipe_info(struct file *file)
 {
     struct pipe_inode_info *pipe = BPF_CORE_READ(file, private_data);
     char pipe_write_sym[11] = "pipe_write";
-    void *file_write_iter_op = BPF_CORE_READ(file, f_op, write_iter);
+    void *file_write_iter_op = NULL;
+    BPF_CORE_READ_INTO(&file_write_iter_op, file, f_op, write_iter);
 
     if (file_write_iter_op != get_symbol_addr(pipe_write_sym))
         return NULL;

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -14241,8 +14241,8 @@ var CoreEvents = map[ID]Definition{
 		},
 		sets: []string{"lsm"},
 		fields: []DataField{
-			{DecodeAs: data.ULONG_T, ArgMeta: trace.ArgMeta{Type: "uint64", Name: "tv_sec"}},
-			{DecodeAs: data.ULONG_T, ArgMeta: trace.ArgMeta{Type: "uint64", Name: "tv_nsec"}},
+			{DecodeAs: data.LONG_T, ArgMeta: trace.ArgMeta{Type: "int64", Name: "tv_sec"}},
+			{DecodeAs: data.LONG_T, ArgMeta: trace.ArgMeta{Type: "int64", Name: "tv_nsec"}},
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "tz_minuteswest"}},
 			{DecodeAs: data.INT_T, ArgMeta: trace.ArgMeta{Type: "int32", Name: "tz_dsttime"}},
 		},


### PR DESCRIPTION
Use BPF_CORE_READ_INTO instead of BPF_CORE_READ when reading through const-qualified pointers to avoid -Wdefault-const-init-var-unsafe warnings from Clang 17+.