### PR TITLE
fix(container): skip Podman conmon cgroups

### DIFF
--- a/pkg/datastores/container/containers.go
+++ b/pkg/datastores/container/containers.go
@@ -362,8 +362,12 @@ func parseContainerIdFromCgroupPath(cgroupPath string) (string, runtime.RuntimeI
 			contRuntime = runtime.Containerd
 			id = pc[strings.LastIndex(pc, ":cri-containerd:")+len(":cri-containerd:"):]
 		case strings.HasPrefix(id, "libpod-"):
-			contRuntime = runtime.Podman
 			id = strings.TrimPrefix(id, "libpod-")
+			// Skip conmon cgroups - conmon is a monitoring process, not a container
+			if strings.HasPrefix(id, "conmon-") {
+				continue
+			}
+			contRuntime = runtime.Podman
 		}
 
 		if contRuntime != runtime.Unknown {

--- a/pkg/datastores/container/containers_test.go
+++ b/pkg/datastores/container/containers_test.go
@@ -31,7 +31,8 @@ func TestParseContainerIdFromCgroupPath(t *testing.T) {
 			expectedIsRoot:      true,
 		},
 		{
-			name:                "crio systemd format with conmon prefix (should be skipped)",
+			// not a container - for more see parseContainerIdFromCgroupPath() logic
+			name:                "crio systemd format with conmon prefix (Unknown)",
 			cgroupPath:          "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podb13213a6_d47e_4bd1_bc00_f175d1ad3b6e.slice/crio-conmon-eb5a56051cf7c5e9e588d0dca94d6673d67d43604686e1485984732b18701057.scope",
 			expectedContainerId: "",
 			expectedRuntime:     runtime.Unknown,
@@ -57,6 +58,14 @@ func TestParseContainerIdFromCgroupPath(t *testing.T) {
 			expectedContainerId: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
 			expectedRuntime:     runtime.Podman,
 			expectedIsRoot:      true,
+		},
+		{
+			// not a container - for more see parseContainerIdFromCgroupPath() logic
+			name:                "podman systemd format with conmon prefix (Unknown)",
+			cgroupPath:          "/machine.slice/libpod-conmon-64de256b4158dbfd331e27f93bf807f141883be795fd1b2ae7f40294f32c5bfd.scope",
+			expectedContainerId: "",
+			expectedRuntime:     runtime.Unknown,
+			expectedIsRoot:      false,
 		},
 		{
 			name:                "docker non-systemd format",


### PR DESCRIPTION
Podman uses conmon (container monitor) processes that have their own cgroups with paths like libpod-conmon-<container-id>. These are monitoring processes, not containers. Previously, Tracee would incorrectly recognize these as containers with ID conmon-<container-id>. Now properly skips conmon cgroups entirely, preventing false container identification.

This is analogous to the CRI-O fix in 63f348f.