### PR TITLE
fix container procfs root errors

### DIFF
--- a/pkg/datastores/container/path_resolver.go
+++ b/pkg/datastores/container/path_resolver.go
@@ -82,7 +82,7 @@ func (cPathRes *ContainerPathResolver) GetHostAbsPath(mountNSAbsolutePath string
 
 	procFSRoot, err := cPathRes.getProcessFSRoot(uint(pid))
 	if err != nil {
-		return "", errfmt.Errorf("could not access process %d FS: %v", pid, err)
+		return "", errfmt.WrapError(fmt.Errorf("could not access process %d FS: %w", pid, err))
 	}
 
 	// register this process in the mount namespace
@@ -104,8 +104,10 @@ func (cPathRes *ContainerPathResolver) getProcessFSRoot(pid uint) (string, error
 	// fs.FS interface requires relative paths, so the '/' prefix should be trimmed.
 	entries, err := fs.ReadDir(cPathRes.fs, strings.TrimPrefix(procRootPath, "/"))
 	if err != nil {
-		// This process is either not alive or we don't have permissions to access.
-		return "", errfmt.Errorf("failed accessing process FS root %s: %v", procRootPath, err)
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
+			return "", fmt.Errorf("%w: %w", ErrContainerFSUnreachable, err)
+		}
+		return "", errfmt.WrapError(fmt.Errorf("failed accessing process FS root %s: %w", procRootPath, err))
 	}
 	if len(entries) == 0 {
 		return "", errfmt.Errorf("process FS root (%s) is empty", procRootPath)
@@ -307,6 +309,6 @@ func (cPathRes *ContainerPathResolver) isFileAccessible(path string) bool {
 }
 
 var (
-	ErrContainerFSUnreachable = errors.New("container file system is unreachable in mount namespace because there are not living children")
+	ErrContainerFSUnreachable = errors.New("container file system is unreachable in mount namespace")
 	ErrNonAbsolutePath        = errors.New("file path is not absolute in its container mount point")
 )

--- a/pkg/datastores/container/path_resolver_test.go
+++ b/pkg/datastores/container/path_resolver_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"fmt"
+	"io/fs"
 	"testing"
 	"testing/fstest"
 
@@ -336,4 +337,45 @@ func TestPathResolver_isFileAccessible(t *testing.T) {
 
 	// Test with a directory (should be accessible but not readable as a file)
 	assert.True(t, pres.isFileAccessible("/proc"))
+}
+
+// errorFS is a fake fs.FS that returns a fixed error for all ReadDir calls.
+type errorFS struct {
+	err error
+}
+
+func (e errorFS) Open(name string) (fs.File, error) {
+	return nil, &fs.PathError{Op: "open", Path: name, Err: e.err}
+}
+
+func (e errorFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	return nil, &fs.PathError{Op: "readdir", Path: name, Err: e.err}
+}
+
+func TestPathResolver_getProcessFSRoot_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	bucket := bucketcache.BucketCache{}
+	bucket.Init(20)
+	pres := InitContainerPathResolver(&bucket)
+	pres.fs = errorFS{err: fs.ErrPermission}
+
+	_, err := pres.getProcessFSRoot(1234)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrContainerFSUnreachable)
+	assert.ErrorIs(t, err, fs.ErrPermission)
+}
+
+func TestPathResolver_getProcessFSRoot_NotExist(t *testing.T) {
+	t.Parallel()
+
+	bucket := bucketcache.BucketCache{}
+	bucket.Init(20)
+	pres := InitContainerPathResolver(&bucket)
+	pres.fs = errorFS{err: fs.ErrNotExist}
+
+	_, err := pres.getProcessFSRoot(1234)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrContainerFSUnreachable)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
 }


