### PR TITLE
feat(events): require explicit tag= syntax for selecting events by tag

### DIFF
--- a/docs/docs/events/index.md
+++ b/docs/docs/events/index.md
@@ -51,8 +51,8 @@ tracee list --wide
 **Use in policies:**
 ```yaml
 rules:
-  - event: syscalls     # All system calls
-  - event: fs           # File system events
+  - event: tag=syscalls     # All system calls
+  - event: tag=fs           # File system events
 ```
 
 **Use on command line:**

--- a/docs/docs/flags/events.1.md
+++ b/docs/docs/flags/events.1.md
@@ -11,7 +11,7 @@ tracee **\-\-events** - Select which events to trace
 
 ## SYNOPSIS
 
-tracee **\-\-events** [<event-name1(,[-]event-name2...)\> | <[-]event-name1(,set1...)\> | <set1(,[-]event-name1,[-]event-name2...)\> | <event1.data.data-field[=|!=]value\> | <event1.retval[=|!=|<|\>|<=|\>=]value\> | <event1.scope.field[=|!=|<|\>|<=|\>=]value\> | <event.scope.container\>] ...
+tracee **\-\-events** [<event-name1(,[-]event-name2...)\> | <tag=tag1(,tag2...)\> | <event1.data.data-field[=|!=]value\> | <event1.retval[=|!=|<|\>|<=|\>=]value\> | <event1.scope.field[=|!=|<|\>|<=|\>=]value\> | <event.scope.container\>] ...
 
 ## DESCRIPTION
 
@@ -19,7 +19,9 @@ The **\-\-events** flag allows you to select which events to trace by defining f
 
 ## FILTERS
 
-- Event or set name: Select specific events using 'event-name1,event-name2...' or predefined event sets using 'event_set_name1,event_set_name2...'. To exclude events, prepend the event name with a dash '-': '-event-name'.
+- Event name: Select specific events using 'event-name1,event-name2...'. To exclude events, prepend the event name with a dash '-': '-event-name'.
+
+- Tag selection: Select events by tag (set) using 'tag=tag1,tag2...'. Multiple tags are combined with OR logic. Common tags include: syscalls, fs, network, proc, default.
 
 - Detector selection by threat properties: Select detectors based on their threat metadata using 'threat.property=value'. See THREAT-BASED DETECTOR SELECTION section below.
 
@@ -108,27 +110,27 @@ Threat selection can be combined with regular events. Multiple `--events` flags 
 
 ```console
 --events threat.severity=critical --events write    # Critical threats OR write events
---events fs --events 'threat.severity>=high'        # Filesystem events OR high+ threats
+--events tag=fs --events 'threat.severity>=high'    # Filesystem events OR high+ threats
 ```
 
 **Note:** Detector selection based on threat properties is performed once at startup. Matching detectors are enabled; non-matching detectors are never loaded.
 
-## DETECTOR TAG SELECTION
+## TAG SELECTION
 
-Detectors can be categorized with tags. You can select all detectors with a specific tag:
+Events are categorized with tags (also known as sets). You can select all events with a specific tag:
 
 ```console
---events containers       # All detectors tagged with "containers"
---events malware          # All detectors tagged with "malware"
---events detectors        # All detectors (existing behavior)
+--events tag=containers       # All events tagged with "containers"
+--events tag=fs               # All filesystem-related events
+--events tag=detectors        # All detector events
 ```
 
 Tags can be combined with other selection methods:
 
 ```console
---events containers,execve                # Detectors with "containers" tag + execve syscall
---events 'threat.severity=critical'       # Critical threats (any tag)
---events malware,'threat.severity>=high'  # Detectors with "malware" tag OR high+ severity threats
+--events tag=containers,execve            # Events with "containers" tag + execve syscall
+--events tag=fs,network                   # Filesystem OR network events
+--events tag=fs --events -open,-openat    # Filesystem events except open(at)
 ```
 
 ## EXAMPLES
@@ -148,13 +150,13 @@ Tags can be combined with other selection methods:
 - To trace all file-system related events, use the following flag:
 
   ```console
-  --events fs
+  --events tag=fs
   ```
 
 - To trace all file-system related events, but not 'open' or 'openat', use the following flag:
 
   ```console
-  --events fs --events '-open,-openat'
+  --events tag=fs --events '-open,-openat'
   ```
 
 - To trace only 'close' events that have 'fd' equal to 5, use the following flag:

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -112,7 +112,7 @@ ERRO permission denied loading eBPF program
    ```yaml
    rules:
      - event: execve        # Specific event
-     # - event: syscalls    # Avoid broad sets
+     # - event: tag=syscalls    # Avoid broad tags
    ```
 
 ## Container Issues

