### PR TITLE
fix(scope): route container!=<id> to ContIDFilter

### DIFF
--- a/pkg/cmd/flags/policy.go
+++ b/pkg/cmd/flags/policy.go
@@ -178,7 +178,7 @@ func parseScopeFilters(p *policy.Policy, scopeFlags []scopeFlag) error {
 				if err := p.ContStartedFilter.Parse("started"); err != nil {
 					return err
 				}
-			case scopeFlag.operator == "=":
+			case scopeFlag.operator == "=" || scopeFlag.operator == "!=":
 				if err := p.ContIDFilter.Parse(scopeFlag.operatorAndValues); err != nil {
 					return err
 				}

--- a/pkg/cmd/flags/policy_test.go
+++ b/pkg/cmd/flags/policy_test.go
@@ -2333,6 +2333,34 @@ func TestParseScopeFilters(t *testing.T) {
 			},
 		},
 		{
+			name:   "container=<id> should set ContIDFilter",
+			policy: policy.NewPolicy(),
+			scopeFlags: []scopeFlag{{
+				full:              "container=abc123",
+				scopeName:         "container",
+				operator:          "=",
+				operatorAndValues: "=abc123",
+			}},
+			validate: func(t *testing.T, p *policy.Policy) {
+				assert.NotNil(t, p.ContIDFilter)
+				assert.True(t, p.ContIDFilter.Enabled())
+			},
+		},
+		{
+			name:   "container!=<id> should set ContIDFilter",
+			policy: policy.NewPolicy(),
+			scopeFlags: []scopeFlag{{
+				full:              "container!=abc123",
+				scopeName:         "container",
+				operator:          "!=",
+				operatorAndValues: "!=abc123",
+			}},
+			validate: func(t *testing.T, p *policy.Policy) {
+				assert.NotNil(t, p.ContIDFilter)
+				assert.True(t, p.ContIDFilter.Enabled())
+			},
+		},
+		{
 			name:   "invalid scope filter",
 			policy: policy.NewPolicy(),
 			scopeFlags: []scopeFlag{{


### PR DESCRIPTION
container!=<id> scope filter silently falls through to the boolean container filter instead of routing to ContIDFilter. This prevents container ID exclusion from populating the cgroup_id_filter BPF map, so       
  exclusion only happens in userspace.        
                                                                                                                                                                                                                      
  The fix adds the != operator alongside = in the container ID case of parseScopeFilters(). The underlying StringFilter, equality computation, and cgroup_id_filter BPF map all already support not-equal operations.
                                                                                                                                                                                                                      
  Files changed:                              
  - pkg/cmd/flags/policy.go — one line: add || scopeFlag.operator == "!=" to the container ID case                                                                                                                    
  - pkg/cmd/flags/policy_test.go — two test cases: container=<id> and container!=<id> both enable ContIDFilter
                                                                                                                                                                                                                      
  2. Explain how to test it                                 
                                                                                                                                                                                                                      
  Create a policy with container!=<id> in scope:            
                                                                                                                                                                                                                      
  apiVersion: tracee.aquasec.com/v1beta1                    
  kind: Policy                                                                                                                                                                                                        
  metadata:                                                 
    name: test-container-exclude                                                                                                                                                                                      
  spec:                                                     
    scope:
      - container                                                                                                                                                                                                     
      - "container!=<container-id-to-exclude>"
    rules:                                                                                                                                                                                                            
      - event: net_packet_http_request                      
                                              
  Before fix: Events from the excluded container still appear — container!=<id> is silently treated as container (boolean).                                                                                           
                                          
  After fix: Events from the excluded container are blocked at kernel level via cgroup_id_filter BPF map. Verify with:                                                                                                
                                                                                                                                                                                                                      
  curl -s http://localhost:3366/metrics | grep tracee_ebpf_events_filtered                                                                                                                                            
                                                                                                                                                                                                                      
  events_filtered should be 0 (kernel blocks them before userspace).
                                                                                                                                                                                                                      
  Unit tests:                                                                                                                                                                                                         
  go test ./pkg/cmd/flags/ -run TestParseScopeFilters -v                                                                                                                                                              
                                                                                                                                                                                                                      
  3. Other comments                                                                                                                                                                                                   
                                                            
  The scope docs list container under string operators supporting = and !=, but the parser only handled = for container IDs. The !=new and !=started cases have their own explicit branches, but the generic !=<id>
  case was missing.                       

  This is useful for excluding specific containers (e.g., infrastructure namespaces) at kernel level to reduce cgroup_skb overhead on nodes with high traffic from non-monitored workloads.