### PR DESCRIPTION
<!--
Checklist:

  1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
  2. Flag your PR with at least one label "kind/xxx".
  3. Flag your PR with at least one label "area/xxx".
  4. Do not use "kind/feature" without explicitly adding a release feature.
  5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
  6. Make sure all tests pass before asking for review.
  7. Explicitly asking a maintainer for review might block you more time.
  8. Be mindful about rebases, try to provide them asap so merges can be done.

PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
-->

### 1. Explain what the PR does

<!-- Best advice is to put copy & paste "make check-pr" PR Comment output -->
Fixes #5234.

  This change makes ContainerPathResolver.GetHostAbsPath handle expected /proc/<pid>/root access
  failures more gracefully in the procfs fallback path.

  Today, Tracee already skips stale or inaccessible cached PIDs when resolving a mount namespace root.
  The gap was the fallback path: after GetAnyProcessInNS("mnt", mountNS) returns a PID, access to /
  proc/<pid>/root could still legitimately fail with:

  - permission denied
  - no such file or directory

  Those cases are expected during event processing:

  - ENOENT can happen if the selected process exits between namespace lookup and procfs access.
  - EACCES can happen because of procfs/ptrace permission boundaries.

  This PR changes that behavior so those expected failures are returned as ErrContainerFSUnreachable
  instead of being treated as unexpected hard errors. Unexpected filesystem errors are still preserved
  and returned.

  The patch also preserves the underlying fs error chain in getProcessFSRoot, which is required for co
  rrect errors.Is(..., fs.ErrPermission/fs.ErrNotExist) handling, and adds focused unit tests for:

  - fallback permission denied
  - fallback not found
  - unexpected fallback fs error
"Replace me with `make check-pr` output"

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->
 Run the focused tests:

  go test ./pkg/datastores/container -run 'TestPathResolver_(GetHostAbsPath_ExpectedProcFSRootErrors|
  GetHostAbsPath_UnexpectedProcFSRootError)' -count=1

  What to verify:

  - fs.ErrPermission from /proc/<pid>/root is treated as ErrContainerFSUnreachable
  - fs.ErrNotExist from /proc/<pid>/root is treated as ErrContainerFSUnreachable
  - unexpected fs errors are still returned as errors

  If you want to exercise the runtime path, run Tracee with exec hash enrichment enabled and trigger
  short-lived container processes. The important behavior is that transient /proc/<pid>/root permission
  denied / not found failures in container path resolution are treated as expected unreachable-
  container cases rather than surfacing as hard resolver errors.
### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->


