### PR TITLE
fix(ci): fix retry logic and build deps in workflows

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libelf-dev clang make gcc pkg-config file
+          sudo apt-get install -y libelf-dev zlib1g-dev clang make gcc pkgconf file
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/trigger-pr-sync.yaml
+++ b/.github/workflows/trigger-pr-sync.yaml
@@ -112,6 +112,7 @@ jobs:
           attempts=0
           rc=0
           http_code=""
+          succeeded=false
 
           while [ "${attempts}" -lt "${max_attempts}" ]; do
               attempts=$((attempts + 1))
@@ -124,6 +125,7 @@ jobs:
               if [ "${rc}" -eq 0 ] \
                   && [ "${http_code}" -ge 200 ] \
                   && [ "${http_code}" -lt 300 ]; then
+                  succeeded=true
                   break
               fi
 
@@ -133,7 +135,7 @@ jobs:
               fi
           done
 
-          if [ "${attempts}" = "${max_attempts}" ]; then
+          if [ "${succeeded}" != true ]; then
               echo "ERROR: Failed after ${max_attempts} attempts (rc=${rc}, http=${http_code})." >&2
               exit 1
           fi


### PR DESCRIPTION
### 1. Explain what the PR does

9b4b9ed2f **fix(ci): fix retry logic and build deps in workflows**

> The trigger-pr-sync retry loop exits 1 when the final attempt
> succeeds because attempts equals max_attempts after break. Track
> success with an explicit flag instead.
> 
> The CodeQL workflow is missing zlib1g-dev, which libbpf needs at
> compile time (libbpf.c includes zlib.h). Also replace the legacy
> pkg-config package with pkgconf.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
