### PR TITLE
k8s: add explicit for prometheus autodiscover

### DIFF
--- a/deploy/helm/tracee/templates/daemonset.yaml
+++ b/deploy/helm/tracee/templates/daemonset.yaml
@@ -42,13 +42,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          {{- if or .Values.config.server.httpAddress .Values.config.server.metrics .Values.config.server.healthz }}
+          ports:
+            - name: metrics
+              containerPort: {{ trimPrefix ":" (.Values.config.server.httpAddress | default ":3366") }}
+              protocol: TCP
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- if .Values.config.healthz }}
+          {{- if .Values.config.server.healthz }}
           readinessProbe:
             httpGet:
               path: /healthz
-              port: {{ trimPrefix ":" .Values.config.listenAddr }}
+              port: {{ trimPrefix ":" (.Values.config.server.httpAddress | default ":3366") }}
           {{- end }}
           volumeMounts:
             - name: tmp-tracee


### PR DESCRIPTION
## Fix: Add explicit port declarations for Prometheus metrics discovery

Fixes #4158

### Problem
Prometheus ServiceMonitor cannot discover Tracee metrics endpoints because the DaemonSet container spec lacks explicit port declarations. While metrics are enabled by default and accessible at `:3366/metrics`, the missing port declaration prevents automatic discovery.

### Solution
- Added explicit `ports` section to DaemonSet container spec with `name: metrics` and `containerPort: 3366`
- Fixed readinessProbe to use correct config path (`.Values.config.server.httpAddress` instead of `.Values.config.listenAddr`)
- Port declaration is conditionally rendered when metrics, healthz, or httpAddress are configured

### Changes
- `deploy/helm/tracee/templates/daemonset.yaml`: Added ports section and fixed readinessProbe config path

### Testing
- Verified port is declared in deployed pod: `Port: 3366/TCP (metrics)`
- Confirmed metrics endpoint remains accessible at `:3366/metrics`
- Helm template renders correctly with default values