### PR TITLE
chore(evt): add support for suite yaml files to setup test scenario with evt tool

### DIFF
--- a/cmd/evt/cmd/stress/cobra.go
+++ b/cmd/evt/cmd/stress/cobra.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -101,10 +100,23 @@ func init() {
 			"\t\t\t\tExample: security_file_open:instances=10:ops=1000:sleep=1ms\n"+
 			"\t\t\t\tDefaults: instances=1, ops=100, sleep=10ns",
 	)
-	if err := stressCmd.MarkFlagRequired("events"); err != nil {
-		stressCmd.PrintErrf("marking required flag: %v\n", err)
-		os.Exit(1)
-	}
+
+	stressCmd.Flags().StringArrayP(
+		"events-file",
+		"E",
+		[]string{},
+		"<path>\t\t\tPath(s) to YAML suite file(s). May be passed multiple times.",
+	)
+	stressCmd.Flags().StringArray(
+		"scenario",
+		[]string{},
+		"<name>\t\t\tScenario(s) to run (repeatable). Mutually exclusive with --all-scenarios.",
+	)
+	stressCmd.Flags().Bool(
+		"all-scenarios",
+		false,
+		"\t\t\tRun all scenarios from the loaded suite file(s). Mutually exclusive with --scenario.",
+	)
 
 	stressCmd.Flags().String(
 		"image",
@@ -185,14 +197,73 @@ func init() {
 	)
 }
 
