### PR TITLE
tests: move Test_TraceeCapture from integration to e2e tests

### DIFF
--- a/.github/actions/run-e2e-tests/action.yaml
+++ b/.github/actions/run-e2e-tests/action.yaml
@@ -39,12 +39,19 @@ runs:
         ./tests/e2e-kernel-test.sh 2>&1 | tee /tmp/e2e-kernel-test.log
         exit ${PIPESTATUS[0]}
       shell: bash
+    - name: Capture Test
+      id: e2e-capture-test
+      run: |
+        ./tests/e2e-capture-test.sh 2>&1 | tee /tmp/e2e-capture-test.log
+        exit ${PIPESTATUS[0]}
+      shell: bash
     - name: Determine Failed Test
       id: failed-test
       if: failure() && (
         steps.e2e-inst-test.conclusion == 'failure' ||
         steps.e2e-net-test.conclusion == 'failure' || 
-        steps.e2e-kernel-test.conclusion == 'failure'
+        steps.e2e-kernel-test.conclusion == 'failure' ||
+        steps.e2e-capture-test.conclusion == 'failure'
         )
       run: |
         if [[ "${{ steps.e2e-inst-test.conclusion }}" == "failure" ]]; then
@@ -53,6 +60,8 @@ runs:
           echo "name=net" >> $GITHUB_OUTPUT
         elif [[ "${{ steps.e2e-kernel-test.conclusion }}" == "failure" ]]; then
           echo "name=kernel" >> $GITHUB_OUTPUT
+        elif [[ "${{ steps.e2e-capture-test.conclusion }}" == "failure" ]]; then
+          echo "name=capture" >> $GITHUB_OUTPUT
         else
           echo "No failed tests. Should not reach this point."
           exit 1

--- a/tests/e2e-capture-test.sh
+++ b/tests/e2e-capture-test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# E2E Capture Test
+#
+# This script runs end-to-end tests for Tracee's file and network capture features.
+# Unlike integration tests that run tracee in-process, this test requires a fully
+# built tracee binary since capture tests need to verify that captured files are
+# written correctly by the running tracee process.
+#
+# Usage: ./tests/e2e-capture-test.sh
+#
+# Prerequisites:
+#   - Must be run as root (or with sudo)
+#   - Tracee must be built (make tracee)
+#   - Docker must be available for network capture tests
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ==============================================================================
+# Load Dependencies
+# ==============================================================================
+__LIB_DIR="${SCRIPT_DIR}/../scripts"
+# shellcheck disable=SC1091
+. "${__LIB_DIR}/lib.sh"
+
+# ==============================================================================
+# Configuration
+# ==============================================================================
+TRACEE_BIN="${SCRIPT_DIR}/../dist/tracee"
+
+# ==============================================================================
+# Pre-flight Checks
+# ==============================================================================
+if [[ ${UID} -ne 0 ]]; then
+    die "need root privileges"
+fi
+
+if [[ ! -d "${SCRIPT_DIR}/../signatures" ]]; then
+    die "need to be in tracee root directory"
+fi
+
+if [[ ! -x "${TRACEE_BIN}" ]]; then
+    info "Tracee binary not found at ${TRACEE_BIN}, building..."
+    make -C "${SCRIPT_DIR}/.." -j"$(nproc)" tracee
+fi
+
+# Verify tracee binary exists after build
+if [[ ! -x "${TRACEE_BIN}" ]]; then
+    die "could not find tracee executable after build"
+fi
+
+# ==============================================================================
+# Environment Information
+# ==============================================================================
+print_section_banner "E2E CAPTURE TEST" "=" 80
+
+KERNEL=$(uname -r)
+KERNEL_MAJ=$(echo "${KERNEL}" | cut -d'.' -f1)
+
+info "KERNEL: ${KERNEL}"
+info "TRACEE: ${TRACEE_BIN}"
+info
+
+if [[ ${KERNEL_MAJ} -lt 5 && "${KERNEL}" != *"el8"* ]]; then
+    info "skip test in kernels < 5.0 (and not RHEL), kernel: ${KERNEL}"
+    exit 0
+fi
+
+# ==============================================================================
+# Run E2E Capture Tests
+# ==============================================================================
+print_section_header "RUNNING CAPTURE TESTS" "=" 80
+
+# Set up Go environment for running tests
+GO_ENV_EBPF=""
+if [[ -n "${GOROOT:-}" ]]; then
+    GO_ENV_EBPF="GOROOT=${GOROOT}"
+fi
+
+# The test requires the tracee binary path
+export TRACEE_BIN
+
+cd "${SCRIPT_DIR}/.."
+
+# Run the Go tests in the e2e-capture package
+# These tests use testutils.NewRunningTracee which runs tracee as a binary
+info "Running e2e-capture tests..."
+
+# Build Go tags for eBPF
+GO_TAGS_EBPF="ebpf"
+
+# Run the tests
+# Note: -p 1 ensures tests run sequentially (important for capture tests)
+# Note: -count=1 disables test caching
+go test \
+    -tags "${GO_TAGS_EBPF}" \
+    -timeout 20m \
+    -race \
+    -v \
+    -p 1 \
+    -count=1 \
+    ./tests/e2e-capture/...
+
+test_status=$?
+
+print_separator '-' 80
+
+if [[ ${test_status} -eq 0 ]]; then
+    info "E2E CAPTURE TESTS PASSED"
+else
+    error "E2E CAPTURE TESTS FAILED"
+fi
+
+exit ${test_status}