###4. make check-pr 
[2026-04-07T10:56:30.920359Z] [checkpatch.sh] [INFO] Tracee Checkpatch Script
[2026-04-07T10:56:30.924776Z] [checkpatch.sh] [INFO] Checking: HEAD
[2026-04-07T10:56:30.930741Z] [checkpatch.sh] [INFO] Comparing against: origin/main
[2026-04-07T10:56:30.941857Z] [checkpatch.sh] [INFO] 
[2026-04-07T10:56:30.945734Z] [checkpatch.sh] [INFO] ==========================================
[2026-04-07T10:56:30.949514Z] [checkpatch.sh] [INFO]  Dependency Check
[2026-04-07T10:56:30.953544Z] [checkpatch.sh] [INFO] ==========================================
[2026-04-07T10:56:30.958122Z] [checkpatch.sh] [INFO] Checking dependencies...
[2026-04-07T10:56:30.968601Z] [checkpatch.sh] [INFO] Adding Go bin directory to PATH: /home/suryansh/go/bin
[2026-04-07T10:56:30.981862Z] [checkpatch.sh] [INFO] Go version: go1.26
[2026-04-07T10:56:30.986259Z] [checkpatch.sh] [WARN] revive not found.
[2026-04-07T10:56:30.991212Z] [checkpatch.sh] [INFO]   Install with: go install github.com/mgechev/revive@8ece20b0789c517bd3a6742db0daa4dd5928146d
[2026-04-07T10:56:30.995882Z] [checkpatch.sh] [WARN] staticcheck not found.
[2026-04-07T10:56:30.999844Z] [checkpatch.sh] [INFO]   Install with: go install honnef.co/go/tools/cmd/staticcheck@5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c
[2026-04-07T10:56:31.004388Z] [checkpatch.sh] [WARN] errcheck not found.
[2026-04-07T10:56:31.009256Z] [checkpatch.sh] [INFO]   Install with: go install github.com/kisielk/errcheck@11c27a7ce69d583465d80d808817d22d6653ee34
[2026-04-07T10:56:31.013960Z] [checkpatch.sh] [WARN] govulncheck not found.
[2026-04-07T10:56:31.017718Z] [checkpatch.sh] [INFO]   Install with: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77
[2026-04-07T10:56:31.022070Z] [checkpatch.sh] [WARN] clang-format-12 not found.
[2026-04-07T10:56:31.026464Z] [checkpatch.sh] [INFO]   Refer to your OS package manager Install via official package manager (e.g., 'sudo apt-get install clang-format-12')
[2026-04-07T10:56:31.030813Z] [checkpatch.sh] [WARN] goimports-reviser not found.
[2026-04-07T10:56:31.035181Z] [checkpatch.sh] [INFO]   Install with: go install github.com/incu6us/goimports-reviser/v3@fa5587e51ba33c58734984cb41370a5b2582d5b7
[2026-04-07T10:56:31.040774Z] [checkpatch.sh] [INFO] [PASS] Dependencies check completed
[2026-04-07T10:56:31.045311Z] [checkpatch.sh] [INFO] 
[2026-04-07T10:56:31.049589Z] [checkpatch.sh] [INFO] ==========================================
[2026-04-07T10:56:31.054023Z] [checkpatch.sh] [INFO]  Documentation Verification
[2026-04-07T10:56:31.057837Z] [checkpatch.sh] [INFO] ==========================================
[2026-04-07T10:56:31.062265Z] [checkpatch.sh] [INFO] Verifying documentation synchronization...
[2026-04-07T10:56:31.083834Z] [verify_man_md_sync.sh] [INFO] ================================================================================
[2026-04-07T10:56:31.088391Z] [verify_man_md_sync.sh] [INFO] Comparing changes from origin/main to HEAD
[2026-04-07T10:56:31.093178Z] [verify_man_md_sync.sh] [INFO] ================================================================================
[2026-04-07T10:56:31.131223Z] [verify_man_md_sync.sh] [INFO] No changes in '.md' or '.1.md' files
[2026-04-07T10:56:31.135658Z] [verify_man_md_sync.sh] [INFO] No changes in '.1' files
[2026-04-07T10:56:31.150780Z] [verify_man_md_sync.sh] [INFO] Documentation files are consistent.
[2026-04-07T10:56:31.156240Z] [checkpatch.sh] [INFO] [PASS] Documentation Verification completed successfully
[2026-04-07T10:56:31.160455Z] [checkpatch.sh] [INFO] 
[2026-04-07T10:56:31.164222Z] [checkpatch.sh] [INFO] ==========================================
[2026-04-07T10:56:31.168254Z] [checkpatch.sh] [INFO]  Code Analysis
[2026-04-07T10:56:31.172673Z] [checkpatch.sh] [INFO] ==========================================
[2026-04-07T10:56:31.177142Z] [checkpatch.sh] [INFO] Verifying and analyzing code...
[2026-04-07T10:56:31.181478Z] [checkpatch.sh] [INFO] Running formatting checks...
[2026-04-07T10:56:31.291363Z] [checkpatch.sh] [ERROR] Code formatting failed
ERROR: clang-format version 22 found, but version 19 is required
Hint: Try installing clang-format-19 or ensure clang-format points to version 19
make[1]: *** [builder/Makefile.checkers:44: .check_clang-format] Error 1
[2026-04-07T10:56:31.301489Z] [checkpatch.sh] [ERROR] Code Analysis failed
make: *** [Makefile:1274: check-pr] Error 1