### PR TITLE
feat(operator): watch for tracee configmap changes

### DIFF
--- a/deploy/helm/tracee/templates/role.yaml
+++ b/deploy/helm/tracee/templates/role.yaml
@@ -22,3 +22,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/k8s/controller/controller.go
+++ b/pkg/k8s/controller/controller.go
@@ -5,13 +5,46 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/aquasecurity/tracee/pkg/k8s/apis/tracee.aquasec.com/v1beta1"
 )
+
+// restartDaemonSet restarts the Tracee DaemonSet by adding a timestamp annotation to the pod template.
+// This uses the same strategy as kubectl rollout restart, causing the daemonset controller to rollout
+// a new daemonset.
+func restartDaemonSet(ctx context.Context, c client.Client, namespace, name string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var ds appsv1.DaemonSet
+
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+	if err := c.Get(ctx, key, &ds); err != nil {
+		logger.Error(err, "unable to fetch daemonset")
+		return ctrl.Result{}, err
+	}
+
+	if ds.Spec.Template.Annotations == nil {
+		ds.Spec.Template.Annotations = make(map[string]string)
+	}
+
+	ds.Spec.Template.Annotations["tracee-operator-restarted"] = time.Now().String()
+
+	if err := c.Update(ctx, &ds); err != nil {
+		logger.Error(err, "unable to update daemonset")
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
 
 // PolicyReconciler is the main controller for the Tracee Policy CRD. It is responsible
 // for updating the Tracee DaemonSet whenever a change is detected in a TraceePolicy
@@ -28,38 +61,9 @@ type PolicyReconciler struct {
 
 // Reconcile is where the reconciliation logic resides. Every time a change is detected in
 // a v1beta1.Policy object, this function will be called. It will update the Tracee
-// DaemonSet, so that the Tracee pods will be restarted with the new policy. It does this
-// by adding a timestamp annotation to the pod template, so that the daemonset controller
-// will rollout a new daemonset ("restarting" the daemonset).
+// DaemonSet, so that the Tracee pods will be restarted with the new policy.
 func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	var ds appsv1.DaemonSet
-
-	key := client.ObjectKey{
-		Namespace: r.TraceeNamespace,
-		Name:      r.TraceeName,
-	}
-	if err := r.Get(ctx, key, &ds); err != nil {
-		logger.Error(err, "unable to fetch daemonset")
-		return ctrl.Result{}, err
-	}
-
-	if ds.Spec.Template.Annotations == nil {
-		ds.Spec.Template.Annotations = make(map[string]string)
-	}
-
-	// we use the same strategy done by kubect rollout restart,
-	// adding a timestamp annotation to the pod template,
-	// so that the daemonset controller will rollout a new daemonset
-	ds.Spec.Template.Annotations["tracee-operator-restarted"] = time.Now().String()
-
-	if err := r.Update(ctx, &ds); err != nil {
-		logger.Error(err, "unable to update daemonset")
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return restartDaemonSet(ctx, r.Client, r.TraceeNamespace, r.TraceeName)
 }
 
 // SetupWithManager is responsible for connecting the PolicyReconciler to the main
@@ -68,5 +72,38 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *PolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.Policy{}).
+		Complete(r)
+}
+
+// ConfigMapReconciler is the controller for the Tracee ConfigMap. It is responsible
+// for updating the Tracee DaemonSet whenever a change is detected in the Tracee ConfigMap.
+type ConfigMapReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	TraceeNamespace string
+	TraceeName      string
+	ConfigMapName   string
+}
+
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;patch;update;
+
+// Reconcile is where the reconciliation logic resides. Every time a change is detected in
+// the Tracee ConfigMap, this function will be called. It will update the Tracee
+// DaemonSet, so that the Tracee pods will be restarted with the new configuration.
+func (r *ConfigMapReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return restartDaemonSet(ctx, r.Client, r.TraceeNamespace, r.TraceeName)
+}
+
+// SetupWithManager is responsible for connecting the ConfigMapReconciler to the main
+// controller manager. It tells the manager that for changes in the Tracee ConfigMap, the
+// ConfigMapReconciler should be invoked. It filters to only watch the specific Tracee ConfigMap.
+func (r *ConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			// Only watch the specific Tracee ConfigMap
+			return obj.GetNamespace() == r.TraceeNamespace && obj.GetName() == r.ConfigMapName
+		})).
 		Complete(r)
 }


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/3876

# Add ConfigMap watching to tracee-operator

## Summary

This PR extends the tracee-operator to watch the Tracee ConfigMap and automatically restart the Tracee DaemonSet when the configuration changes, similar to how it already handles Policy CRD changes.

## Changes

- **Added `ConfigMapReconciler`**: A new reconciler that watches the Tracee ConfigMap and triggers DaemonSet restarts on configuration changes
- **Extracted common restart logic**: Refactored the DaemonSet restart logic into a shared `restartDaemonSet` helper function to eliminate code duplication between `PolicyReconciler` and `ConfigMapReconciler`
- **Added RBAC permissions**: Added `get`, `list`, and `watch` permissions for configmaps to the operator's ClusterRole
- **Configurable ConfigMap name**: Added `--configmap-name` flag (default: `tracee-config`) and `TRACEE_CONFIGMAP_NAME` environment variable support

## Implementation Details

The operator uses a predicate filter to ensure it only watches the specific Tracee ConfigMap (filtered by namespace and name), preventing unnecessary reconciles for other configmaps in the cluster. When the ConfigMap changes, the operator updates the DaemonSet pod template annotation with a timestamp, which triggers Kubernetes to perform a rolling restart of the DaemonSet pods.

## Testing

### Prerequisites

- A Kubernetes cluster (e.g., minikube)
- Helm installed
- Custom tracee image built and available (e.g., `josedonizetti/tracee:test1`), I created and pushed this image so you can test it. 

### Installation

Install the tracee helm chart using your custom image:
```
helm install tracee /path/to/tracee/deploy/helm/tracee \
  --namespace tracee-system \
  --create-namespace \
  --set image.repository=josedonizetti/tracee \
  --set image.tag=test1
```

### Test

1. **Verify ConfigMap changes trigger restarts**:
   
   # Watch the tracee pods
   kubectl get pods -n tracee-system -w
   
   # In another terminal, patch the tracee-config ConfigMap
   kubectl patch configmap tracee-config -n tracee-system --type merge \
     -p '{"data":{"config.yaml":"healthz: true\nmetrics: true\nlog:\n    level: debug\n..."}}'
   
   # Verify the pods restart by checking the daemonset annotation
   kubectl get daemonset tracee -n tracee-system \
     -o jsonpath='{.spec.template.metadata.annotations.tracee-operator-restarted}'
   2. **Verify other ConfigMaps don't trigger restarts**:
   # Create a test configmap in the same namespace
   kubectl create configmap test-config -n tracee-system \
     --from-literal=test.key=test.value
   
   # Update the test configmap
   kubectl patch configmap test-config -n tracee-system --type merge \
     -p '{"data":{"test.key":"updated-value"}}'
   
   # Verify tracee pods do NOT restart (check pod age/timestamps)
   kubectl get pods -n tracee-system
   3. **Verify operator logs show ConfigMap reconciles**:
  
   kubectl logs -n tracee-system -l app=tracee-operator --tail=50
   ## Related

- Follows the same restart pattern as Policy CRD watching
- Uses kubectl rollout restart strategy (timestamp annotation on pod template)