-func getStress(cmd *cobra.Command) (*stress, error) {
-	eventSpecs, err := cmd.Flags().GetStringSlice("events")
+// buildEventSpecs returns the merged list of event specs: from --events-file (if set)
+// then --events. At least one spec is required.
+func buildEventSpecs(cmd *cobra.Command) ([]string, error) {
+	eventsFilePaths, err := cmd.Flags().GetStringArray("events-file")
 	if err != nil {
 		return nil, err
 	}
+	scenarioNames, err := cmd.Flags().GetStringArray("scenario")
+	if err != nil {
+		return nil, err
+	}
+	allScenarios, err := cmd.Flags().GetBool("all-scenarios")
+	if err != nil {
+		return nil, err
+	}
+	cliEvents, err := cmd.Flags().GetStringSlice("events")
+	if err != nil {
+		return nil, err
+	}
+	return eventSpecsFromFilesAndCLI(eventsFilePaths, scenarioNames, allScenarios, cliEvents)
+}
+
+// eventSpecsFromFilesAndCLI builds the merged event spec list from suite files and CLI events.
+// Used by buildEventSpecs; exported for testing.
+func eventSpecsFromFilesAndCLI(eventsFilePaths, scenarioNames []string, allScenarios bool, cliEvents []string) ([]string, error) {
+	if len(eventsFilePaths) == 0 && (len(scenarioNames) > 0 || allScenarios) {
+		return nil, errors.New("--scenario and --all-scenarios require --events-file")
+	}
+	var eventSpecs []string
+	if len(eventsFilePaths) > 0 {
+		suites, err := LoadSuitesFromFiles(eventsFilePaths)
+		if err != nil {
+			return nil, err
+		}
+		scenarios, err := ResolveScenarios(suites, scenarioNames, allScenarios)
+		if err != nil {
+			return nil, err
+		}
+		for _, sc := range scenarios {
+			eventSpecs = append(eventSpecs, FlattenScenario(sc)...)
+		}
+	}
+	eventSpecs = append(eventSpecs, cliEvents...)
 
 	if len(eventSpecs) == 0 {
-		return nil, errors.New("at least one event must be specified")
+		return nil, errors.New("at least one event must be specified (use --events and/or --events-file with --scenario or --all-scenarios)")
+	}
+	return eventSpecs, nil
+}
+
+// uniqueEventNames returns event names from triggers in first-occurrence order, no duplicates.
+func uniqueEventNames(triggers []triggerConfig) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, tc := range triggers {
+		if _, ok := seen[tc.event]; !ok {
+			seen[tc.event] = struct{}{}
+			out = append(out, tc.event)
+		}
+	}
+	return out
+}
+
+func getStress(cmd *cobra.Command) (*stress, error) {
+	eventSpecs, err := buildEventSpecs(cmd)
+	if err != nil {
+		return nil, err
 	}
 
 	// Parse event specifications into trigger configs
@@ -278,11 +349,8 @@ func getStress(cmd *cobra.Command) (*stress, error) {
 		return nil, err
 	}
 
-	// Extract event names from triggers for Tracee
-	eventNames := make([]string, 0, len(triggers))
-	for _, tc := range triggers {
-		eventNames = append(eventNames, tc.event)
-	}
+	// Extract event names for Tracee (unique, first occurrence order)
+	eventNames := uniqueEventNames(triggers)
 
 	s := &stress{
 		triggers:           triggers,

--- a/cmd/evt/cmd/stress/cobra_test.go
+++ b/cmd/evt/cmd/stress/cobra_test.go
@@ -1,0 +1,134 @@
+package stress
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestEventSpecsFromFilesAndCLI_FileOnly_SingleScenarioImplicit(t *testing.T) {
+	specs, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/suite_valid_single_scenario.yaml"},
+		nil, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("eventSpecsFromFilesAndCLI: %v", err)
+	}
+	if want := []string{"security_file_open"}; !slices.Equal(specs, want) {
+		t.Errorf("expected %v, got %v", want, specs)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_FileWithScenario(t *testing.T) {
+	specs, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/suite_valid.yaml"},
+		[]string{"smoke"}, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("eventSpecsFromFilesAndCLI: %v", err)
+	}
+	if want := []string{"security_file_open", "ptrace"}; !slices.Equal(specs, want) {
+		t.Errorf("expected %v, got %v", want, specs)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_FileWithMultipleScenarios(t *testing.T) {
+	specs, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/suite_valid.yaml"},
+		[]string{"filesystem", "smoke"}, false, nil,
+	)
+	if err != nil {
+		t.Fatalf("eventSpecsFromFilesAndCLI: %v", err)
+	}
+	// filesystem has one group with magic_write:instances=2; smoke has security_file_open, ptrace
+	if len(specs) != 3 {
+		t.Errorf("expected 3 specs (filesystem + smoke), got %d: %v", len(specs), specs)
+	}
+	if !strings.Contains(specs[0], "magic_write") {
+		t.Errorf("first spec should be from filesystem: %q", specs[0])
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_FileWithAllScenarios(t *testing.T) {
+	specs, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/suite_valid.yaml"},
+		nil, true, nil,
+	)
+	if err != nil {
+		t.Fatalf("eventSpecsFromFilesAndCLI: %v", err)
+	}
+	// smoke (2) + filesystem (1 from group) = 3
+	if len(specs) != 3 {
+		t.Errorf("expected 3 specs (all scenarios), got %d: %v", len(specs), specs)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_FileAndCLI_MergeOrder(t *testing.T) {
+	specs, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/suite_valid_single_scenario.yaml"},
+		nil, false, []string{"ptrace"},
+	)
+	if err != nil {
+		t.Fatalf("eventSpecsFromFilesAndCLI: %v", err)
+	}
+	if want := []string{"security_file_open", "ptrace"}; !slices.Equal(specs, want) {
+		t.Errorf("expected scenario then CLI order %v, got %v", want, specs)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_CLIOnly(t *testing.T) {
+	specs, err := eventSpecsFromFilesAndCLI(
+		nil, nil, false, []string{"security_file_open", "ptrace"},
+	)
+	if err != nil {
+		t.Fatalf("eventSpecsFromFilesAndCLI: %v", err)
+	}
+	if want := []string{"security_file_open", "ptrace"}; !slices.Equal(specs, want) {
+		t.Errorf("expected %v, got %v", want, specs)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_Empty_Error(t *testing.T) {
+	_, err := eventSpecsFromFilesAndCLI(nil, nil, false, nil)
+	if err == nil {
+		t.Fatal("expected error when no events from any source")
+	}
+	if !strings.Contains(err.Error(), "at least one event") {
+		t.Errorf("error should mention at least one event: %v", err)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_AllScenariosAndNames_Error(t *testing.T) {
+	_, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/suite_valid.yaml"},
+		[]string{"smoke"}, true, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error when both --scenario and --all-scenarios")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutually exclusive: %v", err)
+	}
+}
+
+func TestEventSpecsFromFilesAndCLI_FileNotFound_Error(t *testing.T) {
+	_, err := eventSpecsFromFilesAndCLI(
+		[]string{"testdata/nonexistent.yaml"},
+		[]string{"smoke"}, false, nil,
+	)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestUniqueEventNames(t *testing.T) {
+	triggers := []triggerConfig{
+		{event: "a", instances: 1, ops: 100, sleep: "10ns"},
+		{event: "b", instances: 1, ops: 100, sleep: "10ns"},
+		{event: "a", instances: 2, ops: 200, sleep: "1ms"},
+	}
+	got := uniqueEventNames(triggers)
+	if want := []string{"a", "b"}; !slices.Equal(got, want) {
+		t.Errorf("uniqueEventNames: got %v, want %v", got, want)
+	}
+}

--- a/cmd/evt/cmd/stress/suite.go
+++ b/cmd/evt/cmd/stress/suite.go
@@ -1,0 +1,181 @@
+package stress
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Suite represents a YAML event suite file.
+// Top-level metadata is optional; Scenarios is required and must be non-empty.
+type Suite struct {
+	Name        string     `yaml:"name"`
+	Description string     `yaml:"description"`
+	Scenarios   []Scenario `yaml:"scenarios"`
+}
+
+// Scenario is a named set of event specs, optionally grouped.
+// Name is required and must be unique within the file.
+// At least one of Events or Groups must be non-empty.
+type Scenario struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Events      []string `yaml:"events"`
+	Groups      []Group  `yaml:"groups"`
+}
+
+// Group organizes event specs within a scenario.
+// Purely organizational; execution flattens to a single list.
+type Group struct {
+	Name   string   `yaml:"name"`
+	Events []string `yaml:"events"`
+}
+
+// LoadSuitesFromFiles reads and parses YAML suite files.
+// Returns one *Suite per path in the same order. On first error (file not found,
+// invalid YAML, or validation failure), returns an error that includes the path.
+func LoadSuitesFromFiles(paths []string) ([]*Suite, error) {
+	result := make([]*Suite, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		var s Suite
+		if err := yaml.Unmarshal(data, &s); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		if err := validateSuite(&s, path); err != nil {
+			return nil, err
+		}
+		result = append(result, &s)
+	}
+	return result, nil
+}
+
+// FlattenScenario returns a single slice of event specs: s.Events first, then
+// each group's Events in order. Preserves order; no deduplication.
+func FlattenScenario(s *Scenario) []string {
+	var out []string
+	if len(s.Events) > 0 {
+		out = append(out, s.Events...)
+	}
+	for i := range s.Groups {
+		out = append(out, s.Groups[i].Events...)
+	}
+	return out
+}
+
+// ResolveScenarios returns the scenarios to run based on suite load and flags.
+// If allScenarios is true, returns all scenarios (suite order, then scenario order).
+// If scenarioNames is non-empty, returns those scenarios by name in the requested order.
+// In both cases, when multiple suites define a scenario with the same name, the
+// last-loaded suite wins (later files override earlier ones, like config layering).
+// If neither flag is set, returns the single scenario when exactly one exists; otherwise error.
+func ResolveScenarios(suites []*Suite, scenarioNames []string, allScenarios bool) ([]*Scenario, error) {
+	if allScenarios && len(scenarioNames) > 0 {
+		return nil, errors.New("--scenario and --all-scenarios are mutually exclusive")
+	}
+	if allScenarios {
+		return resolveAllScenarios(suites), nil
+	}
+	if len(scenarioNames) > 0 {
+		return resolveScenariosByName(suites, scenarioNames)
+	}
+	return resolveSingleImplicit(suites)
+}
+
+func resolveAllScenarios(suites []*Suite) []*Scenario {
+	var namesOrder []string
+	byName := make(map[string]*Scenario)
+	for _, s := range suites {
+		for i := range s.Scenarios {
+			sc := &s.Scenarios[i]
+			if byName[sc.Name] == nil {
+				namesOrder = append(namesOrder, sc.Name)
+			}
+			byName[sc.Name] = sc
+		}
+	}
+	out := make([]*Scenario, 0, len(namesOrder))
+	for _, n := range namesOrder {
+		out = append(out, byName[n])
+	}
+	return out
+}
+
+func resolveScenariosByName(suites []*Suite, names []string) ([]*Scenario, error) {
+	// Build a map of scenario name -> last occurrence (last-loaded suite wins).
+	byName := make(map[string]*Scenario)
+	for _, s := range suites {
+		for i := range s.Scenarios {
+			byName[s.Scenarios[i].Name] = &s.Scenarios[i]
+		}
+	}
+	out := make([]*Scenario, 0, len(names))
+	for _, name := range names {
+		sc, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("scenario %q not found", name)
+		}
+		out = append(out, sc)
+	}
+	return out, nil
+}
+
+func resolveSingleImplicit(suites []*Suite) ([]*Scenario, error) {
+	var all []*Scenario
+	for _, s := range suites {
+		for i := range s.Scenarios {
+			all = append(all, &s.Scenarios[i])
+		}
+	}
+	if len(all) == 1 {
+		return all, nil
+	}
+	if len(all) == 0 {
+		return nil, errors.New("no scenarios in loaded files")
+	}
+	var names []string
+	seen := make(map[string]struct{})
+	for _, sc := range all {
+		if _, ok := seen[sc.Name]; !ok {
+			seen[sc.Name] = struct{}{}
+			names = append(names, sc.Name)
+		}
+	}
+	return nil, fmt.Errorf("multiple scenarios available: specify --scenario or --all-scenarios (e.g. --scenario %s)", strings.Join(names, ", "))
+}
+
+// validateSuite checks suite rules.
+func validateSuite(s *Suite, path string) error {
+	if len(s.Scenarios) == 0 {
+		return fmt.Errorf("%s: at least one scenario is required", path)
+	}
+	seen := make(map[string]struct{})
+	for i := range s.Scenarios {
+		sc := &s.Scenarios[i]
+		if sc.Name == "" {
+			return fmt.Errorf("%s: scenario at index %d has no name", path, i)
+		}
+		if _, ok := seen[sc.Name]; ok {
+			return fmt.Errorf("%s: duplicate scenario name %q", path, sc.Name)
+		}
+		seen[sc.Name] = struct{}{}
+		hasEvents := len(sc.Events) > 0
+		hasGroups := false
+		for g := range sc.Groups {
+			if len(sc.Groups[g].Events) > 0 {
+				hasGroups = true
+				break
+			}
+		}
+		if !hasEvents && !hasGroups {
+			return fmt.Errorf("%s: scenario %q must have at least one of events or groups", path, sc.Name)
+		}
+	}
+	return nil
+}

--- a/cmd/evt/cmd/stress/suite_test.go
+++ b/cmd/evt/cmd/stress/suite_test.go
@@ -1,0 +1,254 @@
+package stress
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadSuitesFromFiles_Valid(t *testing.T) {
+	suites, err := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	if err != nil {
+		t.Fatalf("LoadSuitesFromFiles: %v", err)
+	}
+	if len(suites) != 1 {
+		t.Fatalf("expected 1 suite, got %d", len(suites))
+	}
+	s := suites[0]
+	if s.Name != "test-suite" {
+		t.Errorf("suite name: got %q", s.Name)
+	}
+	if len(s.Scenarios) != 2 {
+		t.Fatalf("expected 2 scenarios, got %d", len(s.Scenarios))
+	}
+	if s.Scenarios[0].Name != "smoke" || len(s.Scenarios[0].Events) != 2 {
+		t.Errorf("scenario smoke: got name %q, events %d", s.Scenarios[0].Name, len(s.Scenarios[0].Events))
+	}
+	if s.Scenarios[1].Name != "filesystem" || len(s.Scenarios[1].Groups) != 1 {
+		t.Errorf("scenario filesystem: got name %q, groups %d", s.Scenarios[1].Name, len(s.Scenarios[1].Groups))
+	}
+}
+
+func TestLoadSuitesFromFiles_InvalidNoScenarios(t *testing.T) {
+	_, err := LoadSuitesFromFiles([]string{"testdata/suite_invalid_no_scenarios.yaml"})
+	if err == nil {
+		t.Fatal("expected error for missing scenarios")
+	}
+	if len(err.Error()) == 0 {
+		t.Fatal("error message should not be empty")
+	}
+}
+
+func TestLoadSuitesFromFiles_InvalidEmptyScenarios(t *testing.T) {
+	_, err := LoadSuitesFromFiles([]string{"testdata/suite_invalid_empty_scenarios.yaml"})
+	if err == nil {
+		t.Fatal("expected error for empty scenarios")
+	}
+}
+
+func TestLoadSuitesFromFiles_InvalidDuplicateScenarioName(t *testing.T) {
+	_, err := LoadSuitesFromFiles([]string{"testdata/suite_invalid_duplicate_scenario_name.yaml"})
+	if err == nil {
+		t.Fatal("expected error for duplicate scenario name")
+	}
+	if len(err.Error()) == 0 {
+		t.Fatal("error message should not be empty")
+	}
+}
+
+func TestLoadSuitesFromFiles_InvalidScenarioNoEvents(t *testing.T) {
+	_, err := LoadSuitesFromFiles([]string{"testdata/suite_invalid_scenario_no_events.yaml"})
+	if err == nil {
+		t.Fatal("expected error for scenario with no events or groups")
+	}
+}
+
+func TestLoadSuitesFromFiles_FileNotFound(t *testing.T) {
+	_, err := LoadSuitesFromFiles([]string{"testdata/nonexistent.yaml"})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !os.IsNotExist(errors.Unwrap(err)) {
+		t.Errorf("expected wrapped ErrNotExist, got: %v", err)
+	}
+}
+
+func TestLoadSuitesFromFiles_MultipleFiles(t *testing.T) {
+	suites, err := LoadSuitesFromFiles([]string{
+		"testdata/suite_valid.yaml",
+		"testdata/suite_valid.yaml",
+	})
+	if err != nil {
+		t.Fatalf("LoadSuitesFromFiles: %v", err)
+	}
+	if len(suites) != 2 {
+		t.Fatalf("expected 2 suites, got %d", len(suites))
+	}
+}
+
+func TestFlattenScenario_EventsOnly(t *testing.T) {
+	sc := &Scenario{
+		Name:   "x",
+		Events: []string{"e1", "e2"},
+	}
+	got := FlattenScenario(sc)
+	want := []string{"e1", "e2"}
+	if len(got) != len(want) || (len(got) > 0 && (got[0] != want[0] || got[1] != want[1])) {
+		t.Errorf("FlattenScenario(events only): got %v, want %v", got, want)
+	}
+}
+
+func TestFlattenScenario_GroupsOnly(t *testing.T) {
+	sc := &Scenario{
+		Name: "x",
+		Groups: []Group{
+			{Name: "g1", Events: []string{"a", "b"}},
+			{Name: "g2", Events: []string{"c"}},
+		},
+	}
+	got := FlattenScenario(sc)
+	want := []string{"a", "b", "c"}
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("FlattenScenario(groups only): got %v, want %v", got, want)
+	}
+}
+
+func TestFlattenScenario_EventsAndGroups(t *testing.T) {
+	sc := &Scenario{
+		Name:   "x",
+		Events: []string{"first"},
+		Groups: []Group{
+			{Events: []string{"second", "third"}},
+		},
+	}
+	got := FlattenScenario(sc)
+	want := []string{"first", "second", "third"}
+	if len(got) != 3 || got[0] != "first" || got[1] != "second" || got[2] != "third" {
+		t.Errorf("FlattenScenario(events and groups): got %v, want %v", got, want)
+	}
+}
+
+func TestFlattenScenario_Empty(t *testing.T) {
+	sc := &Scenario{Name: "x"}
+	got := FlattenScenario(sc)
+	if got != nil {
+		t.Errorf("FlattenScenario(empty): got %v, want nil", got)
+	}
+}
+
+func TestResolveScenarios_AllScenarios_SingleSuite(t *testing.T) {
+	suites, err := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got, err := ResolveScenarios(suites, nil, true)
+	if err != nil {
+		t.Fatalf("ResolveScenarios: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 scenarios, got %d", len(got))
+	}
+	if got[0].Name != "smoke" || got[1].Name != "filesystem" {
+		t.Errorf("order: got %q, %q", got[0].Name, got[1].Name)
+	}
+}
+
+func TestResolveScenarios_AllScenarios_MultipleSuites_LastWins(t *testing.T) {
+	suites, err := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml", "testdata/suite_second.yaml"})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got, err := ResolveScenarios(suites, nil, true)
+	if err != nil {
+		t.Fatalf("ResolveScenarios: %v", err)
+	}
+	// Order: first occurrence of each name; smoke appears in both, last wins (suite_second).
+	// Names order from first file: smoke, filesystem; then second file: extra, smoke (overwrite).
+	// So namesOrder = smoke, filesystem, extra (extra is new). Then byName[smoke] = second's smoke.
+	if len(got) != 3 {
+		t.Fatalf("expected 3 scenarios (smoke, filesystem, extra), got %d", len(got))
+	}
+	// resolveAllScenarios: we iterate suite1 (smoke, filesystem), suite2 (extra, smoke). namesOrder = smoke, filesystem, extra. byName[smoke]=2nd, byName[filesystem]=1st, byName[extra]=2nd.
+	if got[0].Name != "smoke" || got[1].Name != "filesystem" || got[2].Name != "extra" {
+		t.Errorf("order: got %q, %q, %q", got[0].Name, got[1].Name, got[2].Name)
+	}
+	// Smoke should be the one from suite_second (only one event: ptrace).
+	if len(got[0].Events) != 1 || got[0].Events[0] != "ptrace" {
+		t.Errorf("smoke should be last-wins from suite_second: got %v", got[0].Events)
+	}
+}
+
+func TestResolveScenarios_ByName_One(t *testing.T) {
+	suites, _ := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	got, err := ResolveScenarios(suites, []string{"filesystem"}, false)
+	if err != nil {
+		t.Fatalf("ResolveScenarios: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "filesystem" {
+		t.Errorf("expected [filesystem], got %v", scenarioNames(got))
+	}
+}
+
+func TestResolveScenarios_ByName_Multiple(t *testing.T) {
+	suites, _ := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	got, err := ResolveScenarios(suites, []string{"filesystem", "smoke"}, false)
+	if err != nil {
+		t.Fatalf("ResolveScenarios: %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "filesystem" || got[1].Name != "smoke" {
+		t.Errorf("expected [filesystem smoke], got %v", scenarioNames(got))
+	}
+}
+
+func TestResolveScenarios_ByName_NotFound(t *testing.T) {
+	suites, _ := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	_, err := ResolveScenarios(suites, []string{"nonexistent"}, false)
+	if err == nil {
+		t.Fatal("expected error for missing scenario")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error should mention scenario name: %v", err)
+	}
+}
+
+func TestResolveScenarios_SingleImplicit_OneScenario(t *testing.T) {
+	suites, _ := LoadSuitesFromFiles([]string{"testdata/suite_valid_single_scenario.yaml"})
+	got, err := ResolveScenarios(suites, nil, false)
+	if err != nil {
+		t.Fatalf("ResolveScenarios: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "only" {
+		t.Errorf("expected single scenario only, got %v", scenarioNames(got))
+	}
+}
+
+func TestResolveScenarios_SingleImplicit_MultipleScenarios_Error(t *testing.T) {
+	suites, _ := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	_, err := ResolveScenarios(suites, nil, false)
+	if err == nil {
+		t.Fatal("expected error when multiple scenarios and no selection")
+	}
+	if !strings.Contains(err.Error(), "multiple scenarios") {
+		t.Errorf("error should mention multiple scenarios: %v", err)
+	}
+}
+
+func TestResolveScenarios_MutualExclusion(t *testing.T) {
+	suites, _ := LoadSuitesFromFiles([]string{"testdata/suite_valid.yaml"})
+	_, err := ResolveScenarios(suites, []string{"smoke"}, true)
+	if err == nil {
+		t.Fatal("expected error when both --scenario and --all-scenarios")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should mention mutually exclusive: %v", err)
+	}
+}
+
+func scenarioNames(scenarios []*Scenario) []string {
+	names := make([]string, len(scenarios))
+	for i, s := range scenarios {
+		names[i] = s.Name
+	}
+	return names
+}

--- a/cmd/evt/cmd/stress/testdata/suite_invalid_duplicate_scenario_name.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_invalid_duplicate_scenario_name.yaml
@@ -1,0 +1,8 @@
+name: duplicate-names
+scenarios:
+  - name: smoke
+    events:
+      - security_file_open
+  - name: smoke
+    events:
+      - ptrace

--- a/cmd/evt/cmd/stress/testdata/suite_invalid_empty_scenarios.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_invalid_empty_scenarios.yaml
@@ -1,0 +1,2 @@
+name: empty-scenarios
+scenarios: []

--- a/cmd/evt/cmd/stress/testdata/suite_invalid_no_scenarios.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_invalid_no_scenarios.yaml
@@ -1,0 +1,2 @@
+name: no-scenarios
+description: Invalid - no scenarios key

--- a/cmd/evt/cmd/stress/testdata/suite_invalid_scenario_no_events.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_invalid_scenario_no_events.yaml
@@ -1,0 +1,4 @@
+name: scenario-no-events
+scenarios:
+  - name: empty
+    description: No events and no groups with events

--- a/cmd/evt/cmd/stress/testdata/suite_second.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_second.yaml
@@ -1,0 +1,9 @@
+name: second-suite
+scenarios:
+  - name: extra
+    events:
+      - sched_process_exec
+  - name: smoke
+    description: overrides first suite smoke
+    events:
+      - ptrace

--- a/cmd/evt/cmd/stress/testdata/suite_valid.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_valid.yaml
@@ -1,0 +1,14 @@
+name: test-suite
+description: Valid suite for unit tests
+
+scenarios:
+  - name: smoke
+    description: Smoke scenario
+    events:
+      - security_file_open
+      - ptrace
+  - name: filesystem
+    groups:
+      - name: file-ops
+        events:
+          - magic_write:instances=2

--- a/cmd/evt/cmd/stress/testdata/suite_valid_single_scenario.yaml
+++ b/cmd/evt/cmd/stress/testdata/suite_valid_single_scenario.yaml
@@ -1,0 +1,5 @@
+name: single
+scenarios:
+  - name: only
+    events:
+      - security_file_open

--- a/docs/contributing/evt-suite-example.yaml
+++ b/docs/contributing/evt-suite-example.yaml
@@ -1,0 +1,32 @@
+# Example event suite for evt stress (--events-file)
+# See evt-tool.md for full format and options.
+
+name: example-suite
+description: Example scenarios for stress testing Tracee events
+
+scenarios:
+  - name: smoke
+    description: Minimal set for quick smoke test
+    events:
+      - security_file_open
+      - ptrace
+      - sched_process_exec
+
+  - name: filesystem
+    description: File and filesystem-related events
+    groups:
+      - name: file-ops
+        events:
+          - security_file_open:instances=5:ops=500
+          - magic_write:instances=2:ops=100
+      - name: vfs
+        events:
+          - vfs_write
+          - vfs_read
+
+  - name: lifecycle
+    description: Process and container lifecycle
+    events:
+      - sched_process_fork:instances=3:ops=200
+      - sched_process_exit
+      - sched_process_exec

--- a/docs/contributing/evt-tool.md
+++ b/docs/contributing/evt-tool.md
@@ -72,13 +72,15 @@ evt trigger --event security_file_open --bypass-flags
 
 Run comprehensive stress tests with multiple event types in isolated containers.
 
+Events can be specified via **CLI flags** (`--events` / `-e`) and/or **YAML suite files** (`--events-file`). At least one event must be provided from any source.
+
 **Usage:**
 
 ```bash
-evt stress --events <event_specs> [flags]
+evt stress [--events <spec> ...] [--events-file <path> ... [--scenario <name> ... | --all-scenarios]] [flags]
 ```
 
-**Event Specification Format:**
+**Event Specification Format (CLI):**
 
 ```
 event[:instances=N:ops=N:sleep=dur]
@@ -89,13 +91,35 @@ event[:instances=N:ops=N:sleep=dur]
 - `ops`: Operations per worker
 - `sleep`: Sleep between operations
 
+**Event Suites (YAML):**
+
+You can load events from YAML suite files with `--events-file` / `-E`. A suite defines named **scenarios** (e.g. smoke, filesystem); each scenario lists event specs (same format as CLI) and optional **groups** for organization. Use `--scenario` to run one or more scenarios (repeatable) or `--all-scenarios` to run all. Events from the selected scenario(s) are merged, then any `--events` / `-e` are appended.
+
+- Format: top-level `name`/`description` (optional), required `scenarios` list. Each scenario has `name`, optional `description`, and either `events` (list of specs) or `groups` (each with `name` and `events`).
+- Example file: [evt-suite-example.yaml](evt-suite-example.yaml).
+
 **Examples:**
 
 ```bash
-# Basic stress test with default settings
+# Basic stress test with CLI events (default settings)
 evt stress --events security_file_open --events ptrace
 
-# Multiple events with custom configurations
+# From a suite file: single scenario (implicit if only one scenario in file)
+evt stress --events-file evt-suite-example.yaml
+
+# From a suite file: named scenario
+evt stress --events-file evt-suite-example.yaml --scenario smoke
+
+# Multiple scenarios from a suite (repeatable --scenario)
+evt stress --events-file evt-suite-example.yaml --scenario smoke --scenario filesystem
+
+# All scenarios from the loaded file(s)
+evt stress --events-file evt-suite-example.yaml --all-scenarios
+
+# Merge suite and CLI: scenario events first, then -e
+evt stress --events-file evt-suite-example.yaml --scenario smoke -e security_bpf_prog
+
+# Multiple events with custom configurations (CLI only)
 evt stress \
   --events security_file_open:instances=10:ops=1000:sleep=1ms \
   --events ptrace:instances=2:ops=100:sleep=100ms
@@ -121,9 +145,14 @@ evt stress \
 **Flags:**
 
 **Event Configuration:**
-- `--events, -e <spec>`: Events to stress test (required, repeatable)
+- `--events, -e <spec>`: Event specs to stress test (repeatable). Merge with events from `--events-file` if both are used.
   - Format: `event[:instances=N:ops=N:sleep=dur]`
   - Example: `security_file_open:instances=10:ops=1000:sleep=1ms`
+- `--events-file, -E <path>`: Path(s) to YAML suite file(s). May be passed multiple times. Use with `--scenario` or `--all-scenarios` to select which scenarios to run.
+- `--scenario <name>`: Scenario(s) to run from the loaded suite file(s). Repeatable (e.g. `--scenario smoke --scenario filesystem`). Mutually exclusive with `--all-scenarios`.
+- `--all-scenarios`: Run all scenarios from the loaded suite file(s). Mutually exclusive with `--scenario`.
+
+At least one event must be specified in total (from `--events` and/or from the selected scenario(s) in `--events-file`).
 
 **Container Configuration:**
 - `--image <name:tag>`: Trigger runner container image


### PR DESCRIPTION
## Suite Event Files for evt stress

Add YAML suite files to evt stress so users can define reusable test scenarios (groups of events with parameters) in a file instead of passing long lists of -e flags on every run.

## What changed

- New --events-file / -E and --scenario flags in evt stress to load events from YAML suite files.
- Suite loader, validator, and scenario resolver in cmd/evt/cmd/stress/suite.go.
- CLI integration in cobra.go: suite events merge with CLI -e flags.
- Example suite, design doc, implementation plan, and docs update.
- Integration test script (scripts/evt-tracee-test.sh) that runs evt stress + Tracee end-to-end and collects JSON events.
- Tests for suite loading, validation, scenario resolution, and CLI flag integration.