### PR TITLE
chore(capabilities): add unit tests for caps

### DIFF
--- a/common/capabilities/capabilities.go
+++ b/common/capabilities/capabilities.go
@@ -1,3 +1,15 @@
+// Package capabilities provides a ring-based Linux capabilities management system
+// for Tracee. It implements a singleton pattern to manage process capabilities
+// through different execution protection rings:
+//
+//   - Full: All capabilities are effective (least secure)
+//   - EBPF: eBPF needed capabilities + Base capabilities
+//   - Specific: Specific requested capabilities + Base capabilities
+//   - Base: Capabilities that are always effective (most secure)
+//
+// The package supports a bypass mode (Bypass=true) where capability changes
+// are tracked in memory but not applied to the actual process, allowing
+// testing and development without root privileges.
 package capabilities
 
 import (
@@ -18,15 +30,36 @@ var caps *Capabilities   // singleton for all packages
 var capsMutex sync.Mutex // mutex to protect access to caps
 var once sync.Once
 
+// RingType represents the execution protection ring level for capabilities.
+// Rings provide different levels of capability access, with Base being the
+// most restrictive and Full being the least restrictive.
 type RingType int
 
 const (
-	Full     RingType = iota // All capabilties are effective
-	EBPF                     // eBPF needed capabilities are effective
-	Specific                 // Specific requested capabilities are effective
-	Base                     // Capabilities that are always effective
+	// Full ring enables all capabilities. This is the least secure mode
+	// and should only be used when necessary.
+	Full RingType = iota
+
+	// EBPF ring enables eBPF-related capabilities plus base capabilities.
+	// Used for eBPF operations that require specific Linux capabilities.
+	EBPF
+
+	// Specific ring enables only the requested capabilities plus base capabilities.
+	// Used for operations that need temporary access to specific capabilities.
+	Specific
+
+	// Base ring contains capabilities that are always effective.
+	// This is the default and most secure ring.
+	Base
 )
 
+// Capabilities manages Linux capabilities through a ring-based execution model.
+// It provides methods to temporarily elevate capabilities for specific operations
+// and automatically return to the base ring afterward.
+//
+// The struct uses a singleton pattern and should be accessed via GetInstance()
+// or Initialize(). When Bypass is true, capability changes are tracked in memory
+// but not applied to the actual process.
 type Capabilities struct {
 	have     *cap.Set
 	all      map[cap.Value]map[RingType]bool
@@ -35,8 +68,15 @@ type Capabilities struct {
 	lock     *sync.Mutex // big lock to guarantee all threads are on the same ring
 }
 
+// Config holds configuration options for initializing the capabilities manager.
 type Config struct {
-	Bypass   bool
+	// Bypass, when true, disables actual capability changes and operates
+	// entirely in memory. Useful for testing and development without root.
+	Bypass bool
+
+	// BaseEbpf, when true, adds eBPF-related capabilities to the base ring
+	// instead of the eBPF ring. This means eBPF capabilities are always
+	// available without needing to switch to the EBPF ring.
 	BaseEbpf bool
 }
 
@@ -58,7 +98,14 @@ func initializeOnce(cfg Config) error {
 	return errfmt.WrapError(err)
 }
 
-// Initialize initializes the "caps" instance (singleton).
+// Initialize initializes the capabilities singleton instance with the given configuration.
+// This function is thread-safe and will only initialize once, even if called multiple times.
+//
+// When Bypass is true, the capabilities manager operates in bypass mode where
+// capability changes are tracked but not applied to the process.
+//
+// Returns an error if initialization fails (e.g., unable to read process capabilities
+// when Bypass is false).
 func Initialize(cfg Config) error {
 	capsMutex.Lock()
 	defer capsMutex.Unlock()
@@ -66,8 +113,11 @@ func Initialize(cfg Config) error {
 	return initializeOnce(cfg)
 }
 
-// GetInstance returns current "caps" instance. It initializes capabilities if
-// needed, bypassing the privilege dropping by default, and not adding eBPF to the base.
+// GetInstance returns the current capabilities instance, initializing it if needed.
+// If the instance doesn't exist, it auto-initializes with Bypass=true and BaseEbpf=false.
+//
+// This is the recommended way to access the capabilities manager for most use cases.
+// Returns nil if initialization fails.
 func GetInstance() *Capabilities {
 	capsMutex.Lock()
 	defer capsMutex.Unlock()
@@ -86,19 +136,41 @@ func GetInstance() *Capabilities {
 }
 
 func (c *Capabilities) initialize(cfg Config) error {
-	if cfg.Bypass {
-		c.bypass = true
-		return nil
-	}
-
+	c.bypass = cfg.Bypass
 	c.baseEbpf = cfg.BaseEbpf
 
+	// Always initialize internal state map, even in bypass mode
+	// Bypass only affects system calls in apply(), not state tracking
 	c.all = make(map[cap.Value]map[RingType]bool)
 
 	for v := cap.Value(0); v < cap.MaxBits(); v++ {
 		c.all[v] = make(map[RingType]bool)
 		c.all[v][Full] = true // all capabilities are effective in Full
 		// all other ring types are false by default
+	}
+
+	// Add eBPF related capabilities to eBPF ring (always update state)
+	if c.baseEbpf {
+		err := c.baseRingAdd(
+			cap.IPC_LOCK,
+			cap.SYS_RESOURCE,
+		)
+		if err != nil {
+			logger.Fatalw("Adding initial capabilities to EBPF ring", "error", err)
+		}
+	} else {
+		err := c.eBPFRingAdd(
+			cap.IPC_LOCK,
+			cap.SYS_RESOURCE,
+		)
+		if err != nil {
+			logger.Fatalw("Adding initial capabilities to EBPF ring", "error", err)
+		}
+	}
+
+	// In bypass mode, skip system calls but keep state initialized
+	if c.bypass {
+		return nil
 	}
 
 	err := c.getProc()
@@ -116,23 +188,6 @@ func (c *Capabilities) initialize(cfg Config) error {
 	err = c.setProc()
 	if err != nil {
 		return errfmt.WrapError(err)
-	}
-
-	// Add eBPF related capabilities to eBPF ring
-
-	if c.baseEbpf {
-		err = c.baseRingAdd(
-			cap.IPC_LOCK,
-			cap.SYS_RESOURCE,
-		)
-	} else {
-		err = c.eBPFRingAdd(
-			cap.IPC_LOCK,
-			cap.SYS_RESOURCE,
-		)
-	}
-	if err != nil {
-		logger.Fatalw("Adding initial capabilities to EBPF ring", "error", err)
 	}
 
 	// Kernels bellow v5.8 do not support cap.BPF + cap.PERFMON (instead of
@@ -201,40 +256,51 @@ func (c *Capabilities) initialize(cfg Config) error {
 	return c.apply(Base) // Base ring is always effective
 }
 
-// Public Methods
-
+// Full temporarily elevates to the Full ring (all capabilities enabled),
+// executes the callback, then returns to the Base ring.
+//
+// When bypass mode is enabled, this method executes the callback without
+// actually changing capabilities.
+//
+// The callback's error is returned. If an error occurs during ring switching,
+// it is wrapped and returned.
 func (c *Capabilities) Full(cb func() error) error {
 	var err error
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if !c.bypass {
-		err = c.apply(Full) // move to ring Full
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
+	err = c.apply(Full) // move to ring Full
+	if err != nil {
+		return errfmt.WrapError(err)
 	}
 
 	errCb := cb() // callback
 
-	if !c.bypass {
-		err = c.apply(Base) // back to ring Base
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
+	err = c.apply(Base) // back to ring Base
+	if err != nil {
+		return errfmt.WrapError(err)
 	}
 
 	return errCb
 }
 
+// EBPF temporarily elevates to the EBPF ring (eBPF capabilities + base),
+// executes the callback, then returns to the Base ring.
+//
+// When baseEbpf is true, this method executes the callback without switching
+// rings (since eBPF caps are already available). In bypass mode, system calls
+// are skipped but state tracking continues.
+//
+// The callback's error is returned. If an error occurs during ring switching,
+// it is wrapped and returned.
 func (c *Capabilities) EBPF(cb func() error) error {
 	var err error
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if !c.bypass && !c.baseEbpf {
+	if !c.baseEbpf {
 		err = c.apply(EBPF) // move to ring EBPF
 		if err != nil {
 			return errfmt.WrapError(err)
@@ -243,7 +309,7 @@ func (c *Capabilities) EBPF(cb func() error) error {
 
 	errCb := cb() // callback
 
-	if !c.bypass && !c.baseEbpf {
+	if !c.baseEbpf {
 		err = c.apply(Base) // back to ring Base
 		if err != nil {
 			return errfmt.WrapError(err)
@@ -253,25 +319,33 @@ func (c *Capabilities) EBPF(cb func() error) error {
 	return errCb
 }
 
+// Specific temporarily enables the specified capabilities in the Specific ring,
+// executes the callback, then returns to the Base ring and cleans up the Specific ring.
+//
+// The Specific ring is cleaned up before the callback executes (internal state only).
+// The process capabilities remain active during the callback, but the internal state
+// is cleared to ensure it doesn't affect subsequent calls. In bypass mode,
+// system calls are skipped but state tracking continues.
+//
+// The callback's error is returned. If an error occurs during ring operations,
+// it is wrapped and returned.
 func (c *Capabilities) Specific(cb func() error, values ...cap.Value) error {
 	var err error
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if !c.bypass {
-		err = c.set(Specific, values...)
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
-		err = c.apply(Specific) // move to ring Specific
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
-		err = c.unset(Specific, values...) // clean specific ring for next calls
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
+	err = c.set(Specific, values...)
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+	err = c.apply(Specific) // move to ring Specific
+	if err != nil {
+		return errfmt.WrapError(err)
+	}
+	err = c.unset(Specific, values...) // clean specific ring for next calls
+	if err != nil {
+		return errfmt.WrapError(err)
 	}
 
 	errCb := cb()
@@ -279,18 +353,18 @@ func (c *Capabilities) Specific(cb func() error, values ...cap.Value) error {
 		logger.Debugw("Capabilities specific ring callback", "error", errCb)
 	}
 
-	if !c.bypass {
-		err = c.apply(Base) // back to ring Base
-		if err != nil {
-			return errfmt.WrapError(err)
-		}
+	err = c.apply(Base) // back to ring Base
+	if err != nil {
+		return errfmt.WrapError(err)
 	}
 
 	return errCb
 }
 
-// setters/getters
-
+// EBPFRingAdd adds the specified capabilities to the EBPF ring.
+// These capabilities will be available when switching to the EBPF ring.
+//
+// Returns an error if any of the specified capabilities are invalid.
 func (c *Capabilities) EBPFRingAdd(values ...cap.Value) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -298,6 +372,10 @@ func (c *Capabilities) EBPFRingAdd(values ...cap.Value) error {
 	return c.eBPFRingAdd(values...)
 }
 
+// EBPFRingRemove removes the specified capabilities from the EBPF ring.
+// These capabilities will no longer be available when switching to the EBPF ring.
+//
+// Returns an error if any of the specified capabilities are invalid.
 func (c *Capabilities) EBPFRingRemove(values ...cap.Value) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -305,6 +383,13 @@ func (c *Capabilities) EBPFRingRemove(values ...cap.Value) error {
 	return c.eBPFRingRemove(values...)
 }
 
+// BaseRingAdd adds the specified capabilities to the base ring and propagates
+// them to all other rings (EBPF and Specific). Base ring capabilities are
+// always effective regardless of the current ring.
+//
+// Internal state is always updated and changes are immediately applied.
+// In bypass mode, system calls are skipped but state tracking continues.
+// Returns an error if any of the specified capabilities are invalid.
 func (c *Capabilities) BaseRingAdd(values ...cap.Value) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -312,14 +397,19 @@ func (c *Capabilities) BaseRingAdd(values ...cap.Value) error {
 	return c.baseRingAdd(values...)
 }
 
+// BaseRingRemove removes the specified capabilities from the base ring and
+// all other rings (EBPF and Specific). Base ring capabilities are always effective,
+// so removing them affects all rings.
+//
+// Internal state is always updated and changes are immediately applied.
+// In bypass mode, system calls are skipped but state tracking continues.
+// Returns an error if any of the specified capabilities are invalid.
 func (c *Capabilities) BaseRingRemove(values ...cap.Value) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	return c.baseRingRemove(values...)
 }
-
-// Private Methods
 
 func (c *Capabilities) eBPFRingAdd(values ...cap.Value) error {
 	logger.Debugw("Adding capabilities to EBPF ring", "capability", values)
@@ -374,27 +464,13 @@ func (c *Capabilities) baseRingRemove(values ...cap.Value) error {
 }
 
 func (c *Capabilities) ringAdd(ring RingType, values ...cap.Value) error {
-	var err error
-
-	if c.bypass {
-		return nil
-	}
-
-	err = c.set(ring, values...)
-
-	return errfmt.WrapError(err)
+	// Always update internal state - bypass only affects system calls in apply()
+	return errfmt.WrapError(c.set(ring, values...))
 }
 
 func (c *Capabilities) ringRemove(ring RingType, values ...cap.Value) error {
-	var err error
-
-	if c.bypass {
-		return nil
-	}
-
-	err = c.unset(ring, values...)
-
-	return errfmt.WrapError(err)
+	// Always update internal state - bypass only affects system calls in apply()
+	return errfmt.WrapError(c.unset(ring, values...))
 }
 
 func (c *Capabilities) getProc() error {
@@ -440,6 +516,12 @@ func (c *Capabilities) unset(t RingType, values ...cap.Value) error {
 }
 
 func (c *Capabilities) apply(t RingType) error {
+	// In bypass mode, skip actual system calls but still track state changes
+	if c.bypass {
+		logger.Debugw("Capabilities change (bypass mode)", "ring", t)
+		return nil
+	}
+
 	var err error
 
 	err = c.getProc()
@@ -462,10 +544,6 @@ func (c *Capabilities) apply(t RingType) error {
 	return c.setProc()
 }
 
-//
-// Error Functions
-//
-
 func couldNotFindCapability(c string) error {
 	return fmt.Errorf("could not find capability: %v", c)
 }
@@ -482,10 +560,17 @@ func couldNotGetProc(e error) error {
 	return fmt.Errorf("could not get capabilities: %v", e)
 }
 
+// ReqByString converts capability string names to cap.Value types.
+// It accepts one or more capability names (e.g., "CAP_SYS_ADMIN", "CAP_NET_ADMIN")
+// and returns the corresponding cap.Value slice.
 //
-// Standalone Functions
+// Returns an error if any of the provided capability names are invalid or not found.
+// Example:
 //
-
+//	values, err := ReqByString("CAP_SYS_ADMIN", "CAP_NET_ADMIN")
+//	if err != nil {
+//	    return err
+//	}
 func ReqByString(values ...string) ([]cap.Value, error) {
 	var found bool
 	var capsToActOn []cap.Value

--- a/common/capabilities/capabilities_test.go
+++ b/common/capabilities/capabilities_test.go
@@ -1,11 +1,13 @@
 package capabilities
 
 import (
+	"errors"
 	"sync"
 	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 )
@@ -144,5 +146,366 @@ func TestCapabilities_Concurrent(t *testing.T) {
 func assureIsRoot(t *testing.T) {
 	if syscall.Geteuid() != 0 {
 		t.Skipf("***** %s must be run as ROOT *****", t.Name())
+	}
+}
+
+func TestInitialize_MultipleCalls(t *testing.T) {
+	// First call should succeed
+	err1 := Initialize(Config{Bypass: true})
+	require.NoError(t, err1)
+
+	// Subsequent calls should also succeed (singleton pattern)
+	err2 := Initialize(Config{Bypass: true})
+	require.NoError(t, err2)
+
+	// Both should return the same instance
+	caps1 := GetInstance()
+	caps2 := GetInstance()
+	assert.Equal(t, caps1, caps2)
+}
+
+func TestCapabilities_Full_WithBypass(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	callbackExecuted := false
+	err = caps.Full(func() error {
+		callbackExecuted = true
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, callbackExecuted, "Callback should have been executed")
+}
+
+func TestCapabilities_Full_CallbackError(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	expectedErr := errors.New("callback error")
+	err = caps.Full(func() error {
+		return expectedErr
+	})
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestCapabilities_EBPF_WithBypass(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	callbackExecuted := false
+	err = caps.EBPF(func() error {
+		callbackExecuted = true
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, callbackExecuted, "Callback should have been executed")
+}
+
+func TestCapabilities_Specific_WithBypass(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	callbackExecuted := false
+	err = caps.Specific(func() error {
+		callbackExecuted = true
+		return nil
+	}, cap.SYS_ADMIN)
+
+	assert.NoError(t, err)
+	assert.True(t, callbackExecuted, "Callback should have been executed")
+}
+
+func TestReqByString_ValidCapabilities(t *testing.T) {
+	// Get the actual string format from the library
+	actualFormat := cap.SYS_ADMIN.String()
+	values, err := ReqByString(actualFormat)
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Equal(t, cap.SYS_ADMIN, values[0])
+}
+
+func TestReqByString_InvalidCapability(t *testing.T) {
+	values, err := ReqByString("CAP_INVALID_CAPABILITY")
+	assert.Error(t, err)
+	assert.Nil(t, values)
+	assert.Contains(t, err.Error(), "could not find capability")
+}
+
+func TestReqByString_MultipleCapabilities(t *testing.T) {
+	// Get the actual string format from the library
+	sysAdminStr := cap.SYS_ADMIN.String()
+	netAdminStr := cap.NET_ADMIN.String()
+	values, err := ReqByString(sysAdminStr, netAdminStr)
+	require.NoError(t, err)
+	require.Len(t, values, 2)
+	assert.Equal(t, cap.SYS_ADMIN, values[0])
+	assert.Equal(t, cap.NET_ADMIN, values[1])
+}
+
+func TestReqByString_EmptyList(t *testing.T) {
+	values, err := ReqByString()
+	require.NoError(t, err)
+	assert.Empty(t, values)
+}
+
+func TestListAvailCaps(t *testing.T) {
+	caps := ListAvailCaps()
+	require.NotEmpty(t, caps)
+
+	// Verify it contains expected capabilities by checking against actual format
+	expectedCap := cap.SYS_ADMIN.String()
+	found := false
+	for _, c := range caps {
+		if c == expectedCap {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Should contain %s", expectedCap)
+}
+
+func TestCapabilities_EBPFRingAdd_StateUpdate(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Clean up any existing state from previous tests
+	cleanupCapabilities(caps, cap.SYS_PTRACE)
+
+	// Initially, CAP_SYS_PTRACE should not be in EBPF ring
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should not be in EBPF ring initially")
+
+	// Add to EBPF ring
+	err = caps.EBPFRingAdd(cap.SYS_PTRACE)
+	require.NoError(t, err)
+
+	// Verify it's now in EBPF ring
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should be in EBPF ring after EBPFRingAdd")
+
+	// Verify it's NOT in Base ring (EBPFRingAdd only adds to EBPF)
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, Base), "CAP_SYS_PTRACE should not be in Base ring after EBPFRingAdd")
+
+	// Verify it's NOT in Specific ring
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, Specific), "CAP_SYS_PTRACE should not be in Specific ring after EBPFRingAdd")
+}
+
+func TestCapabilities_BaseRingAdd_PropagatesToAllRings(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Clean up any existing state from previous tests (singleton pattern means state persists)
+	cleanupCapabilities(caps, cap.SYS_PTRACE)
+
+	// Initially, CAP_SYS_PTRACE should not be in any ring
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, Base), "CAP_SYS_PTRACE should not be in Base ring initially")
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should not be in EBPF ring initially")
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, Specific), "CAP_SYS_PTRACE should not be in Specific ring initially")
+
+	// Add to Base ring (should propagate to all rings)
+	err = caps.BaseRingAdd(cap.SYS_PTRACE)
+	require.NoError(t, err)
+
+	// Verify it's in ALL rings
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, Base), "CAP_SYS_PTRACE should be in Base ring after BaseRingAdd")
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should be in EBPF ring after BaseRingAdd")
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, Specific), "CAP_SYS_PTRACE should be in Specific ring after BaseRingAdd")
+}
+
+func TestCapabilities_EBPFRingRemove_StateUpdate(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Clean up any existing state from previous tests
+	cleanupCapabilities(caps, cap.SYS_PTRACE)
+
+	// First add the capability
+	err = caps.EBPFRingAdd(cap.SYS_PTRACE)
+	require.NoError(t, err)
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should be in EBPF ring after add")
+
+	// Remove from EBPF ring
+	err = caps.EBPFRingRemove(cap.SYS_PTRACE)
+	require.NoError(t, err)
+
+	// Verify it's removed from EBPF ring
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should not be in EBPF ring after EBPFRingRemove")
+}
+
+func TestCapabilities_BaseRingRemove_RemovesFromAllRings(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Clean up any existing state from previous tests
+	cleanupCapabilities(caps, cap.SYS_PTRACE)
+
+	// First add the capability to all rings
+	err = caps.BaseRingAdd(cap.SYS_PTRACE)
+	require.NoError(t, err)
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, Base), "CAP_SYS_PTRACE should be in Base ring after add")
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should be in EBPF ring after add")
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, Specific), "CAP_SYS_PTRACE should be in Specific ring after add")
+
+	// Remove from Base ring (should remove from all rings)
+	err = caps.BaseRingRemove(cap.SYS_PTRACE)
+	require.NoError(t, err)
+
+	// Verify it's removed from ALL rings
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, Base), "CAP_SYS_PTRACE should not be in Base ring after BaseRingRemove")
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should not be in EBPF ring after BaseRingRemove")
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, Specific), "CAP_SYS_PTRACE should not be in Specific ring after BaseRingRemove")
+}
+
+func TestCapabilities_Full_RingState(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Initially, capabilities should be in Full ring (set during initialization)
+	assert.True(t, getCapabilityState(caps, cap.SYS_ADMIN, Full), "CAP_SYS_ADMIN should be in Full ring by default")
+
+	// Use Full() which switches to Full ring, executes callback, then returns to Base
+	capInFullDuringCallback := false
+	capInBaseBeforeCallback := false
+	capInBaseAfterCallback := false
+
+	// Check Base ring before Full() - should be false (capabilities not in Base by default)
+	capInBaseBeforeCallback = getCapabilityState(caps, cap.SYS_ADMIN, Base)
+
+	// Full() switches to Full ring, executes callback, then returns to Base
+	// Use getCapabilityStateUnsafe inside callback since lock is already held
+	err = caps.Full(func() error {
+		// During callback, Full ring should have the capability
+		capInFullDuringCallback = getCapabilityStateUnsafe(caps, cap.SYS_ADMIN, Full)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Verify Full ring has the capability during callback
+	assert.True(t, capInFullDuringCallback, "CAP_SYS_ADMIN should be in Full ring during callback")
+
+	// After callback, check Base ring again
+	capInBaseAfterCallback = getCapabilityState(caps, cap.SYS_ADMIN, Base)
+
+	// Base ring should remain unchanged (Full() doesn't modify Base ring state)
+	assert.Equal(t, capInBaseBeforeCallback, capInBaseAfterCallback, "Base ring state should not change after Full()")
+}
+
+func TestCapabilities_Specific_RingState(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Initially, CAP_SYS_ADMIN should not be in Specific ring
+	assert.False(t, getCapabilityState(caps, cap.SYS_ADMIN, Specific), "CAP_SYS_ADMIN should not be in Specific ring initially")
+
+	// Specific() sets, applies, unsets, then executes callback
+	// Use getCapabilityStateUnsafe inside callback since lock is already held
+	capInSpecificDuringCallback := false
+	err = caps.Specific(func() error {
+		// During callback, check if capability was in Specific ring
+		// Note: Specific() unsets before callback, so it should be false
+		capInSpecificDuringCallback = getCapabilityStateUnsafe(caps, cap.SYS_ADMIN, Specific)
+		return nil
+	}, cap.SYS_ADMIN)
+	require.NoError(t, err)
+
+	// Specific() unsets the capability before callback, so it should be false
+	assert.False(t, capInSpecificDuringCallback, "CAP_SYS_ADMIN should not be in Specific ring during callback (unset before callback)")
+
+	// After callback, should still be false
+	assert.False(t, getCapabilityState(caps, cap.SYS_ADMIN, Specific), "CAP_SYS_ADMIN should not be in Specific ring after callback")
+}
+
+func TestCapabilities_MultipleCapabilities_StateUpdate(t *testing.T) {
+	err := Initialize(Config{Bypass: true})
+	require.NoError(t, err)
+
+	caps := GetInstance()
+	require.NotNil(t, caps)
+
+	// Clean up any existing state from previous tests
+	cleanupCapabilities(caps, cap.SYS_PTRACE, cap.SYS_ADMIN)
+
+	// Add multiple capabilities to EBPF ring
+	err = caps.EBPFRingAdd(cap.SYS_PTRACE, cap.SYS_ADMIN)
+	require.NoError(t, err)
+
+	// Verify both are in EBPF ring
+	assert.True(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should be in EBPF ring")
+	assert.True(t, getCapabilityState(caps, cap.SYS_ADMIN, EBPF), "CAP_SYS_ADMIN should be in EBPF ring")
+
+	// Remove one
+	err = caps.EBPFRingRemove(cap.SYS_PTRACE)
+	require.NoError(t, err)
+
+	// Verify one removed, one still present
+	assert.False(t, getCapabilityState(caps, cap.SYS_PTRACE, EBPF), "CAP_SYS_PTRACE should not be in EBPF ring after remove")
+	assert.True(t, getCapabilityState(caps, cap.SYS_ADMIN, EBPF), "CAP_SYS_ADMIN should still be in EBPF ring")
+}
+
+// getCapabilityState is a test helper that exposes the internal state for testing.
+// It returns whether a capability is enabled for a given ring type.
+//
+// IMPORTANT: This function acquires a lock and should NOT be called from within
+// callbacks passed to Full(), EBPF(), or Specific() methods, as those methods
+// already hold the lock and Go mutexes are not re-entrant (would cause deadlock).
+//
+// Safe usage: Call between method invocations (e.g., after EBPFRingAdd() returns).
+func getCapabilityState(c *Capabilities, capValue cap.Value, ring RingType) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if m, exists := c.all[capValue]; exists {
+		return m[ring]
+	}
+	return false
+}
+
+// getCapabilityStateUnsafe is a test helper that reads state WITHOUT locking.
+// It should ONLY be called when the lock is already held (e.g., from within callbacks).
+// This is safe because the caller already holds the lock, preventing concurrent modifications.
+func getCapabilityStateUnsafe(c *Capabilities, capValue cap.Value, ring RingType) bool {
+	if m, exists := c.all[capValue]; exists {
+		return m[ring]
+	}
+	return false
+}
+
+// cleanupCapabilities removes the specified capabilities from all rings.
+// This is a test helper to ensure clean state between tests (singleton pattern means state persists).
+func cleanupCapabilities(c *Capabilities, values ...cap.Value) {
+	for _, v := range values {
+		_ = c.BaseRingRemove(v)
+		_ = c.EBPFRingRemove(v)
 	}
 }


### PR DESCRIPTION
Fix https://github.com/aquasecurity/tracee/issues/2258

# Refactor capabilities package for better testability

## Summary

This PR refactors the `common/capabilities` package to improve unit test coverage without requiring root privileges or mocks. The key change is decoupling internal state management from actual system capability calls, allowing comprehensive testing of logic and state transitions in bypass mode.

## Problem

Previously, the capabilities package had limited testability because:
- Internal state updates (`c.all` map) were skipped in bypass mode
- Tests couldn't verify that capabilities were correctly added/removed from rings
- Bypass checks were scattered throughout methods, making it hard to test logic flow
- Tests required root privileges or couldn't validate important functionality

## Solution

Refactored the code to:
1. **Always update internal state** - The `c.all` map is always updated regardless of bypass mode
2. **Centralize bypass logic** - Bypass checks only affect actual system calls in `apply()` and `initialize()`
3. **Enable state verification** - Tests can now verify internal state changes without root

## Changes Made

### Code Refactoring (`capabilities.go`)

- **Removed bypass checks from state management methods**:
  - `Full()`, `EBPF()`, `Specific()` - Always call `apply()` and update state
  - `ringAdd()`, `ringRemove()` - Always update internal state
  - `baseRingAdd()`, `baseRingRemove()` - Always propagate to all rings

- **Added bypass check in `apply()`**:
  - System calls (`getProc()`, `setFlag()`, `setProc()`) are skipped in bypass mode
  - Internal state tracking continues regardless

- **Added bypass check in `initialize()`**:
  - System calls (`getProc()`, `DropBound()`, `setProc()`, kernel checks) are skipped in bypass mode
  - Internal state (`c.all` map) is always initialized

- **Updated godoc comments** to reflect that bypass mode only affects system calls, not state tracking

### Test Improvements (`capabilities_test.go`)

- **Added comprehensive state verification tests**:
  - `TestCapabilities_EBPFRingAdd_StateUpdate` - Verifies EBPFRingAdd only adds to EBPF ring
  - `TestCapabilities_BaseRingAdd_PropagatesToAllRings` - Verifies BaseRingAdd propagates to all rings
  - `TestCapabilities_EBPFRingRemove_StateUpdate` - Verifies removal works correctly
  - `TestCapabilities_BaseRingRemove_RemovesFromAllRings` - Verifies BaseRingRemove removes from all rings
  - `TestCapabilities_Full_RingState` - Verifies Full ring state during callbacks
  - `TestCapabilities_Specific_RingState` - Verifies Specific ring behavior
  - `TestCapabilities_MultipleCapabilities_StateUpdate` - Tests multiple capabilities

- **Added test helpers**:
  - `getCapabilityState()` - Thread-safe helper to read capability state (locks)
  - `getCapabilityStateUnsafe()` - Helper for reading state within callbacks (no lock, safe when lock already held)
  - `cleanupCapabilities()` - Helper to clean up state between tests for isolation

- **Improved test isolation**:
  - All tests call `Initialize()` at the start for known state
  - Tests that verify initial state use `cleanupCapabilities()` to remove leftover state
  - Concurrent tests still use `GetInstance()` directly to test singleton behavior