### PR TITLE
fix(enrichment): move enrich logic from --output

### DIFF
--- a/api/v1beta1/detection/constants.go
+++ b/api/v1beta1/detection/constants.go
@@ -2,9 +2,9 @@ package detection
 
 // Enrichment names for use in EnrichmentRequirement
 const (
-	EnrichmentExecEnv   = "exec-env"  // Capture exec environment variables
-	EnrichmentExecHash  = "exec-hash" // Calculate executable hashes
-	EnrichmentContainer = "container" // Enrich container metadata fields
+	EnrichmentEnvironment    = "environment"     // Capture exec environment variables
+	EnrichmentExecutableHash = "executable-hash" // Calculate executable hashes
+	EnrichmentContainer      = "container"       // Enrich container metadata fields
 )
 
 // DataStore names for use in DataStoreRequirement

--- a/api/v1beta1/detection/detector.go
+++ b/api/v1beta1/detection/detector.go
@@ -176,15 +176,15 @@ type DataStoreRequirement struct {
 
 // EnrichmentRequirement specifies a required event enrichment option.
 type EnrichmentRequirement struct {
-	// Name is the enrichment option name: "exec-env", "exec-hash"
+	// Name is the enrichment option name: "environment", "executable-hash"
 	Name string `yaml:"name"`
 
 	// Dependency controls whether this enrichment is required or optional
 	// Zero value (0) = DependencyRequired (default)
 	Dependency DependencyType `yaml:"dependency,omitempty"`
 
-	// Config contains enrichment-specific configuration (e.g., exec-hash mode)
-	// For exec-hash: "inode", "dev-inode", "digest-inode"
+	// Config contains enrichment-specific configuration (e.g., executable-hash mode)
+	// For executable-hash: "inode", "dev-inode", "digest-inode"
 	Config string `yaml:"config,omitempty"`
 }
 

--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -33,7 +33,7 @@ run_tracee() {
         --capabilities add=$CAPABILITIES_ADD \
         --capabilities drop=$CAPABILITIES_DROP \
         --output=json \
-        --enrichment parse-arguments \
+        --enrichment decoded-data \
         --events signatures,container_create,container_remove
     fi
 

--- a/deploy/helm/tracee/templates/tracee-config.yaml
+++ b/deploy/helm/tracee/templates/tracee-config.yaml
@@ -141,20 +141,20 @@ data:
             {{- end }}
         {{- end }}
     {{- $enrichment := .Values.config.enrichment }}
-    {{- if or (index $enrichment "parse-arguments") (index $enrichment "user-stack-trace") (index $enrichment "exec-env") (or (index (index $enrichment "exec-hash") "enabled") (index (index $enrichment "exec-hash") "mode")) }}
+    {{- if or (index $enrichment "decoded-data") (index $enrichment "user-stack") (index $enrichment "environment") (or (index (index $enrichment "executable-hash") "enabled") (index (index $enrichment "executable-hash") "mode")) }}
     enrichment:
-        {{- if (index $enrichment "parse-arguments") }}
-        parse-arguments: {{ index $enrichment "parse-arguments" }}
+        {{- if (index $enrichment "decoded-data") }}
+        decoded-data: {{ index $enrichment "decoded-data" }}
         {{- end }}
-        {{- if (index $enrichment "user-stack-trace") }}
-        user-stack-trace: {{ index $enrichment "user-stack-trace" }}
+        {{- if (index $enrichment "user-stack") }}
+        user-stack: {{ index $enrichment "user-stack" }}
         {{- end }}
-        {{- if (index $enrichment "exec-env") }}
-        exec-env: {{ index $enrichment "exec-env" }}
+        {{- if (index $enrichment "environment") }}
+        environment: {{ index $enrichment "environment" }}
         {{- end }}
-        {{- $execHash := index $enrichment "exec-hash" }}
+        {{- $execHash := index $enrichment "executable-hash" }}
         {{- if or (index $execHash "enabled") (index $execHash "mode") }}
-        exec-hash:
+        executable-hash:
             {{- if (index $execHash "enabled") }}
             enabled: {{ index $execHash "enabled" }}
             {{- end }}

--- a/deploy/helm/tracee/values.yaml
+++ b/deploy/helm/tracee/values.yaml
@@ -127,10 +127,10 @@ config:
     #     regex:
     #       - ^excludedPattern
   enrichment:
-    parse-arguments: true
-    user-stack-trace: false
-    exec-env: false
-    exec-hash:
+    decoded-data: true
+    user-stack: false
+    environment: false
+    executable-hash:
       enabled: true
       mode: dev-inode
   output:

--- a/deploy/kubernetes/tracee/tracee.yaml
+++ b/deploy/kubernetes/tracee/tracee.yaml
@@ -51,10 +51,10 @@ data:
     log:
         level: info
     enrichment:
-        parse-arguments: true
-        user-stack-trace: false
-        exec-env: false
-        exec-hash:
+        decoded-data: true
+        user-stack: false
+        environment: false
+        executable-hash:
             enabled: true
             mode: dev-inode
     output:

--- a/detectors/example_detector.go
+++ b/detectors/example_detector.go
@@ -65,11 +65,11 @@ func (d *ExampleDetector) GetDefinition() detection.DetectorDefinition {
 			},
 			// Enrichments: []detection.EnrichmentRequirement{
 			// 	{
-			// 		Name:       detection.EnrichmentExecEnv,
+			// 		Name:       detection.EnrichmentEnvironment,
 			// 		Dependency: detection.DependencyRequired, // Detector requires env vars
 			// 	},
 			// 	{
-			// 		Name:       detection.EnrichmentExecHash,
+			// 		Name:       detection.EnrichmentExecutableHash,
 			// 		Dependency: detection.DependencyOptional, // Detector works without hashes
 			// 		// Config:  "inode", // Uncomment to require specific hash mode
 			// 	},

--- a/detectors/kubernetes_api_connection.go
+++ b/detectors/kubernetes_api_connection.go
@@ -38,7 +38,7 @@ func (d *KubernetesApiConnection) GetDefinition() detection.DetectorDefinition {
 			},
 			Enrichments: []detection.EnrichmentRequirement{
 				{
-					Name:       "exec-env",
+					Name:       detection.EnrichmentEnvironment,
 					Dependency: detection.DependencyRequired,
 				},
 			},

--- a/detectors/ld_preload.go
+++ b/detectors/ld_preload.go
@@ -46,7 +46,7 @@ func (d *LdPreload) GetDefinition() detection.DetectorDefinition {
 			},
 			Enrichments: []detection.EnrichmentRequirement{
 				{
-					Name:       "exec-env",
+					Name:       detection.EnrichmentEnvironment,
 					Dependency: detection.DependencyRequired,
 				},
 			},

--- a/docs/contributing/building/environment.md
+++ b/docs/contributing/building/environment.md
@@ -29,7 +29,7 @@
     make clean
     make tracee
     sudo ./dist/tracee \
-        --enrichment parse-arguments \
+        --enrichment decoded-data \
         --scope comm=bash \
         --scope follow
     ```

--- a/docs/docs/detectors/api-reference.md
+++ b/docs/docs/detectors/api-reference.md
@@ -468,8 +468,8 @@ type EnrichmentRequirement struct {
 
 **Available enrichments**:
 
-- `exec-env` - Execution environment variables
-- `exec-hash` - Executable file hashes (Config: "inode", "dev-inode", "digest-inode")
+- `environment` - Execution environment variables
+- `executable-hash` - Executable file hashes (Config: "inode", "dev-inode", "digest-inode")
 - `container` - Container metadata fields in Event struct (Name, Image, Pod info)
 
 **Example**:
@@ -480,7 +480,7 @@ DetectorDefinition{
     Requirements: detection.DetectorRequirements{
         Enrichments: []detection.EnrichmentRequirement{
             {
-                Name:       "exec-hash",
+                Name:       "executable-hash",
                 Config:     "digest-inode",
                 Dependency: detection.DependencyRequired,
             },
@@ -601,12 +601,12 @@ DetectorDefinition{
         // Enrichment requirements
         Enrichments: []detection.EnrichmentRequirement{
             {
-                Name:       "exec-hash",
+                Name:       "executable-hash",
                 Config:     "digest-inode",
                 Dependency: detection.DependencyRequired,
             },
             {
-                Name:       "exec-env",
+                Name:       "environment",
                 Dependency: detection.DependencyOptional,
             },
         },

--- a/docs/docs/detectors/yaml-detectors.md
+++ b/docs/docs/detectors/yaml-detectors.md
@@ -128,9 +128,9 @@ requirements:
       scope_filters:            # Scope filters (optional)
         - container=true
   enrichments:                  # Required enrichments (optional)
-    - name: exec-env            # Enrichment name
+    - name: environment         # Enrichment name
       dependency: required      # required or optional
-    - name: exec-hash
+    - name: executable-hash
       config: digest-inode      # Enrichment-specific config
     - name: container           # Container enrichment
       dependency: required

--- a/docs/docs/events/builtin/man/lsm/security_file_mprotect.md
+++ b/docs/docs/events/builtin/man/lsm/security_file_mprotect.md
@@ -24,13 +24,13 @@ Memory protection changes are critical security events as they can indicate code
 : The path of the file associated with the memory region (if file-backed)
 
 **prot** (*int32*)
-: The new access protection for the memory region (parsed to string if parse-arguments enabled)
+: The new access protection for the memory region (decoded to string if decoded-data enabled)
 
 **ctime** (*uint64*)
 : The creation time of the file associated with the memory region
 
 **prev_prot** (*int32*)
-: The previous access protection for the memory region (parsed to string if parse-arguments enabled)
+: The previous access protection for the memory region (decoded to string if decoded-data enabled)
 
 **addr** (*trace.Pointer*)
 : The start of virtual memory address where protection change is requested

--- a/docs/docs/events/builtin/man/security/stack_pivot.md
+++ b/docs/docs/events/builtin/man/security/stack_pivot.md
@@ -25,7 +25,7 @@ This event detects stack pivoting by checking the stack pointer at selected sysc
 ## DATA FIELDS
 
 **syscall** (*int32*)
-: The syscall which was invoked while the stack pointer was outside the stack. The syscall name is parsed if the `parse-arguments` option is specified. This argument is also used as a parameter to select which syscalls should be checked.
+: The syscall which was invoked while the stack pointer was outside the stack. The syscall name is decoded if the `decoded-data` option is specified. This argument is also used as a parameter to select which syscalls should be checked.
 
 **sp** (*trace.Pointer*)
 : The stack pointer value at the time of syscall invocation
@@ -40,7 +40,7 @@ This event detects stack pivoting by checking the stack pointer at selected sysc
 : Size of the memory region containing the stack pointer
 
 **vma_flags** (*uint64*)
-: Memory region flags (parsed if `parse-arguments` is enabled)
+: Memory region flags (decoded if `decoded-data` is enabled)
 
 ## DEPENDENCIES
 

--- a/docs/docs/events/builtin/man/security/suspicious_syscall_source.md
+++ b/docs/docs/events/builtin/man/security/suspicious_syscall_source.md
@@ -21,7 +21,7 @@ Normally, all legitimate code runs from dedicated code regions mapped from execu
 ## DATA FIELDS
 
 **syscall** (*int32*)
-: The system call number invoked from the unusual location (parsed to name if parse-arguments enabled)
+: The system call number invoked from the unusual location (decoded to name if decoded-data enabled)
 
 **ip** (*trace.Pointer*)
 : The instruction pointer address from which the syscall was invoked
@@ -36,7 +36,7 @@ Normally, all legitimate code runs from dedicated code regions mapped from execu
 : Size of the VMA containing the triggering code
 
 **vma_flags** (*uint64*)
-: VMA flags (parsed to names if parse-arguments enabled)
+: VMA flags (decoded to names if decoded-data enabled)
 
 ## DEPENDENCIES
 

--- a/docs/docs/flags/enrichment.1.md
+++ b/docs/docs/flags/enrichment.1.md
@@ -11,7 +11,7 @@ tracee **\-\-enrichment** - Configure enrichment for container events and other 
 
 ## SYNOPSIS
 
-tracee **\-\-enrichment** [container|container.cgroupfs.path=*path*|container.cgroupfs.force|container.docker.socket=*socket_path*|container.containerd.socket=*socket_path*|container.crio.socket=*socket_path*|container.podman.socket=*socket_path*|resolve-fd|exec-env|exec-hash|exec-hash.mode=*mode*|user-stack-trace] [**\-\-enrichment** ...]
+tracee **\-\-enrichment** [container|container.cgroupfs.path=*path*|container.cgroupfs.force|container.docker.socket=*socket_path*|container.containerd.socket=*socket_path*|container.crio.socket=*socket_path*|container.podman.socket=*socket_path*|fd-paths|environment|executable-hash|executable-hash.mode=*mode*|user-stack|decoded-data] [**\-\-enrichment** ...]
 
 ## DESCRIPTION
 
@@ -63,37 +63,37 @@ The `--enrichment` flag allows you to configure enrichment options for container
   - Docker     (`docker`)
   - Podman     (`podman`)
 
-- **resolve-fd**: Enable resolve-fd. When enabled, Tracee will resolve file descriptor arguments to show associated file paths instead of just the descriptor number. This enriches file descriptors with file path translation. May cause pipeline slowdowns.
+- **fd-paths**: Enable fd-paths. When enabled, Tracee will resolve file descriptor arguments to show associated file paths instead of just the descriptor number. This enriches file descriptors with file path translation. May cause pipeline slowdowns.
   Example:
   ```console
-  --enrichment resolve-fd
+  --enrichment fd-paths
   ```
 
-- **parse-arguments**: Enable parse-arguments. When enabled, Tracee will parse event arguments into human-readable strings instead of raw machine-readable values. This converts numeric flags, permissions, syscall types, and other raw values into readable format (e.g., `O_RDONLY` instead of `0`, `PROT_READ` instead of `1`). Recommended for interactive use and readability, but may add processing overhead that impacts performance on high-volume event streams.
+- **decoded-data**: Enable decoded-data. When enabled, Tracee will decode event arguments into human-readable strings instead of raw machine-readable values. This converts numeric flags, permissions, syscall types, and other raw values into readable format (e.g., `O_RDONLY` instead of `0`, `PROT_READ` instead of `1`). Recommended for interactive use and readability, but may add processing overhead that impacts performance on high-volume event streams.
   Example:
   ```console
-  --enrichment parse-arguments
+  --enrichment decoded-data
   ```
 
-- **exec-env**: Enable exec-env. When enabled, Tracee will include execution environment variables in process execution events (particularly useful for `execve` events).
+- **environment**: Enable environment. When enabled, Tracee will include execution environment variables in process execution events (particularly useful for `execve` events).
   Example:
   ```console
-  --enrichment exec-env
+  --enrichment environment
   ```
 
-- **exec-hash**: Enable exec-hash with default settings. When enabled, Tracee will compute hash values for executed binaries.
+- **executable-hash**: Enable executable-hash with default settings. When enabled, Tracee will compute hash values for executed binaries.
 
-- **exec-hash.mode**=*mode*: Enable exec-hash and configure the mode for exec-hash. **Note**: Using this option automatically enables exec-hash, so you don't need to also specify `--enrichment exec-hash`.
+- **executable-hash.mode**=*mode*: Enable executable-hash and configure the mode for executable-hash. **Note**: Using this option automatically enables executable-hash, so you don't need to also specify `--enrichment executable-hash`.
   Example:
   ```console
-  --enrichment exec-hash.mode=sha256
+  --enrichment executable-hash.mode=sha256
   ```
 
-- **user-stack-trace**
-  Enable user-stack-trace. Presence of the flag enables it, absence disables it.
+- **user-stack**
+  Enable user-stack. Presence of the flag enables it, absence disables it.
   Example:
   ```console
-  --enrichment user-stack-trace
+  --enrichment user-stack
   ```
 
 ## EXAMPLES
@@ -121,16 +121,16 @@ The `--enrichment` flag allows you to configure enrichment options for container
    ```
    Note: Since `container.docker.socket` and `container.cgroupfs.path` automatically enable container, you don't need `--enrichment container`.
 
-5. Enable resolve-fd, exec-env, and exec-hash:
+5. Enable fd-paths, environment, and executable-hash:
    ```console
-   --enrichment resolve-fd --enrichment exec-env --enrichment exec-hash
+   --enrichment fd-paths --enrichment environment --enrichment executable-hash
    ```
 
-6. Enable exec-hash with custom mode:
+6. Enable executable-hash with custom mode:
    ```console
-   --enrichment exec-hash.mode=sha256
+   --enrichment executable-hash.mode=sha256
    ```
-   Note: `exec-hash.mode` automatically enables exec-hash, so `--enrichment exec-hash` is not needed.
+   Note: `executable-hash.mode` automatically enables executable-hash, so `--enrichment executable-hash` is not needed.
 
 Please refer to the [documentation](../install/container-engines.md) for more information on container events enrichment.
 

--- a/docs/docs/flags/output.1.md
+++ b/docs/docs/flags/output.1.md
@@ -40,7 +40,7 @@ Output destinations are configured using the format: `--output destinations.<nam
 - **sort-events**: Enable sorting events before passing them to output. May decrease overall program efficiency.
 
 !!! Note
-    The enrichment `parse-arguments` option is automatically enabled when using table format output. It does not need to be specified separately via `--enrichment parse-arguments`.
+    The enrichment `decoded-data` option is automatically enabled when using table format output. It does not need to be specified separately via `--enrichment decoded-data`.
 
 ## EXAMPLES
 

--- a/docs/docs/forensics.md
+++ b/docs/docs/forensics.md
@@ -36,7 +36,7 @@ Tracee can capture the following types of artifacts:
        --output json \
        --scope comm=bash \
        --scope follow \
-       --enrichment parse-arguments \
+       --enrichment decoded-data \
        --artifacts dir.path=/tmp/tracee \
        --artifacts file-write.filters=path=/tmp/*
     ```
@@ -67,7 +67,7 @@ Tracee can capture the following types of artifacts:
        --output json \
        --scope comm=bash \
        --scope follow \
-       --enrichment parse-arguments \
+       --enrichment decoded-data \
        --artifacts dir.path=/tmp/tracee \
        --artifacts file-read.filters=type=pipe \
        --artifacts file-read.filters=fd=stdin
@@ -102,7 +102,7 @@ Tracee can capture the following types of artifacts:
        --output json \
        --scope comm=bash \
        --scope follow \
-       --enrichment parse-arguments \
+       --enrichment decoded-data \
        --artifacts dir.path=/tmp/tracee \
        --artifacts executable
     ```

--- a/docs/docs/install/config/index.md
+++ b/docs/docs/install/config/index.md
@@ -118,11 +118,11 @@ filters, destination file and others.
       containerd-socket: /var/run/containerd/containerd.sock
       crio-socket: /var/run/crio/crio.sock
       podman-socket: /var/run/podman/podman.sock
-    resolve-fd: true
-    exec-hash:
+    fd-paths: true
+    executable-hash:
       enabled: true
       mode: sha256
-    user-stack-trace: true
+    user-stack: true
   ```
 
 ### Capabilities

--- a/docs/docs/install/config/kubernetes.md
+++ b/docs/docs/install/config/kubernetes.md
@@ -17,8 +17,8 @@ data:
       json:
         files:
           - /var/log/tracee.json
-      options:
-        parse-arguments: true
+    enrichment:
+      decoded-data: true
 ```
 
 ## Kubectl

--- a/docs/docs/outputs/index.md
+++ b/docs/docs/outputs/index.md
@@ -29,8 +29,8 @@ output:
       type: file
       format: json
       path: /var/log/tracee/events.json
-  options:
-    parse-arguments: true
+  enrichment:
+    decoded-data: true
 ```
 
 ## Output Components
@@ -71,14 +71,10 @@ Learn about event ordering guarantees and how to enable chronological sorting wh
 
 ### [Options](./output-options.md)
 
-Enrich events with additional context:
+Configure output formatting and behavior:
 
-- `parse-arguments`: Convert raw values to human-readable format
-- `parse-arguments-fds`: Show file paths for file descriptor arguments
-- `stack-addresses`: Include stack traces in events
-- `exec-env`: Include environment variables for process execution events
-- `exec-hash`: Include file hashes for executed binaries
 - `sort-events`: Enable chronological event ordering
+
 
 ### [Logging](./logging.md)
 
@@ -93,7 +89,7 @@ tracee --output destinations.file_out.format=json --output destinations.file_out
 
 **Default table output with parsed arguments:**
 ```console
-tracee --enrichment parse-arguments
+tracee --enrichment decoded-data
 ```
 
 **Send events to webhook:**

--- a/docs/docs/outputs/output-options.md
+++ b/docs/docs/outputs/output-options.md
@@ -4,9 +4,6 @@ Tracee supports different output options for enriching events with additional co
 
 ## Available Options
 
-!!! Note
-    The enrichment `parse-arguments` option is automatically enabled when using table format output. It does not need to be specified separately via `--enrichment parse-arguments`.
-
 ### sort-events
 
 Enable chronological sorting of events. On busy systems, events may be received out of order. This option ensures events are output in the order they occurred.

--- a/docs/docs/policies/usage/cli.md
+++ b/docs/docs/policies/usage/cli.md
@@ -108,15 +108,18 @@ logging:
       pkg:
         - capabilities
 
+# enrichment
+
+enrichment:
+  environment: true
+  executable-hash:
+    enabled: true
+    mode: dev-inode
+  decoded-data: true
+
 # output
 
 output:
-  options:
-    stack-addresses: false
-    exec-env: true
-    exec-hash: dev-inode
-    parse-arguments: true
-    parse-arguments-fds: true
   sort-events: true
   destinations:
     - name: stdout

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -175,7 +175,7 @@ WARN events dropped due to buffer overflow
 
 1. **Use proper output format**:
    ```bash
-   tracee --output json --enrichment parse-arguments
+   tracee --output json --enrichment decoded-data
    ```
 
 2. **Check for mixed output**:
@@ -192,7 +192,7 @@ WARN events dropped due to buffer overflow
 
 1. **Enable argument parsing**:
    ```bash
-   tracee --enrichment parse-arguments
+   tracee --enrichment decoded-data
    ```
 
 2. **Check event definition**: Some events may not include all expected fields

--- a/docs/man/enrichment.1
+++ b/docs/man/enrichment.1
@@ -6,7 +6,7 @@ tracee \f[B]\-\-enrichment\f[R] \- Configure enrichment for container
 events and other enrichment options
 .SS SYNOPSIS
 tracee \f[B]\-\-enrichment\f[R]
-[container|container.cgroupfs.path=\f[I]path\f[R]|container.cgroupfs.force|container.docker.socket=\f[I]socket_path\f[R]|container.containerd.socket=\f[I]socket_path\f[R]|container.crio.socket=\f[I]socket_path\f[R]|container.podman.socket=\f[I]socket_path\f[R]|resolve\-fd|exec\-env|exec\-hash|exec\-hash.mode=\f[I]mode\f[R]|user\-stack\-trace]
+[container|container.cgroupfs.path=\f[I]path\f[R]|container.cgroupfs.force|container.docker.socket=\f[I]socket_path\f[R]|container.containerd.socket=\f[I]socket_path\f[R]|container.crio.socket=\f[I]socket_path\f[R]|container.podman.socket=\f[I]socket_path\f[R]|fd\-paths|environment|executable\-hash|executable\-hash.mode=\f[I]mode\f[R]|user\-stack|decoded\-data]
 [\f[B]\-\-enrichment\f[R] \&...]
 .SS DESCRIPTION
 The \f[CR]\-\-enrichment\f[R] flag allows you to configure enrichment
@@ -109,7 +109,7 @@ Docker (\f[CR]docker\f[R])
 Podman (\f[CR]podman\f[R])
 .RE
 .IP \[bu] 2
-\f[B]resolve\-fd\f[R]: Enable resolve\-fd.
+\f[B]fd\-paths\f[R]: Enable fd\-paths.
 When enabled, Tracee will resolve file descriptor arguments to show
 associated file paths instead of just the descriptor number.
 This enriches file descriptors with file path translation.
@@ -118,12 +118,12 @@ Example:
 .RS 2
 .IP
 .EX
-\-\-enrichment resolve\-fd
+\-\-enrichment fd\-paths
 .EE
 .RE
 .IP \[bu] 2
-\f[B]parse\-arguments\f[R]: Enable parse\-arguments.
-When enabled, Tracee will parse event arguments into human\-readable
+\f[B]decoded\-data\f[R]: Enable decoded\-data.
+When enabled, Tracee will decode event arguments into human\-readable
 strings instead of raw machine\-readable values.
 This converts numeric flags, permissions, syscall types, and other raw
 values into readable format (e.g., \f[CR]O_RDONLY\f[R] instead of
@@ -134,11 +134,11 @@ Example:
 .RS 2
 .IP
 .EX
-\-\-enrichment parse\-arguments
+\-\-enrichment decoded\-data
 .EE
 .RE
 .IP \[bu] 2
-\f[B]exec\-env\f[R]: Enable exec\-env.
+\f[B]environment\f[R]: Enable environment.
 When enabled, Tracee will include execution environment variables in
 process execution events (particularly useful for \f[CR]execve\f[R]
 events).
@@ -146,32 +146,34 @@ Example:
 .RS 2
 .IP
 .EX
-\-\-enrichment exec\-env
+\-\-enrichment environment
 .EE
 .RE
 .IP \[bu] 2
-\f[B]exec\-hash\f[R]: Enable exec\-hash with default settings.
+\f[B]executable\-hash\f[R]: Enable executable\-hash with default
+settings.
 When enabled, Tracee will compute hash values for executed binaries.
 .IP \[bu] 2
-\f[B]exec\-hash.mode\f[R]=\f[I]mode\f[R]: Enable exec\-hash and
-configure the mode for exec\-hash.
-\f[B]Note\f[R]: Using this option automatically enables exec\-hash, so
-you don\[cq]t need to also specify \f[CR]\-\-enrichment exec\-hash\f[R].
+\f[B]executable\-hash.mode\f[R]=\f[I]mode\f[R]: Enable executable\-hash
+and configure the mode for executable\-hash.
+\f[B]Note\f[R]: Using this option automatically enables
+executable\-hash, so you don\[cq]t need to also specify
+\f[CR]\-\-enrichment executable\-hash\f[R].
 Example:
 .RS 2
 .IP
 .EX
-\-\-enrichment exec\-hash.mode=sha256
+\-\-enrichment executable\-hash.mode=sha256
 .EE
 .RE
 .IP \[bu] 2
-\f[B]user\-stack\-trace\f[R] Enable user\-stack\-trace.
+\f[B]user\-stack\f[R] Enable user\-stack.
 Presence of the flag enables it, absence disables it.
 Example:
 .RS 2
 .IP
 .EX
-\-\-enrichment user\-stack\-trace
+\-\-enrichment user\-stack
 .EE
 .RE
 .SS EXAMPLES
@@ -218,23 +220,24 @@ Note: Since \f[CR]container.docker.socket\f[R] and
 don\[cq]t need \f[CR]\-\-enrichment container\f[R].
 .RE
 .IP "5." 3
-Enable resolve\-fd, exec\-env, and exec\-hash:
+Enable fd\-paths, environment, and executable\-hash:
 .RS 4
 .IP
 .EX
-\-\-enrichment resolve\-fd \-\-enrichment exec\-env \-\-enrichment exec\-hash
+\-\-enrichment fd\-paths \-\-enrichment environment \-\-enrichment executable\-hash
 .EE
 .RE
 .IP "6." 3
-Enable exec\-hash with custom mode:
+Enable executable\-hash with custom mode:
 .RS 4
 .IP
 .EX
-\-\-enrichment exec\-hash.mode=sha256
+\-\-enrichment executable\-hash.mode=sha256
 .EE
 .PP
-Note: \f[CR]exec\-hash.mode\f[R] automatically enables exec\-hash, so
-\f[CR]\-\-enrichment exec\-hash\f[R] is not needed.
+Note: \f[CR]executable\-hash.mode\f[R] automatically enables
+executable\-hash, so \f[CR]\-\-enrichment executable\-hash\f[R] is not
+needed.
 .RE
 .PP
 Please refer to the documentation for more information on container

--- a/docs/man/output.1
+++ b/docs/man/output.1
@@ -47,10 +47,10 @@ output.
 May decrease overall program efficiency.
 .PP
 !!!
-Note The enrichment \f[CR]parse\-arguments\f[R] option is automatically
+Note The enrichment \f[CR]decoded\-data\f[R] option is automatically
 enabled when using table format output.
 It does not need to be specified separately via
-\f[CR]\-\-enrichment parse\-arguments\f[R].
+\f[CR]\-\-enrichment decoded\-data\f[R].
 .SS EXAMPLES
 .IP \[bu] 2
 To output events as JSON to stdout using a destination named

--- a/docs/man/security_file_mprotect.1
+++ b/docs/man/security_file_mprotect.1
@@ -24,15 +24,15 @@ protection changes, and associated files.
 The path of the file associated with the memory region (if file\-backed)
 .TP
 \f[B]prot\f[R] (\f[I]int32\f[R])
-The new access protection for the memory region (parsed to string if
-parse\-arguments enabled)
+The new access protection for the memory region (decoded to string if
+decoded\-data enabled)
 .TP
 \f[B]ctime\f[R] (\f[I]uint64\f[R])
 The creation time of the file associated with the memory region
 .TP
 \f[B]prev_prot\f[R] (\f[I]int32\f[R])
-The previous access protection for the memory region (parsed to string
-if parse\-arguments enabled)
+The previous access protection for the memory region (decoded to string
+if decoded\-data enabled)
 .TP
 \f[B]addr\f[R] (\f[I]trace.Pointer\f[R])
 The start of virtual memory address where protection change is requested

--- a/docs/man/stack_pivot.1
+++ b/docs/man/stack_pivot.1
@@ -34,7 +34,7 @@ outside the original stack region.
 \f[B]syscall\f[R] (\f[I]int32\f[R])
 The syscall which was invoked while the stack pointer was outside the
 stack.
-The syscall name is parsed if the \f[CR]parse\-arguments\f[R] option is
+The syscall name is decoded if the \f[CR]decoded\-data\f[R] option is
 specified.
 This argument is also used as a parameter to select which syscalls
 should be checked.
@@ -53,7 +53,7 @@ Start address of the memory region containing the stack pointer
 Size of the memory region containing the stack pointer
 .TP
 \f[B]vma_flags\f[R] (\f[I]uint64\f[R])
-Memory region flags (parsed if \f[CR]parse\-arguments\f[R] is enabled)
+Memory region flags (decoded if \f[CR]decoded\-data\f[R] is enabled)
 .SS DEPENDENCIES
 \f[B]Thread Tracking:\f[R]
 .IP \[bu] 2

--- a/docs/man/suspicious_syscall_source.1
+++ b/docs/man/suspicious_syscall_source.1
@@ -22,8 +22,8 @@ code injection attacks.
 .SS DATA FIELDS
 .TP
 \f[B]syscall\f[R] (\f[I]int32\f[R])
-The system call number invoked from the unusual location (parsed to name
-if parse\-arguments enabled)
+The system call number invoked from the unusual location (decoded to
+name if decoded\-data enabled)
 .TP
 \f[B]ip\f[R] (\f[I]trace.Pointer\f[R])
 The instruction pointer address from which the syscall was invoked
@@ -39,7 +39,7 @@ Start address of the VMA containing the triggering code
 Size of the VMA containing the triggering code
 .TP
 \f[B]vma_flags\f[R] (\f[I]uint64\f[R])
-VMA flags (parsed to names if parse\-arguments enabled)
+VMA flags (decoded to names if decoded\-data enabled)
 .SS DEPENDENCIES
 \f[B]Kernel Probes:\f[R]
 .IP \[bu] 2

--- a/examples/config/global_config.yaml
+++ b/examples/config/global_config.yaml
@@ -48,12 +48,12 @@ enrichment:
     # - container.containerd.socket=/var/run/containerd/containerd.sock
     # - container.crio.socket=/var/run/crio/crio.sock
     # - container.podman.socket=/var/run/podman/podman.sock
-    # - resolve-fd
-    # - parse-arguments
-    # - exec-env
-    # - exec-hash
-    # - exec-hash.mode=dev-inode
-    # - user-stack-trace
+    # - fd-paths
+    # - decoded-data
+    # - environment
+    # - executable-hash
+    # - executable-hash.mode=dev-inode
+    # - user-stack
     #
     # Structured format:
     # container:
@@ -65,13 +65,13 @@ enrichment:
     #     containerd-socket: /var/run/containerd/containerd.sock
     #     crio-socket: /var/run/crio/crio.sock
     #     podman-socket: /var/run/podman/podman.sock
-    # resolve-fd: true
-    # parse-arguments: true
-    # exec-env: false
-    # exec-hash:
+    # fd-paths: true
+    # decoded-data: true
+    # environment: false
+    # executable-hash:
     #     enabled: true
     #     mode: dev-inode     # Options: none, inode, dev-inode, digest-inode
-    # user-stack-trace: true
+    # user-stack: true
 
 # Artifacts capture configuration
 artifacts:
@@ -177,8 +177,6 @@ output:
     # Output options
     # options:
     #     none: false
-    #     parse-arguments-fds: false
-    # sort-events: false
-
+    #     sort-events: false
 # Signatures directory for custom signatures
 signatures-dir: ""

--- a/performance/benchmark/common/tracee.yaml
+++ b/performance/benchmark/common/tracee.yaml
@@ -51,15 +51,17 @@ data:
     listen-addr: :3366
     log:
         level: info
+    enrichment:
+        decoded-data: true
+        environment: false
+        executable-hash:
+            enabled: true
+            mode: dev-inode
     output:
         json:
           files:
             - stdout
         options:
-            parse-arguments: true
-            stack-addresses: false
-            exec-env: false
-            exec-hash: dev-inode
             sort-events: false
 ---
 # Source: tracee/templates/role.yaml

--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -308,11 +308,11 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	// Apply enrichment config to output config
 	// TODO: refactor it to maybe encapsulate enrichemnt as part of the output config,
 	// or as its own field on the config struct
-	cfg.Output.ExecEnv = enrichmentConfig.ExecEnv
-	cfg.Output.StackAddresses = enrichmentConfig.UserStackTrace
-	cfg.Output.ParseArgumentsFDs = enrichmentConfig.ResolveFd
-	cfg.Output.ParseArguments = enrichmentConfig.ParseArguments
-	if enrichmentConfig.ExecHash.Enabled || enrichmentConfig.ExecHash.Mode != "" {
+	cfg.Output.Environment = enrichmentConfig.Environment
+	cfg.Output.UserStack = enrichmentConfig.UserStack
+	cfg.Output.FdPaths = enrichmentConfig.FdPaths
+	cfg.Output.DecodedData = enrichmentConfig.DecodedData
+	if enrichmentConfig.ExecutableHash.Enabled || enrichmentConfig.ExecutableHash.Mode != "" {
 		cfg.Output.CalcHashes = enrichmentConfig.GetCalcHashesOption()
 	}
 

--- a/pkg/cmd/flags/config_test.go
+++ b/pkg/cmd/flags/config_test.go
@@ -405,12 +405,12 @@ enrichment:
     - container.containerd.socket=/var/run/containerd/containerd.sock
     - container.crio.socket=/var/run/crio/crio.sock
     - container.podman.socket=/var/run/podman/podman.sock
-    - resolve-fd
-    - exec-env
-    - exec-hash
-    - exec-hash.mode=dev-inode
-    - user-stack-trace
-    - parse-arguments
+    - fd-paths
+    - environment
+    - executable-hash
+    - executable-hash.mode=dev-inode
+    - user-stack
+    - decoded-data
 `,
 			key: "enrichment",
 			expectedFlags: []string{
@@ -421,12 +421,12 @@ enrichment:
 				"container.containerd.socket=/var/run/containerd/containerd.sock",
 				"container.crio.socket=/var/run/crio/crio.sock",
 				"container.podman.socket=/var/run/podman/podman.sock",
-				"resolve-fd",
-				"exec-env",
-				"exec-hash",
-				"exec-hash.mode=dev-inode",
-				"user-stack-trace",
-				"parse-arguments",
+				"fd-paths",
+				"environment",
+				"executable-hash",
+				"executable-hash.mode=dev-inode",
+				"user-stack",
+				"decoded-data",
 			},
 		},
 		{
@@ -442,13 +442,13 @@ enrichment:
         containerd-socket: /var/run/containerd/containerd.sock
         crio-socket: /var/run/crio/crio.sock
         podman-socket: /var/run/podman/podman.sock
-    resolve-fd: true
-    exec-env: true
-    exec-hash:
+    fd-paths: true
+    environment: true
+    executable-hash:
         enabled: true
         mode: dev-inode
-    user-stack-trace: true
-    parse-arguments: true
+    user-stack: true
+    decoded-data: true
 `,
 			key: "enrichment",
 			expectedFlags: []string{
@@ -459,12 +459,12 @@ enrichment:
 				"container.containerd.socket=/var/run/containerd/containerd.sock",
 				"container.crio.socket=/var/run/crio/crio.sock",
 				"container.podman.socket=/var/run/podman/podman.sock",
-				"resolve-fd",
-				"exec-env",
-				"exec-hash",
-				"exec-hash.mode=dev-inode",
-				"user-stack-trace",
-				"parse-arguments",
+				"fd-paths",
+				"environment",
+				"executable-hash",
+				"executable-hash.mode=dev-inode",
+				"user-stack",
+				"decoded-data",
 			},
 		},
 		{

--- a/pkg/cmd/flags/enrichment_test.go
+++ b/pkg/cmd/flags/enrichment_test.go
@@ -80,62 +80,62 @@ func TestEnrichmentConfig_flags(t *testing.T) {
 			},
 		},
 		{
-			name: "resolve-fd enabled",
+			name: "fd-paths enabled",
 			config: EnrichmentConfig{
-				ResolveFd: true,
+				FdPaths: true,
 			},
 			expected: []string{
-				"resolve-fd",
+				"fd-paths",
 			},
 		},
 		{
-			name: "exec-hash enabled",
+			name: "executable-hash enabled",
 			config: EnrichmentConfig{
-				ExecHash: ExecHashConfig{
+				ExecutableHash: ExecutableHashConfig{
 					Enabled: true,
 				},
 			},
 			expected: []string{
-				"exec-hash",
+				"executable-hash",
 			},
 		},
 		{
-			name: "exec-hash mode",
+			name: "executable-hash mode",
 			config: EnrichmentConfig{
-				ExecHash: ExecHashConfig{
+				ExecutableHash: ExecutableHashConfig{
 					Mode: "dev-inode",
 				},
 			},
 			expected: []string{
-				"exec-hash",
-				"exec-hash.mode=dev-inode",
+				"executable-hash",
+				"executable-hash.mode=dev-inode",
 			},
 		},
 		{
-			name: "user-stack-trace enabled",
+			name: "user-stack enabled",
 			config: EnrichmentConfig{
-				UserStackTrace: true,
+				UserStack: true,
 			},
 			expected: []string{
-				"user-stack-trace",
+				"user-stack",
 			},
 		},
 		{
-			name: "exec-env enabled",
+			name: "environment enabled",
 			config: EnrichmentConfig{
-				ExecEnv: true,
+				Environment: true,
 			},
 			expected: []string{
-				"exec-env",
+				"environment",
 			},
 		},
 		{
-			name: "parse-arguments enabled",
+			name: "decoded-data enabled",
 			config: EnrichmentConfig{
-				ParseArguments: true,
+				DecodedData: true,
 			},
 			expected: []string{
-				"parse-arguments",
+				"decoded-data",
 			},
 		},
 		{
@@ -152,14 +152,14 @@ func TestEnrichmentConfig_flags(t *testing.T) {
 					CrioSocket:       "/var/run/crio/crio.sock",
 					PodmanSocket:     "/var/run/podman/podman.sock",
 				},
-				ResolveFd: true,
-				ExecHash: ExecHashConfig{
+				FdPaths: true,
+				ExecutableHash: ExecutableHashConfig{
 					Enabled: true,
 					Mode:    "dev-inode",
 				},
-				UserStackTrace: true,
-				ExecEnv:        true,
-				ParseArguments: true,
+				UserStack:   true,
+				Environment: true,
+				DecodedData: true,
 			},
 			expected: []string{
 				"container",
@@ -169,12 +169,12 @@ func TestEnrichmentConfig_flags(t *testing.T) {
 				"container.containerd.socket=/var/run/containerd/containerd.sock",
 				"container.crio.socket=/var/run/crio/crio.sock",
 				"container.podman.socket=/var/run/podman/podman.sock",
-				"resolve-fd",
-				"exec-env",
-				"exec-hash",
-				"exec-hash.mode=dev-inode",
-				"user-stack-trace",
-				"parse-arguments",
+				"fd-paths",
+				"environment",
+				"executable-hash",
+				"executable-hash.mode=dev-inode",
+				"user-stack",
+				"decoded-data",
 			},
 		},
 		{
@@ -184,12 +184,12 @@ func TestEnrichmentConfig_flags(t *testing.T) {
 					Enabled:      true,
 					DockerSocket: "/var/run/docker.sock",
 				},
-				ResolveFd: true,
+				FdPaths: true,
 			},
 			expected: []string{
 				"container",
 				"container.docker.socket=/var/run/docker.sock",
-				"resolve-fd",
+				"fd-paths",
 			},
 		},
 	}
@@ -302,56 +302,56 @@ func TestPrepareEnrichment(t *testing.T) {
 				},
 			},
 		},
-		// valid single resolve-fd flags
+		// valid single fd-paths flags
 		{
-			testName: "valid resolve-fd",
-			flags:    []string{"resolve-fd"},
+			testName: "valid fd-paths",
+			flags:    []string{"fd-paths"},
 			expectedReturn: EnrichmentConfig{
-				ResolveFd: true,
+				FdPaths: true,
 			},
 		},
-		// valid single exec-hash flags
+		// valid single executable-hash flags
 		{
-			testName: "valid exec-hash",
-			flags:    []string{"exec-hash"},
+			testName: "valid executable-hash",
+			flags:    []string{"executable-hash"},
 			expectedReturn: EnrichmentConfig{
-				ExecHash: ExecHashConfig{
+				ExecutableHash: ExecutableHashConfig{
 					Enabled: true,
 				},
 			},
 		},
 		{
-			testName: "valid exec-hash.mode",
-			flags:    []string{"exec-hash.mode=dev-inode"},
+			testName: "valid executable-hash.mode",
+			flags:    []string{"executable-hash.mode=dev-inode"},
 			expectedReturn: EnrichmentConfig{
-				ExecHash: ExecHashConfig{
-					Enabled: true, // Setting mode enables exec-hash
+				ExecutableHash: ExecutableHashConfig{
+					Enabled: true, // Setting mode enables executable-hash
 					Mode:    "dev-inode",
 				},
 			},
 		},
-		// valid single user-stack-trace flags
+		// valid single user-stack flags
 		{
-			testName: "valid user-stack-trace",
-			flags:    []string{"user-stack-trace"},
+			testName: "valid user-stack",
+			flags:    []string{"user-stack"},
 			expectedReturn: EnrichmentConfig{
-				UserStackTrace: true,
+				UserStack: true,
 			},
 		},
-		// valid single exec-env flags
+		// valid single environment flags
 		{
-			testName: "valid exec-env",
-			flags:    []string{"exec-env"},
+			testName: "valid environment",
+			flags:    []string{"environment"},
 			expectedReturn: EnrichmentConfig{
-				ExecEnv: true,
+				Environment: true,
 			},
 		},
-		// valid single parse-arguments flags
+		// valid single decoded-data flags
 		{
-			testName: "valid parse-arguments",
-			flags:    []string{"parse-arguments"},
+			testName: "valid decoded-data",
+			flags:    []string{"decoded-data"},
 			expectedReturn: EnrichmentConfig{
-				ParseArguments: true,
+				DecodedData: true,
 			},
 		},
 		// valid multiple flags
@@ -383,7 +383,7 @@ func TestPrepareEnrichment(t *testing.T) {
 		},
 		{
 			testName: "valid all flags",
-			flags:    []string{"container", "container.cgroupfs.path=/host/sys/fs/cgroup", "container.cgroupfs.force", "container.docker.socket=/var/run/docker.sock", "container.containerd.socket=/var/run/containerd/containerd.sock", "container.crio.socket=/var/run/crio/crio.sock", "container.podman.socket=/var/run/podman/podman.sock", "resolve-fd", "exec-env", "exec-hash", "exec-hash.mode=dev-inode", "user-stack-trace", "parse-arguments"},
+			flags:    []string{"container", "container.cgroupfs.path=/host/sys/fs/cgroup", "container.cgroupfs.force", "container.docker.socket=/var/run/docker.sock", "container.containerd.socket=/var/run/containerd/containerd.sock", "container.crio.socket=/var/run/crio/crio.sock", "container.podman.socket=/var/run/podman/podman.sock", "fd-paths", "environment", "executable-hash", "executable-hash.mode=dev-inode", "user-stack", "decoded-data"},
 			expectedReturn: EnrichmentConfig{
 				Container: ContainerEnrichmentConfig{
 					Enabled: true,
@@ -396,19 +396,19 @@ func TestPrepareEnrichment(t *testing.T) {
 					CrioSocket:       "/var/run/crio/crio.sock",
 					PodmanSocket:     "/var/run/podman/podman.sock",
 				},
-				ResolveFd:      true,
-				ExecEnv:        true,
-				ParseArguments: true,
-				ExecHash: ExecHashConfig{
+				FdPaths:     true,
+				Environment: true,
+				DecodedData: true,
+				ExecutableHash: ExecutableHashConfig{
 					Enabled: true,
 					Mode:    "dev-inode",
 				},
-				UserStackTrace: true,
+				UserStack: true,
 			},
 		},
 		{
 			testName: "valid flags in different order",
-			flags:    []string{"user-stack-trace", "container.cgroupfs.path=/host/sys/fs/cgroup", "exec-hash.mode=sha256", "container", "resolve-fd"},
+			flags:    []string{"user-stack", "container.cgroupfs.path=/host/sys/fs/cgroup", "executable-hash.mode=sha256", "container", "fd-paths"},
 			expectedReturn: EnrichmentConfig{
 				Container: ContainerEnrichmentConfig{
 					Enabled: true, // Setting cgroupfs.path enables container
@@ -416,12 +416,12 @@ func TestPrepareEnrichment(t *testing.T) {
 						Path: "/host/sys/fs/cgroup",
 					},
 				},
-				ResolveFd: true,
-				ExecHash: ExecHashConfig{
-					Enabled: true, // Setting mode enables exec-hash
+				FdPaths: true,
+				ExecutableHash: ExecutableHashConfig{
+					Enabled: true, // Setting mode enables executable-hash
 					Mode:    "sha256",
 				},
-				UserStackTrace: true,
+				UserStack: true,
 			},
 		},
 		// valid duplicate flags (last one wins for strings, but bools always set to true)
@@ -455,34 +455,34 @@ func TestPrepareEnrichment(t *testing.T) {
 			expectedError:  invalidEnrichmentFlagError("container=true"),
 		},
 		{
-			testName:       "invalid boolean flag resolve-fd with =true",
-			flags:          []string{"resolve-fd=true"},
+			testName:       "invalid boolean flag fd-paths with =true",
+			flags:          []string{"fd-paths=true"},
 			expectedReturn: EnrichmentConfig{},
-			expectedError:  invalidEnrichmentFlagError("resolve-fd=true"),
+			expectedError:  invalidEnrichmentFlagError("fd-paths=true"),
 		},
 		{
-			testName:       "invalid boolean flag exec-hash with =true",
-			flags:          []string{"exec-hash=true"},
+			testName:       "invalid boolean flag executable-hash with =true",
+			flags:          []string{"executable-hash=true"},
 			expectedReturn: EnrichmentConfig{},
-			expectedError:  invalidEnrichmentFlagError("exec-hash=true"),
+			expectedError:  invalidEnrichmentFlagError("executable-hash=true"),
 		},
 		{
-			testName:       "invalid boolean flag user-stack-trace with =true",
-			flags:          []string{"user-stack-trace=true"},
+			testName:       "invalid boolean flag user-stack with =true",
+			flags:          []string{"user-stack=true"},
 			expectedReturn: EnrichmentConfig{},
-			expectedError:  invalidEnrichmentFlagError("user-stack-trace=true"),
+			expectedError:  invalidEnrichmentFlagError("user-stack=true"),
 		},
 		{
-			testName:       "invalid boolean flag exec-env with =true",
-			flags:          []string{"exec-env=true"},
+			testName:       "invalid boolean flag environment with =true",
+			flags:          []string{"environment=true"},
 			expectedReturn: EnrichmentConfig{},
-			expectedError:  invalidEnrichmentFlagError("exec-env=true"),
+			expectedError:  invalidEnrichmentFlagError("environment=true"),
 		},
 		{
-			testName:       "invalid boolean flag parse-arguments with =true",
-			flags:          []string{"parse-arguments=true"},
+			testName:       "invalid boolean flag decoded-data with =true",
+			flags:          []string{"decoded-data=true"},
 			expectedReturn: EnrichmentConfig{},
-			expectedError:  invalidEnrichmentFlagError("parse-arguments=true"),
+			expectedError:  invalidEnrichmentFlagError("decoded-data=true"),
 		},
 		{
 			testName:       "invalid boolean flag container.cgroupfs.force with =true",
@@ -506,7 +506,7 @@ func TestPrepareEnrichment(t *testing.T) {
 		// valid edge cases
 		{
 			testName: "valid empty string values",
-			flags:    []string{"container.cgroupfs.path=", "exec-hash.mode="},
+			flags:    []string{"container.cgroupfs.path=", "executable-hash.mode="},
 			expectedReturn: EnrichmentConfig{
 				Container: ContainerEnrichmentConfig{
 					Enabled: true, // Setting cgroupfs.path enables container
@@ -514,8 +514,8 @@ func TestPrepareEnrichment(t *testing.T) {
 						Path: "",
 					},
 				},
-				ExecHash: ExecHashConfig{
-					Enabled: true, // Setting mode enables exec-hash
+				ExecutableHash: ExecutableHashConfig{
+					Enabled: true, // Setting mode enables executable-hash
 					Mode:    "",
 				},
 			},
@@ -544,11 +544,11 @@ func TestPrepareEnrichment(t *testing.T) {
 			},
 		},
 		{
-			testName: "valid exec-hash.mode values",
-			flags:    []string{"exec-hash.mode=sha256"},
+			testName: "valid executable-hash.mode values",
+			flags:    []string{"executable-hash.mode=sha256"},
 			expectedReturn: EnrichmentConfig{
-				ExecHash: ExecHashConfig{
-					Enabled: true, // Setting mode enables exec-hash
+				ExecutableHash: ExecutableHashConfig{
+					Enabled: true, // Setting mode enables executable-hash
 					Mode:    "sha256",
 				},
 			},
@@ -587,12 +587,12 @@ func TestPrepareEnrichment(t *testing.T) {
 				assert.Equal(t, tc.expectedReturn.Container.ContainerdSocket, enrichment.Container.ContainerdSocket)
 				assert.Equal(t, tc.expectedReturn.Container.CrioSocket, enrichment.Container.CrioSocket)
 				assert.Equal(t, tc.expectedReturn.Container.PodmanSocket, enrichment.Container.PodmanSocket)
-				assert.Equal(t, tc.expectedReturn.ResolveFd, enrichment.ResolveFd)
-				assert.Equal(t, tc.expectedReturn.ExecEnv, enrichment.ExecEnv)
-				assert.Equal(t, tc.expectedReturn.ParseArguments, enrichment.ParseArguments)
-				assert.Equal(t, tc.expectedReturn.ExecHash.Enabled, enrichment.ExecHash.Enabled)
-				assert.Equal(t, tc.expectedReturn.ExecHash.Mode, enrichment.ExecHash.Mode)
-				assert.Equal(t, tc.expectedReturn.UserStackTrace, enrichment.UserStackTrace)
+				assert.Equal(t, tc.expectedReturn.FdPaths, enrichment.FdPaths)
+				assert.Equal(t, tc.expectedReturn.Environment, enrichment.Environment)
+				assert.Equal(t, tc.expectedReturn.DecodedData, enrichment.DecodedData)
+				assert.Equal(t, tc.expectedReturn.ExecutableHash.Enabled, enrichment.ExecutableHash.Enabled)
+				assert.Equal(t, tc.expectedReturn.ExecutableHash.Mode, enrichment.ExecutableHash.Mode)
+				assert.Equal(t, tc.expectedReturn.UserStack, enrichment.UserStack)
 			}
 		})
 	}

--- a/pkg/cmd/flags/output.go
+++ b/pkg/cmd/flags/output.go
@@ -513,7 +513,7 @@ func getDestinationConfigs(printerMap map[string]string, traceeConfig *config.Ou
 		}
 
 		if printerKind == tableFlag {
-			traceeConfig.ParseArguments = true
+			traceeConfig.DecodedData = true
 		}
 
 		printerCfg, err := PreparePrinterConfig(printerKind, outPath)

--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -38,7 +38,7 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "default format",
 			outputSlice: []string{},
 			expectedOutput: config.OutputConfig{
-				ParseArguments: true,
+				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -53,7 +53,7 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "table to stdout",
 			outputSlice: []string{"table"},
 			expectedOutput: config.OutputConfig{
-				ParseArguments: true,
+				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -68,7 +68,7 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "table to /tmp/table",
 			outputSlice: []string{"table:/tmp/table"},
 			expectedOutput: config.OutputConfig{
-				ParseArguments: true,
+				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -83,7 +83,7 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "table to stdout, and to /tmp/table",
 			outputSlice: []string{"table", "table:/tmp/table"},
 			expectedOutput: config.OutputConfig{
-				ParseArguments: true,
+				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -161,7 +161,7 @@ func TestPrepareOutput(t *testing.T) {
 				"gotemplate=template.tmpl:/tmp/gotemplate1",
 			},
 			expectedOutput: config.OutputConfig{
-				ParseArguments: true,
+				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -284,8 +284,8 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "sort-events",
 			outputSlice: []string{"sort-events"},
 			expectedOutput: config.OutputConfig{
-				ParseArguments: true,
-				EventsSorting:  true,
+				DecodedData:   true,
+				EventsSorting: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -627,10 +627,10 @@ func TestPrepareOutput(t *testing.T) {
 			} else {
 				assert.Equal(t, testcase.expectedOutput.CalcHashes, output.CalcHashes)
 				assert.Equal(t, testcase.expectedOutput.EventsSorting, output.EventsSorting)
-				assert.Equal(t, testcase.expectedOutput.ExecEnv, output.ExecEnv)
-				assert.Equal(t, testcase.expectedOutput.ParseArguments, output.ParseArguments)
-				assert.Equal(t, testcase.expectedOutput.ParseArgumentsFDs, output.ParseArgumentsFDs)
-				assert.Equal(t, testcase.expectedOutput.StackAddresses, output.StackAddresses)
+				assert.Equal(t, testcase.expectedOutput.Environment, output.Environment)
+				assert.Equal(t, testcase.expectedOutput.DecodedData, output.DecodedData)
+				assert.Equal(t, testcase.expectedOutput.FdPaths, output.FdPaths)
+				assert.Equal(t, testcase.expectedOutput.UserStack, output.UserStack)
 				assert.Equal(t, len(testcase.expectedOutput.Streams), len(output.Streams))
 
 				assertPrinterConfigs(t, testcase.expectedOutput.Streams, output.Streams)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,13 +170,13 @@ type CapabilitiesConfig struct {
 //
 
 type OutputConfig struct {
-	StackAddresses bool
-	ExecEnv        bool
-	CalcHashes     digest.CalcHashesOption
+	UserStack   bool
+	Environment bool
+	CalcHashes  digest.CalcHashesOption
 
-	ParseArguments    bool
-	ParseArgumentsFDs bool
-	EventsSorting     bool
+	DecodedData   bool
+	FdPaths       bool
+	EventsSorting bool
 
 	Streams []Stream
 }

--- a/pkg/detectors/registry.go
+++ b/pkg/detectors/registry.go
@@ -35,7 +35,7 @@ func parseHashMode(mode string) digest.CalcHashesOption {
 // EnrichmentOptions represents available enrichment capabilities in Tracee.
 // Used by the detector engine to validate enrichment requirements during registration.
 type EnrichmentOptions struct {
-	ExecEnv      bool                    // Whether exec environment variables are captured
+	Environment  bool                    // Whether exec environment variables are captured
 	ExecHashMode digest.CalcHashesOption // Executable hash calculation mode
 	Container    bool                    // Whether container enrichment is enabled (populates Event.Workload.Container fields and container datastore)
 }
@@ -270,16 +270,16 @@ func (r *registry) RegisterDetector(
 		var actualMode string
 
 		switch enrichReq.Name {
-		case detection.EnrichmentExecEnv:
-			available = r.enrichmentOptions != nil && r.enrichmentOptions.ExecEnv
-		case detection.EnrichmentExecHash:
+		case detection.EnrichmentEnvironment:
+			available = r.enrichmentOptions != nil && r.enrichmentOptions.Environment
+		case detection.EnrichmentExecutableHash:
 			available = r.enrichmentOptions != nil && r.enrichmentOptions.ExecHashMode != digest.CalcHashesNone
 			// If specific config requested, mode must match
 			if available && enrichReq.Config != "" {
 				// Parse requested mode string to enum
 				requestedMode := parseHashMode(enrichReq.Config)
 				if requestedMode == digest.CalcHashesNone {
-					return fmt.Errorf("detector %s requires invalid exec-hash mode: %s", detectorID, enrichReq.Config)
+					return fmt.Errorf("detector %s requires invalid executable-hash mode: %s", detectorID, enrichReq.Config)
 				}
 				actualMode = r.enrichmentOptions.ExecHashMode.String()
 				if requestedMode != r.enrichmentOptions.ExecHashMode {

--- a/pkg/detectors/registry_test.go
+++ b/pkg/detectors/registry_test.go
@@ -686,133 +686,133 @@ func TestRegistry_EnrichmentValidation(t *testing.T) {
 			name:        "no enrichments required - should pass",
 			enrichments: []detection.EnrichmentRequirement{},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: false,
+				Environment: false,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-env required and enabled",
+			name: "enrichment environment required and enabled",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-env", Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentEnvironment, Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: true,
+				Environment: true,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-env required but not enabled",
+			name: "enrichment environment required but not enabled",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-env", Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentEnvironment, Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: false,
+				Environment: false,
 			},
 			expectErr: true,
-			errMsg:    "requires enrichment \"exec-env\" which is not enabled",
+			errMsg:    "requires enrichment \"environment\" which is not enabled",
 		},
 		{
-			name: "exec-env optional and not enabled",
+			name: "enrichment environment optional and not enabled",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-env", Dependency: detection.DependencyOptional},
+				{Name: detection.EnrichmentEnvironment, Dependency: detection.DependencyOptional},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: false,
+				Environment: false,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-hash required and enabled",
+			name: "enrichment executable-hash required and enabled",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      false,
+				Environment:  false,
 				ExecHashMode: digest.CalcHashesInode,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-hash required but not enabled",
+			name: "enrichment executable-hash required but not enabled",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: false,
+				Environment: false,
 			},
 			expectErr: true,
-			errMsg:    "requires enrichment \"exec-hash\" which is not enabled",
+			errMsg:    "requires enrichment \"executable-hash\" which is not enabled",
 		},
 		{
-			name: "exec-hash with specific config - inode mode",
+			name: "enrichment executable-hash with specific config - inode mode",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyRequired, Config: "inode"},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired, Config: "inode"},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      false,
+				Environment:  false,
 				ExecHashMode: digest.CalcHashesInode,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-hash with specific config - dev-inode mode",
+			name: "enrichment executable-hash with specific config - dev-inode mode",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyRequired, Config: "dev-inode"},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired, Config: "dev-inode"},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      false,
+				Environment:  false,
 				ExecHashMode: digest.CalcHashesDevInode,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-hash with specific config - digest-inode mode",
+			name: "enrichment executable-hash with specific config - digest-inode mode",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyRequired, Config: "digest-inode"},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired, Config: "digest-inode"},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      false,
+				Environment:  false,
 				ExecHashMode: digest.CalcHashesDigestInode,
 			},
 			expectErr: false,
 		},
 		{
-			name: "exec-hash mode mismatch - should fail",
+			name: "enrichment executable-hash mode mismatch - should fail",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyRequired, Config: "digest-inode"},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired, Config: "digest-inode"},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      false,
+				Environment:  false,
 				ExecHashMode: digest.CalcHashesInode,
 			},
 			expectErr: true,
-			errMsg:    "requires enrichment \"exec-hash\" with mode \"digest-inode\", but current mode is \"inode\"",
+			errMsg:    "requires enrichment \"executable-hash\" with mode \"digest-inode\", but current mode is \"inode\"",
 		},
 		{
-			name: "exec-hash mode mismatch optional - should not fail",
+			name: "enrichment executable-hash mode mismatch optional - should not fail",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-hash", Dependency: detection.DependencyOptional, Config: "digest-inode"},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyOptional, Config: "digest-inode"},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      false,
+				Environment:  false,
 				ExecHashMode: digest.CalcHashesInode,
 			},
 			expectErr: false, // Optional dependency, should not fail
 		},
 		{
-			name: "multiple enrichments - all enabled",
+			name: "multiple enrichment options - all enabled",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-env", Dependency: detection.DependencyRequired},
-				{Name: "exec-hash", Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentEnvironment, Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv:      true,
+				Environment:  true,
 				ExecHashMode: digest.CalcHashesInode,
 			},
 			expectErr: false,
 		},
 		{
-			name: "container enrichment required and enabled",
+			name: "enrichment container required and enabled",
 			enrichments: []detection.EnrichmentRequirement{
 				{Name: "container", Dependency: detection.DependencyRequired},
 			},
@@ -822,7 +822,7 @@ func TestRegistry_EnrichmentValidation(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "container enrichment required but not enabled",
+			name: "enrichment container required but not enabled",
 			enrichments: []detection.EnrichmentRequirement{
 				{Name: "container", Dependency: detection.DependencyRequired},
 			},
@@ -833,7 +833,7 @@ func TestRegistry_EnrichmentValidation(t *testing.T) {
 			errMsg:    "requires enrichment \"container\" which is not enabled",
 		},
 		{
-			name: "container enrichment optional and not enabled",
+			name: "enrichment container optional and not enabled",
 			enrichments: []detection.EnrichmentRequirement{
 				{Name: "container", Dependency: detection.DependencyOptional},
 			},
@@ -843,28 +843,28 @@ func TestRegistry_EnrichmentValidation(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "mixed enrichments: container required, exec-env optional",
+			name: "mixed enrichment options: container required, environment optional",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "container", Dependency: detection.DependencyRequired},
-				{Name: "exec-env", Dependency: detection.DependencyOptional},
+				{Name: detection.EnrichmentContainer, Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentEnvironment, Dependency: detection.DependencyOptional},
 			},
 			enrichOpts: &EnrichmentOptions{
-				Container: true,
-				ExecEnv:   false,
+				Container:   true,
+				Environment: false,
 			},
 			expectErr: false,
 		},
 		{
-			name: "multiple enrichments - one missing",
+			name: "multiple enrichment options - one missing",
 			enrichments: []detection.EnrichmentRequirement{
-				{Name: "exec-env", Dependency: detection.DependencyRequired},
-				{Name: "exec-hash", Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentEnvironment, Dependency: detection.DependencyRequired},
+				{Name: detection.EnrichmentExecutableHash, Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: true,
+				Environment: true,
 			},
 			expectErr: true,
-			errMsg:    "requires enrichment \"exec-hash\" which is not enabled",
+			errMsg:    "requires enrichment \"executable-hash\" which is not enabled",
 		},
 		{
 			name: "unknown enrichment",
@@ -872,7 +872,7 @@ func TestRegistry_EnrichmentValidation(t *testing.T) {
 				{Name: "unknown-enrichment", Dependency: detection.DependencyRequired},
 			},
 			enrichOpts: &EnrichmentOptions{
-				ExecEnv: false,
+				Environment: false,
 			},
 			expectErr: true,
 			errMsg:    "requires unknown enrichment: unknown-enrichment",

--- a/pkg/detectors/yaml/schema.go
+++ b/pkg/detectors/yaml/schema.go
@@ -77,7 +77,7 @@ type RequirementsSpec struct {
 	// Events lists the events this detector needs to receive
 	Events []EventRequirementSpec `yaml:"events,omitempty"`
 
-	// Enrichments lists required enrichment options (e.g., exec-hash)
+	// Enrichments lists required enrichment options (e.g., executable-hash)
 	Enrichments []EnrichmentRequirementSpec `yaml:"enrichments,omitempty"`
 
 	// Architectures lists supported CPU architectures (e.g., ["amd64", "arm64"])
@@ -118,7 +118,7 @@ type EventRequirementSpec struct {
 
 // EnrichmentRequirementSpec specifies a required enrichment option
 type EnrichmentRequirementSpec struct {
-	// Name is the enrichment option name (e.g., "exec-hash", "exec-env")
+	// Name is the enrichment option name (e.g., "executable-hash", "environment")
 	Name string `yaml:"name"`
 
 	// Dependency controls if this enrichment is required or optional
@@ -126,7 +126,7 @@ type EnrichmentRequirementSpec struct {
 	Dependency string `yaml:"dependency,omitempty"`
 
 	// Config contains enrichment-specific configuration
-	// For exec-hash: "inode", "dev-inode", "digest-inode"
+	// For executable-hash: "inode", "dev-inode", "digest-inode"
 	Config string `yaml:"config,omitempty"`
 }
 

--- a/pkg/detectors/yaml/validator.go
+++ b/pkg/detectors/yaml/validator.go
@@ -246,7 +246,7 @@ func validateEnrichmentRequirement(spec EnrichmentRequirementSpec, filePath stri
 
 	// Validate known enrichment names
 	if !isValidEnrichmentName(spec.Name) {
-		return errfmt.Errorf("%s: unknown enrichment '%s': must be one of exec-env, exec-hash, container", filePath, spec.Name)
+		return errfmt.Errorf("%s: unknown enrichment '%s': must be one of environment, executable-hash, container", filePath, spec.Name)
 	}
 
 	return nil
@@ -364,8 +364,8 @@ func isValidArchitecture(arch string) bool {
 // isValidEnrichmentName checks if an enrichment name is known
 func isValidEnrichmentName(name string) bool {
 	validEnrichments := []string{
-		detection.EnrichmentExecEnv,
-		detection.EnrichmentExecHash,
+		detection.EnrichmentEnvironment,
+		detection.EnrichmentExecutableHash,
 		detection.EnrichmentContainer,
 	}
 	for _, valid := range validEnrichments {

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -159,7 +159,7 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 
 			// Add stack trace if needed
 			var stackAddresses []uint64
-			if t.config.Output.StackAddresses {
+			if t.config.Output.UserStack {
 				stackAddresses = t.getStackAddresses(eCtx.StackID)
 			}
 
@@ -799,14 +799,14 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *events.PipelineEvent
 			pbEvent.Policies.Matched = t.policyManager.MatchedNames(event.MatchedPoliciesBitmap)
 
 			// Parse arguments for output formatting if enabled.
-			if t.config.Output.ParseArguments {
+			if t.config.Output.DecodedData {
 				err := events.ParseDataFields(pbEvent.Data, int(pbEvent.Id))
 				if err != nil {
 					t.handleError(err)
 				}
 			}
 
-			if t.config.Output.ParseArgumentsFDs {
+			if t.config.Output.FdPaths {
 				// Use original timestamp from pipeline metadata for BPF map lookup
 				err := events.ParseDataFieldsFDs(pbEvent.Data, event.Timestamp, t.FDArgPathMap)
 				if err != nil {

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -207,7 +207,7 @@ func New(cfg config.Config) (*Tracee, error) {
 	// Initialize capabilities rings soon
 
 	useBaseEbpf := func(c config.Config) bool {
-		return c.Output.StackAddresses
+		return c.Output.UserStack
 	}
 
 	err = capabilities.Initialize(
@@ -465,7 +465,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 
 	// Initialize Detector Engine
 	enrichOpts := &detectors.EnrichmentOptions{
-		ExecEnv:      t.config.Output.ExecEnv,
+		Environment:  t.config.Output.Environment,
 		ExecHashMode: t.config.Output.CalcHashes,
 		Container:    t.config.EnrichmentEnabled,
 	}
@@ -968,10 +968,10 @@ const (
 func (t *Tracee) getOptionsConfig() uint32 {
 	var cOptVal uint32
 
-	if t.config.Output.ExecEnv {
+	if t.config.Output.Environment {
 		cOptVal = cOptVal | optExecEnv
 	}
-	if t.config.Output.StackAddresses {
+	if t.config.Output.UserStack {
 		cOptVal = cOptVal | optStackAddresses
 	}
 	if t.config.Artifacts.FileWrite.Capture {
@@ -993,7 +993,7 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	case *cgroup.CgroupV1:
 		cOptVal = cOptVal | optCgroupV1
 	}
-	if t.config.Output.ParseArgumentsFDs {
+	if t.config.Output.FdPaths {
 		cOptVal = cOptVal | optTranslateFDFilePath
 	}
 	switch t.config.ProcessStore.Source {

--- a/tests/e2e-inst-test.sh
+++ b/tests/e2e-inst-test.sh
@@ -331,7 +331,7 @@ print_test_header "START TRACE"
     -- \
     --signatures-dir "${SIG_DIR}" \
     --output sort-events \
-    --enrichment parse-arguments \
+    --enrichment decoded-data \
     --stores process \
     --stores dns \
     --server grpc-address=unix:/tmp/tracee.sock \

--- a/tests/e2e-kernel-test.sh
+++ b/tests/e2e-kernel-test.sh
@@ -75,7 +75,7 @@ outputfile="${SCRIPT_TMP_DIR}/tracee-output-$$"
 
 tracee_command="./dist/tracee \
     --output json:$outputfile \
-    --output option:exec-env \
+    --enrichment environment \
     --logging file=$logfile \
     --server healthz \
     --policy ./tests/policies/kernel/kernel.yaml 2>&1 \


### PR DESCRIPTION
# Move enrichment options from output to enrichment config

Moves `parse-arguments`, `exec-env`, `user-stack-trace` (stack-addresses), `exec-hash`, and `resolve-fd` (parse-arguments-fds) from output options to enrichment options. These must now be configured via `--enrichment` flag or `enrichment` section in config files.

## Changes

- **Code**: Simplified enrichment-to-output assignment, removed these options from `SetOption` and `flags()` method
- **Configs**: Updated Helm charts, K8s manifests, and example configs to use `enrichment` section
- **Docs**: Clarified that `parse-arguments` is an enrichment option (auto-enabled with table format)
- **Tests**: Updated to expect errors when these are used as output options, added enrichment test coverage

## Breaking Changes

`--output option:parse-arguments`, `--output option:exec-env`, `--output option:stack-addresses`, `--output option:exec-hash`, and `--output option:parse-arguments-fds` now return errors. Use `--enrichment` instead.

