### PR TITLE
VMs management

### DIFF
--- a/scripts/installation/install-deps-centos.sh
+++ b/scripts/installation/install-deps-centos.sh
@@ -142,6 +142,31 @@ Please create the checksum file with the SHA256 from https://go.dev/dl/"
     # Verify installation
     go version
     info "Go ${GOLANG_VERSION} installed successfully"
+    
+    # Configure Go environment for user if USER_NAME and USER_HOME are set
+    if [ -n "${USER_NAME}" ] && [ -n "${USER_HOME}" ] && [ -d "${USER_HOME}" ]; then
+        info "Configuring Go environment for ${USER_NAME} in ${USER_HOME}/.bashrc"
+        
+        # Add Go paths to .bashrc if not already present
+        if ! grep -q "GOROOT" "${USER_HOME}/.bashrc" 2>/dev/null; then
+            cat >> "${USER_HOME}/.bashrc" << 'EOF'
+
+# Go environment configuration
+export GOROOT="/usr/local/go"
+export GOPATH="${HOME}/go"
+export GOCACHE="${HOME}/.cache/go-build"
+export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+EOF
+            info "Go environment added to ${USER_HOME}/.bashrc"
+        else
+            info "Go environment already configured in .bashrc"
+        fi
+        
+        # Create Go directories with proper ownership
+        mkdir -p "${USER_HOME}/go" "${USER_HOME}/.cache/go-build"
+        chown -R "${USER_NAME}:${USER_NAME}" "${USER_HOME}/go" "${USER_HOME}/.cache"
+        info "Go directories created in ${USER_HOME}"
+    fi
 }
 
 install_clang() {
@@ -204,13 +229,59 @@ install_docker() {
     yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo 2> /dev/null \
         || ${PKG_MANAGER} config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo || true
 
-    # Install Docker CLI
-    ${PKG_MANAGER} install -y docker-ce-cli || {
+    # Install full Docker engine, not just CLI
+    ${PKG_MANAGER} install -y docker-ce docker-ce-cli containerd.io || {
         warn "Could not install Docker from official repo, trying alternatives"
         ${PKG_MANAGER} install -y docker || true
     }
 
+    # Enable and start Docker service
+    systemctl enable docker
+    systemctl start docker
+
     info "Docker installed successfully"
+    
+    # Add user to docker group if USER_NAME is set and not root
+    if [ -n "${USER_NAME}" ] && [ "${USER_NAME}" != "root" ]; then
+        if getent group docker >/dev/null 2>&1; then
+            usermod -aG docker "${USER_NAME}"
+            info "Added ${USER_NAME} to docker group"
+        else
+            info "Docker group not found, skipping group assignment"
+        fi
+    fi
+}
+
+setup_user_vars() {
+    # Setup USER_NAME and USER_HOME variables for user-specific configuration
+    # Use USER_NAME env var if set, otherwise default to current user ($USER)
+    # Caller can override with: USER_NAME=myuser ./install-deps-centos.sh
+    
+    USER_NAME="${USER_NAME:-${USER}}"
+    
+    # Verify user exists
+    if ! id "${USER_NAME}" >/dev/null 2>&1; then
+        info "User ${USER_NAME} not found, skipping user-specific configuration"
+        USER_NAME=""
+        USER_HOME=""
+        return 0
+    fi
+    
+    # Get home directory from passwd database
+    USER_HOME=$(getent passwd "${USER_NAME}" | cut -d: -f6)
+    
+    if [ -z "${USER_HOME}" ]; then
+        info "Could not determine home directory for user ${USER_NAME}, skipping user-specific configuration"
+        USER_NAME=""
+        USER_HOME=""
+        return 0
+    fi
+    
+    info "User configuration will be applied to: ${USER_NAME} (home: ${USER_HOME})"
+    
+    # Export for child processes
+    export USER_NAME
+    export USER_HOME
 }
 
 verify_installation() {
@@ -245,6 +316,9 @@ verify_installation() {
 main() {
     info "=== Tracee Dependencies Installation (CentOS/RHEL) ==="
 
+    # Setup user variables for user-specific configuration
+    setup_user_vars
+    
     install_base_packages
     install_golang
     install_clang

--- a/scripts/vm-setup/config/config.env.example
+++ b/scripts/vm-setup/config/config.env.example
@@ -1,0 +1,6 @@
+# Tracee VM Manager path configuration
+# Copy to ~/.tracee-vm-manager/config.env or set paths via the TUI (Settings).
+# On first run with no args, the TUI will prompt for these if not set.
+
+BASE_IMAGES_DIR=/path/to/base-images
+OUTPUT_IMAGES_DIR=/path/to/output-images

--- a/scripts/vm-setup/debug-vm.sh
+++ b/scripts/vm-setup/debug-vm.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+# Script to debug VM images - check logs, user configuration, and cloud-init status
+# Usage: ./debug-vm.sh -i <qcow2-file> [-l log-file-path]
+
+set -e
+
+usage() {
+    cat << EOF
+Usage: $0 -i <qcow2-file> [-l log-file-path] [-m method]
+
+Options:
+    -i, --image     Path to qcow2 image file (required)
+    -l, --log       Log file path to display (default: /var/log/tracee-vm-init.log)
+    -m, --method    Mount method: guestmount, guestfish, or nbd (default: guestfish)
+                    - guestfish: Use libguestfs (works with locked images, requires libguestfs-tools)
+                    - guestmount: Use FUSE mount (requires libguestfs-tools)
+                    - nbd: Use qemu-nbd (requires VM to be stopped)
+    -h, --help      Show this help message
+
+Examples:
+    $0 -i ~/vms/ubuntu-22.04-generic-5.19.0-50-x86_64.qcow2
+    $0 -i ~/vms/my-vm.qcow2 -l /var/log/cloud-init.log
+    $0 -i ~/vms/my-vm.qcow2 -m nbd
+EOF
+    exit 1
+}
+
+QCOW2_FILE=""
+LOG_FILE="/var/log/tracee-vm-init.log"
+METHOD="guestfish"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -i|--image)
+            QCOW2_FILE="$2"
+            shift 2
+            ;;
+        -l|--log)
+            LOG_FILE="$2"
+            shift 2
+            ;;
+        -m|--method)
+            METHOD="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+if [ -z "$QCOW2_FILE" ]; then
+    echo "Error: Image file is required"
+    usage
+fi
+
+# Expand tilde in path
+QCOW2_FILE="${QCOW2_FILE/#\~/$HOME}"
+
+MOUNT_POINT="/mnt/vm-debug-$$"
+NBD_DEVICE="/dev/nbd0"
+
+if [ ! -f "$QCOW2_FILE" ]; then
+    echo "Error: qcow2 file not found: $QCOW2_FILE"
+    exit 1
+fi
+
+# Check if the image is valid and show info
+echo "=== Image information ==="
+echo "File: $QCOW2_FILE"
+echo "Size: $(du -h "$QCOW2_FILE" | cut -f1)"
+echo ""
+
+# Check if processes are using the file
+echo "=== Checking for processes using this image ==="
+PROCS=$(sudo fuser "$QCOW2_FILE" 2>/dev/null || true)
+if [ -n "$PROCS" ]; then
+    echo "⚠️  WARNING: Image is currently in use by process(es): $PROCS"
+    echo ""
+    echo "Processes:"
+    for pid in $PROCS; do
+        ps -p "$pid" -o pid,cmd 2>/dev/null || true
+    done
+    echo ""
+    if [ "$METHOD" != "guestfish" ]; then
+        echo "ERROR: Cannot mount with '$METHOD' while VM is running."
+        echo "Options:"
+        echo "  1. Stop the VM and try again"
+        echo "  2. Use guestfish method: -m guestfish"
+        exit 1
+    fi
+    echo "Continuing with guestfish (can read locked images)..."
+else
+    echo "No processes currently using the image."
+fi
+echo ""
+
+# Method-specific functions
+use_guestfish() {
+    if ! command -v guestfish &> /dev/null; then
+        echo "Error: guestfish not found. Install with: sudo dnf install libguestfs-tools"
+        exit 1
+    fi
+    
+    echo "Using guestfish to access $QCOW2_FILE..."
+    echo ""
+    
+    # First check if we can access the filesystem at all
+    echo "=== Filesystem inspection ==="
+    if ! sudo guestfish --ro -a "$QCOW2_FILE" -i ls / &>/dev/null; then
+        echo "ERROR: Cannot access filesystem. Trying without auto-mount..."
+        echo ""
+        echo "=== Available filesystems ==="
+        sudo guestfish --ro -a "$QCOW2_FILE" <<EOF
+run
+list-filesystems
+EOF
+        echo ""
+        echo "This suggests the image may be corrupted or cloud-init hasn't created the filesystem yet."
+        return 1
+    fi
+    
+    echo "Root directory contents:"
+    sudo guestfish --ro -a "$QCOW2_FILE" -i ls / | head -20
+    echo ""
+    
+    # Check if /var/log exists
+    if ! sudo guestfish --ro -a "$QCOW2_FILE" -i ls /var/log/ &>/dev/null; then
+        echo "ERROR: /var/log directory doesn't exist!"
+        echo "This suggests cloud-init has not run yet or the system hasn't booted."
+        echo ""
+        echo "Checking /var directory:"
+        sudo guestfish --ro -a "$QCOW2_FILE" -i ls /var/ 2>/dev/null || echo "Cannot list /var"
+        return 1
+    fi
+    
+    # Try to cat the log file
+    echo "=== Contents of $LOG_FILE ==="
+    if sudo guestfish --ro -a "$QCOW2_FILE" -i cat "$LOG_FILE" 2>/dev/null; then
+        echo ""
+        echo "=== End of log file ==="
+    else
+        echo "Log file not found: $LOG_FILE"
+    fi
+    
+    echo ""
+    echo "=== All files in /var/log ==="
+    sudo guestfish --ro -a "$QCOW2_FILE" -i ll /var/log/ 2>/dev/null | head -30
+    
+    echo ""
+    echo "=== Cloud-init related files ==="
+    sudo guestfish --ro -a "$QCOW2_FILE" -i ll /var/log/ 2>/dev/null | grep -i cloud || echo "No cloud-init logs found"
+    
+    echo ""
+    echo "=== Checking cloud-init status ==="
+    if sudo guestfish --ro -a "$QCOW2_FILE" -i cat /var/lib/cloud/instance/boot-finished 2>/dev/null; then
+        echo "Cloud-init boot finished marker found"
+    else
+        echo "Cloud-init boot NOT finished - the system may still be initializing or cloud-init failed"
+    fi
+    
+    echo ""
+    echo "=== Most recent cloud-init log (if exists) ==="
+    sudo guestfish --ro -a "$QCOW2_FILE" -i cat /var/log/cloud-init-output.log 2>/dev/null | tail -100 || echo "No cloud-init-output.log found"
+    
+    echo ""
+    echo "=== User Configuration Check ==="
+    
+    echo "Checking if users exist:"
+    if sudo guestfish --ro -a "$QCOW2_FILE" -i cat /etc/passwd 2>/dev/null | grep -E "^(ubuntu|ec2-user|alpine):" ; then
+        echo "✓ User found"
+    else
+        echo "✗ User NOT found - cloud-init users module likely failed"
+    fi
+    echo ""
+    
+    echo "Checking password configuration:"
+    if sudo guestfish --ro -a "$QCOW2_FILE" -i cat /etc/shadow 2>/dev/null | grep -E "^(ubuntu|ec2-user|alpine):" ; then
+        echo "✓ Password hash exists"
+    else
+        echo "✗ No password hash - password login will fail"
+    fi
+    echo ""
+    
+    echo "Checking SSH authorized_keys:"
+    for user_home in /home/ubuntu /home/ec2-user /home/alpine /root; do
+        if sudo guestfish --ro -a "$QCOW2_FILE" -i cat "${user_home}/.ssh/authorized_keys" 2>/dev/null; then
+            echo "✓ Found authorized_keys in ${user_home}"
+            break
+        fi
+    done 2>&1 | grep -q "✓" || echo "✗ No authorized_keys file found - SSH key login will fail"
+    echo ""
+    
+    echo "Checking SSH server configuration:"
+    if sudo guestfish --ro -a "$QCOW2_FILE" -i cat /etc/ssh/sshd_config 2>/dev/null | grep -E "^(PasswordAuthentication|PubkeyAuthentication|PermitRootLogin)" ; then
+        echo "✓ SSH config found"
+    else
+        echo "⚠ Could not read SSH config"
+    fi
+    echo ""
+    
+    echo "Checking user groups:"
+    if sudo guestfish --ro -a "$QCOW2_FILE" -i cat /etc/group 2>/dev/null | grep -E "^(docker|sudo|wheel):" ; then
+        echo "✓ Groups configured"
+    else
+        echo "⚠ Standard groups not found"
+    fi
+    
+    echo ""
+    echo "=== Cloud-init errors (last 50 lines) ==="
+    sudo guestfish --ro -a "$QCOW2_FILE" -i cat /var/log/cloud-init.log 2>/dev/null | grep -A 5 -i "error\|fail\|exception\|traceback" | tail -50 || echo "No errors found"
+    
+    echo ""
+    echo "=== To explore interactively, run: ==="
+    echo "sudo guestfish --ro -a '$QCOW2_FILE' -i"
+}
+
+use_guestmount() {
+    if ! command -v guestmount &> /dev/null; then
+        echo "Error: guestmount not found. Install with: sudo dnf install libguestfs-tools"
+        exit 1
+    fi
+    
+    echo "Using guestmount to access $QCOW2_FILE..."
+    sudo mkdir -p "$MOUNT_POINT"
+    
+    echo "Mounting image at $MOUNT_POINT..."
+    sudo guestmount -a "$QCOW2_FILE" -i --ro "$MOUNT_POINT"
+    
+    display_logs_and_wait
+}
+
+use_nbd() {
+    echo "Using qemu-nbd to access $QCOW2_FILE..."
+    
+    # Load NBD module
+    if ! lsmod | grep -q nbd; then
+        echo "Loading NBD kernel module..."
+        sudo modprobe nbd max_part=8
+    fi
+    
+    # Connect qcow2 to NBD device (read-only)
+    echo "Connecting image to $NBD_DEVICE (read-only)..."
+    sudo qemu-nbd --read-only --connect="$NBD_DEVICE" "$QCOW2_FILE"
+    
+    # Wait for partitions to be detected
+    sleep 2
+    
+    # Show partition information
+    echo "Partitions found:"
+    sudo fdisk -l "$NBD_DEVICE" | grep "^$NBD_DEVICE"
+    
+    # Determine the root partition (usually p1 or p2)
+    if [ -b "${NBD_DEVICE}p1" ]; then
+        ROOT_PART="${NBD_DEVICE}p1"
+    elif [ -b "${NBD_DEVICE}p2" ]; then
+        ROOT_PART="${NBD_DEVICE}p2"
+    else
+        echo "Error: Could not find root partition"
+        exit 1
+    fi
+    
+    echo "Using root partition: $ROOT_PART"
+    
+    # Create mount point and mount (read-only)
+    sudo mkdir -p "$MOUNT_POINT"
+    sudo mount -o ro "$ROOT_PART" "$MOUNT_POINT"
+    
+    display_logs_and_wait
+}
+
+display_logs_and_wait() {
+    echo ""
+    echo "=== Image mounted at $MOUNT_POINT ==="
+    echo ""
+    
+    # Try to display the requested log file
+    FULL_LOG_PATH="${MOUNT_POINT}${LOG_FILE}"
+    if [ -f "$FULL_LOG_PATH" ]; then
+        echo "=== Contents of $LOG_FILE ==="
+        sudo cat "$FULL_LOG_PATH"
+        echo ""
+        echo "=== End of log file ==="
+    else
+        echo "Log file not found: $LOG_FILE"
+        echo ""
+        echo "Available log files in /var/log:"
+        sudo ls -lh "${MOUNT_POINT}/var/log/" 2>/dev/null || echo "Could not list /var/log"
+    fi
+    
+    echo ""
+    echo "=== Other useful logs to check ==="
+    echo "Cloud-init logs:"
+    sudo ls -lh "${MOUNT_POINT}/var/log/cloud-init"* 2>/dev/null || echo "No cloud-init logs found"
+    
+    echo ""
+    echo "Press Enter to unmount and exit, or Ctrl+C to keep mounted for manual inspection..."
+    read
+}
+
+cleanup() {
+    echo "Cleaning up..."
+    if mountpoint -q "$MOUNT_POINT" 2>/dev/null; then
+        sudo umount "$MOUNT_POINT" 2>/dev/null || sudo fusermount -u "$MOUNT_POINT" 2>/dev/null || true
+    fi
+    if [ -d "$MOUNT_POINT" ]; then
+        sudo rmdir "$MOUNT_POINT" 2>/dev/null || true
+    fi
+    if [ -b "$NBD_DEVICE" ]; then
+        sudo qemu-nbd --disconnect "$NBD_DEVICE" 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
+
+# Execute the appropriate method
+case "$METHOD" in
+    guestfish)
+        use_guestfish
+        ;;
+    guestmount)
+        use_guestmount
+        ;;
+    nbd)
+        use_nbd
+        ;;
+    *)
+        echo "Error: Invalid method '$METHOD'. Must be: guestfish, guestmount, or nbd"
+        usage
+        ;;
+esac

--- a/scripts/vm-setup/distros/README.md
+++ b/scripts/vm-setup/distros/README.md
@@ -1,0 +1,37 @@
+# Distro modules for VM Manager
+
+Each file in this directory is a **sourced** script (not executed directly). The orchestrator `vm-manager.sh` discovers distros and sources the chosen module when needed.
+
+## Contract
+
+A distro script must define:
+
+- **`DISTRO_ID`** – Identifier used in menus and for sourcing (e.g. `ubuntu`).
+- **`DISTRO_NAME`** – Human-readable name (e.g. `Ubuntu`).
+
+Optional functions (if missing, the manager skips or shows a generic message):
+
+- **`distro_download base_dir codename arch`** – **Core logic (no TUI).** Download and verify image into `base_dir`. Uses only `echo` for output so it works from flag-based CLI. Return 0 on success. If present, `$0 download --distro <id> --codename <name> --arch <arch>` will call this.
+- **`distro_download_run base_dir`** – **TUI.** Interactive download: prompt release/arch (with gum), then call `distro_download`. Return 0 on success.
+- **`distro_handles_base base_file`** – Return 0 if this distro “handles” the given base filename (e.g. Ubuntu cloud image pattern). Used to show distro-specific build instructions.
+- **`distro_build_instructions base_file script_dir`** – Print customize/build steps for this base image (e.g. generate-cloud-init, cloud-localds). Called when user picks “Build” and selected a base file this distro handles.
+
+- **`distro_build_run base_file script_dir output_dir base_images_dir`** – **Core logic (no TUI).** Run generate-cloud-init and cloud-localds; write ISO to `script_dir/generated/`. If present, the TUI offers "Run these steps now?" after instructions.
+
+- **`distro_infer_base_image vm_name base_dir`** – **(Optional.)** If this distro can infer a base image path from a VM name (e.g. from a cloud-init ISO name), echo the absolute path and return 0; otherwise return 1. Used by "Run a VM" when an ISO needs a base disk. If the distro provides this, it should also set **`DISTRO_VM_NAME_PREFIX`** (e.g. `ubuntu`) so the manager only calls this when `vm_name` starts with `${DISTRO_VM_NAME_PREFIX}-`.
+
+- **`distro_list_base_images base_dir arch_suffix`** – **(Optional.)** Echo one line per base image this distro handles for the given arch: `filename|label`. Used by the Build flow to show a release picker (e.g. "20.04 LTS (focal)").
+
+- **`distro_release_to_codename release`** – **(Optional.)** For CLI `download --distro <id> --release <ver>`: echo the distro’s codename for that release and return 0, or return 1 if unknown. E.g. Ubuntu `24.04` → `noble`.
+
+## Discovery
+
+The manager lists distros by sourcing each `distros/*.sh` and reading `DISTRO_ID` and `DISTRO_NAME`. Only distros that define `distro_download_run` are offered in the Download menu.
+
+## Example: stub for “coming soon”
+
+```bash
+DISTRO_ID="centos"
+DISTRO_NAME="CentOS (coming soon)"
+# No distro_download_run – manager will not offer in download list, or can show “not implemented”.
+```

