### PR TITLE
ebpf: fix execve/execveat returnValue index corruption

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -419,8 +419,7 @@ int syscall__execve_exit(void *ctx)
             &p.event->args_buf, (const char *const *) sys->args.args[2] /*envp*/, 2);
     }
 
-    save_to_submit_buf(
-        &p.event->args_buf, (void *) &sys->ret, sizeof(long), p.event->args_buf.argnum);
+    save_to_submit_buf(&p.event->args_buf, (void *) &sys->ret, sizeof(long), 3);
     return events_perf_submit(&p);
 }
 
@@ -483,8 +482,7 @@ int syscall__execveat_exit(void *ctx)
     }
     save_to_submit_buf(&p.event->args_buf, (void *) &sys->args.args[4] /*flags*/, sizeof(int), 4);
 
-    save_to_submit_buf(
-        &p.event->args_buf, (void *) &sys->ret, sizeof(long), p.event->args_buf.argnum);
+    save_to_submit_buf(&p.event->args_buf, (void *) &sys->ret, sizeof(long), 5);
     return events_perf_submit(&p);
 }
 


### PR DESCRIPTION
Use hardcoded schema indices instead of argnum for returnValue in execve/execveat exit handlers. Using argnum caused buffer corruption when OPT_EXEC_ENV was disabled, writing returnValue at wrong index and corrupting the envp field decoder.

Error: "string size too big: 4294967295" when decoding envp argument.

Fixes: execve returnValue at index 3, execveat returnValue at index 5.