### PR TITLE
refactor(tracee): encapsulate enrichment config

### DIFF
--- a/pkg/cmd/flags/output_test.go
+++ b/pkg/cmd/flags/output_test.go
@@ -38,7 +38,6 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "default format",
 			outputSlice: []string{},
 			expectedOutput: config.OutputConfig{
-				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -53,7 +52,6 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "table to stdout",
 			outputSlice: []string{"table"},
 			expectedOutput: config.OutputConfig{
-				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -68,7 +66,6 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "table to /tmp/table",
 			outputSlice: []string{"table:/tmp/table"},
 			expectedOutput: config.OutputConfig{
-				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -83,7 +80,6 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "table to stdout, and to /tmp/table",
 			outputSlice: []string{"table", "table:/tmp/table"},
 			expectedOutput: config.OutputConfig{
-				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -161,7 +157,6 @@ func TestPrepareOutput(t *testing.T) {
 				"gotemplate=template.tmpl:/tmp/gotemplate1",
 			},
 			expectedOutput: config.OutputConfig{
-				DecodedData: true,
 				Streams: []config.Stream{
 					{
 						Name: "default-stream",
@@ -284,7 +279,6 @@ func TestPrepareOutput(t *testing.T) {
 			testName:    "sort-events",
 			outputSlice: []string{"sort-events"},
 			expectedOutput: config.OutputConfig{
-				DecodedData:   true,
 				EventsSorting: true,
 				Streams: []config.Stream{
 					{
@@ -620,17 +614,13 @@ func TestPrepareOutput(t *testing.T) {
 				}
 			}()
 
-			output, err := PrepareOutput(testcase.outputSlice, config.ContainerModeDisabled)
+			enrichmentConfig := &config.EnrichmentConfig{}
+			output, err := PrepareOutput(testcase.outputSlice, config.ContainerModeDisabled, enrichmentConfig)
 			if err != nil {
 				require.NotNil(t, testcase.expectedError)
 				assert.Contains(t, err.Error(), testcase.expectedError.Error())
 			} else {
-				assert.Equal(t, testcase.expectedOutput.CalcHashes, output.CalcHashes)
 				assert.Equal(t, testcase.expectedOutput.EventsSorting, output.EventsSorting)
-				assert.Equal(t, testcase.expectedOutput.Environment, output.Environment)
-				assert.Equal(t, testcase.expectedOutput.DecodedData, output.DecodedData)
-				assert.Equal(t, testcase.expectedOutput.FdPaths, output.FdPaths)
-				assert.Equal(t, testcase.expectedOutput.UserStack, output.UserStack)
 				assert.Equal(t, len(testcase.expectedOutput.Streams), len(output.Streams))
 
 				assertPrinterConfigs(t, testcase.expectedOutput.Streams, output.Streams)

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -59,7 +59,7 @@ func (t *Tracee) handleEvents(ctx context.Context, initialized chan<- struct{}) 
 
 	// Enrichment stage: container events are enriched with additional runtime data.
 
-	if t.config.EnrichmentEnabled {
+	if t.config.Enrichment.EnrichContainers() {
 		eventsChan, errc = t.enrichContainerEvents(ctx, eventsChan)
 		t.stats.Channels["enrich"] = eventsChan
 		errcList = append(errcList, errc)
@@ -159,7 +159,7 @@ func (t *Tracee) decodeEvents(ctx context.Context, sourceChan chan []byte) (<-ch
 
 			// Add stack trace if needed
 			var stackAddresses []uint64
-			if t.config.Output.UserStack {
+			if t.config.Enrichment.EnrichUserStack() {
 				stackAddresses = t.getStackAddresses(eCtx.StackID)
 			}
 
@@ -799,14 +799,14 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *events.PipelineEvent
 			pbEvent.Policies.Matched = t.policyManager.MatchedNames(event.MatchedPoliciesBitmap)
 
 			// Parse arguments for output formatting if enabled.
-			if t.config.Output.DecodedData {
+			if t.config.Enrichment.EnrichDecodedData() {
 				err := events.ParseDataFields(pbEvent.Data, int(pbEvent.Id))
 				if err != nil {
 					t.handleError(err)
 				}
 			}
 
-			if t.config.Output.FdPaths {
+			if t.config.Enrichment.EnrichFDPaths() {
 				// Use original timestamp from pipeline metadata for BPF map lookup
 				err := events.ParseDataFieldsFDs(pbEvent.Data, event.Timestamp, t.FDArgPathMap)
 				if err != nil {

--- a/pkg/ebpf/processor_funcs.go
+++ b/pkg/ebpf/processor_funcs.go
@@ -126,7 +126,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 	}
 
 	// capture executed files
-	if t.config.Artifacts.Exec || t.config.Output.CalcHashes != digest.CalcHashesNone {
+	if t.config.Artifacts.Exec || t.shouldCalcHashes() {
 		filePath, err := parse.ArgVal[string](event.Args, "pathname")
 		if err != nil {
 			return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
@@ -187,7 +187,7 @@ func (t *Tracee) processSchedProcessExec(event *trace.Event) error {
 				}
 			}
 			// check exec'ed hash ?
-			if t.config.Output.CalcHashes != digest.CalcHashesNone {
+			if t.shouldCalcHashes() {
 				dev, err := parse.ArgVal[uint32](event.Args, "dev")
 				if err != nil {
 					return errfmt.Errorf("error parsing sched_process_exec args: %v", err)
@@ -408,7 +408,7 @@ func (t *Tracee) processSharedObjectLoaded(event *trace.Event) error {
 	if containerId == "" {
 		containerId = "host"
 	}
-	if t.config.Output.CalcHashes != digest.CalcHashesNone {
+	if t.shouldCalcHashes() {
 		fileKey := digest.NewKey(filePath, uint32(event.MountNS),
 			digest.WithDevice(dev),
 			digest.WithInode(ino, int64(fileCtime)),

--- a/tests/compatibility/compatibility_test.go
+++ b/tests/compatibility/compatibility_test.go
@@ -62,8 +62,7 @@ func TestCompatibility(t *testing.T) {
 		Capabilities: &config.CapabilitiesConfig{
 			BypassCaps: true,
 		},
-		EnrichmentEnabled: false,
-		BPFObjPath:        testBinaryPath, // Use test binary for uprobe attachment
+		BPFObjPath: testBinaryPath, // Use test binary for uprobe attachment
 	}
 
 	initialPolicies := make([]interface{}, 0, len(policies))
@@ -384,7 +383,6 @@ func TestClockDetection(t *testing.T) {
 		Capabilities: &config.CapabilitiesConfig{
 			BypassCaps: true,
 		},
-		EnrichmentEnabled: false,
 	}
 
 	// Use a minimal policy to avoid unnecessary overhead

--- a/tests/integration/container_events_test.go
+++ b/tests/integration/container_events_test.go
@@ -48,12 +48,16 @@ func Test_ContainerCreateRemove(t *testing.T) {
 		Capabilities: &config.CapabilitiesConfig{
 			BypassCaps: true,
 		},
-		EnrichmentEnabled: true, // Enable container enrichment for this test
+		Enrichment: &config.EnrichmentConfig{
+			Container: config.ContainerEnrichmentConfig{
+				Enabled: true, // Enable container enrichment for this test
+			},
+			Sockets: runtime.Sockets{},
+		},
 	}
 
 	// Register docker socket for the test
-	cfg.Sockets = runtime.Sockets{}
-	cfg.Sockets.Register(runtime.Docker, "/var/run/docker.sock")
+	cfg.Enrichment.Sockets.Register(runtime.Docker, "/var/run/docker.sock")
 
 	// Enable container events (derived events from cgroup operations)
 	containerEvents := []events.ID{
@@ -242,12 +246,16 @@ func Test_ExistingContainers(t *testing.T) {
 		Capabilities: &config.CapabilitiesConfig{
 			BypassCaps: true,
 		},
-		EnrichmentEnabled: true, // Enable container enrichment for this test
+		Enrichment: &config.EnrichmentConfig{
+			Container: config.ContainerEnrichmentConfig{
+				Enabled: true, // Enable container enrichment for this test
+			},
+			Sockets: runtime.Sockets{},
+		},
 	}
 
 	// Register docker socket for the test
-	cfg.Sockets = runtime.Sockets{}
-	cfg.Sockets.Register(runtime.Docker, "/var/run/docker.sock")
+	cfg.Enrichment.Sockets.Register(runtime.Docker, "/var/run/docker.sock")
 
 	// Enable ExistingContainer event
 	existingContainerEvents := []events.ID{

--- a/tests/integration/dependencies_test.go
+++ b/tests/integration/dependencies_test.go
@@ -244,7 +244,7 @@ func Test_EventsDependencies(t *testing.T) {
 				Capabilities: &config.CapabilitiesConfig{
 					BypassCaps: true,
 				},
-				EnrichmentEnabled: false,
+				Enrichment: nil, // Disable enrichment
 			}
 			// Initialize OSInfo to prevent nil pointer dereference in probes compatibility
 			osInfo, err := environment.GetOSInfo()

--- a/tests/integration/event_filters_test.go
+++ b/tests/integration/event_filters_test.go
@@ -2330,7 +2330,7 @@ func Test_EventFilters(t *testing.T) {
 				Capabilities: &config.CapabilitiesConfig{
 					BypassCaps: true,
 				},
-				EnrichmentEnabled: false,
+				Enrichment: nil, // Disable enrichment
 			}
 			ps := testutils.NewPolicies(tc.policyFiles)
 			initialPolicies := make([]interface{}, 0, len(ps))


### PR DESCRIPTION
Refactor enrichment options from `OutputConfig` to `EnrichmentConfig` structure.

- `EnrichmentConfig` is now a full struct in `pkg/config` with `ToConfig()` in flags package
- `GetRuntimeSockets()` and `CalcHashesOption` conversion moved to flags package (runs during parsing)
- Added nil-safe getters (`EnrichUserStack()`, `EnrichContainers()`, etc.)

Added tests for conversion logic, socket handling, and nil safety. All tests pass.