--- a/docs/man/events.1
+++ b/docs/man/events.1
@@ -8,9 +8,7 @@ date: 2024/12 \&...
 tracee \f[B]\-\-events\f[R] \- Select which events to trace
 .SS SYNOPSIS
 tracee \f[B]\-\-events\f[R] [<event\-name1(,[\-]event\-name2\&...)> |
-<[\-]event\-name1(,set1\&...)> |
-<set1(,[\-]event\-name1,[\-]event\-name2\&...)> |
-<event1.data.data\-field[=|!=]value> |
+<tag=tag1(,tag2\&...)> | <event1.data.data\-field[=|!=]value> |
 <event1.retval[=|!=|<|>|<=|>=]value> |
 <event1.scope.field[=|!=|<|>|<=|>=]value> | <event.scope.container>]
 \&...
@@ -19,11 +17,14 @@ The \f[B]\-\-events\f[R] flag allows you to select which events to trace
 by defining filters.
 .SS FILTERS
 .IP \[bu] 2
-Event or set name: Select specific events using
-`event\-name1,event\-name2\&...' or predefined event sets using
-`event_set_name1,event_set_name2\&...'.
+Event name: Select specific events using
+`event\-name1,event\-name2\&...'.
 To exclude events, prepend the event name with a dash `\-':
 `\-event\-name'.
+.IP \[bu] 2
+Tag selection: Select events by tag (set) using `tag=tag1,tag2\&...'.
+Multiple tags are combined with OR logic.
+Common tags include: syscalls, fs, network, proc, default.
 .IP \[bu] 2
 Detector selection by threat properties: Select detectors based on their
 threat metadata using `threat.property=value'.
@@ -135,29 +136,29 @@ Multiple \f[CR]\-\-events\f[R] flags are combined additively (OR logic):
 .IP
 .EX
 \-\-events threat.severity=critical \-\-events write    # Critical threats OR write events
-\-\-events fs \-\-events \[aq]threat.severity>=high\[aq]        # Filesystem events OR high+ threats
+\-\-events tag=fs \-\-events \[aq]threat.severity>=high\[aq]    # Filesystem events OR high+ threats
 .EE
 .PP
 \f[B]Note:\f[R] Detector selection based on threat properties is
 performed once at startup.
 Matching detectors are enabled; non\-matching detectors are never
 loaded.
-.SS DETECTOR TAG SELECTION
-Detectors can be categorized with tags.
-You can select all detectors with a specific tag:
+.SS TAG SELECTION
+Events are categorized with tags (also known as sets).
+You can select all events with a specific tag:
 .IP
 .EX
-\-\-events containers       # All detectors tagged with \[dq]containers\[dq]
-\-\-events malware          # All detectors tagged with \[dq]malware\[dq]
-\-\-events detectors        # All detectors (existing behavior)
+\-\-events tag=containers       # All events tagged with \[dq]containers\[dq]
+\-\-events tag=fs               # All filesystem\-related events
+\-\-events tag=detectors        # All detector events
 .EE
 .PP
 Tags can be combined with other selection methods:
 .IP
 .EX
-\-\-events containers,execve                # Detectors with \[dq]containers\[dq] tag + execve syscall
-\-\-events \[aq]threat.severity=critical\[aq]       # Critical threats (any tag)
-\-\-events malware,\[aq]threat.severity>=high\[aq]  # Detectors with \[dq]malware\[dq] tag OR high+ severity threats
+\-\-events tag=containers,execve            # Events with \[dq]containers\[dq] tag + execve syscall
+\-\-events tag=fs,network                   # Filesystem OR network events
+\-\-events tag=fs \-\-events \-open,\-openat    # Filesystem events except open(at)
 .EE
 .SS EXAMPLES
 .IP \[bu] 2
@@ -181,7 +182,7 @@ To trace all file\-system related events, use the following flag:
 .RS 2
 .IP
 .EX
-\-\-events fs
+\-\-events tag=fs
 .EE
 .RE
 .IP \[bu] 2
@@ -190,7 +191,7 @@ use the following flag:
 .RS 2
 .IP
 .EX
-\-\-events fs \-\-events \[aq]\-open,\-openat\[aq]
+\-\-events tag=fs \-\-events \[aq]\-open,\-openat\[aq]
 .EE
 .RE
 .IP \[bu] 2

--- a/pkg/cmd/flags/errors.go
+++ b/pkg/cmd/flags/errors.go
@@ -9,6 +9,10 @@ func InvalidEventError(event string) error {
 	return fmt.Errorf("invalid event to trace: %s", event)
 }
 
+func InvalidTagError(tag string) error {
+	return fmt.Errorf("invalid tag: %s", tag)
+}
+
 func InvalidEventExcludeError(event string) error {
 	return fmt.Errorf("invalid event to exclude: %s", event)
 }

--- a/pkg/cmd/flags/event_test.go
+++ b/pkg/cmd/flags/event_test.go
@@ -223,6 +223,43 @@ func TestParseEventFlag(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		// Tag selection
+		{
+			name:      "ValidEventFlag_TagSelection",
+			eventFlag: "tag=fs",
+			expected: []eventFlag{
+				{
+					full:              "tag=fs",
+					eventFilter:       "tag",
+					eventName:         "tag",
+					eventOptionType:   "",
+					eventOptionName:   "",
+					operator:          "=",
+					values:            "fs",
+					operatorAndValues: "=fs",
+					filter:            "",
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:      "ValidEventFlag_TagSelectionMultiple",
+			eventFlag: "tag=fs,network",
+			expected: []eventFlag{
+				{
+					full:              "tag=fs,network",
+					eventFilter:       "tag",
+					eventName:         "tag",
+					eventOptionType:   "",
+					eventOptionName:   "",
+					operator:          "=",
+					values:            "fs,network",
+					operatorAndValues: "=fs,network",
+					filter:            "",
+				},
+			},
+			expectedError: nil,
+		},
 
 		// Invalid
 		// InvalidFlagEmpty

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -2524,8 +2524,12 @@ func TestParseEventFiltersDetectorTags(t *testing.T) {
 		{
 			name: "detector tag selection - test_tag_a",
 			eventFlags: []eventFlag{{
-				full:      "test_tag_a",
-				eventName: "test_tag_a",
+				full:              "tag=test_tag_a",
+				eventFilter:       "tag",
+				eventName:         "tag",
+				operator:          "=",
+				values:            "test_tag_a",
+				operatorAndValues: "=test_tag_a",
 			}},
 			validate: func(t *testing.T, p *policy.Policy, eMap map[string]events.ID) {
 				// Should have detector_event1 and detector_event3 (both have "test_tag_a" tag)
@@ -2538,8 +2542,12 @@ func TestParseEventFiltersDetectorTags(t *testing.T) {
 		{
 			name: "detector tag selection - test_tag_b",
 			eventFlags: []eventFlag{{
-				full:      "test_tag_b",
-				eventName: "test_tag_b",
+				full:              "tag=test_tag_b",
+				eventFilter:       "tag",
+				eventName:         "tag",
+				operator:          "=",
+				values:            "test_tag_b",
+				operatorAndValues: "=test_tag_b",
 			}},
 			validate: func(t *testing.T, p *policy.Policy, eMap map[string]events.ID) {
 				// Should have only detector_event2
@@ -2553,8 +2561,12 @@ func TestParseEventFiltersDetectorTags(t *testing.T) {
 			name: "detector tag with regular event",
 			eventFlags: []eventFlag{
 				{
-					full:      "test_tag_a",
-					eventName: "test_tag_a",
+					full:              "tag=test_tag_a",
+					eventFilter:       "tag",
+					eventName:         "tag",
+					operator:          "=",
+					values:            "test_tag_a",
+					operatorAndValues: "=test_tag_a",
 				},
 				{
 					full:      "write",
@@ -2570,10 +2582,14 @@ func TestParseEventFiltersDetectorTags(t *testing.T) {
 			},
 		},
 		{
-			name: "all detectors set",
+			name: "all detectors tag",
 			eventFlags: []eventFlag{{
-				full:      "detectors",
-				eventName: "detectors",
+				full:              "tag=detectors",
+				eventFilter:       "tag",
+				eventName:         "tag",
+				operator:          "=",
+				values:            "detectors",
+				operatorAndValues: "=detectors",
 			}},
 			validate: func(t *testing.T, p *policy.Policy, eMap map[string]events.ID) {
 				// Should have all detector events (including built-in detectors, so check for ours)

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -736,7 +736,7 @@ func Test_EventFilters(t *testing.T) {
 							DefaultActions: []string{"log"},
 							Rules: []k8s.Rule{
 								{
-									Event:   "fs", // fs set
+									Event:   "tag=fs", // fs tag (set)
 									Filters: []string{},
 								},
 							},


### PR DESCRIPTION
BREAKING CHANGE: Event selection by tag (set) now requires explicit tag= prefix instead of implicit fallback from event names to sets.

Before: --events fs                    (implicit set selection)
After:  --events tag=fs               (explicit tag selection)
        --events tag=fs,network       (multiple tags with OR logic)

Changes:
- Add tag= parsing support in parseEventFlag
- Update parseEventFilters to handle tag= and remove implicit set fallback
- Update help text to use new tag= syntax
- Update documentation and examples
- Update tests for new syntax
