### PR TITLE
fix(ci): fix ff-merge permissions and document

### DIFF
--- a/.github/workflows/ff-check.yaml
+++ b/.github/workflows/ff-check.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
 
     permissions:
-      contents: read
-      issues: write
+      contents: read  # read repo for ff-check (no push needed)
+      issues: write   # post comments via the issues API endpoint
 
     steps:
       - name: Checking if fast forwarding is possible

--- a/.github/workflows/ff-merge.yaml
+++ b/.github/workflows/ff-merge.yaml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
 
     permissions:
-      contents: write
-      pull-requests: read
-      issues: write
+      contents: write      # git push (fast-forward the target branch)
+      pull-requests: write # fetch PR metadata and post PR comments
+      issues: write        # post comments via the issues API endpoint
 
     steps:
       - name: Fast forwarding


### PR DESCRIPTION
### 1. Explain what the PR does

6f37372a0 **fix(ci): fix ff-merge permissions and document**

> Upgrade pull-requests from read to write so the
> fast-forward action can fetch PR metadata and post
> comments on issue_comment-triggered runs.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