--- a/tests/e2e-capture/capture_test.go
+++ b/tests/e2e-capture/capture_test.go
@@ -1,4 +1,4 @@
-package integration
+package e2ecapture
 
 import (
 	"context"
@@ -22,6 +22,10 @@ import (
 	"github.com/aquasecurity/tracee/pkg/pcaps"
 	"github.com/aquasecurity/tracee/tests/testutils"
 )
+
+// busyboxImage is the pinned busybox image used in e2e capture tests
+// Using ECR Public mirror to avoid Docker Hub rate limits
+const busyboxImage = "public.ecr.aws/docker/library/busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee"
 
 func Test_TraceeCapture(t *testing.T) {
 	// TODO: This test is skipped due to BPF file capture bugs (to be investigated):
@@ -143,6 +147,13 @@ func Test_TraceeCapture(t *testing.T) {
 				t.Fail()
 			}
 		})
+	}
+}
+
+func coolDown(t *testing.T, d time.Duration) {
+	if d > 0 {
+		t.Logf("  ... cooling down for %v", d)
+		time.Sleep(d)
 	}
 }
 


### PR DESCRIPTION
### 1. Explain what the PR does

Fixes #5187.
This PR addresses the miscategorization of `Test_TraceeCapture` by moving it from `tests/integration` to a new `tests/e2e-capture` directory. The test is an end-to-end test, as it uses `testutils.NewRunningTracee` to run Tracee as an external binary, unlike true integration tests that run Tracee in-process.

Changes include:
*   Moved `capture_test.go` to `tests/e2e-capture/` and updated its package.
*   Created `tests/e2e-capture-test.sh` to execute these new e2e capture tests.
*   Updated `.github/actions/run-e2e-tests/action.yaml` to include the capture test in the CI workflow.

### 2. Explain how to test it

To test the e2e capture tests locally:

```bash
sudo ./tests/e2e-capture-test.sh
```

Look for "E2E CAPTURE TESTS PASSED" or "E2E CAPTURE TESTS FAILED" in the output. Note that the test is currently skipped due to known BPF file capture bugs (see issue #5171).

### 3. Other comments

The `Test_TraceeCapture` is currently skipped due to known BPF file capture bugs, as detailed in #5171. Once #5171 is resolved, the skip can be removed, and this test will run as part of the e2e test suite.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ff5a052-6818-4ff7-b68b-47f317a4eba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ff5a052-6818-4ff7-b68b-47f317a4eba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

