### PR TITLE
refactor(artifacts): rename capture to artifacts

### DIFF
--- a/pkg/cmd/cobra/cobra.go
+++ b/pkg/cmd/cobra/cobra.go
@@ -204,8 +204,8 @@ func GetTraceeRunner(c *cobra.Command, version string) (cmd.Runner, error) {
 	if err != nil {
 		return runner, err
 	}
-	capture := artifactsConfig.GetCapture()
-	cfg.Capture = &capture
+	artifacts := artifactsConfig.GetArtifactsConfig()
+	cfg.Artifacts = &artifacts
 
 	// Capabilities command line flags
 

--- a/pkg/cmd/flags/artifacts_test.go
+++ b/pkg/cmd/flags/artifacts_test.go
@@ -19,10 +19,10 @@ func TestPrepareArtifacts(t *testing.T) {
 
 	t.Run("various artifacts options", func(t *testing.T) {
 		testCases := []struct {
-			testName        string
-			artifactsSlice  []string
-			expectedCapture config.CaptureConfig
-			expectedError   error
+			testName          string
+			artifactsSlice    []string
+			expectedArtifacts config.ArtifactsConfig
+			expectedError     error
 		}{
 			{
 				testName:       "invalid artifacts option - no dot",
@@ -37,9 +37,9 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-write with filters auto-enables",
 				artifactsSlice: []string{"file-write.filters=path=/tmp*"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileWrite: config.FileCaptureConfig{
+					FileWrite: config.FileArtifactsConfig{
 						Capture:    true,
 						PathFilter: []string{"/tmp"},
 					},
@@ -48,9 +48,9 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-read with filters auto-enables",
 				artifactsSlice: []string{"file-read.filters=path=/etc*"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileRead: config.FileCaptureConfig{
+					FileRead: config.FileArtifactsConfig{
 						Capture:    true,
 						PathFilter: []string{"/etc"},
 					},
@@ -79,22 +79,22 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "invalid file-write filter - empty path",
 				artifactsSlice: []string{"file-write.filters=path=*"},
-				expectedError:  errors.New("capture path filter cannot be empty"),
+				expectedError:  errors.New("artifacts path filter cannot be empty"),
 			},
 			{
 				testName:       "invalid file-write type filter",
 				artifactsSlice: []string{"file-write.filters=type=non-existing"},
-				expectedError:  errors.New("unsupported file type filter value for capture - non-existing"),
+				expectedError:  errors.New("unsupported file type filter value for artifacts - non-existing"),
 			},
 			{
 				testName:       "invalid file-write fd filter",
 				artifactsSlice: []string{"file-write.filters=fd=non-existing"},
-				expectedError:  errors.New("unsupported file FD filter value for capture - non-existing"),
+				expectedError:  errors.New("unsupported file FD filter value for artifacts - non-existing"),
 			},
 			{
 				testName:       "artifacts memory-regions enabled",
 				artifactsSlice: []string{"memory-regions"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Mem:        true,
 				},
@@ -102,7 +102,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts executable enabled",
 				artifactsSlice: []string{"executable"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Exec:       true,
 				},
@@ -110,7 +110,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts kernel-modules enabled",
 				artifactsSlice: []string{"kernel-modules"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Module:     true,
 				},
@@ -118,9 +118,9 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-write enabled",
 				artifactsSlice: []string{"file-write"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileWrite: config.FileCaptureConfig{
+					FileWrite: config.FileArtifactsConfig{
 						Capture: true,
 					},
 				},
@@ -128,7 +128,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network enabled",
 				artifactsSlice: []string{"network"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle: true,
@@ -139,7 +139,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap split",
 				artifactsSlice: []string{"network.pcap.split=process,command,container"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle:    false,
@@ -153,7 +153,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with multiple pcap split types",
 				artifactsSlice: []string{"network.pcap.split=command,container"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle:    false,
@@ -167,7 +167,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap split and snaplen",
 				artifactsSlice: []string{"network.pcap.split=command,container", "network.pcap.snaplen=120b"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle:    false,
@@ -181,7 +181,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap options filtered",
 				artifactsSlice: []string{"network.pcap.options=filtered"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle:   true,
@@ -193,7 +193,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap options none",
 				artifactsSlice: []string{"network.pcap.options=none"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle:   true,
@@ -205,7 +205,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap snaplen max",
 				artifactsSlice: []string{"network.pcap.snaplen=max"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle: true,
@@ -216,7 +216,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap snaplen headers",
 				artifactsSlice: []string{"network.pcap.snaplen=headers"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle: true,
@@ -227,7 +227,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap snaplen default",
 				artifactsSlice: []string{"network.pcap.snaplen=default"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle: true,
@@ -238,7 +238,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts network with pcap snaplen kb",
 				artifactsSlice: []string{"network.pcap.snaplen=1kb"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Net: config.PcapsConfig{
 						CaptureSingle: true,
@@ -249,7 +249,7 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts bpf-programs enabled",
 				artifactsSlice: []string{"bpf-programs"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 					Bpf:        true,
 				},
@@ -257,9 +257,9 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-write filtered by path",
 				artifactsSlice: []string{"file-write.filters=path=/tmp*"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileWrite: config.FileCaptureConfig{
+					FileWrite: config.FileArtifactsConfig{
 						Capture:    true,
 						PathFilter: []string{"/tmp"},
 					},
@@ -268,9 +268,9 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-read enabled",
 				artifactsSlice: []string{"file-read"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileRead: config.FileCaptureConfig{
+					FileRead: config.FileArtifactsConfig{
 						Capture: true,
 					},
 				},
@@ -278,9 +278,9 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-read filtered by path",
 				artifactsSlice: []string{"file-read.filters=path=/tmp*"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileRead: config.FileCaptureConfig{
+					FileRead: config.FileArtifactsConfig{
 						Capture:    true,
 						PathFilter: []string{"/tmp"},
 					},
@@ -289,53 +289,53 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts file-read filtered by type",
 				artifactsSlice: []string{"file-read.filters=type=pipe"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileRead: config.FileCaptureConfig{
+					FileRead: config.FileArtifactsConfig{
 						Capture:    true,
-						TypeFilter: config.CapturePipeFiles,
+						TypeFilter: config.ArtifactsPipeFiles,
 					},
 				},
 			},
 			{
 				testName:       "artifacts file-read filtered by fd",
 				artifactsSlice: []string{"file-read.filters=fd=stdin"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileRead: config.FileCaptureConfig{
+					FileRead: config.FileArtifactsConfig{
 						Capture:    true,
-						TypeFilter: config.CaptureStdinFiles,
+						TypeFilter: config.ArtifactsStdinFiles,
 					},
 				},
 			},
 			{
 				testName:       "artifacts file-write filtered by type",
 				artifactsSlice: []string{"file-write.filters=type=socket"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileWrite: config.FileCaptureConfig{
+					FileWrite: config.FileArtifactsConfig{
 						Capture:    true,
-						TypeFilter: config.CaptureSocketFiles,
+						TypeFilter: config.ArtifactsSocketFiles,
 					},
 				},
 			},
 			{
 				testName:       "artifacts file-write filtered by fd",
 				artifactsSlice: []string{"file-write.filters=fd=stdout"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileWrite: config.FileCaptureConfig{
+					FileWrite: config.FileArtifactsConfig{
 						Capture:    true,
-						TypeFilter: config.CaptureStdoutFiles,
+						TypeFilter: config.ArtifactsStdoutFiles,
 					},
 				},
 			},
 			{
 				testName:       "multiple artifacts options",
 				artifactsSlice: []string{"file-write", "executable", "memory-regions", "kernel-modules", "bpf-programs"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
-					FileWrite:  config.FileCaptureConfig{Capture: true},
+					FileWrite:  config.FileArtifactsConfig{Capture: true},
 					Mem:        true,
 					Exec:       true,
 					Module:     true,
@@ -345,14 +345,14 @@ func TestPrepareArtifacts(t *testing.T) {
 			{
 				testName:       "artifacts dir path",
 				artifactsSlice: []string{"dir.path=/custom/path"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/custom/path/out",
 				},
 			},
 			{
 				testName:       "artifacts dir clear",
 				artifactsSlice: []string{"dir.clear"},
-				expectedCapture: config.CaptureConfig{
+				expectedArtifacts: config.ArtifactsConfig{
 					OutputPath: "/tmp/tracee/out",
 				},
 			},
@@ -381,8 +381,8 @@ func TestPrepareArtifacts(t *testing.T) {
 				artifactsConfig, err := PrepareArtifacts(tc.artifactsSlice)
 				if tc.expectedError == nil {
 					require.NoError(t, err)
-					capture := artifactsConfig.GetCapture()
-					assert.Equal(t, tc.expectedCapture, capture, tc.testName)
+					artifacts := artifactsConfig.GetArtifactsConfig()
+					assert.Equal(t, tc.expectedArtifacts, artifacts, tc.testName)
 				} else {
 					require.Error(t, err)
 					// Extract just the error message without function prefix
@@ -400,8 +400,8 @@ func TestPrepareArtifacts(t *testing.T) {
 		d, _ := os.CreateTemp("", "TestPrepareArtifacts-*")
 		artifactsConfig, err := PrepareArtifacts([]string{fmt.Sprintf("dir.path=%s", d.Name()), "dir.clear"})
 		require.NoError(t, err)
-		capture := artifactsConfig.GetCapture()
-		assert.Equal(t, config.CaptureConfig{OutputPath: fmt.Sprintf("%s/out", d.Name())}, capture)
+		artifacts := artifactsConfig.GetArtifactsConfig()
+		assert.Equal(t, config.ArtifactsConfig{OutputPath: fmt.Sprintf("%s/out", d.Name())}, artifacts)
 		require.NoDirExists(t, d.Name()+"out")
 	})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,7 @@ func invalidStreamConfigError(streamName string) error {
 // proper management.
 type Config struct {
 	InitialPolicies   []interface{} // due to circular dependency, policy.Policy cannot be used here
-	Capture           *CaptureConfig
+	Artifacts         *ArtifactsConfig
 	Capabilities      *CapabilitiesConfig
 	Output            *OutputConfig
 	ProcessStore      process.ProcTreeConfig
@@ -72,19 +72,19 @@ func (c Config) Validate() error {
 		return invalidKernelArtifactsBufferSizeError
 	}
 
-	// Capture
-	if len(c.Capture.FileWrite.PathFilter) > 3 {
+	// Artifacts
+	if len(c.Artifacts.FileWrite.PathFilter) > 3 {
 		return invalidArtifactsFileWriteTooManyPathFiltersError
 	}
-	for _, filter := range c.Capture.FileWrite.PathFilter {
+	for _, filter := range c.Artifacts.FileWrite.PathFilter {
 		if len(filter) > 50 {
 			return invalidPathFilterError(filter)
 		}
 	}
-	if len(c.Capture.FileRead.PathFilter) > 3 {
+	if len(c.Artifacts.FileRead.PathFilter) > 3 {
 		return invalidArtifactsFileReadTooManyPathFiltersError
 	}
-	for _, filter := range c.Capture.FileWrite.PathFilter {
+	for _, filter := range c.Artifacts.FileWrite.PathFilter {
 		if len(filter) > 50 {
 			return invalidPathFilterError(filter)
 		}
@@ -106,13 +106,13 @@ func (c Config) Validate() error {
 }
 
 //
-// Capture
+// Artifacts
 //
 
-type CaptureConfig struct {
+type ArtifactsConfig struct {
 	OutputPath string
-	FileWrite  FileCaptureConfig
-	FileRead   FileCaptureConfig
+	FileWrite  FileArtifactsConfig
+	FileRead   FileArtifactsConfig
 	Module     bool
 	Exec       bool
 	Mem        bool
@@ -120,30 +120,30 @@ type CaptureConfig struct {
 	Net        PcapsConfig
 }
 
-type FileCaptureConfig struct {
+type FileArtifactsConfig struct {
 	Capture    bool
 	PathFilter []string
-	TypeFilter FileCaptureType
+	TypeFilter FileArtifactsType
 }
 
-// FileCaptureType represents file type capture configuration flags
+// FileArtifactsType represents file type artifacts configuration flags
 // Values should match the filter values in the eBPF file (
-// CaptureRegularFiles -> FILTER_NORMAL_FILES)
-type FileCaptureType uint
+// ArtifactsRegularFiles -> FILTER_NORMAL_FILES)
+type FileArtifactsType uint
 
 // Filters for file types flags
 const (
-	CaptureRegularFiles FileCaptureType = 1 << iota
-	CapturePipeFiles
-	CaptureSocketFiles
-	CaptureELFFiles
+	ArtifactsRegularFiles FileArtifactsType = 1 << iota
+	ArtifactsPipeFiles
+	ArtifactsSocketFiles
+	ArtifactsELFFiles
 )
 
 // Filters for FDs flags
 const (
-	CaptureStdinFiles FileCaptureType = 1 << (iota + 16)
-	CaptureStdoutFiles
-	CaptureStderrFiles
+	ArtifactsStdinFiles FileArtifactsType = 1 << (iota + 16)
+	ArtifactsStdoutFiles
+	ArtifactsStderrFiles
 )
 
 type PcapsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -16,7 +16,7 @@ func validConfig() Config {
 				Artifacts: 512,  // power of 2
 			},
 		},
-		Capture:     &CaptureConfig{},
+		Artifacts:   &ArtifactsConfig{},
 		Output:      &OutputConfig{},
 		BPFObjBytes: []byte{1, 2, 3},
 	}
@@ -68,7 +68,7 @@ func TestConfig_Validate(t *testing.T) {
 			name: "too many file-write path filters",
 			config: func() Config {
 				cfg := validConfig()
-				cfg.Capture.FileWrite.PathFilter = []string{"/tmp*", "/var*", "/usr*", "/etc*"} // 4 filters > 3
+				cfg.Artifacts.FileWrite.PathFilter = []string{"/tmp*", "/var*", "/usr*", "/etc*"} // 4 filters > 3
 				return cfg
 			}(),
 			expectError:   true,
@@ -78,7 +78,7 @@ func TestConfig_Validate(t *testing.T) {
 			name: "too many file-read path filters",
 			config: func() Config {
 				cfg := validConfig()
-				cfg.Capture.FileRead.PathFilter = []string{"/tmp*", "/var*", "/usr*", "/etc*"} // 4 filters > 3
+				cfg.Artifacts.FileRead.PathFilter = []string{"/tmp*", "/var*", "/usr*", "/etc*"} // 4 filters > 3
 				return cfg
 			}(),
 			expectError:   true,
@@ -89,7 +89,7 @@ func TestConfig_Validate(t *testing.T) {
 			config: func() Config {
 				cfg := validConfig()
 				longFilter := "/this/is/a/very/long/path/that/exceeds/fifty/characters*"
-				cfg.Capture.FileWrite.PathFilter = []string{longFilter}
+				cfg.Artifacts.FileWrite.PathFilter = []string{longFilter}
 				return cfg
 			}(),
 			expectError:   true,
@@ -100,8 +100,8 @@ func TestConfig_Validate(t *testing.T) {
 			config: func() Config {
 				cfg := validConfig()
 				longFilter := "/this/is/a/very/long/path/that/exceeds/fifty/characters*"
-				cfg.Capture.FileRead.PathFilter = []string{"/tmp*"}
-				cfg.Capture.FileWrite.PathFilter = []string{longFilter}
+				cfg.Artifacts.FileRead.PathFilter = []string{"/tmp*"}
+				cfg.Artifacts.FileWrite.PathFilter = []string{longFilter}
 				return cfg
 			}(),
 			expectError:   true,
@@ -111,7 +111,7 @@ func TestConfig_Validate(t *testing.T) {
 			name: "valid path filter length - exactly 50 characters",
 			config: func() Config {
 				cfg := validConfig()
-				cfg.Capture.FileWrite.PathFilter = []string{"/this/is/a/path/exactly/fifty/characters/long*"}
+				cfg.Artifacts.FileWrite.PathFilter = []string{"/this/is/a/path/exactly/fifty/characters/long*"}
 				return cfg
 			}(),
 			expectError: false,
@@ -175,8 +175,8 @@ func TestConfig_Validate(t *testing.T) {
 			name: "maximum valid path filters",
 			config: func() Config {
 				cfg := validConfig()
-				cfg.Capture.FileWrite.PathFilter = []string{"/tmp*", "/var*", "/usr*"} // exactly 3 filters
-				cfg.Capture.FileRead.PathFilter = []string{"/etc*", "/opt*", "/home*"} // exactly 3 filters
+				cfg.Artifacts.FileWrite.PathFilter = []string{"/tmp*", "/var*", "/usr*"} // exactly 3 filters
+				cfg.Artifacts.FileRead.PathFilter = []string{"/etc*", "/opt*", "/home*"} // exactly 3 filters
 				return cfg
 			}(),
 			expectError: false,

--- a/pkg/ebpf/net_capture.go
+++ b/pkg/ebpf/net_capture.go
@@ -178,7 +178,7 @@ func (t *Tracee) processNetCapEvent(event *trace.Event) {
 		// length field to the length of the captured data.
 		//
 
-		captureLength := t.config.Capture.Net.CaptureLength // after last known header
+		captureLength := t.config.Artifacts.Net.CaptureLength // after last known header
 
 		// parse packet
 		layer3 := packet.NetworkLayer()

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -81,7 +81,7 @@ type Tracee struct {
 	eventDerivations derive.Table
 	// Artifacts
 	fileHashes     *digest.Cache
-	capturedFiles  map[string]int64
+	artifactsFiles map[string]int64
 	writtenFiles   map[string]string
 	netCapturePcap *pcaps.Pcaps
 	// Internal Data
@@ -242,31 +242,31 @@ func New(cfg config.Config) (*Tracee, error) {
 	// NOTE: This deep copy is a *reminder* that the inner slices are not shared
 	// between the original and the injected config.
 	// TODO: This logic should be removed when config changes in runtime is a thing.
-	getNewCaptureConfig := func() config.CaptureConfig {
-		fileReadPathFilter := make([]string, 0, len(cfg.Capture.FileRead.PathFilter))
-		copy(fileReadPathFilter, cfg.Capture.FileRead.PathFilter)
-		fileRead := config.FileCaptureConfig{
-			Capture:    cfg.Capture.FileRead.Capture,
+	getNewArtifactsConfig := func() config.ArtifactsConfig {
+		fileReadPathFilter := make([]string, 0, len(cfg.Artifacts.FileRead.PathFilter))
+		copy(fileReadPathFilter, cfg.Artifacts.FileRead.PathFilter)
+		fileRead := config.FileArtifactsConfig{
+			Capture:    cfg.Artifacts.FileRead.Capture,
 			PathFilter: fileReadPathFilter,
-			TypeFilter: cfg.Capture.FileRead.TypeFilter,
+			TypeFilter: cfg.Artifacts.FileRead.TypeFilter,
 		}
 
-		fileWritePathFilter := make([]string, 0, len(cfg.Capture.FileWrite.PathFilter))
-		copy(fileWritePathFilter, cfg.Capture.FileWrite.PathFilter)
-		fileWrite := config.FileCaptureConfig{
-			Capture:    cfg.Capture.FileWrite.Capture,
+		fileWritePathFilter := make([]string, 0, len(cfg.Artifacts.FileWrite.PathFilter))
+		copy(fileWritePathFilter, cfg.Artifacts.FileWrite.PathFilter)
+		fileWrite := config.FileArtifactsConfig{
+			Capture:    cfg.Artifacts.FileWrite.Capture,
 			PathFilter: fileWritePathFilter,
-			TypeFilter: cfg.Capture.FileWrite.TypeFilter,
+			TypeFilter: cfg.Artifacts.FileWrite.TypeFilter,
 		}
 
-		return config.CaptureConfig{
+		return config.ArtifactsConfig{
 			FileRead:  fileRead,
 			FileWrite: fileWrite,
-			Module:    cfg.Capture.Module,
-			Exec:      cfg.Capture.Exec,
-			Mem:       cfg.Capture.Mem,
-			Bpf:       cfg.Capture.Bpf,
-			Net:       cfg.Capture.Net,
+			Module:    cfg.Artifacts.Module,
+			Exec:      cfg.Artifacts.Exec,
+			Mem:       cfg.Artifacts.Mem,
+			Bpf:       cfg.Artifacts.Bpf,
+			Net:       cfg.Artifacts.Net,
 		}
 	}
 
@@ -274,7 +274,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		HeartbeatEnabled:   cfg.HealthzEnabled,
 		DNSStoreConfig:     cfg.DNSStore,
 		ProcessStoreConfig: cfg.ProcessStore,
-		CaptureConfig:      getNewCaptureConfig(),
+		ArtifactsConfig:    getNewArtifactsConfig(),
 	}
 	pm, err := policy.NewManager(pmCfg, depsManager, initialPolicies...)
 	if err != nil {
@@ -289,7 +289,7 @@ func New(cfg config.Config) (*Tracee, error) {
 		stats:              metrics.NewStats(),
 		writtenFiles:       make(map[string]string),
 		readFiles:          make(map[string]string),
-		capturedFiles:      make(map[string]int64),
+		artifactsFiles:     make(map[string]int64),
 		streamsManager:     streams.NewStreamsManager(),
 		policyManager:      pm,
 		eventsDependencies: depsManager,
@@ -635,14 +635,14 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 		return errfmt.WrapError(err)
 	}
 
-	// Initialize capture directory
+	// Initialize artifacts directory
 
-	if err := os.MkdirAll(t.config.Capture.OutputPath, 0755); err != nil {
+	if err := os.MkdirAll(t.config.Artifacts.OutputPath, 0755); err != nil {
 		t.Close()
 		return errfmt.Errorf("error creating output path: %v", err)
 	}
 
-	t.OutDir, err = fileutil.OpenExistingDir(t.config.Capture.OutputPath)
+	t.OutDir, err = fileutil.OpenExistingDir(t.config.Artifacts.OutputPath)
 	if err != nil {
 		t.Close()
 		return errfmt.Errorf("error opening out directory: %v", err)
@@ -650,7 +650,7 @@ func (t *Tracee) Init(ctx gocontext.Context) error {
 
 	// Initialize network capture (all needed pcap files)
 
-	t.netCapturePcap, err = pcaps.New(t.config.Capture.Net, t.OutDir)
+	t.netCapturePcap, err = pcaps.New(t.config.Artifacts.Net, t.OutDir)
 	if err != nil {
 		t.Close()
 		return errfmt.Errorf("error initializing network capture: %v", err)
@@ -974,19 +974,19 @@ func (t *Tracee) getOptionsConfig() uint32 {
 	if t.config.Output.StackAddresses {
 		cOptVal = cOptVal | optStackAddresses
 	}
-	if t.config.Capture.FileWrite.Capture {
+	if t.config.Artifacts.FileWrite.Capture {
 		cOptVal = cOptVal | optCaptureFilesWrite
 	}
-	if t.config.Capture.FileRead.Capture {
+	if t.config.Artifacts.FileRead.Capture {
 		cOptVal = cOptVal | optCaptureFileRead
 	}
-	if t.config.Capture.Module {
+	if t.config.Artifacts.Module {
 		cOptVal = cOptVal | optCaptureModules
 	}
-	if t.config.Capture.Bpf {
+	if t.config.Artifacts.Bpf {
 		cOptVal = cOptVal | optCaptureBpf
 	}
-	if t.config.Capture.Mem {
+	if t.config.Artifacts.Mem {
 		cOptVal = cOptVal | optExtractDynCode
 	}
 	switch t.cgroups.GetDefaultCgroup().(type) {
@@ -1374,16 +1374,16 @@ func (t *Tracee) populateBPFMaps() error {
 	}
 
 	// Initialize the net_packet configuration eBPF map.
-	if pcaps.PcapsEnabled(t.config.Capture.Net) {
+	if pcaps.PcapsEnabled(t.config.Artifacts.Net) {
 		bpfNetConfigMap, err := t.bpfModule.GetMap("netconfig_map")
 		if err != nil {
 			return errfmt.WrapError(err)
 		}
 
 		netConfigVal := make([]byte, 8) // u32 capture_options + u32 capture_length
-		options := pcaps.GetPcapOptions(t.config.Capture.Net)
+		options := pcaps.GetPcapOptions(t.config.Artifacts.Net)
 		binary.LittleEndian.PutUint32(netConfigVal[0:4], uint32(options))
-		binary.LittleEndian.PutUint32(netConfigVal[4:8], t.config.Capture.Net.CaptureLength)
+		binary.LittleEndian.PutUint32(netConfigVal[4:8], t.config.Artifacts.Net.CaptureLength)
 
 		cZero := uint32(0)
 		err = bpfNetConfigMap.Update(unsafe.Pointer(&cZero), unsafe.Pointer(&netConfigVal[0]))
@@ -1410,8 +1410,8 @@ func (t *Tracee) populateBPFMaps() error {
 		return err
 	}
 
-	for i := uint32(0); i < uint32(len(t.config.Capture.FileWrite.PathFilter)); i++ {
-		filterFilePathWriteBytes := []byte(t.config.Capture.FileWrite.PathFilter[i])
+	for i := uint32(0); i < uint32(len(t.config.Artifacts.FileWrite.PathFilter)); i++ {
+		filterFilePathWriteBytes := []byte(t.config.Artifacts.FileWrite.PathFilter[i])
 		if err = fileWritePathFilterMap.Update(unsafe.Pointer(&i), unsafe.Pointer(&filterFilePathWriteBytes[0])); err != nil {
 			return err
 		}
@@ -1423,8 +1423,8 @@ func (t *Tracee) populateBPFMaps() error {
 		return err
 	}
 
-	for i := uint32(0); i < uint32(len(t.config.Capture.FileRead.PathFilter)); i++ {
-		filterFilePathReadBytes := []byte(t.config.Capture.FileRead.PathFilter[i])
+	for i := uint32(0); i < uint32(len(t.config.Artifacts.FileRead.PathFilter)); i++ {
+		filterFilePathReadBytes := []byte(t.config.Artifacts.FileRead.PathFilter[i])
 		if err = fileReadPathFilterMap.Update(unsafe.Pointer(&i), unsafe.Pointer(&filterFilePathReadBytes[0])); err != nil {
 			return err
 		}
@@ -1438,7 +1438,7 @@ func (t *Tracee) populateBPFMaps() error {
 
 	// Should match the value of CAPTURE_READ_TYPE_FILTER_IDX in eBPF code
 	captureReadTypeFilterIndex := uint32(0)
-	captureReadTypeFilterVal := uint32(t.config.Capture.FileRead.TypeFilter)
+	captureReadTypeFilterVal := uint32(t.config.Artifacts.FileRead.TypeFilter)
 	if err = fileTypeFilterMap.Update(unsafe.Pointer(&captureReadTypeFilterIndex),
 		unsafe.Pointer(&captureReadTypeFilterVal)); err != nil {
 		return errfmt.WrapError(err)
@@ -1446,7 +1446,7 @@ func (t *Tracee) populateBPFMaps() error {
 
 	// Should match the value of CAPTURE_WRITE_TYPE_FILTER_IDX in eBPF code
 	captureWriteTypeFilterIndex := uint32(1)
-	captureWriteTypeFilterVal := uint32(t.config.Capture.FileWrite.TypeFilter)
+	captureWriteTypeFilterVal := uint32(t.config.Artifacts.FileWrite.TypeFilter)
 	if err = fileTypeFilterMap.Update(unsafe.Pointer(&captureWriteTypeFilterIndex),
 		unsafe.Pointer(&captureWriteTypeFilterVal)); err != nil {
 		return errfmt.WrapError(err)
@@ -1744,7 +1744,7 @@ func (t *Tracee) initBPF() error {
 		}
 	}
 
-	if pcaps.PcapsEnabled(t.config.Capture.Net) {
+	if pcaps.PcapsEnabled(t.config.Artifacts.Net) {
 		t.netCapChannel = make(chan []byte, 1000)
 		t.lostNetCapChannel = make(chan uint64)
 		t.netCapPerfMap, err = t.bpfModule.InitPerfBuf(
@@ -1837,7 +1837,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 
 	// Network capture perf buffer (similar to regular pipeline)
 
-	if pcaps.PcapsEnabled(t.config.Capture.Net) {
+	if pcaps.PcapsEnabled(t.config.Artifacts.Net) {
 		t.netCapPerfMap.Poll(pollTimeout)
 		go t.handleNetCaptureEvents(ctx)
 	}
@@ -1864,7 +1864,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	if t.config.Buffers.Kernel.Artifacts > 0 {
 		t.fileWrPerfMap.Stop()
 	}
-	if pcaps.PcapsEnabled(t.config.Capture.Net) {
+	if pcaps.PcapsEnabled(t.config.Artifacts.Net) {
 		t.netCapPerfMap.Stop()
 	}
 	t.bpfLogsPerfMap.Stop()
@@ -1872,16 +1872,16 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	// TODO: move logic below somewhere else (related to file writes)
 
 	// record index of written files
-	if t.config.Capture.FileWrite.Capture {
-		err := updateCaptureMapFile(t.OutDir, "written_files", t.writtenFiles, t.config.Capture.FileWrite)
+	if t.config.Artifacts.FileWrite.Capture {
+		err := updateArtifactsMapFile(t.OutDir, "written_files", t.writtenFiles, t.config.Artifacts.FileWrite)
 		if err != nil {
 			return err
 		}
 	}
 
 	// record index of read files
-	if t.config.Capture.FileRead.Capture {
-		err := updateCaptureMapFile(t.OutDir, "read_files", t.readFiles, t.config.Capture.FileRead)
+	if t.config.Artifacts.FileRead.Capture {
+		err := updateArtifactsMapFile(t.OutDir, "read_files", t.readFiles, t.config.Artifacts.FileRead)
 		if err != nil {
 			return err
 		}
@@ -1892,7 +1892,7 @@ func (t *Tracee) Run(ctx gocontext.Context) error {
 	return nil
 }
 
-func updateCaptureMapFile(fileDir *os.File, filePath string, capturedFiles map[string]string, cfg config.FileCaptureConfig) error {
+func updateArtifactsMapFile(fileDir *os.File, filePath string, artifactsFiles map[string]string, cfg config.FileArtifactsConfig) error {
 	f, err := fileutil.OpenAt(fileDir, filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return errfmt.Errorf("error logging captured files")
@@ -1902,16 +1902,16 @@ func updateCaptureMapFile(fileDir *os.File, filePath string, capturedFiles map[s
 			logger.Errorw("Closing file", "error", err)
 		}
 	}()
-	for fileName, filePath := range capturedFiles {
-		captureFiltered := false
-		// TODO: We need a method to decide if the capture was filtered by FD or type.
+	for fileName, filePath := range artifactsFiles {
+		artifactsFiltered := false
+		// TODO: We need a method to decide if the artifacts was filtered by FD or type.
 		for _, filterPrefix := range cfg.PathFilter {
 			if !strings.HasPrefix(filePath, filterPrefix) {
-				captureFiltered = true
+				artifactsFiltered = true
 				break
 			}
 		}
-		if captureFiltered {
+		if artifactsFiltered {
 			// Don't write mapping of files that were not actually captured
 			continue
 		}
@@ -2177,7 +2177,7 @@ func (t *Tracee) netEnabled() bool {
 	}
 
 	// if called before capture meta-events are set to be traced:
-	return pcaps.PcapsEnabled(t.config.Capture.Net)
+	return pcaps.PcapsEnabled(t.config.Artifacts.Net)
 }
 
 // AddReadyCallback sets a callback function to be called when the tracee started all its probes

--- a/pkg/policy/policy_manager.go
+++ b/pkg/policy/policy_manager.go
@@ -22,7 +22,7 @@ import (
 type ManagerConfig struct {
 	DNSStoreConfig     dns.Config
 	ProcessStoreConfig process.ProcTreeConfig
-	CaptureConfig      config.CaptureConfig
+	ArtifactsConfig    config.ArtifactsConfig
 	HeartbeatEnabled   bool
 }
 
@@ -219,41 +219,41 @@ func (m *Manager) selectConfiguredEvents() {
 		m.selectEvent(events.SignalHeartbeat, newEventFlags(eventFlagsWithSubmit(PolicyAll)))
 	}
 
-	// Pseudo events added by capture (if enabled by the user)
+	// Pseudo events added by artifacts (if enabled by the user)
 
-	getCaptureEventsFlags := func(cfg config.CaptureConfig) map[events.ID]*eventFlags {
-		captureEvents := make(map[events.ID]*eventFlags)
+	getArtifactsEventsFlags := func(cfg config.ArtifactsConfig) map[events.ID]*eventFlags {
+		artifactsEvents := make(map[events.ID]*eventFlags)
 
-		// INFO: All capture events should be placed, at least for now, to all matched policies, or else
-		// the event won't be set to matched policy in eBPF and should_submit() won't submit the capture
+		// INFO: All artifacts events should be placed, at least for now, to all matched policies, or else
+		// the event won't be set to matched policy in eBPF and should_submit() won't submit the artifacts
 		// event to userland.
 
 		if cfg.Exec {
-			captureEvents[events.CaptureExec] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureExec] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 		if cfg.FileWrite.Capture {
-			captureEvents[events.CaptureFileWrite] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureFileWrite] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 		if cfg.FileRead.Capture {
-			captureEvents[events.CaptureFileRead] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureFileRead] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 		if cfg.Module {
-			captureEvents[events.CaptureModule] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureModule] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 		if cfg.Mem {
-			captureEvents[events.CaptureMem] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureMem] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 		if cfg.Bpf {
-			captureEvents[events.CaptureBpf] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureBpf] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 		if pcaps.PcapsEnabled(cfg.Net) {
-			captureEvents[events.CaptureNetPacket] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
+			artifactsEvents[events.CaptureNetPacket] = newEventFlags(eventFlagsWithSubmit(PolicyAll))
 		}
 
-		return captureEvents
+		return artifactsEvents
 	}
 
-	for id, flags := range getCaptureEventsFlags(m.cfg.CaptureConfig) {
+	for id, flags := range getArtifactsEventsFlags(m.cfg.ArtifactsConfig) {
 		m.selectEvent(id, flags)
 	}
 }

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -32,7 +32,7 @@ func Test_EventsDependencies(t *testing.T) {
 	testCases := []struct {
 		name              string
 		events            []events.ID
-		captureConfig     *config.CaptureConfig // For internal/capture events
+		artifactsConfig   *config.ArtifactsConfig // For internal/artifacts events
 		expectedLogs      []string
 		expectedEvents    []events.ID
 		unexpectedEvents  []events.ID
@@ -202,7 +202,7 @@ func Test_EventsDependencies(t *testing.T) {
 		{
 			name:            "capture_mem requires security_file_mprotect",
 			events:          []events.ID{events.ExecTest}, // Avoid triggering default event set
-			captureConfig:   &config.CaptureConfig{Mem: true, OutputPath: "/tmp/tracee-test"},
+			artifactsConfig: &config.ArtifactsConfig{Mem: true, OutputPath: "/tmp/tracee-test"},
 			expectedKprobes: []string{"security_file_mprotect"},
 		},
 	}
@@ -276,7 +276,7 @@ func Test_EventsDependencies(t *testing.T) {
 			defer closeLogsDone()
 
 			// start tracee
-			trc, err := testutils.StartTracee(ctx, t, testConfig, nil, testCaseInst.captureConfig)
+			trc, err := testutils.StartTracee(ctx, t, testConfig, nil, testCaseInst.artifactsConfig)
 			if err != nil {
 				cancel()
 				t.Fatal(err)

--- a/tests/testutils/tracee_integrated.go
+++ b/tests/testutils/tracee_integrated.go
@@ -69,7 +69,7 @@ func (b *EventBuffer) GetCopy() []*pb.Event {
 }
 
 // load tracee into memory with args
-func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *config.OutputConfig, capture *config.CaptureConfig) (*tracee.Tracee, error) {
+func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *config.OutputConfig, artifacts *config.ArtifactsConfig) (*tracee.Tracee, error) {
 	initialize.SetLibbpfgoCallbacks()
 
 	kernelConfig, err := initialize.KernelConfig()
@@ -89,11 +89,11 @@ func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 		return nil, err
 	}
 
-	if capture == nil {
-		capture = PrepareCapture()
+	if artifacts == nil {
+		artifacts = PrepareArtifacts()
 	}
 
-	cfg.Capture = capture
+	cfg.Artifacts = artifacts
 
 	defaultBufferPages := (4096 * 1024) / os.Getpagesize() // 4 MB of contiguous pages
 	cfg.Buffers = config.BuffersConfig{
@@ -157,12 +157,12 @@ func StartTracee(ctx context.Context, t *testing.T, cfg config.Config, output *c
 	return trc, nil
 }
 
-// prepareCapture prepares a capture config for tracee
-func PrepareCapture() *config.CaptureConfig {
+// prepareArtifacts prepares an artifacts config for tracee
+func PrepareArtifacts() *config.ArtifactsConfig {
 	// taken from tracee-rule github project, might have to adjust...
-	// prepareCapture is called with nil input
-	return &config.CaptureConfig{
-		FileWrite: config.FileCaptureConfig{
+	// prepareArtifacts is called with nil input
+	return &config.ArtifactsConfig{
+		FileWrite: config.FileArtifactsConfig{
 			PathFilter: []string{},
 		},
 		OutputPath: filepath.Join("/tmp/tracee", "out"),


### PR DESCRIPTION
# Refactor: Rename internal "capture" terminology to "artifacts"

## Summary

Renames internal Go code structures, types, and variables from "capture" to "artifacts" to align with the external `--artifacts` flag (which replaced `--capture`).

## Changes

- `CaptureConfig` → `ArtifactsConfig`
- `FileCaptureConfig` → `FileArtifactsConfig`
- `FileCaptureType` → `FileArtifactsType`
- All related constants (`CaptureRegularFiles` → `ArtifactsRegularFiles`, etc.)
- Method names (`GetCapture()` → `GetArtifactsConfig()`, etc.)
- Variable names (`capturedFiles` → `artifactsFiles`, etc.)
- Comments and error messages updated

## What Was NOT Changed

**Event names** (`CaptureExec`, `CaptureFileWrite`, `CaptureFileRead`, etc.) were kept as-is for backward compatibility, as they are used in policies, signatures, and external integrations.

**C code** function names (`capture_file_write`, `capture_file_read`, etc.) were kept as-is since they are internal implementation details.

**Question**: Does it make sense to keep event names unchanged, or should we consider renaming them in a future breaking change?

## Testing

- All unit tests passing
- No logic changes, only renames (verified via git diff: 227 insertions, 227 deletions)