### PR TITLE
test: fix intermittent failure in security_file_open filter test

### DIFF
--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -1873,8 +1873,8 @@ func Test_EventFilters(t *testing.T) {
 								{
 									Event: "security_file_open",
 									Filters: []string{
+										"data.pathname=/etc/ld.so.cache",
 										"data.pathname=/etc/netconfig",
-										"data.pathname!=/usr/lib/*",
 									},
 								},
 								{


### PR DESCRIPTION
Replace overly broad negative filter with explicit pathname matches to prevent non-deterministic test failures. The previous filter used OR semantics that matched any file not under /usr/lib/, causing failures when cat opened files in varying order.