### PR TITLE
ebpf: fix bpf_attach event for kernel 6.13+

### DIFF
--- a/pkg/ebpf/c/vmlinux.h
+++ b/pkg/ebpf/c/vmlinux.h
@@ -1290,6 +1290,7 @@ struct trace_event_call {
         char *name;
         struct tracepoint *tp;
     };
+    void *filter; // removed in kernel 6.13, used for CO-RE detection
     void *module; // only from 5.15
     int flags;
 };

--- a/pkg/ebpf/probes/common.go
+++ b/pkg/ebpf/probes/common.go
@@ -1,6 +1,9 @@
 package probes
 
 import (
+	"errors"
+	"syscall"
+
 	bpf "github.com/aquasecurity/libbpfgo"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
@@ -16,8 +19,25 @@ func enableDisableAutoload(module *bpf.Module, programName string, autoload bool
 
 	prog, err := module.GetProgram(programName)
 	if err != nil {
+		// Program not found (ENOENT) is expected for probes that don't exist in this kernel version
+		// or for optional probes that may not be compiled into the BPF object.
+		// This is not an error - just means the probe can't be used.
+		if errors.Is(err, syscall.ENOENT) {
+			return nil
+		}
 		return errfmt.WrapError(err)
 	}
 
-	return prog.SetAutoload(autoload)
+	err = prog.SetAutoload(autoload)
+	if err != nil {
+		// EINVAL means the BPF object is already loaded and autoload cannot be changed.
+		// This is expected when probes are being removed/disabled after loading.
+		// We can safely ignore this since the program state is already determined.
+		if errors.Is(err, syscall.EINVAL) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
The bpf_attach event stopped working on kernel 6.13+ because this kernel version removed TRACE_EVENT_FL_FILTERED_BIT from trace_event_call flags, shifting TRACE_EVENT_FL_KPROBE_BIT and TRACE_EVENT_FL_UPROBE_BIT down by one position. This caused incorrect probe type detection for kprobes and uprobes, resulting in no events being generated.

Solution:
- eBPF: Use CO-RE to detect kernel version by checking for the presence of the 'filter' field in trace_event_call struct, and dynamically determine correct bit offsets for TRACE_EVENT_FL_KPROBE/UPROBE flags
- eBPF: Add vmlinux.h definition for 'filter' field to enable CO-RE check

Additional improvements:
- eBPF: Handle missing optional helper probe data gracefully by using zero_helpers fallback when bpf_attach_map lookup fails
- Go: Handle ENOENT and EINVAL errors in enableDisableAutoload to prevent noisy debug logs for expected probe autoload failures

Tested on kernel 6.12 and 6.18 with full backward/forward compatibility.

Fixes #5167
