### PR TITLE
Add debug message to stack_pivot test

### DIFF
--- a/tests/e2e-inst-signatures/e2e-stack_pivot.go
+++ b/tests/e2e-inst-signatures/e2e-stack_pivot.go
@@ -69,6 +69,7 @@ func (sig *e2eStackPivot) OnEvent(event protocol.Event) error {
 		} else {
 			// False positive, mark it so that the test will fail
 			sig.falsePositive = true
+			sig.log.Warnw("False positive detected", "event", event)
 		}
 	}
 


### PR DESCRIPTION
This should help debug intermittent test failures, which I haven't been able to reproduce.
