### PR TITLE
fix(helm): fix helm deploy

### DIFF
--- a/deploy/helm/tracee/templates/tracee-config.yaml
+++ b/deploy/helm/tracee/templates/tracee-config.yaml
@@ -29,11 +29,27 @@ data:
         pipeline: {{ .Values.config.pipeline }}
         {{- end }}
     {{- end }}
-    healthz: {{ .Values.config.healthz }}
-    metrics: {{ .Values.config.metrics }}
-    pprof: {{ .Values.config.pprof }}
-    pyroscope: {{ .Values.config.pyroscope }}
-    listen-addr: {{ .Values.config.listenAddr }}
+    {{- if or .Values.config.server.httpAddress .Values.config.server.metrics .Values.config.server.healthz .Values.config.server.pprof .Values.config.server.pyroscope }}
+    server:
+        {{- if .Values.config.server.httpAddress }}
+        http-address: {{ .Values.config.server.httpAddress | quote }}
+        {{- end }}
+        {{- if .Values.config.server.grpcAddress }}
+        grpc-address: {{ .Values.config.server.grpcAddress | quote }}
+        {{- end }}
+        {{- if .Values.config.server.metrics }}
+        metrics: {{ .Values.config.server.metrics }}
+        {{- end }}
+        {{- if .Values.config.server.healthz }}
+        healthz: {{ .Values.config.server.healthz }}
+        {{- end }}
+        {{- if .Values.config.server.pprof }}
+        pprof: {{ .Values.config.server.pprof }}
+        {{- end }}
+        {{- if .Values.config.server.pyroscope }}
+        pyroscope: {{ .Values.config.server.pyroscope }}
+        {{- end }}
+    {{- end }}
     {{- if .Values.config.workdir }}
     runtime:
       - workdir={{ .Values.config.workdir }}
@@ -129,9 +145,11 @@ data:
             {{- end }}
         {{- end }}
     output:
-        {{ .Values.config.output.format }}:
-            files:
-                - stdout
+        destinations:
+            - name: stdout_json
+              type: file
+              format: {{ .Values.config.output.format | default "json" }}
+              path: stdout
         options:
             parse-arguments: {{ .Values.config.output.options.parseArguments }}
             stack-addresses: {{ .Values.config.output.options.stackAddresses }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -83,11 +83,13 @@ config:
   kernelArtifacts: ""
   kernelControlPlane: ""
   pipeline: ""
-  healthz: true
-  metrics: true
-  pprof: false
-  pyroscope: false
-  listenAddr: :3366
+  server:
+    httpAddress: ":3366"
+    grpcAddress: ""
+    metrics: true
+    healthz: true
+    pprof: false
+    pyroscope: false
   workdir: ""
   signaturesDir: ""
   log:


### PR DESCRIPTION
# Fix Helm Chart Configuration Format for Tracee v0.24.1+

## Summary

This PR updates the Tracee Helm chart to use the new configuration format introduced in Tracee v0.24.1+. The chart was using deprecated configuration options that prevented Tracee from starting its HTTP server and outputting events in JSON format.

## Changes

### 1. Server Configuration Format Update

**Before (deprecated):**
```yaml
healthz: true
metrics: true
pprof: false
pyroscope: false
listen-addr: :3366
```

**After (new format):**
```yaml
server:
    http-address: ":3366"
    metrics: true
    healthz: true
    pprof: false
    pyroscope: false
```

- Updated `deploy/helm/tracee/templates/tracee-config.yaml` to use the new `server:` section
- Updated `deploy/helm/tracee/values.yaml` to move server configuration under `config.server`
- Changed `listenAddr` to `server.httpAddress` in values structure

**Impact:** Without this change, Tracee's HTTP server would not start, causing health probes to fail and preventing access to `/healthz` and `/metrics` endpoints.

### 2. Output Configuration Format Update

**Before (deprecated):**
```yaml
output:
    json:
        files:
            - stdout
```

**After (new format):**
```yaml
output:
    destinations:
        - name: stdout_json
          type: file
          format: json
          path: stdout
```

- Updated the output template to use the new `destinations` array format
- Ensured JSON format is the default for Kubernetes deployments
- Added default fallback to `json` format if not specified

**Impact:** Without this change, Tracee would default to table format output instead of JSON, making it difficult to integrate with log aggregation systems and SIEM tools.

## Files Changed

- `deploy/helm/tracee/templates/tracee-config.yaml`: Updated server and output configuration sections
- `deploy/helm/tracee/values.yaml`: Restructured server configuration under `config.server` and ensured JSON default
