### PR TITLE
fix(tests): prevent goroutine leak in ExecPinnedCmdWithTimeout

### DIFF
--- a/tests/testutils/exec.go
+++ b/tests/testutils/exec.go
@@ -69,7 +69,8 @@ func ExecPinnedCmdWithTimeout(command string, timeout time.Duration) (int, error
 
 	pid := cmd.Process.Pid
 
-	cmdDone := make(chan error)
+	// Use buffered channel to prevent goroutine leak when timeout fires
+	cmdDone := make(chan error, 1)
 	go func() {
 		cmdDone <- cmd.Wait() // wait for command to exit
 	}()


### PR DESCRIPTION
Use buffered channel (capacity 1) instead of unbuffered to allow goroutine to exit cleanly when timeout fires before cmd.Wait() completes.