### PR TITLE
Fix file_modification event & tv_nsec read

### DIFF
--- a/pkg/ebpf/c/common/filesystem.h
+++ b/pkg/ebpf/c/common/filesystem.h
@@ -78,6 +78,12 @@ statfunc u64 get_ctime_nanosec_from_inode(struct inode *inode)
         ts = BPF_CORE_READ(old_inode_v66, i_ctime);
     }
 
+    // Kernels >= 6.13 (commit 4e40eff) with CONFIG_FS_MGTIME use bit 31 of tv_nsec
+    // as an internal multigranularity floor flag (MG_FLOOR). The kernel's
+    // inode_get_ctime() strips it, but BPF reads the raw field. Safe to mask
+    // unconditionally since valid tv_nsec values (0-999999999) never reach bit 31.
+    ts.tv_nsec &= ~(1L << 31);
+
     return get_time_nanosec_timespec(&ts);
 }
 

--- a/pkg/ebpf/c/maps.h
+++ b/pkg/ebpf/c/maps.h
@@ -370,7 +370,7 @@ struct file_modification_map {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, 10240);
     __type(key, file_mod_key_t);
-    __type(value, s32);
+    __type(value, file_mod_value_t);
 } file_modification_map SEC(".maps");
 
 typedef struct file_modification_map file_modification_map_t;

--- a/pkg/ebpf/c/types.h
+++ b/pkg/ebpf/c/types.h
@@ -660,6 +660,12 @@ enum file_modification_op {
     FILE_MODIFICATION_DONE,
 };
 
+typedef struct file_mod_value {
+    s32 op;
+    u64 open_ctime;
+    u64 open_size;
+} file_mod_value_t;
+
 #define MAX_STACK_DEPTH 20 // max depth of each stack trace to track
 
 typedef __u64 stack_trace_t[MAX_STACK_DEPTH];

--- a/pkg/events/core.go
+++ b/pkg/events/core.go
@@ -14502,8 +14502,8 @@ var CoreEvents = map[ID]Definition{
 					{handle: probes.FilpClose, required: true},
 					{handle: probes.FileUpdateTime, required: true},
 					{handle: probes.FileUpdateTimeRet, required: true},
-					{handle: probes.FileModified, required: false},    // not required because doesn't ...
-					{handle: probes.FileModifiedRet, required: false}, // ... exist in kernels < 5.3
+					{handle: probes.FileModified, required: false},    // doesn't exist in kernels < 5.3
+					{handle: probes.FileModifiedRet, required: false}, // doesn't exist in kernels < 5.3
 				},
 			},
 		},


### PR DESCRIPTION
Close: #5242

### 1. Explain what the PR does
a3b4accb2 **fix(ebpf): mask bit 31 from tv_nsec**

> Mask MG_FLOOR flag (bit 31) from tv_nsec in get_ctime_nanosec_from_inode
> to strip the multigranularity floor marker that kernels >= 6.13 with
> CONFIG_FS_MGTIME store in the raw inode field (commit 4e40eff).

--

0072d7fe5 **fix(ebpf): detect file_modification on filesystems bypassing VFS write hooks**

> Filesystems like btrfs update inode timestamps directly without calling
> file_modified()/file_update_time(), so Tracee's write-time kprobes never
> fire and file_modification events go undetected.
> 
> Add a close-time fallback in trace_filp_close: compare ctime and file
> size at close against values captured at fd_install. If either changed,
> submit the event. The existing write-time detection path continues to
> work for filesystems that call file_modified() (e.g. tmpfs, ext4).
> 
> - Introduce file_mod_value_t (op, open_ctime, open_size) as the
>   file_modification_map value type, replacing the bare s32
> - Filter fd_install to only track regular files opened for writing
>   (FMODE_WRITE), reducing map pressure
> - Defer path string extraction in filp_close until an event is actually
>   submitted
> - Use get_file_id() instead of get_file_info() where only device, inode,
>   and ctime are needed, avoiding unnecessary path resolution

--


### 2. Explain how to test it

One may want to test writing to files on tmpfs, ext4, btrfs etc. After, compare the new ctime output by Tracee with what you can get from the file via `stat --printf='%.9Z\n' ${filename} | sed 's/\.//'`.


### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