--- a/scripts/vm-setup/distros/ubuntu.sh
+++ b/scripts/vm-setup/distros/ubuntu.sh
@@ -1,0 +1,718 @@
+# Ubuntu distro module. Source from vm-manager; provides download and build instructions.
+# Uses: print_error, print_info, print_step_header, download_with_progress (from vm-manager-lib).
+# shellcheck shell=bash
+# DISTRO_ID / DISTRO_NAME are read by vm-manager.sh when this file is sourced
+# shellcheck disable=SC2034
+DISTRO_ID="ubuntu"
+DISTRO_NAME="Ubuntu"
+# VM names from our build look like ubuntu-20.04-aws-5.15.0-1084-x86_64; prefix for "Run a VM" inference
+# shellcheck disable=SC2034
+DISTRO_VM_NAME_PREFIX="ubuntu"
+
+# LTS releases first, then latest (most recent available)
+UBUNTU_RELEASE_LABELS=("20.04 LTS (focal)" "22.04 LTS (jammy)" "24.04 LTS (noble)" "Latest (25.04 plucky)")
+UBUNTU_RELEASE_CODENAMES=("focal" "jammy" "noble" "plucky")
+UBUNTU_ARCH_LABELS=("x86_64 (amd64)" "aarch64 (arm64)")
+UBUNTU_ARCH_NAMES=("amd64" "arm64")
+# Kernel flavours to try when updating from repo (GA + cloud only; no HWE/lowlatency)
+# plucky has no linux-image-*-gke in repo
+UBUNTU_KERNEL_FLAVOURS_GENERIC=(generic aws azure gcp gke)
+UBUNTU_KERNEL_FLAVOURS_FOCAL=(generic aws azure gcp gke)
+UBUNTU_KERNEL_FLAVOURS_JAMMY=(generic aws azure gcp gke)
+UBUNTU_KERNEL_FLAVOURS_NOBLE=(generic aws azure gcp gke)
+UBUNTU_KERNEL_FLAVOURS_PLUCKY=(generic aws azure gcp)
+# GPG key for SHA256SUMS signature verification (override with env var if the key changes)
+UBUNTU_IMAGE_SIGNING_KEY="${UBUNTU_IMAGE_SIGNING_KEY:-D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81}"
+
+# Get remote Last-Modified as epoch (empty if unavailable). Uses curl or wget.
+_ubuntu_remote_epoch() {
+    local url="${1:?}"
+    local raw
+    if command -v curl &>/dev/null; then
+        raw=$(curl -sI -L "${url}" 2>/dev/null | grep -i '^last-modified:' | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')
+    elif command -v wget &>/dev/null; then
+        raw=$(wget --spider -S "${url}" 2>&1 | grep -i '^[[:space:]]*last-modified:' | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r')
+    fi
+    if [[ -z "${raw}" ]]; then return; fi
+    # GNU date (Linux) or BSD date (macOS)
+    date -d "${raw}" +%s 2>/dev/null || date -j -f "%a, %d %b %Y %H:%M:%S %Z" "${raw}" +%s 2>/dev/null
+}
+
+# Internal: fetch SHA256SUMS and SHA256SUMS.gpg. No output.
+_ubuntu_fetch_checksums() {
+    local base_url="${1:?}"
+    local sums_file="${2:?}"
+    local sums_gpg="${3:?}"
+    if command -v curl &>/dev/null; then
+        curl -fsSL -o "${sums_file}" "${base_url}/SHA256SUMS" && curl -fsSL -o "${sums_gpg}" "${base_url}/SHA256SUMS.gpg"
+    else
+        wget -q -O "${sums_file}" "${base_url}/SHA256SUMS" && wget -q -O "${sums_gpg}" "${base_url}/SHA256SUMS.gpg"
+    fi
+}
+
+# Internal: run gpg verify. Returns 0 if OK. Tries to import key if missing.
+_ubuntu_verify_gpg() {
+    local sums_gpg="${1:?}"
+    local sums_file="${2:?}"
+    if ! command -v gpg &>/dev/null; then
+        return 1
+    fi
+    if gpg --keyid-format long --verify "${sums_gpg}" "${sums_file}" 2>/dev/null; then
+        return 0
+    fi
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${UBUNTU_IMAGE_SIGNING_KEY}" 2>/dev/null
+    gpg --keyid-format long --verify "${sums_gpg}" "${sums_file}" 2>/dev/null
+}
+
+# Internal: run sha256sum -c. Returns 0 if OK.
+_ubuntu_verify_sha256() {
+    local base_dir="${1:?}"
+    local codename="${2:?}"
+    command -v sha256sum &>/dev/null || return 1
+    (cd "${base_dir}" && sha256sum -c --ignore-missing "${codename}-current-SHA256SUMS" >/dev/null 2>&1)
+}
+
+# Core download + verify (no TUI). For flag-based CLI. Uses echo only.
+distro_download() {
+    local base_dir="${1:?}"
+    local codename="${2:?}"
+    local arch="${3:?}"
+    local filename="${codename}-server-cloudimg-${arch}.img"
+    local url="https://cloud-images.ubuntu.com/${codename}/current/${filename}"
+    local dest="${base_dir}/${filename}"
+    local base_url="https://cloud-images.ubuntu.com/${codename}/current"
+    local sums_file="${base_dir}/${codename}-current-SHA256SUMS"
+    local sums_gpg="${base_dir}/${codename}-current-SHA256SUMS.gpg"
+    mkdir -p "${base_dir}"
+
+    if ! command -v curl &>/dev/null && ! command -v wget &>/dev/null; then
+        echo "Error: Neither wget nor curl found." >&2
+        return 1
+    fi
+
+    download_with_progress "${url}" "${dest}.tmp"
+    local status=$?
+    if [[ ${status} -ne 0 ]]; then
+        echo "Download failed (exit ${status}). Check URL: ${url}" >&2
+        return "${status}"
+    fi
+    mv "${dest}.tmp" "${dest}"
+    echo "Downloaded to ${dest}"
+
+    _ubuntu_fetch_checksums "${base_url}" "${sums_file}" "${sums_gpg}" || true
+    if [[ ! -f "${sums_file}" ]] || [[ ! -f "${sums_gpg}" ]]; then
+        echo "Error: Failed to fetch checksum files." >&2
+        return 1
+    fi
+
+    if _ubuntu_verify_gpg "${sums_gpg}" "${sums_file}"; then
+        echo "GPG signature OK (SHA256SUMS signed by Ubuntu)."
+    else
+        echo "Warning: GPG verification failed. Continuing with checksum only." >&2
+    fi
+    if _ubuntu_verify_sha256 "${base_dir}" "${codename}"; then
+        echo "Image: OK"
+        echo "Checksum OK. Verified."
+    else
+        echo "Error: Checksum verification failed. Image may be corrupted." >&2
+        return 1
+    fi
+    echo "Saved to ${dest}. Checksum files kept: ${sums_file}, ${sums_gpg}"
+    return 0
+}
+
+# TUI: prompt release/arch, then run download+verify with step headers, spin, aligned gum output.
+distro_download_run() {
+    local base_dir="${1:?}"
+    local release_choice arch_choice codename arch i
+    release_choice=$(printf '%s\n' "${UBUNTU_RELEASE_LABELS[@]}" | gum choose --header "Ubuntu release")
+    [[ -z "${release_choice}" ]] && return 1
+    codename=""
+    for i in "${!UBUNTU_RELEASE_LABELS[@]}"; do
+        if [[ "${UBUNTU_RELEASE_LABELS[i]}" == "${release_choice}" ]]; then
+            codename="${UBUNTU_RELEASE_CODENAMES[i]}"
+            break
+        fi
+    done
+    [[ -z "${codename}" ]] && return 1
+    arch_choice=$(printf '%s\n' "${UBUNTU_ARCH_LABELS[@]}" | gum choose --header "Architecture")
+    [[ -z "${arch_choice}" ]] && return 1
+    arch=""
+    for i in "${!UBUNTU_ARCH_LABELS[@]}"; do
+        if [[ "${UBUNTU_ARCH_LABELS[i]}" == "${arch_choice}" ]]; then
+            arch="${UBUNTU_ARCH_NAMES[i]}"
+            break
+        fi
+    done
+    [[ -z "${arch}" ]] && return 1
+
+    local filename="${codename}-server-cloudimg-${arch}.img"
+    local dest="${base_dir}/${filename}"
+    local url="https://cloud-images.ubuntu.com/${codename}/current/${filename}"
+    local base_url="https://cloud-images.ubuntu.com/${codename}/current"
+    local sums_file="${base_dir}/${codename}-current-SHA256SUMS"
+    local sums_gpg="${base_dir}/${codename}-current-SHA256SUMS.gpg"
+
+    if [[ -f "${dest}" ]]; then
+        local remote_epoch local_epoch
+        remote_epoch=$(_ubuntu_remote_epoch "${url}")
+        local_epoch=""
+        if [[ -n "${remote_epoch}" ]] && command -v stat &>/dev/null; then
+            local_epoch=$(stat -c %Y "${dest}" 2>/dev/null || stat -f %m "${dest}" 2>/dev/null)
+        fi
+        if [[ -n "${remote_epoch}" && -n "${local_epoch}" ]]; then
+            if (( remote_epoch > local_epoch )); then
+                if ! gum confirm "A newer image is available online. Download?"; then
+                    return 0
+                fi
+            else
+                if ! gum confirm "Local image appears up to date. Re-download anyway?"; then
+                    return 0
+                fi
+            fi
+        else
+            if ! gum confirm "File already exists: ${dest}. Re-download?"; then
+                return 0
+            fi
+        fi
+    fi
+
+    if ! command -v curl &>/dev/null && ! command -v wget &>/dev/null; then
+        print_error "Neither wget nor curl found. Install one to download images."
+        return 1
+    fi
+
+    mkdir -p "${base_dir}"
+
+    print_step_header "1. Download"
+    gum format "Downloading **${filename}**..."
+    download_with_progress "${url}" "${dest}.tmp"
+    local status=$?
+    if [[ ${status} -ne 0 ]]; then
+        print_error "Download failed (exit ${status}). Check URL: ${url}"
+        return "${status}"
+    fi
+    mv "${dest}.tmp" "${dest}"
+    gum format "Downloaded to **${dest}**"
+    echo ""
+
+    print_step_header "2. Verify"
+    if command -v curl &>/dev/null; then
+        gum spin --title "Fetching checksums..." -- bash -c "curl -fsSL -o '${sums_file}' '${base_url}/SHA256SUMS' && curl -fsSL -o '${sums_gpg}' '${base_url}/SHA256SUMS.gpg'"
+    else
+        gum spin --title "Fetching checksums..." -- bash -c "wget -q -O '${sums_file}' '${base_url}/SHA256SUMS' && wget -q -O '${sums_gpg}' '${base_url}/SHA256SUMS.gpg'"
+    fi
+    if [[ ! -f "${sums_file}" ]] || [[ ! -f "${sums_gpg}" ]]; then
+        print_error "Failed to fetch checksum files."
+        return 1
+    fi
+    gum format "Verifying signature and checksum..."
+    if _ubuntu_verify_gpg "${sums_gpg}" "${sums_file}"; then
+        gum format "  GPG signature OK (SHA256SUMS signed by Ubuntu)."
+    else
+        print_info "Importing Ubuntu image signing key..."
+        if _ubuntu_verify_gpg "${sums_gpg}" "${sums_file}"; then
+            gum format "  GPG signature OK (SHA256SUMS signed by Ubuntu)."
+        else
+            print_error "GPG verification failed. To verify manually: gpg --keyserver keyserver.ubuntu.com --recv-keys ${UBUNTU_IMAGE_SIGNING_KEY}. Continuing with checksum only."
+        fi
+    fi
+    if ! command -v sha256sum &>/dev/null; then
+        print_error "sha256sum not found. Cannot verify image."
+        return 1
+    fi
+    if _ubuntu_verify_sha256 "${base_dir}" "${codename}"; then
+        gum format "  Image: OK"
+        gum format "  Checksum OK. Verified."
+    else
+        print_error "Checksum verification failed. Image may be corrupted."
+        return 1
+    fi
+    gum format "  Saved to **${dest}**. Checksum files kept: **${sums_file}**, **${sums_gpg}**"
+    echo ""
+    return 0
+}
+
+distro_handles_base() {
+    local base_file="${1:?}"
+    [[ "${base_file}" == *-server-cloudimg-*.img || "${base_file}" == *-server-cloudimg-*.qcow2 ]]
+}
+
+# Echo "filename|label" per base image in base_dir for arch_suffix (e.g. amd64). Used by Build flow.
+distro_list_base_images() {
+    local base_dir="${1:?}"
+    local arch_suffix="${2:?}"
+    local f name codename label
+    for f in "${base_dir}"/*-server-cloudimg-${arch_suffix}.img "${base_dir}"/*-server-cloudimg-${arch_suffix}.qcow2; do
+        [[ -f "${f}" ]] || continue
+        name=$(basename "${f}")
+        codename="${name%-server-cloudimg-*}"
+        case "${codename}" in
+            focal)  label="20.04 LTS (focal)" ;;
+            jammy)  label="22.04 LTS (jammy)" ;;
+            noble)  label="24.04 LTS (noble)" ;;
+            plucky) label="25.04 (plucky)" ;;
+            *)      label="${codename}" ;;
+        esac
+        echo "${name}|${label}"
+    done
+}
+
+# Map release (e.g. 24.04) to codename for CLI download. Echo codename and return 0, or return 1.
+distro_release_to_codename() {
+    local codename
+    codename=$(_ubuntu_codename_from_version "${1:?}")
+    [[ -z "${codename}" ]] && return 1
+    echo "${codename}"
+    return 0
+}
+
+# Prompt for architecture, kernel flavour, and kernel version (from repo). Sets _ubuntu_build_* for use by distro_build_instructions and distro_build_run.
+# Returns 0 if user completed the flow, 1 if cancelled. Call before distro_build_instructions in the TUI build flow.
+distro_build_prompt_options() {
+    local base_file="${1:?}"
+    local script_dir="${2:?}"
+    if ! _ubuntu_base_to_version_arch "${base_file}"; then
+        print_error "Could not parse base filename: ${base_file}"
+        return 1
+    fi
+    local version="${_ubuntu_build_version}"
+    local default_arch="${_ubuntu_build_arch}"
+    local codename
+    codename=$(_ubuntu_codename_from_version "${version}")
+    [[ -z "${codename}" ]] && codename="jammy"
+
+    # Arch already implied by base image choice in vm-manager
+    _ubuntu_build_arch="${default_arch}"
+    local arch_name
+    arch_name=$(_ubuntu_arch_to_binary "${default_arch}")
+
+    # Kernel flavour (GA + HWE for this release)
+    local flavours flavour_choice
+    flavours=($(_ubuntu_flavours_for_codename "${codename}"))
+    flavour_choice=$(printf '%s\n' "${flavours[@]}" | gum choose --header "Kernel flavour")
+    [[ -z "${flavour_choice}" ]] && return 1
+    _ubuntu_build_flavour="${flavour_choice}"
+
+    # Use cached kernel list for this release/arch/flavour; fetch only if missing (no prompt).
+    if ! _ubuntu_fetch_kernel_versions "${script_dir}" "${codename}" "${arch_name}" "${_ubuntu_build_flavour}"; then
+        print_error "No kernel versions from repo. Enter version manually (see Ubuntu package list for latest)."
+        local suggested
+        suggested=$(_ubuntu_default_kernel "${version}")
+        _ubuntu_build_kernel=$(gum input --header "Kernel version" --placeholder "${suggested}" --value "${suggested}")
+        [[ -z "${_ubuntu_build_kernel}" ]] && _ubuntu_build_kernel="${suggested}"
+        return 0
+    fi
+
+    local cache_file="${HOME}/.tracee-vm-manager/cache/kernel-versions/${codename}-${arch_name}-${_ubuntu_build_flavour}.txt"
+    local versions=()
+    while IFS= read -r line; do
+        [[ -n "${line}" ]] && versions+=("${line}")
+    done <"${cache_file}"
+    if [[ ${#versions[@]} -eq 0 ]]; then
+        local suggested
+        suggested=$(_ubuntu_default_kernel "${version}")
+        _ubuntu_build_kernel=$(gum input --header "Kernel version" --placeholder "${suggested}" --value "${suggested}")
+        [[ -z "${_ubuntu_build_kernel}" ]] && _ubuntu_build_kernel="${suggested}"
+        return 0
+    fi
+    # Newest last in file (sort -V); show newest first in chooser
+    local i
+    local kernel_choice
+    kernel_choice=$(for i in $(seq $((${#versions[@]} - 1)) -1 0); do echo "${versions[i]}"; done | gum choose --header "Kernel version (from repo)")
+    [[ -z "${kernel_choice}" ]] && return 1
+    _ubuntu_build_kernel="${kernel_choice}"
+    return 0
+}
+
+# Parse Ubuntu base filename (e.g. jammy-server-cloudimg-arm64.img) to version and arch for generate-cloud-init.
+# Sets _ubuntu_build_version and _ubuntu_build_arch (e.g. 22.04, aarch64). Returns 0 if parsed.
+_ubuntu_base_to_version_arch() {
+    local base_file="${1:?}"
+    local base_name="${base_file%.*}"
+    # ...-server-cloudimg-<arch>  -> codename is first segment, arch is last
+    if [[ ! "${base_name}" =~ ^(.+)-server-cloudimg-(.+)$ ]]; then
+        return 1
+    fi
+    local codename="${BASH_REMATCH[1]}"
+    local arch="${BASH_REMATCH[2]}"
+    case "${codename}" in
+        focal) _ubuntu_build_version="20.04" ;;
+        jammy) _ubuntu_build_version="22.04" ;;
+        noble) _ubuntu_build_version="24.04" ;;
+        plucky) _ubuntu_build_version="25.04" ;;
+        *) return 1 ;;
+    esac
+    case "${arch}" in
+        amd64) _ubuntu_build_arch="x86_64" ;;
+        arm64) _ubuntu_build_arch="aarch64" ;;
+        *) _ubuntu_build_arch="${arch}" ;;
+    esac
+    return 0
+}
+
+# Fallback kernel version when repo is unavailable. Not kept in sync with Ubuntu; newer
+# kernels appear in the repo—use "Update kernel list from repo" or enter version manually.
+_ubuntu_default_kernel() {
+    local version="${1:?}"
+    case "${version}" in
+        20.04) echo "5.15.0-91" ;;
+        22.04) echo "5.19.0-50" ;;
+        24.04) echo "6.11.0-29" ;;
+        25.04) echo "6.11.0-29" ;;
+        *) echo "6.11.0-29" ;;
+    esac
+}
+
+# Codename from Ubuntu version (e.g. 22.04 -> jammy)
+_ubuntu_codename_from_version() {
+    case "${1:?}" in
+        20.04) echo "focal" ;;
+        22.04) echo "jammy" ;;
+        24.04) echo "noble" ;;
+        25.04) echo "plucky" ;;
+        *) echo "" ;;
+    esac
+}
+
+# Infer base image path from Ubuntu-style VM name (e.g. ubuntu-20.04-aws-5.15.0-1084-x86_64).
+# Echo path to existing base file and return 0, or return 1.
+distro_infer_base_image() {
+    local vm_name="${1:?}"
+    local base_dir="${2:?}"
+    local version arch_suffix codename base_file
+    # Allow optional -local or -aws suffix (environment-aware image names)
+    if [[ ! "${vm_name}" =~ ^ubuntu-([0-9]+\.[0-9]+)-.+-((x86_64|aarch64))(-(local|aws))?$ ]]; then
+        return 1
+    fi
+    version="${BASH_REMATCH[1]}"
+    arch_suffix="${BASH_REMATCH[2]}"
+    case "${arch_suffix}" in
+        x86_64) arch_suffix="amd64" ;;
+        aarch64) arch_suffix="arm64" ;;
+    esac
+    codename=$(_ubuntu_codename_from_version "${version}")
+    [[ -z "${codename}" ]] && return 1
+    for base_file in "${base_dir}/${codename}-server-cloudimg-${arch_suffix}.img" "${base_dir}/${codename}-server-cloudimg-${arch_suffix}.qcow2"; do
+        if [[ -f "${base_file}" ]]; then
+            echo "${base_file}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Suite for -updates repo (e.g. jammy -> jammy-updates)
+_ubuntu_suite_for_updates() {
+    local codename="${1:?}"
+    echo "${codename}-updates"
+}
+
+# Our arch name to Ubuntu binary arch (x86_64 -> amd64, aarch64 -> arm64)
+_ubuntu_arch_to_binary() {
+    case "${1:?}" in
+        x86_64) echo "amd64" ;;
+        aarch64) echo "arm64" ;;
+        *) echo "${1}" ;;
+    esac
+}
+
+# Return list of kernel flavours to try for a given codename (GA + HWE).
+_ubuntu_flavours_for_codename() {
+    case "${1:?}" in
+        focal)  echo "${UBUNTU_KERNEL_FLAVOURS_FOCAL[@]}" ;;
+        jammy)  echo "${UBUNTU_KERNEL_FLAVOURS_JAMMY[@]}" ;;
+        noble)  echo "${UBUNTU_KERNEL_FLAVOURS_NOBLE[@]}" ;;
+        plucky) echo "${UBUNTU_KERNEL_FLAVOURS_PLUCKY[@]}" ;;
+        *)      echo "${UBUNTU_KERNEL_FLAVOURS_GENERIC[@]}" ;;
+    esac
+}
+
+# Main-menu entry: update kernel list from repo for all releases, archs, and flavours (no prompts).
+# Runs each fetch under a gum spin with status (release/arch/flavour).
+distro_update_kernel_list() {
+    local script_dir="${1:?}"
+    local codename arch_name flavour ok=0 fail=0
+    local flavours
+    gum format "Updating kernel lists from Ubuntu repo (all releases, archs, flavours)..."
+    echo ""
+    for codename in "${UBUNTU_RELEASE_CODENAMES[@]}"; do
+        flavours=($(_ubuntu_flavours_for_codename "${codename}"))
+        for arch_name in "${UBUNTU_ARCH_NAMES[@]}"; do
+            for flavour in "${flavours[@]}"; do
+                if gum spin --title "${codename}/${arch_name}/${flavour}..." -- bash -c '
+                    . "$1/vm-manager-lib.sh"
+                    . "$1/distros/ubuntu.sh"
+                    _ubuntu_fetch_kernel_versions "$1" "$2" "$3" "$4" --update
+                ' _ "${script_dir}" "${codename}" "${arch_name}" "${flavour}"; then
+                    ((ok++)) || true
+                else
+                    ((fail++)) || true
+                fi
+            done
+        done
+    done
+    echo ""
+    gum format "Updated **${ok}** kernel lists."
+    [[ ${fail} -gt 0 ]] && gum format "Failed: **${fail}** (release/arch/flavour not in repo or fetch error)."
+    echo ""
+    return 0
+}
+
+# Base URL for Ubuntu package lists: arm64/armhf etc. are on ports.ubuntu.com.
+_ubuntu_packages_base_url() {
+    local binary_arch="${1:?}"
+    case "${binary_arch}" in
+        amd64|i386) echo "http://archive.ubuntu.com/ubuntu" ;;
+        *) echo "http://ports.ubuntu.com/ubuntu-ports" ;;
+    esac
+}
+
+# Fetch available kernel versions from Ubuntu repo for codename/arch/flavour.
+# Writes one version per line to cache file, sorted (newest last). Uses -updates suite.
+# arm64/armhf use ports.ubuntu.com; amd64 uses archive.ubuntu.com.
+# Returns 0 on success. If --update or cache missing, fetches; otherwise uses cache.
+_ubuntu_fetch_kernel_versions() {
+    local script_dir="${1:?}"
+    local codename="${2:?}"
+    local binary_arch="${3:?}"
+    local flavour="${4:?}"
+    local do_update=false
+    [[ "${5:-}" == "--update" ]] && do_update=true
+    local suite
+    suite=$(_ubuntu_suite_for_updates "${codename}")
+    local cache_dir="${HOME}/.tracee-vm-manager/cache/kernel-versions"
+    local cache_file="${cache_dir}/${codename}-${binary_arch}-${flavour}.txt"
+    mkdir -p "${cache_dir}"
+
+    if [[ "${do_update}" != "true" && -f "${cache_file}" && -s "${cache_file}" ]]; then
+        return 0
+    fi
+
+    if ! command -v curl &>/dev/null && ! command -v wget &>/dev/null; then
+        print_error "Neither curl nor wget found. Cannot fetch kernel list."
+        return 1
+    fi
+
+    local base_url
+    base_url=$(_ubuntu_packages_base_url "${binary_arch}")
+    local url="${base_url}/dists/${suite}/main/binary-${binary_arch}/Packages.gz"
+    local tmp_packages
+    tmp_packages=$(mktemp -t "ubuntu-Packages.XXXXXXXX.gz")
+    if command -v curl &>/dev/null; then
+        curl -fsSL -o "${tmp_packages}" "${url}" 2>/dev/null || true
+    else
+        wget -q -O "${tmp_packages}" "${url}" 2>/dev/null || true
+    fi
+    if [[ ! -s "${tmp_packages}" ]]; then
+        url="${base_url}/dists/${codename}/main/binary-${binary_arch}/Packages.gz"
+        if command -v curl &>/dev/null; then
+            curl -fsSL -o "${tmp_packages}" "${url}" 2>/dev/null || true
+        else
+            wget -q -O "${tmp_packages}" "${url}" 2>/dev/null || true
+        fi
+    fi
+    if [[ ! -s "${tmp_packages}" ]]; then
+        rm -f "${tmp_packages}"
+        print_error "${codename}/${binary_arch}/${flavour}: Failed to fetch Packages.gz (tried ${base_url}; network or ${suite} unavailable)."
+        return 1
+    fi
+    if [[ -n "${TRACEE_VM_DEBUG:-}" ]]; then
+        echo "  [debug] ${codename}/${binary_arch}/${flavour}: fetched ${url}" >&2
+        echo "  [debug] sample Package lines matching linux-image.*${flavour}:" >&2
+        gunzip -c "${tmp_packages}" 2>/dev/null | grep -E "^Package: linux-image.*${flavour}" | head -5 >&2
+    fi
+    local tmp_txt
+    tmp_txt=$(mktemp -t "ubuntu-Packages.XXXXXXXX.txt")
+    gunzip -c "${tmp_packages}" 2>/dev/null >"${tmp_txt}"
+    rm -f "${tmp_packages}"
+    # Parse Package: linux-image-X.Y.Z-N-flavour or linux-image-unsigned-X.Y.Z-N-flavour -> X.Y.Z-N (portable sed)
+    sed -n \
+        -e 's/^Package: linux-image-\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\)-'"${flavour}"'$/\1/p' \
+        -e 's/^Package: linux-image-unsigned-\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*\)-'"${flavour}"'$/\1/p' \
+        <"${tmp_txt}" | sort -uV >"${cache_file}.tmp"
+    # HWE flavours are meta-packages (Package: linux-image-generic-hwe-22.04) with no version in name; extract ABI from Version: (e.g. 6.8.0-94.96~22.04.1 -> 6.8.0-94)
+    if [[ ! -s "${cache_file}.tmp" && "${flavour}" == *"-hwe-"* ]]; then
+        awk -v flav="${flavour}" '
+            $0 == "Package: linux-image-" flav { in_meta=1; next }
+            in_meta && /^$/ { in_meta=0; next }
+            in_meta && /^Version:/ { v=$2; gsub(/~.*$/,"",v); gsub(/^[[:space:]]+|[[:space:]]+$/,"",v); split(v,a,"-"); split(a[2],b,"."); if (a[1]!="" && b[1]!="") print a[1]"-"b[1]; in_meta=0; next }
+            in_meta && /^Depends:/ { for (i=2;i<=NF;i++) if ($i ~ /^\(=/) { v=($i=="(=" && i<NF) ? $(i+1) : $i; gsub(/[()=,]|~.*$/,"",v); gsub(/^[[:space:]]+|[[:space:]]+$/,"",v); split(v,a,"-"); split(a[2],b,"."); if (a[1]!="" && b[1]!="") print a[1]"-"b[1]; in_meta=0; exit } }
+        ' "${tmp_txt}" | sort -uV >>"${cache_file}.tmp"
+    fi
+    if [[ -n "${TRACEE_VM_DEBUG:-}" && ! -s "${cache_file}.tmp" ]]; then
+        echo "  [debug] no lines matched sed pattern for flavour=${flavour}; Package lines containing 'linux-image' and '${flavour}':" >&2
+        grep "linux-image" "${tmp_txt}" | grep "${flavour}" | head -5 >&2
+    fi
+    rm -f "${tmp_txt}"
+    if [[ -s "${cache_file}.tmp" ]]; then
+        mv "${cache_file}.tmp" "${cache_file}"
+        return 0
+    fi
+    rm -f "${cache_file}.tmp"
+    print_error "${codename}/${binary_arch}/${flavour}: No linux-image-*-${flavour} packages in repo (flavour not offered for this release/arch)."
+    return 1
+}
+
+distro_build_instructions() {
+    local base_file="${1:?}"
+    local script_dir="${2:?}"
+    local env="${3:-local}"
+    if ! _ubuntu_base_to_version_arch "${base_file}"; then
+        gum format "Could not parse **${base_file}** (expected codename-server-cloudimg-arch.img). Use generate-cloud-init.sh manually."
+        return
+    fi
+    local version="${_ubuntu_build_version}"
+    local arch="${_ubuntu_build_arch}"
+    local flavour="${_ubuntu_build_flavour:-generic}"
+    local kernel="${_ubuntu_build_kernel:-}"
+    [[ -z "${kernel}" ]] && kernel=$(_ubuntu_default_kernel "${version}")
+    local image_name="ubuntu-${version}-${flavour}-${kernel}-${arch}-${env}"
+    gum format "To customize **${base_file}** (Ubuntu ${version}, ${arch}, kernel ${flavour} ${kernel}, env ${env}):" \
+        "1. Generate cloud-init: \`${script_dir}/generate-cloud-init.sh -d ubuntu -v ${version} -f ${flavour} -k ${kernel} -a ${arch} -e ${env}\`" \
+        "2. Create ISO: \`cloud-localds ${script_dir}/generated/${image_name}-cloud-init.iso ${script_dir}/generated/${image_name}-user-data.yaml ${script_dir}/generated/${image_name}-meta-data.yaml\`" \
+        "3. Copy ISO and base image to VM dir, then run VM. See vm-setup-plan/WORKFLOW-CUSTOM-IMAGE.md for full steps."
+}
+
+# Run generate-cloud-init and cloud-localds for the given base.
+# Usage: distro_build_run base_file script_dir output_dir base_images_dir [tui] [env]
+# If 5th arg is "tui", use gum spin for each step and gum format for output; otherwise echo (CLI).
+# 6th arg env: local or aws (default local).
+distro_build_run() {
+    local base_file="${1:?}"
+    local script_dir="${2:?}"
+    local output_dir="${3:?}"
+    local base_images_dir="${4:?}"
+    local use_tui="${5:-}"
+    local env="${6:-local}"
+    if ! _ubuntu_base_to_version_arch "${base_file}"; then
+        if [[ "${use_tui}" == "tui" ]]; then
+            print_error "Could not parse base filename: ${base_file}"
+        else
+            echo "Error: Could not parse base filename: ${base_file}" >&2
+        fi
+        return 1
+    fi
+    local version="${_ubuntu_build_version}"
+    local arch="${_ubuntu_build_arch}"
+    local flavour="${_ubuntu_build_flavour:-generic}"
+    local kernel="${_ubuntu_build_kernel:-}"
+    [[ -z "${kernel}" ]] && kernel=$(_ubuntu_default_kernel "${version}")
+    local image_name="ubuntu-${version}-${flavour}-${kernel}-${arch}-${env}"
+    local gen_dir="${output_dir}"
+    mkdir -p "${gen_dir}"
+
+    # Check for existing cloud-init ISO and disk image
+    local existing_iso="${gen_dir}/${image_name}-cloud-init.iso"
+    local existing_disk=""
+    if [[ -f "${gen_dir}/${image_name}.img" ]]; then
+        existing_disk="${gen_dir}/${image_name}.img"
+    elif [[ -f "${gen_dir}/${image_name}.qcow2" ]]; then
+        existing_disk="${gen_dir}/${image_name}.qcow2"
+    fi
+
+    if [[ -f "${existing_iso}" ]] || [[ -n "${existing_disk}" ]]; then
+        if [[ "${use_tui}" == "tui" ]]; then
+            echo ""
+            gum format "## Existing files detected for **${image_name}**"
+            echo ""
+            [[ -f "${existing_iso}" ]] && gum format "  - Cloud-init ISO: **$(basename "${existing_iso}")**"
+            [[ -n "${existing_disk}" ]] && gum format "  - Disk image: **$(basename "${existing_disk}")**"
+            echo ""
+            if [[ -n "${existing_disk}" ]]; then
+                gum format "> The disk image will be **removed** so the next run starts fresh from the base image with the new cloud-init ISO."
+                echo ""
+            fi
+            if ! gum confirm "Rebuild cloud-init and remove existing disk?"; then
+                gum format "Build cancelled."
+                return 0
+            fi
+            # Remove existing disk image so next run copies fresh from base
+            if [[ -n "${existing_disk}" ]]; then
+                rm -f "${existing_disk}"
+                gum format "  Removed **$(basename "${existing_disk}")**"
+                echo ""
+            fi
+        else
+            if [[ -f "${existing_iso}" ]]; then
+                echo "Existing cloud-init ISO found: ${existing_iso}"
+            fi
+            if [[ -n "${existing_disk}" ]]; then
+                echo "Existing disk image found: ${existing_disk}"
+                echo "The disk image will be removed so the next run starts fresh."
+                rm -f "${existing_disk}"
+                echo "Removed: ${existing_disk}"
+            fi
+        fi
+    fi
+
+    # Prompt for SSH public key to inject into the VM
+    local ssh_key_arg=""
+    if [[ "${use_tui}" == "tui" ]]; then
+        local -a ssh_keys=()
+        local key_file
+        for key_file in ~/.ssh/*.pub; do
+            [[ -f "${key_file}" ]] && ssh_keys+=("${key_file}")
+        done
+        if [[ ${#ssh_keys[@]} -gt 0 ]]; then
+            local chosen_key
+            chosen_key=$(printf '%s\n' "${ssh_keys[@]}" | gum choose --header "SSH public key to inject into VM")
+            if [[ -n "${chosen_key}" ]]; then
+                ssh_key_arg="-s ${chosen_key}"
+                gum format "  SSH key: **$(basename "${chosen_key}")**"
+                echo ""
+            fi
+        else
+            gum format "> No SSH public keys found in ~/.ssh/. VM will use password auth only."
+            echo ""
+        fi
+    else
+        # CLI: use default key resolution in generate-cloud-init.sh
+        :
+    fi
+
+    if [[ "${use_tui}" == "tui" ]]; then
+        print_step_header "1. Generate cloud-init"
+        # shellcheck disable=SC2086
+        if ! gum spin --title "Generating cloud-init config..." -- "${script_dir}/generate-cloud-init.sh" -d ubuntu -v "${version}" -f "${flavour}" -k "${kernel}" -a "${arch}" -e "${env}" ${ssh_key_arg} -o "${gen_dir}" >/dev/null 2>&1; then
+            print_error "generate-cloud-init.sh failed."
+            return 1
+        fi
+        gum format "  Generated **${image_name}-user-data.yaml** and **${image_name}-meta-data.yaml**"
+        echo ""
+        print_step_header "2. Create ISO"
+        if ! command -v cloud-localds &>/dev/null; then
+            print_error "cloud-localds not found. Install cloud-utils (or cloud-init package)."
+            return 1
+        fi
+        local iso_err
+        iso_err=$(mktemp -t "cloud-localds.XXXXXXXX.err")
+        if ! (cd "${gen_dir}" && cloud-localds "${image_name}-cloud-init.iso" "${image_name}-user-data.yaml" "${image_name}-meta-data.yaml" </dev/null) 2>"${iso_err}"; then
+            print_error "Failed to create cloud-init ISO."
+            [[ -s "${iso_err}" ]] && cat "${iso_err}" >&2
+            rm -f "${iso_err}"
+            return 1
+        fi
+        rm -f "${iso_err}"
+        gum format "  Created **${image_name}-cloud-init.iso**"
+        echo ""
+    else
+        # shellcheck disable=SC2086
+        if ! "${script_dir}/generate-cloud-init.sh" -d ubuntu -v "${version}" -f "${flavour}" -k "${kernel}" -a "${arch}" -e "${env}" ${ssh_key_arg} -o "${gen_dir}" >/dev/null 2>&1; then
+            echo "Error: generate-cloud-init.sh failed." >&2
+            return 1
+        fi
+        if ! command -v cloud-localds &>/dev/null; then
+            echo "Error: cloud-localds not found. Install cloud-utils (or cloud-init package)." >&2
+            return 1
+        fi
+        (cd "${gen_dir}" && cloud-localds "${image_name}-cloud-init.iso" "${image_name}-user-data.yaml" "${image_name}-meta-data.yaml" < /dev/null) >/dev/null 2>&1
+        if [[ ! -f "${gen_dir}/${image_name}-cloud-init.iso" ]]; then
+            echo "Error: Failed to create cloud-init ISO." >&2
+            return 1
+        fi
+        echo "Generated: ${gen_dir}/${image_name}-cloud-init.iso"
+        echo "Next: Copy base image to ${output_dir}, then run the VM with start-vm-virtiofs.sh (see WORKFLOW-CUSTOM-IMAGE.md)."
+    fi
+    return 0
+}

--- a/scripts/vm-setup/generate-cloud-init.sh
+++ b/scripts/vm-setup/generate-cloud-init.sh
@@ -1,0 +1,414 @@
+#!/bin/bash
+# Generate cloud-init configuration from templates
+# This script creates customized cloud-init files for VM provisioning
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Default values
+DISTRO=""
+VERSION=""
+KERNEL_FLAVOR=""
+KERNEL_VERSION=""
+ARCH=""
+ENVIRONMENT=""
+SSH_PUBKEY_FILE=""
+
+# Usage function
+usage() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Generate cloud-init configuration files and ISO for VM provisioning.
+
+OPTIONS:
+    -d, --distro DISTRO              Distribution name (ubuntu, centos, alpine)
+    -v, --distro-version VERSION     Distribution version (22.04, 24.04, 9, etc.)
+    -f, --kernel-flavor FLAVOR       Kernel flavor (generic, aws, gcp, azure, mainline, vanilla, lts)
+    -k, --kernel-version VERSION     Kernel version (5.19.0-50, 6.11.0-29, etc.)
+    -a, --arch ARCH                  Architecture (x86_64, aarch64)
+    -e, --env ENVIRONMENT            Environment type (local, aws)
+    -s, --ssh-key FILE               SSH public key file to inject (default: ~/.ssh/tracee_team_ed25519.pub)
+    -o, --output-dir DIR             Output directory (default: ${SCRIPT_DIR}/generated)
+    -h, --help                       Show this help message
+
+EXAMPLES:
+    # Ubuntu 22.04 with generic kernel for local development
+    $(basename "$0") -d ubuntu -v 22.04 -f generic -k 5.19.0-50 -a x86_64 -e local
+
+    # Ubuntu 24.04 with AWS kernel for CI/CD
+    $(basename "$0") --distro ubuntu --distro-version 24.04 --kernel-flavor aws \\
+        --kernel-version 6.11.0-29 --arch x86_64 --env aws
+
+    # CentOS Stream 9 for local development
+    $(basename "$0") -d centos -v 9 -f generic -k 5.14.0-503 -a x86_64 -e local
+
+    # Alpine 3.19 with vanilla kernel
+    $(basename "$0") -d alpine -v 3.19 -f vanilla -k 6.6.0 -a x86_64 -e local
+
+SUPPORTED DISTRIBUTIONS:
+    ubuntu          Ubuntu/Debian (uses apt-get)
+    centos          CentOS/RHEL/Rocky/AlmaLinux (uses dnf/yum)
+    alpine          Alpine Linux (uses apk)
+
+KERNEL FLAVORS BY DISTRO:
+    Ubuntu/Debian:  generic, aws, gcp, azure, mainline
+    CentOS/RHEL:    generic, standard, mainline, elrepo
+    Alpine:         vanilla, lts
+
+ENVIRONMENTS:
+    local           Local development (includes mount points for shared directories)
+    aws             AWS/CI/CD (optimized for GitHub Actions, no local mounts)
+
+OUTPUT:
+    Generated files are placed in: ${SCRIPT_DIR}/generated/
+    - {image-name}-user-data.yaml    Cloud-init user data configuration
+    - {image-name}-meta-data.yaml    Cloud-init metadata
+    
+    Next steps:
+    1. cd ${SCRIPT_DIR}/generated/
+    2. cloud-localds {image-name}-cloud-init.iso {image-name}-user-data.yaml {image-name}-meta-data.yaml
+    3. Copy ISO to your VM directory
+    4. Boot VM with the cloud-init ISO
+
+NAMING CONVENTION:
+    Generated files follow: {distro}-{version}-{flavor}-{kernel-version}-{arch}
+    Example: ubuntu-22.04-generic-5.19.0-50-x86_64
+
+EOF
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d|--distro)
+            DISTRO="$2"
+            shift 2
+            ;;
+        -v|--distro-version)
+            VERSION="$2"
+            shift 2
+            ;;
+        -f|--kernel-flavor)
+            KERNEL_FLAVOR="$2"
+            shift 2
+            ;;
+        -k|--kernel-version)
+            KERNEL_VERSION="$2"
+            shift 2
+            ;;
+        -a|--arch)
+            ARCH="$2"
+            shift 2
+            ;;
+        -e|--env)
+            ENVIRONMENT="$2"
+            shift 2
+            ;;
+        -s|--ssh-key)
+            SSH_PUBKEY_FILE="$2"
+            shift 2
+            ;;
+        -o|--output-dir)
+            OUTPUT_DIR_ARG="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$DISTRO" ]]; then
+    echo "Error: --distro is required" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+fi
+
+if [[ -z "$VERSION" ]]; then
+    echo "Error: --distro-version is required" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+fi
+
+if [[ -z "$KERNEL_FLAVOR" ]]; then
+    echo "Error: --kernel-flavor is required" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+fi
+
+if [[ -z "$KERNEL_VERSION" ]]; then
+    echo "Error: --kernel-version is required" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+fi
+
+if [[ -z "$ARCH" ]]; then
+    echo "Error: --arch is required" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+fi
+
+if [[ -z "$ENVIRONMENT" ]]; then
+    echo "Error: --env is required" >&2
+    echo "Use --help for usage information" >&2
+    exit 1
+fi
+
+# Validate distro
+case "$DISTRO" in
+    ubuntu|debian|centos|rhel|rocky|almalinux|alpine)
+        ;;
+    *)
+        echo "Error: Unsupported distro: $DISTRO" >&2
+        echo "Supported: ubuntu, debian, centos, rhel, rocky, almalinux, alpine" >&2
+        exit 1
+        ;;
+esac
+
+# Validate environment
+case "$ENVIRONMENT" in
+    local|aws)
+        ;;
+    *)
+        echo "Error: Unsupported environment: $ENVIRONMENT" >&2
+        echo "Supported: local, aws" >&2
+        exit 1
+        ;;
+esac
+
+# Validate architecture
+case "$ARCH" in
+    x86_64|aarch64|arm64)
+        ;;
+    *)
+        echo "Error: Unsupported architecture: $ARCH" >&2
+        echo "Supported: x86_64, aarch64, arm64" >&2
+        exit 1
+        ;;
+esac
+
+# Resolve SSH public key
+if [[ -z "${SSH_PUBKEY_FILE}" ]]; then
+    # Default: look for tracee team key, fall back to common keys
+    for candidate in ~/.ssh/tracee_team_ed25519.pub ~/.ssh/id_ed25519.pub ~/.ssh/id_rsa.pub; do
+        if [[ -f "${candidate}" ]]; then
+            SSH_PUBKEY_FILE="${candidate}"
+            break
+        fi
+    done
+fi
+if [[ -n "${SSH_PUBKEY_FILE}" ]] && [[ -f "${SSH_PUBKEY_FILE}" ]]; then
+    SSH_PUBKEY=$(cat "${SSH_PUBKEY_FILE}")
+    SSH_KEY_NAME=$(basename "${SSH_PUBKEY_FILE}" .pub)
+else
+    echo "Warning: No SSH public key found. VM will only be accessible via console password." >&2
+    SSH_PUBKEY=""
+    SSH_KEY_NAME="none"
+fi
+
+# Build image name (include environment so local and aws builds coexist)
+IMAGE_NAME="${DISTRO}-${VERSION}-${KERNEL_FLAVOR}-${KERNEL_VERSION}-${ARCH}-${ENVIRONMENT}"
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║        Generating Cloud-Init Configuration                 ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Select template based on distro family
+case "$DISTRO" in
+    ubuntu|debian)
+        USER_DATA_TEMPLATE_FILE="user-data-ubuntu-template.yaml"
+        ;;
+    centos|rhel|rocky|almalinux)
+        USER_DATA_TEMPLATE_FILE="user-data-centos-template.yaml"
+        ;;
+    alpine)
+        USER_DATA_TEMPLATE_FILE="user-data-alpine-template.yaml"
+        ;;
+    *)
+        echo "Error: No template available for distro: $DISTRO" >&2
+        echo "Available: ubuntu, debian, centos, rhel, rocky, almalinux, alpine" >&2
+        exit 1
+        ;;
+esac
+
+echo "Configuration:"
+echo "  Distro:         ${DISTRO} ${VERSION}"
+echo "  Kernel:         ${KERNEL_FLAVOR} ${KERNEL_VERSION}"
+echo "  Architecture:   ${ARCH}"
+echo "  Environment:    ${ENVIRONMENT}"
+echo "  SSH Key:        ${SSH_KEY_NAME} (${SSH_PUBKEY_FILE:-none})"
+echo "  Template:       ${USER_DATA_TEMPLATE_FILE}"
+echo "  Image Name:     ${IMAGE_NAME}"
+echo ""
+
+# Read templates
+if [[ ! -f "${SCRIPT_DIR}/templates/${USER_DATA_TEMPLATE_FILE}" ]]; then
+    echo "Error: Template file not found: ${SCRIPT_DIR}/templates/${USER_DATA_TEMPLATE_FILE}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${SCRIPT_DIR}/templates/meta-data-template.yaml" ]]; then
+    echo "Error: Template file not found: ${SCRIPT_DIR}/templates/meta-data-template.yaml" >&2
+    exit 1
+fi
+
+USER_DATA_TEMPLATE=$(cat "${SCRIPT_DIR}/templates/${USER_DATA_TEMPLATE_FILE}")
+META_DATA_TEMPLATE=$(cat "${SCRIPT_DIR}/templates/meta-data-template.yaml")
+
+# Read step files (common sections)
+# Step files are already properly indented for runcmd section
+INIT_SERVICES=$(cat "${SCRIPT_DIR}/templates/steps/init-services.yaml")
+DOWNLOAD_SCRIPTS=$(cat "${SCRIPT_DIR}/templates/steps/download-scripts.yaml")
+DISABLE_UNATTENDED=$(cat "${SCRIPT_DIR}/templates/steps/ubuntu-disable-unattended-upgrades.yaml")
+INSTALL_TOOLS=$(cat "${SCRIPT_DIR}/templates/steps/install-tools.yaml")
+SETUP_VIRTFS=$(cat "${SCRIPT_DIR}/templates/steps/setup-virtfs.yaml")
+FINALIZE=$(cat "${SCRIPT_DIR}/templates/steps/finalize.yaml")
+WRITE_VM_CONFIGS=$(cat "${SCRIPT_DIR}/templates/steps/write-vm-configs.yaml")
+
+# Embed locally-maintained scripts (these will eventually be fetched from the repo)
+if [[ ! -f "${SCRIPT_DIR}/scripts/install-kernel.sh" ]]; then
+    echo "Error: Kernel installation script not found: ${SCRIPT_DIR}/scripts/install-kernel.sh" >&2
+    exit 1
+fi
+INSTALL_KERNEL=$(cat "${SCRIPT_DIR}/scripts/install-kernel.sh" | sed 's/^/    /')
+
+if [[ ! -f "${SCRIPT_DIR}/scripts/setup-motd.sh" ]]; then
+    echo "Error: MOTD setup script not found: ${SCRIPT_DIR}/scripts/setup-motd.sh" >&2
+    exit 1
+fi
+SETUP_MOTD=$(cat "${SCRIPT_DIR}/scripts/setup-motd.sh" | sed 's/^/    /')
+
+# Determine username based on distro
+case "$DISTRO" in
+    ubuntu|debian)
+        USERNAME="ubuntu"
+        ;;
+    centos|rhel|rocky|almalinux)
+        USERNAME="ec2-user"
+        ;;
+    alpine)
+        USERNAME="alpine"
+        ;;
+    *)
+        USERNAME="ubuntu"
+        ;;
+esac
+
+# Build SSH access hint based on environment
+if [[ "${SSH_KEY_NAME}" != "none" ]]; then
+    SSH_KEY_FLAG="-i ~/.ssh/${SSH_KEY_NAME} "
+else
+    SSH_KEY_FLAG=""
+fi
+case "${ENVIRONMENT}" in
+    aws)
+        SSH_ACCESS_HINT="SSH Access (from your workstation):
+    ssh ${SSH_KEY_FLAG}${USERNAME}@<instance-public-ip>"
+        ;;
+    *)
+        SSH_ACCESS_HINT="SSH Access:
+    ssh ${SSH_KEY_FLAG}-p 2222 ${USERNAME}@localhost"
+        ;;
+esac
+
+# Replace variables in template
+USER_DATA="${USER_DATA_TEMPLATE//\$\{DISTRO\}/${DISTRO}}"
+USER_DATA="${USER_DATA//\$\{VERSION\}/${VERSION}}"
+USER_DATA="${USER_DATA//\$\{KERNEL_FLAVOR\}/${KERNEL_FLAVOR}}"
+USER_DATA="${USER_DATA//\$\{KERNEL_VERSION\}/${KERNEL_VERSION}}"
+USER_DATA="${USER_DATA//\$\{ENVIRONMENT\}/${ENVIRONMENT}}"
+USER_DATA="${USER_DATA//\$\{SSH_PUBKEY\}/${SSH_PUBKEY}}"
+USER_DATA="${USER_DATA//\$\{SSH_KEY_NAME\}/${SSH_KEY_NAME}}"
+USER_DATA="${USER_DATA//\$\{SSH_ACCESS_HINT\}/${SSH_ACCESS_HINT}}"
+
+# Replace variables in step files
+# Note: Most variables (DISTRO, VERSION, etc.) are now sourced from /tmp/tracee-vm-env.sh
+# at runtime, so we only need to replace variables that aren't in the env file:
+# - USERNAME: Not in env file, needs generation-time replacement
+INIT_SERVICES="${INIT_SERVICES//\$\{USERNAME\}/${USERNAME}}"
+SETUP_VIRTFS="${SETUP_VIRTFS//\$\{USERNAME\}/${USERNAME}}"
+
+META_DATA="${META_DATA_TEMPLATE//\$\{DISTRO\}/${DISTRO}}"
+META_DATA="${META_DATA//\$\{VERSION\}/${VERSION}}"
+META_DATA="${META_DATA//\$\{KERNEL_FLAVOR\}/${KERNEL_FLAVOR}}"
+META_DATA="${META_DATA//\$\{KERNEL_VERSION\}/${KERNEL_VERSION}}"
+META_DATA="${META_DATA//\$\{ARCH\}/${ARCH}}"
+
+# Replace placeholders with steps using awk for proper multiline handling
+USER_DATA=$(echo "$USER_DATA" | awk -v init_svc="$INIT_SERVICES" -v download="$DOWNLOAD_SCRIPTS" -v disable_unattended="$DISABLE_UNATTENDED" -v tools="$INSTALL_TOOLS" -v virtfs="$SETUP_VIRTFS" -v finalize="$FINALIZE" -v kernel="$INSTALL_KERNEL" -v motd="$SETUP_MOTD" -v write_vm_configs="$WRITE_VM_CONFIGS" '
+/^  # WRITE_VM_CONFIGS_PLACEHOLDER$/ {
+    print write_vm_configs
+    next
+}
+/^  # INIT_SERVICES_PLACEHOLDER$/ {
+    print init_svc
+    next
+}
+/^  # DOWNLOAD_SCRIPTS_PLACEHOLDER$/ {
+    print download
+    next
+}
+/^  # DISABLE_UNATTENDED_UPGRADES_PLACEHOLDER$/ {
+    print disable_unattended
+    next
+}
+/^  # INSTALL_TOOLS_PLACEHOLDER$/ {
+    print tools
+    next
+}
+/^  # SETUP_VIRTFS_PLACEHOLDER$/ {
+    print virtfs
+    next
+}
+/^  # FINALIZE_PLACEHOLDER$/ {
+    print finalize
+    next
+}
+/# MOTD_SCRIPT_PLACEHOLDER/ {
+    print "    cat > /tmp/setup-motd.sh <<'"'"'MOTD_SCRIPT'"'"'"
+    print motd
+    print "    MOTD_SCRIPT"
+    next
+}
+/# KERNEL_SCRIPT_PLACEHOLDER/ {
+    print "  - |"
+    print "    cat > /tmp/install-kernel.sh <<'"'"'KERNEL_SCRIPT'"'"'"
+    print kernel
+    print "    KERNEL_SCRIPT"
+    next
+}
+{ print }
+')
+
+# Write output files
+OUTPUT_DIR="${OUTPUT_DIR_ARG:-${SCRIPT_DIR}/generated}"
+mkdir -p "${OUTPUT_DIR}"
+
+echo "$USER_DATA" > "${OUTPUT_DIR}/${IMAGE_NAME}-user-data.yaml"
+echo "$META_DATA" > "${OUTPUT_DIR}/${IMAGE_NAME}-meta-data.yaml"
+
+echo "✓ Generated files:"
+echo "  ${OUTPUT_DIR}/${IMAGE_NAME}-user-data.yaml"
+echo "  ${OUTPUT_DIR}/${IMAGE_NAME}-meta-data.yaml"
+echo ""
+echo "Next steps:"
+echo "  1. Create cloud-init ISO from the generated files:"
+echo "     cloud-localds ${IMAGE_NAME}-cloud-init.iso \\"
+echo "         ${OUTPUT_DIR}/${IMAGE_NAME}-user-data.yaml \\"
+echo "         ${OUTPUT_DIR}/${IMAGE_NAME}-meta-data.yaml"
+echo ""
+echo "  2. Boot VM with the cloud-init ISO and base image"
+echo ""
+echo "Note: VM images are not included in the repository."
+echo "      Download them separately or use the VM management scripts (coming soon)."
+echo ""

--- a/scripts/vm-setup/generated/ubuntu-22.04-generic-5.19.0-50-x86_64-meta-data.yaml
+++ b/scripts/vm-setup/generated/ubuntu-22.04-generic-5.19.0-50-x86_64-meta-data.yaml
@@ -1,0 +1,2 @@
+instance-id: ubuntu-22.04-generic-5.19.0-50-x86_64
+local-hostname: ubuntu-22.04-generic

--- a/scripts/vm-setup/generated/ubuntu-22.04-generic-5.19.0-50-x86_64-user-data.yaml
+++ b/scripts/vm-setup/generated/ubuntu-22.04-generic-5.19.0-50-x86_64-user-data.yaml
@@ -1,0 +1,423 @@
+#cloud-config
+# Cloud-init configuration for Ubuntu/Debian Tracee VMs
+# Distro: ubuntu 22.04 | Kernel: generic 5.19.0-50 | Env: local
+
+# Create ubuntu group (GID will match UID 1000)
+# Docker group will be created automatically during Docker installation
+groups:
+  - ubuntu
+
+users:
+  - name: ubuntu
+    uid: 1000
+    primary_group: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    shell: /bin/bash
+    # Set password to 'ubuntu' (plaintext, cloud-init will hash it)
+    # For console/emergency access
+    plain_text_passwd: ubuntu
+    lock_passwd: false
+    ssh_authorized_keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOEDKA/c+LS9J7ZtnYBnJqaQLKjgKwl3o7/+cJhHrsWh tracee-team@aquasecurity
+
+hostname: ubuntu-22.04-generic
+disable_root: true
+ssh_pwauth: true
+timezone: UTC
+
+# Automatically grow partition and resize filesystem to use all available space
+# This fixes GPT partition table issues when disk is expanded
+growpart:
+  mode: auto
+  devices: ['/']
+  ignore_growroot_disabled: false
+
+resize_rootfs: true
+
+# Install essential packages
+packages:
+  - build-essential
+  - git
+  - curl
+  - wget
+  - vim
+  - nano
+  - jq
+
+# Write helper scripts
+write_files:
+  # Environment variables for installation scripts
+  # Source this file in runcmd blocks: . /tmp/tracee-vm-env.sh
+  - path: /tmp/tracee-vm-env.sh
+    permissions: '0644'
+    content: |
+      # Tracee VM environment variables for cloud-init scripts
+      export DISTRO="ubuntu"
+      export VERSION="22.04"
+      export KERNEL_FLAVOR="generic"
+      export KERNEL_VERSION="5.19.0-50"
+      export ENVIRONMENT="local"
+      export USER_NAME="ubuntu"
+  
+  # Blacklist floppy driver to prevent fd0 I/O errors in VM
+  - path: /etc/modprobe.d/blacklist-floppy.conf
+    permissions: '0644'
+    content: |
+      # Prevent floppy driver from loading in VM environment
+      # VMs don't have physical floppy drives and the driver causes harmless I/O errors
+      blacklist floppy
+  
+  # Virtiofs mount entries for local development (fstab approach)
+  # Written to /tmp and conditionally appended to /etc/fstab by setup-virtfs script
+  - path: /tmp/virtiofs-mounts.conf
+    permissions: '0644'
+    content: |
+      # Virtiofs mounts for local development
+      # virtiofs provides full POSIX semantics (file locking, timestamps, mmap, etc.)
+      # nofail: don't block boot if virtiofs not available
+      tracee      /mnt/tracee    virtiofs  rw,nofail 0 0
+  
+  - path: /etc/motd
+    content: |
+      ════════════════════════════════════════════════════════════════
+                  Welcome to Tracee Development VM
+      ════════════════════════════════════════════════════════════════
+      
+      Distro:     ubuntu 22.04
+      Kernel:     generic 5.19.0-50
+      SSH Key:    ~/.ssh/tracee_team_ed25519
+      Console:    ubuntu / ubuntu (for emergency access)
+      Project:    https://github.com/aquasecurity/tracee
+      
+      ════════════════════════════════════════════════════════════════
+
+  - path: /home/ubuntu/.bash_aliases
+    content: |
+      # Tracee development aliases
+      alias tracee-build='cd /mnt/tracee && make'
+      alias tracee-test='cd /mnt/tracee && make test'
+      alias tracee-clean='cd /mnt/tracee && make clean'
+    owner: ubuntu:ubuntu
+    permissions: '0644'
+
+# Run installation scripts from Tracee repo
+runcmd:
+  # Initialize logging and services
+  - |
+    echo "Tracee VM initialization started at $(date)" | tee -a /var/log/tracee-vm-init.log
+    systemctl enable ssh
+    systemctl start ssh
+  
+  # Clone Tracee scripts from GitHub using sparse-checkout
+  # This gets ALL scripts with proper structure in one efficient operation
+  - |
+    echo "Cloning Tracee scripts from GitHub..." | tee -a /var/log/tracee-vm-init.log
+    
+    # Configure repository and branch (can be overridden via environment)
+    TRACEE_REPO="${TRACEE_REPO:-https://github.com/aquasecurity/tracee.git}"
+    TRACEE_BRANCH="${TRACEE_BRANCH:-main}"
+    
+    cd /tmp
+    
+    # Use git sparse-checkout to clone only the scripts/ folder (efficient & complete)
+    # --filter=blob:none: don't download file contents until needed (faster)
+    # --sparse: enable sparse-checkout mode
+    # --depth=1: shallow clone (only latest commit, faster)
+    git clone       --filter=blob:none       --sparse       --depth=1       --branch="${TRACEE_BRANCH}"       "${TRACEE_REPO}"       tracee 2>&1 | tee -a /var/log/tracee-vm-init.log
+    
+    cd tracee
+    
+    # Configure sparse-checkout to only get the scripts/ directory
+    git sparse-checkout set scripts 2>&1 | tee -a /var/log/tracee-vm-init.log
+    
+    echo "Tracee scripts cloned successfully from ${TRACEE_REPO} (branch: ${TRACEE_BRANCH})" | tee -a /var/log/tracee-vm-init.log
+  
+  # Install all dependencies using Tracee's install-deps-${DISTRO}.sh
+  # This script handles everything: packages, Go, Clang, Go tools, Docker, user environment
+  # The USER_NAME env var (from tracee-vm-env.sh) tells install-deps which user to configure
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Installing ${DISTRO} dependencies via install-deps-${DISTRO}.sh..." | tee -a /var/log/tracee-vm-init.log
+    echo "This includes: base packages, Go, Clang, Go tools, Docker, and user environment setup" | tee -a /var/log/tracee-vm-init.log
+    echo "Configuring user environment for: ${USER_NAME}" | tee -a /var/log/tracee-vm-init.log
+    
+    cd /tmp/tracee
+    DEPS_SCRIPT="./scripts/installation/install-deps-${DISTRO}.sh"
+    
+    if [ -f "${DEPS_SCRIPT}" ]; then
+      USER_NAME="${USER_NAME}" ${DEPS_SCRIPT} 2>&1 | tee -a /var/log/tracee-vm-init.log
+    else
+      echo "Error: ${DEPS_SCRIPT} not found, cannot install dependencies" | tee -a /var/log/tracee-vm-init.log
+      exit 1
+    fi
+    
+    echo "Dependencies installation completed successfully" | tee -a /var/log/tracee-vm-init.log
+    
+    # Install AMI tooling for AWS environments (Go, GitHub runner, etc.)
+    if [ "${ENVIRONMENT}" = "aws" ]; then
+      AMI_SCRIPT="./scripts/installation/install-ami-tooling.sh"
+      if [ -f "${AMI_SCRIPT}" ]; then
+        echo "Installing AWS/GitHub tooling..." | tee -a /var/log/tracee-vm-init.log
+        ${AMI_SCRIPT} 2>&1 | tee -a /var/log/tracee-vm-init.log
+      else
+        echo "Error: ${AMI_SCRIPT} not found, cannot install AWS tooling" | tee -a /var/log/tracee-vm-init.log
+        exit 1
+      fi
+    fi
+  
+  # Environment-specific setup
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    if [ "${ENVIRONMENT}" = "local" ]; then
+      echo "Setting up local development environment..." | tee -a /var/log/tracee-vm-init.log
+      mkdir -p /mnt/tracee
+      chown ubuntu:ubuntu /mnt/tracee
+      
+      # Append virtiofs mounts to /etc/fstab (distro-agnostic approach)
+      # Virtiofs config was written to /tmp/virtiofs-mounts.conf via write_files
+      if [ -f /tmp/virtiofs-mounts.conf ]; then
+        echo "" >> /etc/fstab  # Add blank line for readability
+        cat /tmp/virtiofs-mounts.conf >> /etc/fstab
+        echo "Virtiofs mounts added to /etc/fstab (will auto-mount after reboot)" | tee -a /var/log/tracee-vm-init.log
+      else
+        echo "Warning: /tmp/virtiofs-mounts.conf not found, skipping fstab update" | tee -a /var/log/tracee-vm-init.log
+      fi
+      
+      # Reload systemd to pick up fstab changes
+      systemctl daemon-reload
+      
+      echo "Local development environment configured" | tee -a /var/log/tracee-vm-init.log
+    fi
+  
+  # Install kernel LAST (using embedded script below)
+  # NOTE: Currently embedded for reliability, but we might change this to fetch
+  #       from the repo branch in the future (like other scripts) to ensure
+  #       we always use the latest version from the branch.
+  # IMPORTANT: Kernel installation must be last because it reboots the VM!
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Installing kernel generic 5.19.0-50..." | tee -a /var/log/tracee-vm-init.log
+    
+  - |
+    cat > /tmp/install-kernel.sh <<'KERNEL_SCRIPT'
+    #!/bin/bash
+    # Install specific kernel version (distro-agnostic)
+    # Usage: ./install-kernel.sh -d ubuntu -f generic -k 5.19.0-50
+    #        ./install-kernel.sh --distro auto --flavor generic --kernel-version 5.19.0-50
+    
+    set -euo pipefail
+    
+    # Function to show usage
+    usage() {
+        cat << EOF
+    Usage: $0 -d DISTRO -f FLAVOR -k VERSION
+    
+    Install a specific kernel version (distro-agnostic).
+    
+    Required Arguments:
+      -d, --distro DISTRO              Target distribution (ubuntu, centos, alpine, or auto for auto-detect)
+      -f, --flavor FLAVOR              Kernel flavor (generic, aws, gcp, azure, mainline, lts, vanilla)
+      -k, --kernel-version VERSION     Kernel version (e.g., 5.19.0-50)
+    
+    Examples:
+      $0 -d ubuntu -f generic -k 5.19.0-50
+      $0 --distro auto --flavor generic --kernel-version 5.19.0-50
+      $0 -d centos -f standard -k 5.15.0-1
+    
+    Supported Distros:
+      - ubuntu, debian    (flavors: generic, aws, gcp, azure, mainline)
+      - centos, rhel      (flavors: generic, standard, mainline, elrepo)
+      - alpine            (flavors: vanilla, lts)
+      - auto              (auto-detect from /etc/os-release)
+    
+    EOF
+        exit 1
+    }
+    
+    # Initialize variables
+    DISTRO=""
+    KERNEL_FLAVOR=""
+    KERNEL_VERSION=""
+    
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -d|--distro)
+                DISTRO="$2"
+                shift 2
+                ;;
+            -f|--flavor)
+                KERNEL_FLAVOR="$2"
+                shift 2
+                ;;
+            -k|--kernel-version)
+                KERNEL_VERSION="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                ;;
+            *)
+                echo "Error: Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+    
+    # Validate required arguments
+    if [ -z "$DISTRO" ] || [ -z "$KERNEL_FLAVOR" ] || [ -z "$KERNEL_VERSION" ]; then
+        echo "Error: All arguments are required (-d, -f, -k)"
+        echo ""
+        usage
+    fi
+    
+    echo "Installing kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION} on ${DISTRO}..."
+    
+    # Auto-detect distro if specified as "auto"
+    if [ "$DISTRO" = "auto" ]; then
+        if [ -f /etc/os-release ]; then
+            . /etc/os-release
+            case "$ID" in
+                ubuntu|debian) DISTRO="ubuntu" ;;
+                centos|rhel|rocky|almalinux) DISTRO="centos" ;;
+                alpine) DISTRO="alpine" ;;
+                *)
+                    echo "Error: Could not auto-detect distro from ID: $ID"
+                    exit 1
+                    ;;
+            esac
+            echo "Auto-detected distro: ${DISTRO}"
+        else
+            echo "Error: Cannot auto-detect distro (/etc/os-release not found)"
+            exit 1
+        fi
+    fi
+    
+    # Install kernel based on distro
+    case "${DISTRO}" in
+        ubuntu|debian)
+            case "${KERNEL_FLAVOR}" in
+                generic)
+                    apt-get update -y
+                    apt-get install -y                         "linux-image-${KERNEL_VERSION}-generic"                         "linux-headers-${KERNEL_VERSION}-generic"                         "linux-modules-extra-${KERNEL_VERSION}-generic"                         "linux-tools-${KERNEL_VERSION}-generic"
+                    ;;
+                
+                aws)
+                    apt-get update -y
+                    apt-get install -y                         "linux-image-${KERNEL_VERSION}"                         "linux-headers-${KERNEL_VERSION}"                         "linux-modules-extra-${KERNEL_VERSION}"
+                    ;;
+                
+                gcp)
+                    apt-get update -y
+                    apt-get install -y                         "linux-image-${KERNEL_VERSION}"                         "linux-headers-${KERNEL_VERSION}"
+                    ;;
+                
+                azure)
+                    apt-get update -y
+                    apt-get install -y                         "linux-image-${KERNEL_VERSION}"                         "linux-headers-${KERNEL_VERSION}"
+                    ;;
+                
+                mainline)
+                    apt-get update -y
+                    apt-get install -y software-properties-common
+                    add-apt-repository -y ppa:canonical-kernel-team/ppa || true
+                    apt-get update -y
+                    apt-get install -y                         "linux-image-unsigned-${KERNEL_VERSION}-generic"                         "linux-headers-${KERNEL_VERSION}-generic"
+                    ;;
+                
+                *)
+                    echo "Unknown kernel flavor for Ubuntu/Debian: ${KERNEL_FLAVOR}"
+                    exit 1
+                    ;;
+            esac
+            
+            # Update GRUB
+            update-grub
+            ;;
+        
+        centos|rhel|rocky|almalinux)
+            case "${KERNEL_FLAVOR}" in
+                generic|standard)
+                    # Install from standard repos
+                    dnf install -y                         "kernel-${KERNEL_VERSION}"                         "kernel-headers-${KERNEL_VERSION}"                         "kernel-devel-${KERNEL_VERSION}"                         "kernel-tools-${KERNEL_VERSION}" ||                     yum install -y                         "kernel-${KERNEL_VERSION}"                         "kernel-headers-${KERNEL_VERSION}"                         "kernel-devel-${KERNEL_VERSION}"                         "kernel-tools-${KERNEL_VERSION}"
+                    ;;
+                
+                mainline|elrepo)
+                    # Install from ELRepo for newer kernels
+                    dnf install -y elrepo-release || yum install -y elrepo-release
+                    dnf --enablerepo=elrepo-kernel install -y                         "kernel-ml-${KERNEL_VERSION}"                         "kernel-ml-headers-${KERNEL_VERSION}"                         "kernel-ml-devel-${KERNEL_VERSION}" ||                     yum --enablerepo=elrepo-kernel install -y                         "kernel-ml-${KERNEL_VERSION}"                         "kernel-ml-headers-${KERNEL_VERSION}"                         "kernel-ml-devel-${KERNEL_VERSION}"
+                    ;;
+                
+                *)
+                    echo "Unknown kernel flavor for CentOS/RHEL: ${KERNEL_FLAVOR}"
+                    exit 1
+                    ;;
+            esac
+            
+            # Update GRUB2
+            grub2-mkconfig -o /boot/grub2/grub.cfg || grubby --set-default="/boot/vmlinuz-${KERNEL_VERSION}"
+            ;;
+        
+        alpine)
+            case "${KERNEL_FLAVOR}" in
+                vanilla|standard)
+                    apk update
+                    apk add                         "linux-vanilla~=${KERNEL_VERSION%.*}"                         "linux-vanilla-dev~=${KERNEL_VERSION%.*}"
+                    ;;
+                
+                lts)
+                    apk update
+                    apk add                         "linux-lts~=${KERNEL_VERSION%.*}"                         "linux-lts-dev~=${KERNEL_VERSION%.*}"
+                    ;;
+                
+                *)
+                    echo "Unknown kernel flavor for Alpine: ${KERNEL_FLAVOR}"
+                    echo "Supported flavors: vanilla, lts"
+                    exit 1
+                    ;;
+            esac
+            
+            # Update bootloader
+            update-extlinux || true
+            ;;
+        
+        *)
+            echo "Unsupported distro: ${DISTRO}"
+            echo "Supported distros: ubuntu, debian, centos, rhel, rocky, almalinux, alpine"
+            exit 1
+            ;;
+    esac
+    
+    echo "Kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION} installed successfully on ${DISTRO}"
+    KERNEL_SCRIPT
+    
+    chmod +x /tmp/install-kernel.sh
+    /tmp/install-kernel.sh \
+      -d "ubuntu" \
+      -f "generic" \
+      -k "5.19.0-50" \
+      2>&1 | tee -a /var/log/tracee-vm-init.log
+  
+  # Finalize initialization and reboot
+  - |
+    echo "VM initialization complete (marker for tracking)" | tee -a /var/log/tracee-vm-init.log
+    touch /tmp/tracee-vm-init.done
+    echo "VM initialization completed at $(date)" | tee -a /var/log/tracee-vm-init.log
+    
+    # Reboot to activate new kernel (if kernel was installed)
+    reboot
+
+final_message: |
+  Tracee VM is ready!
+  
+  Distro:  ubuntu 22.04
+  Kernel:  generic 5.19.0-50 (active after reboot)
+  
+  SSH Access:
+    ssh -i ~/.ssh/tracee_team_ed25519 -p 2222 ubuntu@localhost
+  
+  The system took ${UPTIME} seconds to boot.

--- a/scripts/vm-setup/scripts/install-kernel.sh
+++ b/scripts/vm-setup/scripts/install-kernel.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+# Install specific kernel version (distro-agnostic)
+# Usage: ./install-kernel.sh -d ubuntu -f generic -k 5.19.0-50
+#        ./install-kernel.sh --distro auto --flavor generic --kernel-version 5.19.0-50
+
+set -euo pipefail
+
+# Function to show usage
+usage() {
+    cat << EOF
+Usage: $0 -d DISTRO -f FLAVOR -k VERSION
+
+Install a specific kernel version (distro-agnostic).
+
+Required Arguments:
+  -d, --distro DISTRO              Target distribution (ubuntu, centos, alpine, or auto for auto-detect)
+  -f, --flavor FLAVOR              Kernel flavor (generic, aws, gcp, azure, mainline, lts, vanilla)
+  -k, --kernel-version VERSION     Kernel version (e.g., 5.19.0-50)
+
+Examples:
+  $0 -d ubuntu -f generic -k 5.19.0-50
+  $0 --distro auto --flavor generic --kernel-version 5.19.0-50
+  $0 -d centos -f standard -k 5.15.0-1
+
+Supported Distros:
+  - ubuntu, debian    (flavors: generic, aws, gcp, azure, mainline)
+  - centos, rhel      (flavors: generic, standard, mainline, elrepo)
+  - alpine            (flavors: vanilla, lts)
+  - auto              (auto-detect from /etc/os-release)
+
+EOF
+    exit 1
+}
+
+# Initialize variables
+DISTRO=""
+KERNEL_FLAVOR=""
+KERNEL_VERSION=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d|--distro)
+            DISTRO="$2"
+            shift 2
+            ;;
+        -f|--flavor)
+            KERNEL_FLAVOR="$2"
+            shift 2
+            ;;
+        -k|--kernel-version)
+            KERNEL_VERSION="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$DISTRO" ] || [ -z "$KERNEL_FLAVOR" ] || [ -z "$KERNEL_VERSION" ]; then
+    echo "Error: All arguments are required (-d, -f, -k)"
+    echo ""
+    usage
+fi
+
+echo "Installing kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION} on ${DISTRO}..."
+
+# Auto-detect distro if specified as "auto"
+if [ "$DISTRO" = "auto" ]; then
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        case "$ID" in
+            ubuntu|debian) DISTRO="ubuntu" ;;
+            centos|rhel|rocky|almalinux) DISTRO="centos" ;;
+            alpine) DISTRO="alpine" ;;
+            *)
+                echo "Error: Could not auto-detect distro from ID: $ID"
+                exit 1
+                ;;
+        esac
+        echo "Auto-detected distro: ${DISTRO}"
+    else
+        echo "Error: Cannot auto-detect distro (/etc/os-release not found)"
+        exit 1
+    fi
+fi
+
+# Install kernel based on distro
+case "${DISTRO}" in
+    ubuntu|debian)
+        case "${KERNEL_FLAVOR}" in
+            generic)
+                apt-get update -y
+                apt-get install -y \
+                    "linux-image-${KERNEL_VERSION}-generic" \
+                    "linux-headers-${KERNEL_VERSION}-generic" \
+                    "linux-modules-extra-${KERNEL_VERSION}-generic" \
+                    "linux-tools-${KERNEL_VERSION}-generic"
+                ;;
+            
+            aws)
+                apt-get update -y
+                apt-get install -y \
+                    "linux-image-${KERNEL_VERSION}" \
+                    "linux-headers-${KERNEL_VERSION}" \
+                    "linux-modules-extra-${KERNEL_VERSION}"
+                ;;
+            
+            gcp)
+                apt-get update -y
+                apt-get install -y \
+                    "linux-image-${KERNEL_VERSION}" \
+                    "linux-headers-${KERNEL_VERSION}"
+                ;;
+            
+            azure)
+                apt-get update -y
+                apt-get install -y \
+                    "linux-image-${KERNEL_VERSION}" \
+                    "linux-headers-${KERNEL_VERSION}"
+                ;;
+            
+            mainline)
+                apt-get update -y
+                apt-get install -y software-properties-common
+                add-apt-repository -y ppa:canonical-kernel-team/ppa || true
+                apt-get update -y
+                apt-get install -y \
+                    "linux-image-unsigned-${KERNEL_VERSION}-generic" \
+                    "linux-headers-${KERNEL_VERSION}-generic"
+                ;;
+            
+            *)
+                echo "Unknown kernel flavor for Ubuntu/Debian: ${KERNEL_FLAVOR}"
+                exit 1
+                ;;
+        esac
+        
+        # Update GRUB
+        update-grub
+        ;;
+    
+    centos|rhel|rocky|almalinux)
+        case "${KERNEL_FLAVOR}" in
+            generic|standard)
+                # Install from standard repos
+                dnf install -y \
+                    "kernel-${KERNEL_VERSION}" \
+                    "kernel-headers-${KERNEL_VERSION}" \
+                    "kernel-devel-${KERNEL_VERSION}" \
+                    "kernel-tools-${KERNEL_VERSION}" || \
+                yum install -y \
+                    "kernel-${KERNEL_VERSION}" \
+                    "kernel-headers-${KERNEL_VERSION}" \
+                    "kernel-devel-${KERNEL_VERSION}" \
+                    "kernel-tools-${KERNEL_VERSION}"
+                ;;
+            
+            mainline|elrepo)
+                # Install from ELRepo for newer kernels
+                dnf install -y elrepo-release || yum install -y elrepo-release
+                dnf --enablerepo=elrepo-kernel install -y \
+                    "kernel-ml-${KERNEL_VERSION}" \
+                    "kernel-ml-headers-${KERNEL_VERSION}" \
+                    "kernel-ml-devel-${KERNEL_VERSION}" || \
+                yum --enablerepo=elrepo-kernel install -y \
+                    "kernel-ml-${KERNEL_VERSION}" \
+                    "kernel-ml-headers-${KERNEL_VERSION}" \
+                    "kernel-ml-devel-${KERNEL_VERSION}"
+                ;;
+            
+            *)
+                echo "Unknown kernel flavor for CentOS/RHEL: ${KERNEL_FLAVOR}"
+                exit 1
+                ;;
+        esac
+        
+        # Update GRUB2
+        grub2-mkconfig -o /boot/grub2/grub.cfg || grubby --set-default="/boot/vmlinuz-${KERNEL_VERSION}"
+        ;;
+    
+    alpine)
+        case "${KERNEL_FLAVOR}" in
+            vanilla|standard)
+                apk update
+                apk add \
+                    "linux-vanilla~=${KERNEL_VERSION%.*}" \
+                    "linux-vanilla-dev~=${KERNEL_VERSION%.*}"
+                ;;
+            
+            lts)
+                apk update
+                apk add \
+                    "linux-lts~=${KERNEL_VERSION%.*}" \
+                    "linux-lts-dev~=${KERNEL_VERSION%.*}"
+                ;;
+            
+            *)
+                echo "Unknown kernel flavor for Alpine: ${KERNEL_FLAVOR}"
+                echo "Supported flavors: vanilla, lts"
+                exit 1
+                ;;
+        esac
+        
+        # Update bootloader
+        update-extlinux || true
+        ;;
+    
+    *)
+        echo "Unsupported distro: ${DISTRO}"
+        echo "Supported distros: ubuntu, debian, centos, rhel, rocky, almalinux, alpine"
+        exit 1
+        ;;
+esac
+
+echo "Kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION} installed successfully on ${DISTRO}"

--- a/scripts/vm-setup/scripts/setup-motd.sh
+++ b/scripts/vm-setup/scripts/setup-motd.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Setup dynamic MOTD for Tracee Development VM
+# Shows running vs expected kernel, highlights mismatch on login.
+#
+# Usage: setup-motd.sh <distro> <version> <kernel_flavor> <kernel_version> [ssh_key_name]
+#
+# NOTE: Currently embedded for reliability, but may be fetched from
+#       the repo branch in the future (like other scripts).
+
+DISTRO="${1:?Usage: setup-motd.sh <distro> <version> <flavor> <kernel_version> [ssh_key_name]}"
+VERSION="${2:?}"
+KERNEL_FLAVOR="${3:?}"
+KERNEL_VERSION="${4:?}"
+SSH_KEY_NAME="${5:-none}"
+
+# Clear default static MOTD
+: > /etc/motd
+
+# Disable default MOTD scripts (Ubuntu ads, help text, etc.)
+# No-op on distros without update-motd.d
+if [ -d /etc/update-motd.d ]; then
+    chmod -x /etc/update-motd.d/* 2>/dev/null || true
+fi
+
+# Write our dynamic MOTD script
+cat > /etc/update-motd.d/01-tracee << 'MOTD_EOF'
+#!/bin/sh
+EXPECTED_FLAVOR="__KERNEL_FLAVOR__"
+EXPECTED_VERSION="__KERNEL_VERSION__"
+RUNNING_KERNEL=$(uname -r)
+
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo "            Welcome to Tracee Development VM"
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+echo "  Distro:     __DISTRO__ __VERSION__"
+
+# Check if running kernel matches expected
+case "$RUNNING_KERNEL" in
+  *"$EXPECTED_VERSION"*)
+    echo "  Kernel:     $EXPECTED_FLAVOR $EXPECTED_VERSION (running: $RUNNING_KERNEL) ✓"
+    ;;
+  *)
+    echo "  Kernel:     $EXPECTED_FLAVOR $EXPECTED_VERSION (expected)"
+    echo "  Running:    $RUNNING_KERNEL  ← MISMATCH (reboot may be needed)"
+    ;;
+esac
+
+if [ "__SSH_KEY_NAME__" != "none" ]; then
+  echo "  SSH Key:    ~/.ssh/__SSH_KEY_NAME__"
+fi
+echo "  Console:    ubuntu / ubuntu (for emergency access)"
+echo "  Project:    https://github.com/aquasecurity/tracee"
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+MOTD_EOF
+
+# Replace placeholders with actual values
+sed -i "s|__DISTRO__|${DISTRO}|g" /etc/update-motd.d/01-tracee
+sed -i "s|__VERSION__|${VERSION}|g" /etc/update-motd.d/01-tracee
+sed -i "s|__KERNEL_FLAVOR__|${KERNEL_FLAVOR}|g" /etc/update-motd.d/01-tracee
+sed -i "s|__KERNEL_VERSION__|${KERNEL_VERSION}|g" /etc/update-motd.d/01-tracee
+sed -i "s|__SSH_KEY_NAME__|${SSH_KEY_NAME}|g" /etc/update-motd.d/01-tracee
+
+chmod +x /etc/update-motd.d/01-tracee
+
+echo "Dynamic MOTD installed"

--- a/scripts/vm-setup/start-vm-virtiofs.sh
+++ b/scripts/vm-setup/start-vm-virtiofs.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+# Start Tracee VM with virtiofs shared directories
+#
+# This script:
+# 1. Detects target architecture from VM name
+# 2. Starts virtiofsd daemons for host directory sharing (native arch only)
+# 3. Launches QEMU with appropriate settings per architecture
+
+set -e
+
+# Configuration
+VM_NAME="${1:-ubuntu-22.04-generic-5.19.0-50-x86_64}"
+VM_DIR="${VM_DIR:-${HOME}/vms}"
+TRACEE_DIR="${TRACEE_DIR:-${HOME}/code/tracee}"
+VIRTIOFSD="${VIRTIOFSD:-/usr/libexec/virtiofsd}"
+
+# VM resources
+VM_RAM="${VM_RAM:-4G}"
+VM_CPUS="${VM_CPUS:-4}"
+SSH_PORT="${SSH_PORT:-2222}"
+
+# Socket and log paths
+TRACEE_SOCK="/tmp/vhost-tracee.sock"
+VIRTIOFSD_LOG="/tmp/virtiofsd-tracee.log"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║        Starting Tracee VM with Virtiofs                    ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Detect target and host architecture early (before virtiofsd decision)
+HOST_ARCH=$(uname -m)
+TARGET_ARCH="x86_64"
+if [[ "${VM_NAME}" == *-aarch64-* ]] || [[ "${VM_NAME}" == *-arm64-* ]]; then
+    TARGET_ARCH="aarch64"
+fi
+
+# Determine if we can use KVM (same arch) or must fall back to TCG
+USE_KVM=0
+if [[ "${TARGET_ARCH}" == "${HOST_ARCH}" ]]; then
+    USE_KVM=1
+fi
+
+# Virtiofs requires shared memory (memfd+numa) which only works reliably with KVM.
+# For cross-arch TCG emulation, skip virtiofs — use SSH/scp for file transfer instead.
+USE_VIRTIOFS=0
+if [[ "${USE_KVM}" -eq 1 ]]; then
+    USE_VIRTIOFS=1
+fi
+
+# Check if VM image exists (.qcow2 or .img)
+VM_DISK=""
+VM_FORMAT=""
+if [ -f "${VM_DIR}/${VM_NAME}.qcow2" ]; then
+    VM_DISK="${VM_DIR}/${VM_NAME}.qcow2"
+    VM_FORMAT="qcow2"
+elif [ -f "${VM_DIR}/${VM_NAME}.img" ]; then
+    VM_DISK="${VM_DIR}/${VM_NAME}.img"
+    if command -v qemu-img &>/dev/null; then
+        VM_FORMAT=$(qemu-img info "${VM_DISK}" 2>/dev/null | awk '/^file format:/{print $3}')
+    fi
+    VM_FORMAT="${VM_FORMAT:-qcow2}"
+else
+    echo -e "${RED}Error: VM image not found: ${VM_DIR}/${VM_NAME}.qcow2 or ${VM_DIR}/${VM_NAME}.img${NC}"
+    exit 1
+fi
+
+# QEMU needs write access to the disk image
+if [ ! -w "${VM_DISK}" ]; then
+    echo -e "${RED}Error: VM image is not writable: ${VM_DISK}${NC}"
+    echo "QEMU needs write access. Fix with: chmod u+w ${VM_DISK}"
+    exit 1
+fi
+
+# Check if cloud-init ISO exists
+if [ ! -f "${VM_DIR}/${VM_NAME}-cloud-init.iso" ]; then
+    echo -e "${YELLOW}Warning: cloud-init ISO not found: ${VM_DIR}/${VM_NAME}-cloud-init.iso${NC}"
+    echo "VM will boot without cloud-init configuration"
+fi
+
+# Check if shared directories exist
+if [ ! -d "${TRACEE_DIR}" ]; then
+    echo -e "${RED}Error: Tracee directory not found: ${TRACEE_DIR}${NC}"
+    exit 1
+fi
+
+# Clean up old sockets and logs
+rm -f "${TRACEE_SOCK}"
+rm -f "${VIRTIOFSD_LOG}"
+
+# Trap to clean up on exit
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    pkill -P $$ virtiofsd 2>/dev/null || true
+    rm -f "${TRACEE_SOCK}"
+    echo "Done."
+}
+trap cleanup EXIT INT TERM
+
+echo "Configuration:"
+echo "  VM Name:        ${VM_NAME}"
+echo "  VM Image:       ${VM_DISK}"
+echo "  Target arch:    ${TARGET_ARCH}"
+echo "  RAM:            ${VM_RAM}"
+echo "  CPUs:           ${VM_CPUS}"
+echo "  SSH Port:       localhost:${SSH_PORT}"
+echo "  Tracee Dir:     ${TRACEE_DIR}"
+echo "  Disk format:    ${VM_FORMAT}"
+echo "  Host UID:GID:   $(id -u):$(id -g)"
+echo "  VM UID:GID:     1000:1000 (mapped to host)"
+echo ""
+
+# Start virtiofsd only when using KVM (native arch)
+VIRTIOFSD_PID=""
+if [[ "${USE_VIRTIOFS}" -eq 1 ]]; then
+    if ! command -v "${VIRTIOFSD}" &> /dev/null; then
+        echo -e "${RED}Error: virtiofsd not found at ${VIRTIOFSD}${NC}"
+        echo "Try: which virtiofsd || find /usr -name virtiofsd 2>/dev/null"
+        echo ""
+        echo "Install with:"
+        echo "  Fedora: sudo dnf install qemu-virtiofsd"
+        echo "  Ubuntu: sudo apt install qemu-system-gui"
+        exit 1
+    fi
+    echo "Starting virtiofsd for tracee..."
+    echo "  Log file: ${VIRTIOFSD_LOG}"
+    "${VIRTIOFSD}" \
+        --socket-path="${TRACEE_SOCK}" \
+        --shared-dir="${TRACEE_DIR}" \
+        --cache=never \
+        --sandbox=none \
+        --inode-file-handles=never \
+        --translate-uid="map:1000:$(id -u):1" \
+        --translate-gid="map:1000:$(id -g):1" \
+        >> "${VIRTIOFSD_LOG}" 2>&1 &
+    VIRTIOFSD_PID=$!
+
+    echo "Waiting for virtiofsd socket..."
+    for i in {1..15}; do
+        if [ -S "${TRACEE_SOCK}" ]; then
+            if ! kill -0 "${VIRTIOFSD_PID}" 2>/dev/null; then
+                echo -e "${RED}Error: virtiofsd process died${NC}"
+                echo "Check log: ${VIRTIOFSD_LOG}"
+                tail -20 "${VIRTIOFSD_LOG}"
+                exit 1
+            fi
+            echo -e "${GREEN}✓ Socket ready! (PID: ${VIRTIOFSD_PID})${NC}"
+            break
+        fi
+        if [ $i -eq 15 ]; then
+            echo -e "${RED}Error: Timeout waiting for socket${NC}"
+            echo "Check log: ${VIRTIOFSD_LOG}"
+            tail -20 "${VIRTIOFSD_LOG}"
+            exit 1
+        fi
+        sleep 1
+    done
+    ls -lh "${TRACEE_SOCK}"
+    echo ""
+else
+    echo -e "${YELLOW}Virtiofs disabled (cross-arch TCG). Using 9p for shared directories.${NC}"
+    echo "  Shared: ${TRACEE_DIR} → /mnt/tracee (via 9p)"
+    echo ""
+fi
+
+# Build QEMU command based on target architecture
+QEMU_CMD=()
+if [[ "${TARGET_ARCH}" == "aarch64" ]]; then
+    QEMU_BINARY="qemu-system-aarch64"
+    if ! command -v "${QEMU_BINARY}" &>/dev/null; then
+        echo -e "${RED}Error: ${QEMU_BINARY} not found. Install qemu-system-aarch64.${NC}"
+        exit 1
+    fi
+    # Find UEFI firmware code and vars template
+    AARCH64_CODE=""
+    AARCH64_VARS_TEMPLATE=""
+    for fw in /usr/share/AAVMF/AAVMF_CODE.fd /usr/share/edk2/aarch64/QEMU_EFI.fd /usr/share/qemu-efi-aarch64/QEMU_EFI.fd; do
+        [[ -f "${fw}" ]] && { AARCH64_CODE="${fw}"; break; }
+    done
+    for vars in /usr/share/AAVMF/AAVMF_VARS.fd /usr/share/edk2/aarch64/QEMU_VARS.fd; do
+        [[ -f "${vars}" ]] && { AARCH64_VARS_TEMPLATE="${vars}"; break; }
+    done
+    if [[ -z "${AARCH64_CODE}" ]] || [[ -z "${AARCH64_VARS_TEMPLATE}" ]]; then
+        echo -e "${RED}Error: aarch64 UEFI firmware not found.${NC}"
+        echo "Install one of: edk2-aarch64, qemu-efi-aarch64, AAVMF"
+        exit 1
+    fi
+    # Per-VM writable copy of EFI variable store
+    AARCH64_VARS="${VM_DIR}/${VM_NAME}-efivars.fd"
+    if [[ ! -f "${AARCH64_VARS}" ]]; then
+        cp "${AARCH64_VARS_TEMPLATE}" "${AARCH64_VARS}"
+        echo "  Created EFI vars: $(basename "${AARCH64_VARS}")"
+    fi
+    echo "  UEFI code:      ${AARCH64_CODE}"
+    echo "  UEFI vars:      ${AARCH64_VARS}"
+
+    QEMU_CMD=("${QEMU_BINARY}" -machine "virt,gic-version=max")
+    if [[ "${USE_KVM}" -eq 1 ]]; then
+        QEMU_CMD+=(-enable-kvm -cpu host -m "${VM_RAM}" -smp "${VM_CPUS}")
+    else
+        # TCG cross-arch
+        QEMU_CMD+=(-cpu cortex-a57 -m "${VM_RAM}" -smp "${VM_CPUS}")
+        echo -e "${YELLOW}  Cross-arch emulation (TCG) — ${VM_CPUS} cores, ${VM_RAM} RAM, will be slow.${NC}"
+    fi
+    QEMU_CMD+=(
+        # UEFI firmware (pflash): read-only code + writable per-VM variable store
+        -drive "if=pflash,format=raw,file=${AARCH64_CODE},readonly=on"
+        -drive "if=pflash,format=raw,file=${AARCH64_VARS}"
+    )
+    # Virtiofs (KVM only) or 9p fallback for cross-arch TCG
+    if [[ "${USE_VIRTIOFS}" -eq 1 ]]; then
+        QEMU_CMD+=(
+            -object "memory-backend-memfd,id=mem,size=${VM_RAM},share=on"
+            -numa node,memdev=mem
+            -chardev "socket,id=char-tracee,path=${TRACEE_SOCK}"
+            -device vhost-user-fs-pci,chardev=char-tracee,tag=tracee
+        )
+    else
+        # 9p filesystem sharing: works with TCG (no shared memory needed)
+        QEMU_CMD+=(
+            -fsdev "local,id=tracee_dev,path=${TRACEE_DIR},security_model=none"
+            -device "virtio-9p-pci,fsdev=tracee_dev,mount_tag=tracee"
+        )
+    fi
+    QEMU_CMD+=(
+        -drive "if=virtio,format=${VM_FORMAT},file=${VM_DISK}"
+    )
+    if [ -f "${VM_DIR}/${VM_NAME}-cloud-init.iso" ]; then
+        QEMU_CMD+=(-drive "if=virtio,format=raw,file=${VM_DIR}/${VM_NAME}-cloud-init.iso,readonly=on")
+    fi
+    QEMU_CMD+=(
+        -netdev "user,id=net0,hostfwd=tcp::${SSH_PORT}-:22"
+        -device virtio-net-pci,netdev=net0
+        -nographic
+    )
+else
+    # x86_64: SeaBIOS (QEMU default) works for all Ubuntu cloud images (hybrid GPT).
+    QEMU_CMD=(
+        qemu-system-x86_64
+        -enable-kvm
+        -cpu host
+        -m "${VM_RAM}"
+        -smp "${VM_CPUS}"
+        # Shared memory for virtiofs
+        -object "memory-backend-memfd,id=mem,size=${VM_RAM},share=on"
+        -numa node,memdev=mem
+        # Virtiofs for tracee
+        -chardev "socket,id=char-tracee,path=${TRACEE_SOCK}"
+        -device vhost-user-fs-pci,chardev=char-tracee,tag=tracee
+        # Main disk
+        -drive "if=virtio,format=${VM_FORMAT},file=${VM_DISK}"
+    )
+    if [ -f "${VM_DIR}/${VM_NAME}-cloud-init.iso" ]; then
+        QEMU_CMD+=(-cdrom "${VM_DIR}/${VM_NAME}-cloud-init.iso")
+    fi
+    QEMU_CMD+=(
+        -net nic,model=virtio
+        -net "user,hostfwd=tcp::${SSH_PORT}-:22"
+        -nographic
+        -serial mon:stdio
+    )
+fi
+
+echo ""
+echo "Starting QEMU..."
+echo ""
+echo -e "${GREEN}VM is starting...${NC}"
+echo "SSH access: ssh -p ${SSH_PORT} ubuntu@localhost"
+if [[ -n "${VIRTIOFSD_PID}" ]]; then
+    echo ""
+    echo "Debug info:"
+    echo "  virtiofsd PID: ${VIRTIOFSD_PID}"
+    echo "  virtiofsd log: ${VIRTIOFSD_LOG}"
+fi
+echo ""
+echo "Press Ctrl+A then X to quit QEMU"
+echo "════════════════════════════════════════════════════════════"
+echo ""
+
+# Start QEMU (foreground)
+exec "${QEMU_CMD[@]}"

--- a/scripts/vm-setup/templates/meta-data-template.yaml
+++ b/scripts/vm-setup/templates/meta-data-template.yaml
@@ -1,0 +1,2 @@
+instance-id: ${DISTRO}-${VERSION}-${KERNEL_FLAVOR}-${KERNEL_VERSION}-${ARCH}
+local-hostname: ${DISTRO}-${VERSION}-${KERNEL_FLAVOR}

--- a/scripts/vm-setup/templates/steps/README.md
+++ b/scripts/vm-setup/templates/steps/README.md
@@ -1,0 +1,241 @@
+# Cloud-Init Template Steps
+
+This directory contains reusable steps that are shared across multiple distro-specific templates to follow the DRY (Don't Repeat Yourself) principle.
+
+## Available Steps
+
+### `download-scripts.yaml`
+**Purpose:** Downloads all installation scripts and libraries from the Tracee GitHub repository.
+
+**What it does:**
+- Creates directory structure in `/tmp/tracee/`
+- Downloads all `lib*.sh` files
+- Downloads installation scripts (clang, golang, deps, ami-tooling)
+- Downloads GPG keys
+- Makes scripts executable
+
+**Used by:** All distro templates (ubuntu, centos, alpine)
+
+**Variables used:**
+- `${DISTRO}` - For distro-specific install-deps script
+
+---
+
+### `install-tools.yaml`
+**Purpose:** Installs all dependencies via `install-deps-${DISTRO}.sh`.
+
+**What it does:**
+- Runs the distro-specific `install-deps-${DISTRO}.sh` script
+- The script installs: base packages, Go, Clang, Go tools, Docker
+- Configures user environment (Go paths, Docker group) for `USER_NAME`
+- Installs AWS/AMI tooling (if `ENVIRONMENT=aws`)
+
+**Used by:** All distro templates (ubuntu, centos, alpine)
+
+**Variables used:**
+- `${DISTRO}` - Selects the appropriate install-deps script
+- `${ENVIRONMENT}` - For conditional AWS tooling installation
+- `${USER_NAME}` - Passed to install-deps script for user environment configuration
+
+---
+
+### `setup-virtfs.yaml`
+**Purpose:** Configures automatic mounting of virtfs shares for local development.
+
+**What it does:**
+- Creates `/mnt/tracee` and `/mnt/libbpfgo` directories
+- Sets ownership to appropriate user
+- Creates systemd mount units for auto-mounting
+- Enables mount units for boot
+
+**Used by:** All distro templates (ubuntu, centos, alpine)
+
+**Variables used:**
+- `${USERNAME}` - Dynamically set by generator (ubuntu/ec2-user/alpine)
+- `${ENVIRONMENT}` - Only runs if `ENVIRONMENT=local`
+
+---
+
+### `finalize.yaml`
+**Purpose:** Final steps before reboot.
+
+**What it does:**
+- Creates `/tmp/tracee-vm-init.done` marker file
+- Logs completion timestamp
+- Schedules reboot to activate new kernel
+
+**Used by:** All distro templates (ubuntu, centos, alpine)
+
+**Variables used:**
+- None
+
+---
+
+## How Steps Work
+
+### 1. Templates Use Placeholders
+
+Distro-specific templates contain placeholders:
+
+```yaml
+runcmd:
+  - echo "Starting setup..." | tee -a /var/log/tracee-vm-init.log
+  
+  # DOWNLOAD_SCRIPTS_PLACEHOLDER
+  
+  # Install kernel
+  # KERNEL_SCRIPT_PLACEHOLDER
+  
+  # INSTALL_TOOLS_PLACEHOLDER
+  
+  # SETUP_VIRTFS_PLACEHOLDER
+  
+  # FINALIZE_PLACEHOLDER
+```
+
+### 2. Generator Script Injects Steps
+
+`generate-cloud-init.sh` reads step files and replaces placeholders:
+
+```bash
+# Read steps
+DOWNLOAD_SCRIPTS=$(cat "${SCRIPT_DIR}/templates/steps/download-scripts.yaml")
+INSTALL_TOOLS=$(cat "${SCRIPT_DIR}/templates/partials/install-tools.yaml")
+SETUP_VIRTFS=$(cat "${SCRIPT_DIR}/templates/partials/setup-virtfs.yaml")
+FINALIZE=$(cat "${SCRIPT_DIR}/templates/partials/finalize.yaml")
+
+# Replace variables in steps
+SETUP_VIRTFS="${SETUP_VIRTFS//\$\{USERNAME\}/${USERNAME}}"
+
+# Inject into template
+USER_DATA="${USER_DATA//  # DOWNLOAD_SCRIPTS_PLACEHOLDER/$DOWNLOAD_SCRIPTS}"
+USER_DATA="${USER_DATA//  # INSTALL_TOOLS_PLACEHOLDER/$INSTALL_TOOLS}"
+USER_DATA="${USER_DATA//  # SETUP_VIRTFS_PLACEHOLDER/$SETUP_VIRTFS}"
+USER_DATA="${USER_DATA//  # FINALIZE_PLACEHOLDER/$FINALIZE}"
+```
+
+### 3. Generated YAML Contains Full Content
+
+The final generated `user-data.yaml` has all steps expanded with proper indentation and variable substitution.
+
+## Benefits of Using Steps
+
+### 1. DRY Principle ✓
+- Common logic written once
+- Reduces duplication across templates
+- Single source of truth for shared sections
+
+### 2. Maintainability ✓
+- Update partial once, affects all templates
+- Easier to spot and fix bugs
+- Clear separation of concerns
+
+### 3. Consistency ✓
+- All distros use identical script download logic
+- All distros use identical tool installation logic
+- Reduces drift between distro templates
+
+### 4. Readability ✓
+- Distro templates focus on distro-specific differences
+- Common logic abstracted away
+- Easier to see what makes each distro unique
+
+## Distro-Specific vs Step Logic
+
+### What Stays in Distro Templates
+
+**Package manager operations:**
+- `apt-get` vs `dnf` vs `apk`
+- Lock file checking (`dpkg` vs `rpm`)
+- System updates
+
+**User configuration:**
+- Username (ubuntu vs ec2-user vs alpine)
+- Groups (sudo vs wheel)
+- Default packages
+
+**Service management:**
+- SSH service name (ssh vs sshd)
+- Init system (systemd vs OpenRC)
+
+### What Goes in Steps
+
+**Script downloads:**
+- Same GitHub URLs for all distros
+- Same directory structure
+- Same lib files
+
+**Tool installation:**
+- Uses distro-agnostic scripts
+- Conditional logic handled in scripts themselves
+- Same workflow for all distros
+
+**Virtfs setup:**
+- Same systemd mount units
+- Only username differs (handled by variable)
+
+**Finalization:**
+- Same marker file
+- Same reboot command
+
+## Adding New Steps
+
+To add a new reusable section:
+
+1. **Create step file:**
+   ```bash
+   touch templates/steps/my-new-section.yaml
+   ```
+
+2. **Add placeholder to templates:**
+   ```yaml
+   # MY_NEW_SECTION_PLACEHOLDER
+   ```
+
+3. **Update generator script:**
+   ```bash
+   MY_NEW_SECTION=$(cat "${SCRIPT_DIR}/templates/steps/my-new-section.yaml")
+   USER_DATA="${USER_DATA//  # MY_NEW_SECTION_PLACEHOLDER/$MY_NEW_SECTION}"
+   ```
+
+4. **Test with all distros:**
+   ```bash
+   ./generate-cloud-init.sh -d ubuntu ...
+   ./generate-cloud-init.sh -d centos ...
+   ./generate-cloud-init.sh -d alpine ...
+   ```
+
+## Variable Substitution in Steps
+
+Steps can use template variables:
+
+- `${DISTRO}` - Distribution name
+- `${VERSION}` - Distribution version
+- `${KERNEL_FLAVOR}` - Kernel flavor
+- `${KERNEL_VERSION}` - Kernel version
+- `${ENVIRONMENT}` - Environment type (local/aws)
+- `${USERNAME}` - Distro-specific username (dynamically set)
+
+Variables are replaced by the generator script before injection.
+
+## Best Practices
+
+1. **Keep steps distro-agnostic**
+   - Don't reference specific package managers
+   - Use conditionals for distro-specific behavior
+
+2. **Use clear placeholder names**
+   - Name should describe what the partial does
+   - Use ALL_CAPS with underscores
+
+3. **Document step purpose**
+   - Add comments at the top
+   - Explain any complex logic
+
+4. **Test across all distros**
+   - Ensure partial works for ubuntu, centos, alpine
+   - Verify variable substitution works correctly
+
+5. **Keep steps focused**
+   - One step = one responsibility
+   - Don't combine unrelated functionality

--- a/scripts/vm-setup/templates/steps/download-scripts.yaml
+++ b/scripts/vm-setup/templates/steps/download-scripts.yaml
@@ -1,0 +1,31 @@
+  # Clone Tracee scripts from GitHub using sparse-checkout
+  # This gets ALL scripts with proper structure in one efficient operation
+  - |
+    echo "Cloning Tracee scripts from GitHub..." | tee -a /var/log/tracee-vm-init.log
+    
+    # Configure repository and branch (can be overridden via environment)
+    TRACEE_REPO="${TRACEE_REPO:-https://github.com/aquasecurity/tracee.git}"
+    TRACEE_BRANCH="${TRACEE_BRANCH:-main}"
+    
+    cd /tmp
+    
+    # Clone without checkout first (--sparse flag has a bug in git 2.25.x on focal)
+    # --filter=blob:none: don't download file contents until needed (faster)
+    # --no-checkout: defer checkout until sparse-checkout is configured
+    # --depth=1: shallow clone (only latest commit, faster)
+    git clone \
+      --filter=blob:none \
+      --no-checkout \
+      --depth=1 \
+      --branch="${TRACEE_BRANCH}" \
+      "${TRACEE_REPO}" \
+      tracee 2>&1 | tee -a /var/log/tracee-vm-init.log
+    
+    cd tracee || { echo "ERROR: git clone failed, /tmp/tracee not created" | tee -a /var/log/tracee-vm-init.log; exit 1; }
+    
+    # Initialize sparse-checkout and limit to scripts/ directory only
+    git sparse-checkout init --cone 2>&1 | tee -a /var/log/tracee-vm-init.log
+    git sparse-checkout set scripts 2>&1 | tee -a /var/log/tracee-vm-init.log
+    git checkout 2>&1 | tee -a /var/log/tracee-vm-init.log
+    
+    echo "Tracee scripts cloned successfully from ${TRACEE_REPO} (branch: ${TRACEE_BRANCH})" | tee -a /var/log/tracee-vm-init.log

--- a/scripts/vm-setup/templates/steps/finalize.yaml
+++ b/scripts/vm-setup/templates/steps/finalize.yaml
@@ -1,0 +1,8 @@
+  # Finalize initialization and reboot
+  - |
+    echo "VM initialization complete (marker for tracking)" | tee -a /var/log/tracee-vm-init.log
+    touch /tmp/tracee-vm-init.done
+    echo "VM initialization completed at $(date)" | tee -a /var/log/tracee-vm-init.log
+    
+    # Reboot to activate new kernel (if kernel was installed)
+    reboot

--- a/scripts/vm-setup/templates/steps/init-services.yaml
+++ b/scripts/vm-setup/templates/steps/init-services.yaml
@@ -1,0 +1,9 @@
+  # Initialize logging, services, and fix common cloud-image quirks
+  - |
+    echo "Tracee VM initialization started at $(date)" | tee -a /var/log/tracee-vm-init.log
+    systemctl enable ssh
+    systemctl start ssh
+    
+    # Fix home directory ownership (user may pre-exist in cloud images,
+    # cloud-init user module can leave /home/<user> owned by root)
+    chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}

--- a/scripts/vm-setup/templates/steps/install-tools.yaml
+++ b/scripts/vm-setup/templates/steps/install-tools.yaml
@@ -1,0 +1,33 @@
+  # Install all dependencies using Tracee's install-deps-${DISTRO}.sh
+  # This script handles everything: packages, Go, Clang, Go tools, Docker, user environment
+  # The USER_NAME env var (from tracee-vm-env.sh) tells install-deps which user to configure
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Installing ${DISTRO} dependencies via install-deps-${DISTRO}.sh..." | tee -a /var/log/tracee-vm-init.log
+    echo "This includes: base packages, Go, Clang, Go tools, Docker, and user environment setup" | tee -a /var/log/tracee-vm-init.log
+    echo "Configuring user environment for: ${USER_NAME}" | tee -a /var/log/tracee-vm-init.log
+    
+    cd /tmp/tracee
+    DEPS_SCRIPT="./scripts/installation/install-deps-${DISTRO}.sh"
+    
+    if [ -f "${DEPS_SCRIPT}" ]; then
+      USER_NAME="${USER_NAME}" ${DEPS_SCRIPT} 2>&1 | tee -a /var/log/tracee-vm-init.log
+    else
+      echo "Error: ${DEPS_SCRIPT} not found, cannot install dependencies" | tee -a /var/log/tracee-vm-init.log
+      exit 1
+    fi
+    
+    echo "Dependencies installation completed successfully" | tee -a /var/log/tracee-vm-init.log
+    
+    # Install AMI tooling for AWS environments (Go, GitHub runner, etc.)
+    if [ "${ENVIRONMENT}" = "aws" ]; then
+      AMI_SCRIPT="./scripts/installation/install-ami-tooling.sh"
+      if [ -f "${AMI_SCRIPT}" ]; then
+        echo "Installing AWS/GitHub tooling..." | tee -a /var/log/tracee-vm-init.log
+        ${AMI_SCRIPT} 2>&1 | tee -a /var/log/tracee-vm-init.log
+      else
+        echo "Error: ${AMI_SCRIPT} not found, cannot install AWS tooling" | tee -a /var/log/tracee-vm-init.log
+        exit 1
+      fi
+    fi

--- a/scripts/vm-setup/templates/steps/setup-virtfs.yaml
+++ b/scripts/vm-setup/templates/steps/setup-virtfs.yaml
@@ -1,0 +1,22 @@
+  # Environment-specific setup
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    if [ "${ENVIRONMENT}" = "local" ]; then
+      echo "Setting up local development environment..." | tee -a /var/log/tracee-vm-init.log
+      mkdir -p /mnt/tracee
+      chown ${USERNAME}:${USERNAME} /mnt/tracee
+      
+      # Mount shared directories (tries virtiofs first, falls back to 9p)
+      if [ -x /tmp/mount-shared-dirs.sh ]; then
+        /tmp/mount-shared-dirs.sh 2>&1 | tee -a /var/log/tracee-vm-init.log
+        chown ${USERNAME}:${USERNAME} /mnt/tracee
+      else
+        echo "Warning: /tmp/mount-shared-dirs.sh not found, skipping shared dir mount" | tee -a /var/log/tracee-vm-init.log
+      fi
+      
+      # Reload systemd to pick up fstab changes
+      systemctl daemon-reload
+      
+      echo "Local development environment configured" | tee -a /var/log/tracee-vm-init.log
+    fi

--- a/scripts/vm-setup/templates/steps/ubuntu-disable-unattended-upgrades.yaml
+++ b/scripts/vm-setup/templates/steps/ubuntu-disable-unattended-upgrades.yaml
@@ -1,0 +1,9 @@
+  # Disable unattended upgrades to prevent apt lock contention
+  # Uses the existing script from the cloned Tracee repo
+  - |
+    echo "Disabling unattended upgrades..." | tee -a /var/log/tracee-vm-init.log
+    if [ -x /tmp/tracee/scripts/disable-unattended-upgrades.sh ]; then
+      /tmp/tracee/scripts/disable-unattended-upgrades.sh 2>&1 | tee -a /var/log/tracee-vm-init.log
+    else
+      echo "Warning: disable-unattended-upgrades.sh not found, skipping" | tee -a /var/log/tracee-vm-init.log
+    fi

--- a/scripts/vm-setup/templates/steps/write-vm-configs.yaml
+++ b/scripts/vm-setup/templates/steps/write-vm-configs.yaml
@@ -1,0 +1,27 @@
+  # Blacklist floppy driver to prevent fd0 I/O errors in VM
+  - path: /etc/modprobe.d/blacklist-floppy.conf
+    permissions: '0644'
+    content: |
+      # Prevent floppy driver from loading in VM environment
+      # VMs don't have physical floppy drives and the driver causes harmless I/O errors
+      blacklist floppy
+  
+  # Shared directory mount script for local development
+  # Tries virtiofs first (KVM, fast), falls back to 9p (TCG cross-arch)
+  - path: /tmp/mount-shared-dirs.sh
+    permissions: '0755'
+    content: |
+      #!/bin/sh
+      # Mount shared directories: try virtiofs first, fall back to 9p
+      MOUNT_TAG="tracee"
+      MOUNT_POINT="/mnt/tracee"
+      
+      if mount -t virtiofs "${MOUNT_TAG}" "${MOUNT_POINT}" 2>/dev/null; then
+        echo "Mounted ${MOUNT_POINT} via virtiofs"
+        echo "${MOUNT_TAG} ${MOUNT_POINT} virtiofs rw,nofail 0 0" >> /etc/fstab
+      elif mount -t 9p -o trans=virtio,version=9p2000.L "${MOUNT_TAG}" "${MOUNT_POINT}" 2>/dev/null; then
+        echo "Mounted ${MOUNT_POINT} via 9p"
+        echo "${MOUNT_TAG} ${MOUNT_POINT} 9p trans=virtio,version=9p2000.L,rw,nofail 0 0" >> /etc/fstab
+      else
+        echo "Warning: could not mount ${MOUNT_POINT} (no virtiofs or 9p device)"
+      fi

--- a/scripts/vm-setup/templates/user-data-alpine-template.yaml
+++ b/scripts/vm-setup/templates/user-data-alpine-template.yaml
@@ -1,0 +1,139 @@
+#cloud-config
+# Cloud-init configuration for Alpine Linux Tracee VMs
+# Distro: ${DISTRO} ${VERSION} | Kernel: ${KERNEL_FLAVOR} ${KERNEL_VERSION} | Env: ${ENVIRONMENT}
+
+# Create alpine group (GID will match UID 1000)
+# Docker group will be created automatically during Docker installation
+groups:
+  - alpine
+
+users:
+  - name: alpine
+    uid: 1000
+    primary_group: alpine
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [wheel]
+    shell: /bin/bash
+    # Set password to 'alpine' (plaintext, cloud-init will hash it)
+    # For console/emergency access
+    plain_text_passwd: alpine
+    lock_passwd: false
+    ssh_authorized_keys:
+      - ${SSH_PUBKEY}
+
+hostname: ${DISTRO}-${VERSION}-${KERNEL_FLAVOR}
+disable_root: true
+ssh_pwauth: true
+timezone: UTC
+
+# Automatically grow partition and resize filesystem to use all available space
+# This fixes GPT partition table issues when disk is expanded
+growpart:
+  mode: auto
+  devices: ['/']
+  ignore_growroot_disabled: false
+
+resize_rootfs: true
+
+# Install essential packages
+packages:
+  - build-base
+  - git
+  - curl
+  - wget
+  - vim
+  - nano
+  - jq
+  - bash
+
+# Write helper scripts
+write_files:
+  # Environment variables for installation scripts
+  # Source this file in runcmd blocks: . /tmp/tracee-vm-env.sh
+  - path: /tmp/tracee-vm-env.sh
+    permissions: '0644'
+    content: |
+      # Tracee VM environment variables for cloud-init scripts
+      export DISTRO="${DISTRO}"
+      export VERSION="${VERSION}"
+      export KERNEL_FLAVOR="${KERNEL_FLAVOR}"
+      export KERNEL_VERSION="${KERNEL_VERSION}"
+      export ENVIRONMENT="${ENVIRONMENT}"
+      export SSH_KEY_NAME="${SSH_KEY_NAME}"
+      export USER_NAME="alpine"
+  
+  # WRITE_VM_CONFIGS_PLACEHOLDER
+  
+  - path: /etc/motd
+    content: |
+      ════════════════════════════════════════════════════════════════
+                  Welcome to Tracee Development VM
+      ════════════════════════════════════════════════════════════════
+      
+      Distro:     ${DISTRO} ${VERSION}
+      Kernel:     ${KERNEL_FLAVOR} ${KERNEL_VERSION}
+      SSH Key:    ~/.ssh/${SSH_KEY_NAME}
+      Console:    alpine / alpine (for emergency access)
+      Project:    https://github.com/aquasecurity/tracee
+      
+      ════════════════════════════════════════════════════════════════
+
+  - path: /home/alpine/.bash_aliases
+    content: |
+      # Tracee development aliases
+      alias tracee-build='cd /mnt/tracee && make'
+      alias tracee-test='cd /mnt/tracee && make test'
+      alias tracee-clean='cd /mnt/tracee && make clean'
+    owner: alpine:alpine
+    permissions: '0644'
+
+# Run installation scripts from Tracee repo
+runcmd:
+  # Initialize logging and services
+  - |
+    echo "Tracee VM initialization started at $(date)" | tee -a /var/log/tracee-vm-init.log
+    rc-service sshd start
+    rc-update add sshd default
+  
+  # Update package lists and upgrade existing packages
+  - echo "Updating and upgrading system packages..." | tee -a /var/log/tracee-vm-init.log
+  - apk update 2>&1 | tee -a /var/log/tracee-vm-init.log
+  - apk upgrade 2>&1 | tee -a /var/log/tracee-vm-init.log
+  - echo "System packages updated" | tee -a /var/log/tracee-vm-init.log
+  
+  # DOWNLOAD_SCRIPTS_PLACEHOLDER
+  
+  # INSTALL_TOOLS_PLACEHOLDER
+  
+  # SETUP_VIRTFS_PLACEHOLDER
+  
+  # Install kernel LAST (using embedded script below)
+  # NOTE: Currently embedded for reliability, but we might change this to fetch
+  #       from the repo branch in the future (like other scripts) to ensure
+  #       we always use the latest version from the branch.
+  # IMPORTANT: Kernel installation must be last because it reboots the VM!
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Installing kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION}..." | tee -a /var/log/tracee-vm-init.log
+    
+    # KERNEL_SCRIPT_PLACEHOLDER
+    
+    chmod +x /tmp/install-kernel.sh
+    /tmp/install-kernel.sh \
+      -d "${DISTRO}" \
+      -f "${KERNEL_FLAVOR}" \
+      -k "${KERNEL_VERSION}" \
+      2>&1 | tee -a /var/log/tracee-vm-init.log
+  
+  # FINALIZE_PLACEHOLDER
+
+final_message: |
+  Tracee VM is ready!
+  
+  Distro:  ${DISTRO} ${VERSION}
+  Kernel:  ${KERNEL_FLAVOR} ${KERNEL_VERSION} (active after reboot)
+  
+  ${SSH_ACCESS_HINT}
+  
+  The system took ${UPTIME} seconds to boot.

--- a/scripts/vm-setup/templates/user-data-centos-template.yaml
+++ b/scripts/vm-setup/templates/user-data-centos-template.yaml
@@ -1,0 +1,155 @@
+#cloud-config
+# Cloud-init configuration for CentOS/RHEL/Rocky/AlmaLinux Tracee VMs
+# Distro: ${DISTRO} ${VERSION} | Kernel: ${KERNEL_FLAVOR} ${KERNEL_VERSION} | Env: ${ENVIRONMENT}
+
+# Create ec2-user group (GID will match UID 1000)
+# Docker group will be created automatically during Docker installation
+groups:
+  - ec2-user
+
+users:
+  - name: ec2-user
+    uid: 1000
+    primary_group: ec2-user
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [wheel]
+    shell: /bin/bash
+    # Set password to 'centos' (plaintext, cloud-init will hash it)
+    # For console/emergency access
+    plain_text_passwd: centos
+    lock_passwd: false
+    ssh_authorized_keys:
+      - ${SSH_PUBKEY}
+
+hostname: ${DISTRO}-${VERSION}-${KERNEL_FLAVOR}
+disable_root: true
+ssh_pwauth: true
+timezone: UTC
+
+# Automatically grow partition and resize filesystem to use all available space
+# This fixes GPT partition table issues when disk is expanded
+growpart:
+  mode: auto
+  devices: ['/']
+  ignore_growroot_disabled: false
+
+resize_rootfs: true
+
+# Install essential packages
+packages:
+  - gcc
+  - make
+  - git
+  - curl
+  - wget
+  - vim
+  - nano
+  - jq
+
+# Write helper scripts
+write_files:
+  # Environment variables for installation scripts
+  # Source this file in runcmd blocks: . /tmp/tracee-vm-env.sh
+  - path: /tmp/tracee-vm-env.sh
+    permissions: '0644'
+    content: |
+      # Tracee VM environment variables for cloud-init scripts
+      export DISTRO="${DISTRO}"
+      export VERSION="${VERSION}"
+      export KERNEL_FLAVOR="${KERNEL_FLAVOR}"
+      export KERNEL_VERSION="${KERNEL_VERSION}"
+      export ENVIRONMENT="${ENVIRONMENT}"
+      export SSH_KEY_NAME="${SSH_KEY_NAME}"
+      export USER_NAME="ec2-user"
+  
+  # WRITE_VM_CONFIGS_PLACEHOLDER
+  
+  - path: /etc/motd
+    content: |
+      ════════════════════════════════════════════════════════════════
+                  Welcome to Tracee Development VM
+      ════════════════════════════════════════════════════════════════
+      
+      Distro:     ${DISTRO} ${VERSION}
+      Kernel:     ${KERNEL_FLAVOR} ${KERNEL_VERSION}
+      SSH Key:    ~/.ssh/${SSH_KEY_NAME}
+      Console:    ec2-user / centos (for emergency access)
+      Project:    https://github.com/aquasecurity/tracee
+      
+      ════════════════════════════════════════════════════════════════
+
+  - path: /home/ec2-user/.bash_aliases
+    content: |
+      # Tracee development aliases
+      alias tracee-build='cd /mnt/tracee && make'
+      alias tracee-test='cd /mnt/tracee && make test'
+      alias tracee-clean='cd /mnt/tracee && make clean'
+    owner: ec2-user:ec2-user
+    permissions: '0644'
+
+# Run installation scripts from Tracee repo
+runcmd:
+  # Initialize logging and services
+  - |
+    echo "Tracee VM initialization started at $(date)" | tee -a /var/log/tracee-vm-init.log
+    systemctl enable sshd
+    systemctl start sshd
+  
+  # Wait for package manager to be available
+  - echo "Waiting for package manager..." | tee -a /var/log/tracee-vm-init.log
+  - |
+    timeout=300
+    elapsed=0
+    while fuser /var/lib/rpm/.rpm.lock >/dev/null 2>&1; do
+      if [ $elapsed -ge $timeout ]; then
+        echo "Timeout waiting for rpm lock" | tee -a /var/log/tracee-vm-init.log
+        break
+      fi
+      echo "Waiting for other package operations to complete... (${elapsed}s)" | tee -a /var/log/tracee-vm-init.log
+      sleep 5
+      elapsed=$((elapsed + 5))
+    done
+  - echo "Package manager available, proceeding..." | tee -a /var/log/tracee-vm-init.log
+  
+  # Update package lists and upgrade existing packages
+  - echo "Updating and upgrading system packages..." | tee -a /var/log/tracee-vm-init.log
+  - dnf check-update -y 2>&1 | tee -a /var/log/tracee-vm-init.log || true
+  - dnf upgrade -y 2>&1 | tee -a /var/log/tracee-vm-init.log
+  - echo "System packages updated" | tee -a /var/log/tracee-vm-init.log
+  
+  # DOWNLOAD_SCRIPTS_PLACEHOLDER
+  
+  # INSTALL_TOOLS_PLACEHOLDER
+  
+  # SETUP_VIRTFS_PLACEHOLDER
+  
+  # Install kernel LAST (using embedded script below)
+  # NOTE: Currently embedded for reliability, but we might change this to fetch
+  #       from the repo branch in the future (like other scripts) to ensure
+  #       we always use the latest version from the branch.
+  # IMPORTANT: Kernel installation must be last because it reboots the VM!
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Installing kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION}..." | tee -a /var/log/tracee-vm-init.log
+    
+    # KERNEL_SCRIPT_PLACEHOLDER
+    
+    chmod +x /tmp/install-kernel.sh
+    /tmp/install-kernel.sh \
+      -d "${DISTRO}" \
+      -f "${KERNEL_FLAVOR}" \
+      -k "${KERNEL_VERSION}" \
+      2>&1 | tee -a /var/log/tracee-vm-init.log
+  
+  # FINALIZE_PLACEHOLDER
+
+final_message: |
+  Tracee VM is ready!
+  
+  Distro:  ${DISTRO} ${VERSION}
+  Kernel:  ${KERNEL_FLAVOR} ${KERNEL_VERSION} (active after reboot)
+  
+  ${SSH_ACCESS_HINT}
+  
+  The system took ${UPTIME} seconds to boot.

--- a/scripts/vm-setup/templates/user-data-ubuntu-template.yaml
+++ b/scripts/vm-setup/templates/user-data-ubuntu-template.yaml
@@ -1,0 +1,136 @@
+#cloud-config
+# Cloud-init configuration for Ubuntu/Debian Tracee VMs
+# Distro: ${DISTRO} ${VERSION} | Kernel: ${KERNEL_FLAVOR} ${KERNEL_VERSION} | Env: ${ENVIRONMENT}
+
+# Create ubuntu group (GID will match UID 1000)
+# Docker group will be created automatically during Docker installation
+groups:
+  - ubuntu
+
+users:
+  - name: ubuntu
+    uid: 1000
+    primary_group: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [sudo]
+    shell: /bin/bash
+    # Set password to 'ubuntu' (plaintext, cloud-init will hash it)
+    # For console/emergency access
+    plain_text_passwd: ubuntu
+    lock_passwd: false
+    ssh_authorized_keys:
+      - ${SSH_PUBKEY}
+
+hostname: ${DISTRO}-${VERSION}-${KERNEL_FLAVOR}
+disable_root: true
+ssh_pwauth: true
+timezone: UTC
+
+# Automatically grow partition and resize filesystem to use all available space
+# This fixes GPT partition table issues when disk is expanded
+growpart:
+  mode: auto
+  devices: ['/']
+  ignore_growroot_disabled: false
+
+resize_rootfs: true
+
+# Install essential packages
+packages:
+  - build-essential
+  - git
+  - curl
+  - wget
+  - vim
+  - nano
+  - jq
+
+# Write helper scripts
+write_files:
+  # Environment variables for installation scripts
+  # Source this file in runcmd blocks: . /tmp/tracee-vm-env.sh
+  - path: /tmp/tracee-vm-env.sh
+    permissions: '0644'
+    content: |
+      # Tracee VM environment variables for cloud-init scripts
+      export DISTRO="${DISTRO}"
+      export VERSION="${VERSION}"
+      export KERNEL_FLAVOR="${KERNEL_FLAVOR}"
+      export KERNEL_VERSION="${KERNEL_VERSION}"
+      export ENVIRONMENT="${ENVIRONMENT}"
+      export SSH_KEY_NAME="${SSH_KEY_NAME}"
+      export USER_NAME="ubuntu"
+  
+  # WRITE_VM_CONFIGS_PLACEHOLDER
+  
+  - path: /home/ubuntu/.bash_aliases
+    content: |
+      # Tracee development aliases
+      alias tracee-build='cd /mnt/tracee && make'
+      alias tracee-test='cd /mnt/tracee && make test'
+      alias tracee-clean='cd /mnt/tracee && make clean'
+    owner: ubuntu:ubuntu
+    permissions: '0644'
+    defer: true
+
+# Run installation scripts from Tracee repo
+runcmd:
+  # INIT_SERVICES_PLACEHOLDER
+  
+  # Setup dynamic MOTD (embedded script, like kernel installer)
+  # NOTE: Currently embedded for reliability, but may be fetched from
+  #       the repo branch in the future (like other scripts).
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Setting up dynamic MOTD..." | tee -a /var/log/tracee-vm-init.log
+    
+    # MOTD_SCRIPT_PLACEHOLDER
+    
+    chmod +x /tmp/setup-motd.sh
+    /tmp/setup-motd.sh \
+      "${DISTRO}" \
+      "${VERSION}" \
+      "${KERNEL_FLAVOR}" \
+      "${KERNEL_VERSION}" \
+      "${SSH_KEY_NAME}" \
+      2>&1 | tee -a /var/log/tracee-vm-init.log
+  
+  # DOWNLOAD_SCRIPTS_PLACEHOLDER
+  
+  # DISABLE_UNATTENDED_UPGRADES_PLACEHOLDER
+  
+  # INSTALL_TOOLS_PLACEHOLDER
+  
+  # SETUP_VIRTFS_PLACEHOLDER
+  
+  # Install kernel LAST (using embedded script below)
+  # NOTE: Currently embedded for reliability, but we might change this to fetch
+  #       from the repo branch in the future (like other scripts) to ensure
+  #       we always use the latest version from the branch.
+  # IMPORTANT: Kernel installation must be last because it reboots the VM!
+  - |
+    . /tmp/tracee-vm-env.sh
+    
+    echo "Installing kernel ${KERNEL_FLAVOR} ${KERNEL_VERSION}..." | tee -a /var/log/tracee-vm-init.log
+    
+    # KERNEL_SCRIPT_PLACEHOLDER
+    
+    chmod +x /tmp/install-kernel.sh
+    /tmp/install-kernel.sh \
+      -d "${DISTRO}" \
+      -f "${KERNEL_FLAVOR}" \
+      -k "${KERNEL_VERSION}" \
+      2>&1 | tee -a /var/log/tracee-vm-init.log
+  
+  # FINALIZE_PLACEHOLDER
+
+final_message: |
+  Tracee VM is ready!
+  
+  Distro:  ${DISTRO} ${VERSION}
+  Kernel:  ${KERNEL_FLAVOR} ${KERNEL_VERSION} (active after reboot)
+  
+  ${SSH_ACCESS_HINT}
+  
+  The system took ${UPTIME} seconds to boot.

--- a/scripts/vm-setup/vm-manager-lib.sh
+++ b/scripts/vm-setup/vm-manager-lib.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# VM Manager library: config, prompts, path wizard.
+# Source from vm-manager.sh. Expects CONFIG_DIR, CONFIG_FILE, SCRIPT_DIR to be set.
+
+set -euo pipefail
+
+# Load path config if present
+load_config() {
+    if [[ -f "${CONFIG_FILE}" ]]; then
+        set -a
+        # shellcheck source=/dev/null disable=SC1090
+        . "${CONFIG_FILE}"
+        set +a
+    fi
+}
+
+exit_gum_required() {
+    cat << EOF
+Interactive mode requires 'gum' to be installed.
+
+Install instructions:
+  https://github.com/charmbracelet/gum#installation
+
+Examples:
+  Ubuntu/Debian:  sudo apt install gum
+  Fedora:         sudo dnf install gum
+  macOS:          brew install gum
+
+You can use the manager without the TUI by passing commands and flags, for example:
+  $0 download --distro ubuntu --version 24.04 --arch x86_64
+  $0 run-dev <image-name>
+  $0 --help
+EOF
+    exit 1
+}
+
+print_error() {
+    gum style --foreground 196 --bold "$*" >&2
+}
+
+print_info() {
+    gum style --foreground 6 "$*" >&2
+}
+
+# Print a step/section header so output is clearly grouped (e.g. "1. Download", "2. Verify").
+print_step_header() {
+    gum format "## $*"
+}
+
+# Download URL to dest_tmp with a progress bar (polls file size). Returns exit code of curl/wget.
+download_with_progress() {
+    local url="${1:?}"
+    local dest_tmp="${2:?}"
+    local total_bytes
+    total_bytes=$(curl -sI -L "${url}" 2>/dev/null | grep -i '^content-length:' | awk '{print $2}' | tr -d '\r')
+    [[ -z "${total_bytes}" || ! "${total_bytes}" =~ ^[0-9]+$ ]] && total_bytes=0
+    if command -v curl &>/dev/null; then
+        curl -fsSL -o "${dest_tmp}" "${url}" &
+    else
+        wget -q -O "${dest_tmp}" "${url}" &
+    fi
+    local pid=$!
+    local current=0 pct=0 total_mb=0 cur_mb=0
+    [[ "${total_bytes}" -gt 0 ]] && total_mb=$((total_bytes / 1024 / 1024))
+    while kill -0 "${pid}" 2>/dev/null; do
+        current=$(stat -c %s "${dest_tmp}" 2>/dev/null || stat -f %z "${dest_tmp}" 2>/dev/null || echo 0)
+        cur_mb=$((current / 1024 / 1024))
+        if [[ "${total_bytes}" -gt 0 ]]; then
+            pct=$((current * 100 / total_bytes))
+            [[ ${pct} -gt 100 ]] && pct=100
+            local filled=$((pct * 24 / 100))
+            local empty=$((24 - filled))
+            local bar
+            bar=$(printf "%${filled}s" "" | tr ' ' '=')$(printf "%${empty}s" "" | tr ' ' ' ')
+            printf "\r  [%s] %3d%%  %s MB / %s MB   " "${bar}" "${pct}" "${cur_mb}" "${total_mb}"
+        else
+            printf "\r  Downloading... %s MB   " "${cur_mb}"
+        fi
+        sleep 0.25
+    done
+    if [[ "${total_bytes}" -gt 0 ]]; then
+        printf "\r  [========================] 100%%  %s MB / %s MB   \n" "${total_mb}" "${total_mb}"
+    else
+        printf "\r  Done. %s MB   \n" "${cur_mb}"
+    fi
+    wait "${pid}"
+}
+
+# Prompt for a path until non-empty. On Ctrl+C exits (trap must be set by caller).
+prompt_path() {
+    local header="$1"
+    local default="$2"
+    local val
+    while true; do
+        val=$(gum input --header "${header}" --placeholder "Path" --value "${default}")
+        local status=$?
+        if (( status != 0 )); then
+            exit 130
+        fi
+        val="${val#"${val%%[![:space:]]*}"}"
+        val="${val%"${val##*[![:space:]]}"}"
+        if [[ -n "${val}" ]]; then
+            if [[ -d "${val}" ]]; then
+                print_info "Directory exists, using it."
+            fi
+            echo "${val}"
+            return
+        fi
+        print_error "Path cannot be empty. Please enter a valid directory path."
+    done
+}
+
+run_path_wizard() {
+    local base_dir output_dir s3_bucket
+    trap 'exit 130' INT
+    base_dir=$(prompt_path "Base images directory – where upstream cloud images are downloaded and kept (e.g. ${HOME}/vms/base-images)" "${HOME}/vms/base-images")
+    gum format "Base images directory: **${base_dir}**"
+    output_dir=$(prompt_path "Output images directory – where customized/created images are written (e.g. ${HOME}/vms)" "${HOME}/vms")
+    gum format "Output images directory: **${output_dir}**"
+    s3_bucket=$(gum input --header "S3 bucket for AMI upload (optional – leave empty if not pushing to AWS)" --placeholder "e.g. my-tracee-ami-bucket" --value "${S3_BUCKET:-}")
+    s3_bucket="${s3_bucket#"${s3_bucket%%[![:space:]]*}"}"
+    s3_bucket="${s3_bucket%"${s3_bucket##*[![:space:]]}"}"
+    if [[ -n "${s3_bucket}" ]]; then
+        gum format "S3 bucket: **${s3_bucket}**"
+    fi
+    mkdir -p "${CONFIG_DIR}"
+    cat > "${CONFIG_FILE}" << EOF
+# Tracee VM Manager path configuration (generated)
+BASE_IMAGES_DIR="${base_dir}"
+OUTPUT_IMAGES_DIR="${output_dir}"
+S3_BUCKET="${s3_bucket:-}"
+EOF
+    BASE_IMAGES_DIR="${base_dir}"
+    OUTPUT_IMAGES_DIR="${output_dir}"
+    S3_BUCKET="${s3_bucket:-}"
+    export BASE_IMAGES_DIR OUTPUT_IMAGES_DIR S3_BUCKET
+    gum format "Paths saved to ${CONFIG_FILE}"
+}

--- a/scripts/vm-setup/vm-manager.sh
+++ b/scripts/vm-setup/vm-manager.sh
@@ -1,0 +1,601 @@
+#!/bin/bash
+# VM Image Manager – distro-agnostic orchestrator. Interactive TUI or command dispatch.
+# Sources: vm-manager-lib.sh (config, prompts), distros/*.sh (download, build per distro).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="${HOME}/.tracee-vm-manager"
+# CONFIG_FILE used by vm-manager-lib.sh when sourced
+# shellcheck disable=SC2034
+CONFIG_FILE="${CONFIG_DIR}/config.env"
+DISTROS_DIR="${SCRIPT_DIR}/distros"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/vm-manager-lib.sh"
+
+# Discover distros that provide download: set DISTRO_IDS, DISTRO_NAMES, DISTRO_FILES
+discover_download_distros() {
+    DISTRO_IDS=()
+    DISTRO_NAMES=()
+    DISTRO_FILES=()
+    local f
+    for f in "${DISTROS_DIR}"/*.sh; do
+        [[ -f "${f}" ]] || continue
+        # shellcheck source=/dev/null
+        . "${f}"
+        if type distro_download_run &>/dev/null; then
+            # shellcheck disable=SC2153
+            DISTRO_IDS+=("${DISTRO_ID}")
+            # shellcheck disable=SC2153
+            DISTRO_NAMES+=("${DISTRO_NAME}")
+            DISTRO_FILES+=("${f}")
+        fi
+    done
+}
+
+# Discover distros that provide kernel list update (distro_update_kernel_list).
+discover_update_kernel_distros() {
+    DISTRO_IDS=()
+    DISTRO_NAMES=()
+    DISTRO_FILES=()
+    local f
+    for f in "${DISTROS_DIR}"/*.sh; do
+        [[ -f "${f}" ]] || continue
+        # shellcheck source=/dev/null
+        . "${f}"
+        if type distro_update_kernel_list &>/dev/null; then
+            # shellcheck disable=SC2153
+            DISTRO_IDS+=("${DISTRO_ID}")
+            # shellcheck disable=SC2153
+            DISTRO_NAMES+=("${DISTRO_NAME}")
+            DISTRO_FILES+=("${f}")
+        fi
+    done
+}
+
+run_interactive_tui() {
+    trap 'exit 130' INT
+    load_config
+    if [[ -z "${BASE_IMAGES_DIR:-}" ]] || [[ -z "${OUTPUT_IMAGES_DIR:-}" ]]; then
+        gum format "# First run: set paths"
+        run_path_wizard
+    fi
+    while true; do
+        choice=$(gum choose \
+            "Development VMs (local)" \
+            "AWS VMs" \
+            "Download a base image" \
+            "Update kernel list from repo" \
+            "Settings" \
+            "Quit" \
+            --header "What do you want to do?")
+        case "${choice}" in
+            "Development VMs (local)") run_env_submenu "local" ;;
+            "AWS VMs") run_env_submenu "aws" ;;
+            "Download a base image") run_action_download ;;
+            "Update kernel list from repo") run_action_update_kernel_list ;;
+            "Settings") run_path_wizard ;;
+            "Quit"|"") exit 0 ;;
+            *) gum format "Unknown choice: ${choice}" ;;
+        esac
+    done
+}
+
+run_env_submenu() {
+    local env="$1"
+    local header sub
+    if [[ "${env}" == "local" ]]; then
+        header="Development VMs (local)"
+        sub=$(gum choose \
+            "Build / customize an image" \
+            "Run a VM" \
+            --header "${header}")
+    else
+        header="AWS VMs"
+        sub=$(gum choose \
+            "Build / customize an image" \
+            "Run a VM (test locally)" \
+            "Convert to AMI - WIP" \
+            "Push AMI to AWS - WIP" \
+            --header "${header}")
+    fi
+    case "${sub}" in
+        "Run a VM"*) run_action_run_vm "${env}" ;;
+        "Build / customize"*) run_action_build "${env}" ;;
+        "Convert to AMI"*) run_action_convert_ami ;;
+        "Push AMI to AWS"*) run_action_push_ami ;;
+        ""|*) return ;;
+    esac
+}
+
+# Ask distros (by sourcing each) if they can infer a base image for this VM name.
+# Echo path and return 0 if any distro returns a path; else return 1.
+infer_base_image_via_distros() {
+    local vm_name="${1:?}"
+    local base_dir="${2:?}"
+    local f result
+    for f in "${DISTROS_DIR}"/*.sh; do
+        [[ -f "${f}" ]] || continue
+        # shellcheck source=/dev/null
+        . "${f}"
+        if type distro_infer_base_image &>/dev/null && [[ -n "${DISTRO_VM_NAME_PREFIX:-}" ]] && [[ "${vm_name}" == ${DISTRO_VM_NAME_PREFIX}-* ]]; then
+            result=$(distro_infer_base_image "${vm_name}" "${base_dir}") || true
+            if [[ -n "${result}" ]] && [[ -f "${result}" ]]; then
+                echo "${result}"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+run_action_run_vm() {
+    local env="${1:-local}"
+    gum format "# Run a VM"
+    echo ""
+    mkdir -p "${OUTPUT_IMAGES_DIR}"
+    local choices=() names=() dirs=() need_bases=() name
+    # Names that have a cloud-init ISO (so we don't list the same name again as disk-only)
+    local iso_names=()
+    # 1) Cloud-init ISOs in output dir (filter by environment suffix)
+    local f
+    for f in "${OUTPUT_IMAGES_DIR}"/*-${env}-cloud-init.iso; do
+        [[ -f "${f}" ]] || continue
+        name=$(basename "${f}" -cloud-init.iso)
+        iso_names+=("${name}")
+        if [[ -f "${OUTPUT_IMAGES_DIR}/${name}.qcow2" ]] || [[ -f "${OUTPUT_IMAGES_DIR}/${name}.img" ]]; then
+            choices+=("${name} (cloud-init, ready)")
+            names+=("${name}")
+            dirs+=("${OUTPUT_IMAGES_DIR}")
+            need_bases+=(0)
+        else
+            choices+=("${name} (cloud-init, need base)")
+            names+=("${name}")
+            dirs+=("${OUTPUT_IMAGES_DIR}")
+            need_bases+=(1)
+        fi
+    done
+    # 2) Disks in output dir without an ISO (filter by environment suffix, no duplicate name)
+    local seen added_disk_names=()
+    for f in "${OUTPUT_IMAGES_DIR}"/*-${env}.qcow2 "${OUTPUT_IMAGES_DIR}"/*-${env}.img; do
+        [[ -f "${f}" ]] || continue
+        name=$(basename "${f}" .qcow2)
+        name=${name%.img}
+        seen=0
+        for n in "${iso_names[@]}"; do [[ "${n}" == "${name}" ]] && { seen=1; break; }; done
+        [[ "${seen}" -eq 1 ]] && continue
+        for n in "${added_disk_names[@]}"; do [[ "${n}" == "${name}" ]] && { seen=1; break; }; done
+        [[ "${seen}" -eq 1 ]] && continue
+        added_disk_names+=("${name}")
+        choices+=("${name} (output)")
+        names+=("${name}")
+        dirs+=("${OUTPUT_IMAGES_DIR}")
+        need_bases+=(0)
+    done
+    # 3) Legacy images (no -local/-aws suffix) – show only under Development VMs (local)
+    if [[ "${env}" == "local" ]]; then
+        for f in "${OUTPUT_IMAGES_DIR}"/*-cloud-init.iso; do
+            [[ -f "${f}" ]] || continue
+            name=$(basename "${f}" -cloud-init.iso)
+            [[ "${name}" == *-local || "${name}" == *-aws ]] && continue
+            seen=0
+            for n in "${iso_names[@]}"; do [[ "${n}" == "${name}" ]] && { seen=1; break; }; done
+            [[ "${seen}" -eq 1 ]] && continue
+            iso_names+=("${name}")
+            if [[ -f "${OUTPUT_IMAGES_DIR}/${name}.qcow2" ]] || [[ -f "${OUTPUT_IMAGES_DIR}/${name}.img" ]]; then
+                choices+=("${name} (cloud-init, ready, legacy)")
+                names+=("${name}")
+                dirs+=("${OUTPUT_IMAGES_DIR}")
+                need_bases+=(0)
+            else
+                choices+=("${name} (cloud-init, need base, legacy)")
+                names+=("${name}")
+                dirs+=("${OUTPUT_IMAGES_DIR}")
+                need_bases+=(1)
+            fi
+        done
+        for f in "${OUTPUT_IMAGES_DIR}"/*.qcow2 "${OUTPUT_IMAGES_DIR}"/*.img; do
+            [[ -f "${f}" ]] || continue
+            name=$(basename "${f}" .qcow2)
+            name=${name%.img}
+            [[ "${name}" == *-local || "${name}" == *-aws ]] && continue
+            seen=0
+            for n in "${iso_names[@]}"; do [[ "${n}" == "${name}" ]] && { seen=1; break; }; done
+            [[ "${seen}" -eq 1 ]] && continue
+            for n in "${added_disk_names[@]}"; do [[ "${n}" == "${name}" ]] && { seen=1; break; }; done
+            [[ "${seen}" -eq 1 ]] && continue
+            added_disk_names+=("${name}")
+            choices+=("${name} (output, legacy)")
+            names+=("${name}")
+            dirs+=("${OUTPUT_IMAGES_DIR}")
+            need_bases+=(0)
+        done
+    fi
+    # Base images are not listed: running would modify the original. Use "need base" to copy then run.
+    if [[ ${#choices[@]} -eq 0 ]]; then
+        gum format "No runnable images found. Build a cloud-init ISO or download a base image first."
+        return
+    fi
+    local choice
+    choice=$(printf '%s\n' "${choices[@]}" | gum choose --header "Select image to run")
+    [[ -z "${choice}" ]] && return
+    local i
+    for i in "${!choices[@]}"; do
+        if [[ "${choices[i]}" != "${choice}" ]]; then
+            continue
+        fi
+        local img="${names[i]}" run_dir="${dirs[i]}" need_base="${need_bases[i]}"
+        if [[ "${need_base}" -eq 1 ]]; then
+            local src
+            src=$(infer_base_image_via_distros "${img}" "${BASE_IMAGES_DIR}") || true
+            if [[ -z "${src}" ]] || [[ ! -f "${src}" ]]; then
+                # Could not infer: prompt for base image
+                local base_options=() base_paths=()
+                for f in "${BASE_IMAGES_DIR}"/*.qcow2 "${BASE_IMAGES_DIR}"/*.img; do
+                    [[ -f "${f}" ]] || continue
+                    base_options+=("$(basename "${f}")")
+                    base_paths+=("${f}")
+                done
+                if [[ ${#base_options[@]} -eq 0 ]]; then
+                    gum format "No base images in **${BASE_IMAGES_DIR}**. Download one first."
+                    return
+                fi
+                local base_choice
+                base_choice=$(printf '%s\n' "${base_options[@]}" | gum choose --header "Select base image to use as disk")
+                [[ -z "${base_choice}" ]] && return
+                local j
+                for j in "${!base_options[@]}"; do
+                    if [[ "${base_options[j]}" == "${base_choice}" ]]; then
+                        src="${base_paths[j]}"
+                        break
+                    fi
+                done
+            fi
+            if [[ -n "${src}" ]] && [[ -f "${src}" ]]; then
+                # Prompt for disk size
+                local disk_size
+                disk_size=$(printf '%s\n' "20G" "40G" "60G" "80G" "100G" | gum choose --header "Disk size for VM")
+                [[ -z "${disk_size}" ]] && return
+                # Detect backing file format
+                local base_fmt="qcow2"
+                if command -v qemu-img &>/dev/null; then
+                    base_fmt=$(qemu-img info "${src}" 2>/dev/null | awk '/^file format:/{print $3}')
+                    base_fmt="${base_fmt:-qcow2}"
+                fi
+                local dst="${OUTPUT_IMAGES_DIR}/${img}.qcow2"
+                local abs_src
+                abs_src=$(realpath "${src}")
+                gum format "Creating **${disk_size}** overlay disk backed by **$(basename "${src}")**..."
+                if ! qemu-img create -f qcow2 -b "${abs_src}" -F "${base_fmt}" "${dst}" "${disk_size}" >/dev/null 2>&1; then
+                    print_error "Failed to create overlay disk image."
+                    return
+                fi
+                gum format "  Created **$(basename "${dst}")** (${disk_size}, backed by $(basename "${src}"))"
+                echo ""
+                run_dir="${OUTPUT_IMAGES_DIR}"
+            fi
+        fi
+        local mode
+        mode=$(gum choose "Dev mode (virtiofs, ports)" "Simple run" --header "How to run?")
+        [[ -z "${mode}" ]] && return
+        if [[ "${mode}" == "Dev mode (virtiofs, ports)" ]]; then
+            VM_NAME="${img}" VM_DIR="${run_dir}" "${SCRIPT_DIR}/start-vm-virtiofs.sh" "${img}"
+        else
+            gum format "Simple run not yet implemented. Use: VM_DIR=${run_dir} ${SCRIPT_DIR}/start-vm-virtiofs.sh ${img}"
+        fi
+        return
+    done
+}
+
+run_action_build() {
+    local env="${1:-local}"
+    gum format "# Build / customize an image"
+    echo ""
+    local action
+    action=$(printf '%s\n' "Pick existing base image" "Download a base image first" | gum choose --header "Build from base or download?")
+    [[ -z "${action}" ]] && return
+    if [[ "${action}" == "Download a base image first" ]]; then
+        run_action_download
+        return
+    fi
+    mkdir -p "${BASE_IMAGES_DIR}"
+    # Ask architecture first, then show only base images for that arch
+    local arch_choice arch_suffix
+    arch_choice=$(printf '%s\n' "x86_64 (amd64)" "aarch64 (arm64)" | gum choose --header "Architecture")
+    [[ -z "${arch_choice}" ]] && return
+    if [[ "${arch_choice}" == *"x86_64"* ]]; then
+        arch_suffix="amd64"
+    else
+        arch_suffix="arm64"
+    fi
+    local bases=() labels=() distro_files=() line
+    for f in "${DISTROS_DIR}"/*.sh; do
+        [[ -f "${f}" ]] || continue
+        # shellcheck source=/dev/null
+        . "${f}"
+        if type distro_list_base_images &>/dev/null; then
+            while IFS= read -r line; do
+                [[ -z "${line}" ]] && continue
+                bases+=("${line%%|*}")
+                labels+=("${line#*|}")
+                distro_files+=("${f}")
+            done < <(distro_list_base_images "${BASE_IMAGES_DIR}" "${arch_suffix}")
+        fi
+    done
+    if [[ ${#bases[@]} -eq 0 ]]; then
+        gum format "No base images for **${arch_suffix}** in **${BASE_IMAGES_DIR}**. Download one first or pick another architecture."
+        return
+    fi
+    local choice
+    choice=$(printf '%s\n' "${labels[@]}" | gum choose --header "Select release (${arch_suffix})")
+    [[ -z "${choice}" ]] && return
+    local i base_file selected_distro_file
+    for i in "${!labels[@]}"; do
+        if [[ "${labels[i]}" == "${choice}" ]]; then
+            base_file="${bases[i]}"
+            selected_distro_file="${distro_files[i]}"
+            break
+        fi
+    done
+    [[ -z "${base_file}" ]] || [[ -z "${selected_distro_file}" ]] && return
+    # shellcheck source=/dev/null
+    . "${selected_distro_file}"
+    local found=0
+    if type distro_handles_base &>/dev/null && type distro_build_instructions &>/dev/null; then
+        if distro_handles_base "${base_file}"; then
+            if type distro_build_prompt_options &>/dev/null; then
+                if ! distro_build_prompt_options "${base_file}" "${SCRIPT_DIR}"; then
+                    return
+                fi
+                found=1
+                if type distro_build_run &>/dev/null && gum confirm "Run generate-cloud-init and create ISO now?"; then
+                    distro_build_run "${base_file}" "${SCRIPT_DIR}" "${OUTPUT_IMAGES_DIR}" "${BASE_IMAGES_DIR}" tui "${env}"
+                fi
+            else
+                distro_build_instructions "${base_file}" "${SCRIPT_DIR}" "${env}"
+                found=1
+                if type distro_build_run &>/dev/null && gum confirm "Run generate-cloud-init and create ISO now?"; then
+                    distro_build_run "${base_file}" "${SCRIPT_DIR}" "${OUTPUT_IMAGES_DIR}" "${BASE_IMAGES_DIR}" tui "${env}"
+                fi
+            fi
+        fi
+    fi
+    if [[ ${found} -eq 0 ]]; then
+        gum format "No distro-specific instructions for **${base_file}**. Use generate-cloud-init.sh and start-vm-virtiofs.sh for your distro; see vm-setup-plan docs."
+    fi
+}
+
+run_action_download() {
+    discover_download_distros
+    if [[ ${#DISTRO_NAMES[@]} -eq 0 ]]; then
+        gum format "No distro modules with download support found in ${DISTROS_DIR}."
+        return
+    fi
+    local choice
+    choice=$(printf '%s\n' "${DISTRO_NAMES[@]}" | gum choose --header "Choose distribution")
+    [[ -z "${choice}" ]] && return
+    local i
+    for i in "${!DISTRO_NAMES[@]}"; do
+        if [[ "${DISTRO_NAMES[i]}" == "${choice}" ]]; then
+            gum format "# Download – ${choice}"
+            echo ""
+            # shellcheck source=/dev/null
+            . "${DISTRO_FILES[i]}"
+            distro_download_run "${BASE_IMAGES_DIR}"
+            return
+        fi
+    done
+}
+
+run_action_update_kernel_list() {
+    discover_update_kernel_distros
+    if [[ ${#DISTRO_NAMES[@]} -eq 0 ]]; then
+        gum format "No distro modules with kernel list update support found in ${DISTROS_DIR}."
+        return
+    fi
+    local choice
+    choice=$(printf '%s\n' "${DISTRO_NAMES[@]}" | gum choose --header "Update kernel list for")
+    [[ -z "${choice}" ]] && return
+    local i
+    for i in "${!DISTRO_NAMES[@]}"; do
+        if [[ "${DISTRO_NAMES[i]}" == "${choice}" ]]; then
+            gum format "# Update kernel list – ${choice}"
+            echo ""
+            # shellcheck source=/dev/null
+            . "${DISTRO_FILES[i]}"
+            distro_update_kernel_list "${SCRIPT_DIR}"
+            return
+        fi
+    done
+}
+
+run_action_convert_ami() {
+    gum format "# Convert to AMI (QCOW2 → raw)"
+    echo ""
+    mkdir -p "${OUTPUT_IMAGES_DIR}"
+    local candidates=()
+    local f name
+    for f in "${OUTPUT_IMAGES_DIR}"/*-aws.qcow2; do
+        [[ -f "${f}" ]] || continue
+        name=$(basename "${f}" .qcow2)
+        candidates+=("${name}")
+    done
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        gum format "No AWS QCOW2 images found in **${OUTPUT_IMAGES_DIR}**. Build an image under **AWS VMs** first."
+        return
+    fi
+    local choice
+    choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Select image to convert to raw")
+    [[ -z "${choice}" ]] && return
+    local raw_path="${OUTPUT_IMAGES_DIR}/${choice}.raw"
+    if [[ -f "${raw_path}" ]]; then
+        if ! gum confirm "**${choice}.raw** already exists. Overwrite?"; then
+            return
+        fi
+        rm -f "${raw_path}"
+    fi
+    gum format "Converting **${choice}.qcow2** to raw (this may take a few minutes)..."
+    if ! qemu-img convert -f qcow2 -O raw "${OUTPUT_IMAGES_DIR}/${choice}.qcow2" "${raw_path}"; then
+        print_error "qemu-img convert failed."
+        return
+    fi
+    gum format "Created **${raw_path}**. Use **Push AMI to AWS** to upload and import."
+}
+
+run_action_push_ami() {
+    gum format "# Push AMI to AWS"
+    echo ""
+    if ! command -v aws &>/dev/null; then
+        print_error "AWS CLI not found. Install it (e.g. pip install awscli or your distro package)."
+        return
+    fi
+    if ! aws sts get-caller-identity &>/dev/null; then
+        print_error "AWS credentials not configured. Run: aws configure"
+        return
+    fi
+    load_config
+    if [[ -z "${S3_BUCKET:-}" ]]; then
+        gum format "S3 bucket for AMI upload is not set. Configure it in **Settings**."
+        return
+    fi
+    mkdir -p "${OUTPUT_IMAGES_DIR}"
+    local candidates=()
+    local f name
+    for f in "${OUTPUT_IMAGES_DIR}"/*-aws.raw; do
+        [[ -f "${f}" ]] || continue
+        name=$(basename "${f}" .raw)
+        candidates+=("${name}")
+    done
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        gum format "No AWS raw images found in **${OUTPUT_IMAGES_DIR}**. Use **Convert to AMI** first."
+        return
+    fi
+    local choice
+    choice=$(printf '%s\n' "${candidates[@]}" | gum choose --header "Select raw image to push to AWS")
+    [[ -z "${choice}" ]] && return
+    local raw_path="${OUTPUT_IMAGES_DIR}/${choice}.raw"
+    local s3_key="${choice}.raw"
+    gum format "Uploading **${choice}.raw** to **s3://${S3_BUCKET}/${s3_key}**..."
+    if ! aws s3 cp "${raw_path}" "s3://${S3_BUCKET}/${s3_key}"; then
+        print_error "S3 upload failed."
+        return
+    fi
+    gum format "Starting EC2 import task..."
+    local task_output
+    task_output=$(aws ec2 import-image --disk-containers "Format=raw,UserBucket={S3Bucket=${S3_BUCKET},S3Key=${s3_key}}")
+    local import_task_id
+    import_task_id=$(echo "${task_output}" | grep -o '"ImportTaskId": "[^"]*"' | cut -d'"' -f4)
+    if [[ -z "${import_task_id}" ]]; then
+        print_error "Failed to start import task."
+        return
+    fi
+    gum format "Import task **${import_task_id}** started. Waiting for completion..."
+    while true; do
+        local status
+        status=$(aws ec2 describe-import-image-tasks --import-task-ids "${import_task_id}" --query 'ImportImageTasks[0].Status' --output text 2>/dev/null || echo "unknown")
+        case "${status}" in
+            completed)
+                local ami_id
+                ami_id=$(aws ec2 describe-import-image-tasks --import-task-ids "${import_task_id}" --query 'ImportImageTasks[0].ImageId' --output text 2>/dev/null)
+                gum format "AMI created: **${ami_id}**"
+                return
+                ;;
+            deleted|deleting|cancelled|cancelling)
+                print_error "Import task failed or was cancelled: ${status}"
+                return
+                ;;
+        esac
+        sleep 10
+    done
+}
+
+# --- Main ---
+load_config
+
+if [[ $# -eq 0 ]]; then
+    if ! command -v gum &>/dev/null; then
+        exit_gum_required
+    fi
+    run_interactive_tui
+    exit 0
+fi
+
+case "${1:-}" in
+    run-dev)
+        shift
+        VM_NAME="${1:-}"
+        if [[ -z "${VM_NAME}" ]]; then
+            echo "Usage: $0 run-dev <image-name>" >&2
+            exit 1
+        fi
+        VM_DIR="${OUTPUT_IMAGES_DIR:-${HOME}/vms}" "${SCRIPT_DIR}/start-vm-virtiofs.sh" "${VM_NAME}"
+        ;;
+    download)
+        shift
+        dl_distro=""
+        dl_codename=""
+        dl_release=""
+        dl_arch="amd64"
+        while [[ $# -gt 0 ]]; do
+            case "${1}" in
+                --distro) dl_distro="${2:-}"; shift 2 ;;
+                --codename) dl_codename="${2:-}"; shift 2 ;;
+                --release) dl_release="${2:-}"; shift 2 ;;
+                --arch) dl_arch="${2:-}"; shift 2 ;;
+                *) echo "Unknown flag: ${1}. Use $0 --help" >&2; exit 1 ;;
+            esac
+        done
+        if [[ -z "${dl_distro}" ]]; then
+            echo "Usage: $0 download --distro <id> [--codename <name>] [--release <version>] [--arch <arch>]" >&2
+            echo "  e.g. $0 download --distro ubuntu --codename noble --arch amd64" >&2
+            echo "  or   $0 download --distro ubuntu --release 24.04 --arch amd64" >&2
+            exit 1
+        fi
+        distro_file="${DISTROS_DIR}/${dl_distro}.sh"
+        if [[ ! -f "${distro_file}" ]]; then
+            echo "Distro not found: ${distro_file}" >&2
+            exit 1
+        fi
+        # shellcheck source=/dev/null
+        . "${distro_file}"
+        if [[ -z "${dl_codename}" && -n "${dl_release}" ]]; then
+            if type distro_release_to_codename &>/dev/null; then
+                dl_codename=$(distro_release_to_codename "${dl_release}") || {
+                    echo "Unknown release for ${dl_distro}: ${dl_release}. Use --codename." >&2
+                    exit 1
+                }
+            else
+                echo "Release mapping for ${dl_distro} not supported. Use --codename." >&2
+                exit 1
+            fi
+        fi
+        if [[ -z "${dl_codename}" ]]; then
+            echo "Usage: $0 download --distro <id> --codename <name> [--arch <arch>]" >&2
+            exit 1
+        fi
+        if ! type distro_download &>/dev/null; then
+            echo "Distro ${dl_distro} does not support download (no distro_download)." >&2
+            exit 1
+        fi
+        echo "Download – ${DISTRO_NAME:-${dl_distro}} (${dl_codename}, ${dl_arch})"
+        echo ""
+        distro_download "${BASE_IMAGES_DIR}" "${dl_codename}" "${dl_arch}"
+        exit $?
+        ;;
+    --help|-h)
+        cat << EOF
+Usage: $0 [COMMAND] [FLAGS...]
+       $0                    # Interactive TUI (requires gum)
+       $0 run-dev <image>    # Run image in dev mode (virtiofs)
+       $0 download --distro <id> [--codename <name>|--release <ver>] [--arch <arch>]
+       $0 customize ...      # (TODO) Customize image
+
+Interactive mode requires gum: https://github.com/charmbracelet/gum#installation
+EOF
+        ;;
+    *)
+        echo "Unknown command: ${1:-}. Use $0 --help" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
### 1. Explain what the PR does

796a8c193 **feat(vm-setup): add VM image manager with TUI, cloud-init generation, and multi-arch support**

> Introduce a VM management toolkit for building, customizing, and running
> Tracee development VMs locally or for AWS.
> 
> - TUI (gum-based) with environment-aware menus: Development VMs (local)
>   and AWS VMs, each with Build/Run sub-options; AWS adds Convert to AMI
>   and Push AMI to AWS
> - Cloud-init generation from distro templates (Ubuntu, CentOS, Alpine)
>   with modular step files for init services, kernel install, MOTD,
>   unattended upgrades, shared directories, and tool installation
> - Distro plugin system (distros/*.sh) with Ubuntu implementation:
>   base image download, kernel list from APT repo, build flow with
>   flavour/version selection, and base image inference for Run
> - Multi-arch QEMU support: x86_64 (KVM + SeaBIOS) and aarch64
>   (UEFI/pflash with cortex-a57 TCG fallback on x86_64 hosts)
> - Virtiofs for native-arch KVM, 9p fallback for cross-arch TCG
> - QCOW2 overlay disks backed by base images with selectable size
> - Configurable SSH key injection (picks from ~/.ssh/*.pub)
> - Environment suffix in image names (-local/-aws) so both coexist
> - Dynamic MOTD with kernel version mismatch detection
> - Embedded script support (install-kernel.sh, setup-motd.sh) for
>   reliability before scripts are merged upstream

--

### 2. Explain how to test it

`./scripts/vm-setup/vm-manager.sh` and play a bit:


<img width="388" height="230" alt="image" src="https://github.com/user-attachments/assets/556c952d-70d9-4a48-967e-1143d59921ed" />


### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
