### PR TITLE
ci(libbpfgo): run full PR suite for upstream compat

### DIFF
--- a/.github/actions/swap-upstream-libbpfgo/action.yaml
+++ b/.github/actions/swap-upstream-libbpfgo/action.yaml
@@ -1,0 +1,12 @@
+name: Swap to Upstream libbpfgo
+description: |
+  Replace the pinned libbpfgo dependency with upstream main branch.
+  Must run after checkout and Go installation.
+runs:
+  using: composite
+  steps:
+    - name: Swap libbpfgo to upstream main
+      run: |
+        go get github.com/aquasecurity/libbpfgo@main
+        go mod tidy
+      shell: sh

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,19 @@
 name: PR
 
 on:
+  workflow_call:
+    inputs:
+      tracee_ref:
+        description: "Tracee ref to checkout"
+        required: false
+        default: "main"
+        type: string
+      upstream_libbpfgo:
+        description: "Use upstream libbpfgo (main branch) instead of pinned version"
+        required: false
+        default: false
+        type: boolean
+
   workflow_dispatch:
     inputs:
       tracee_ref:
@@ -11,6 +24,11 @@ on:
         required: true
         default: "main"
         type: string
+      upstream_libbpfgo:
+        description: "Use upstream libbpfgo (main branch) instead of pinned version"
+        required: false
+        default: false
+        type: boolean
 
   pull_request:
     branches:
@@ -44,7 +62,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TRACEE_REF: ${{ github.event.inputs.tracee_ref || github.ref }}
+  TRACEE_REF: ${{ inputs.tracee_ref || github.event.inputs.tracee_ref || github.ref }}
   # Go 1.26 randomizes the heap base address, breaking the eBPF stack_pivot
   # detector's Go heap recognition (see plans/tracee/stack-pivot-go126-issue.md).
   GOEXPERIMENT: norandomizedheapbase64
@@ -104,6 +122,7 @@ jobs:
 
   verify-docs:
     name: Verify Documentation
+    if: inputs.upstream_libbpfgo != true
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
     permissions:
       contents: read
@@ -123,6 +142,7 @@ jobs:
 
   verify-analyze-code:
     name: Verify and Analyze Code
+    if: inputs.upstream_libbpfgo != true
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
     permissions:
       contents: read
@@ -188,6 +208,7 @@ jobs:
 
   verify-tools:
     name: Verify Other Tools
+    if: inputs.upstream_libbpfgo != true
     needs:
       - verify-analyze-code
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
@@ -225,6 +246,7 @@ jobs:
 
   unit-tests:
     name: Unit Tests (x86_64)
+    if: ${{ !cancelled() && !failure() }}
     needs:
       - verify-analyze-code
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
@@ -243,7 +265,12 @@ jobs:
       - name: Setup Tracee
         uses: ./.github/actions/setup-tracee-alpine
 
+      - name: Swap to upstream libbpfgo
+        if: inputs.upstream_libbpfgo == true
+        uses: ./.github/actions/swap-upstream-libbpfgo
+
       - name: Cache Go modules
+        if: inputs.upstream_libbpfgo != true
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
@@ -257,6 +284,7 @@ jobs:
 
   unit-tests-arm64:
     name: Unit Tests (ARM64)
+    if: ${{ !cancelled() && !failure() }}
     needs:
       - verify-analyze-code
     runs-on: ${{ vars.UBUNTU_ARM64_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04-arm') }}
@@ -292,7 +320,12 @@ jobs:
       - name: Setup Tracee
         uses: ./.github/actions/setup-tracee-alpine
 
+      - name: Swap to upstream libbpfgo
+        if: inputs.upstream_libbpfgo == true
+        uses: ./.github/actions/swap-upstream-libbpfgo
+
       - name: Cache Go modules
+        if: inputs.upstream_libbpfgo != true
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
@@ -310,10 +343,11 @@ jobs:
 
   integration-tests:
     name: Integration Tests (x86_64)
+    if: ${{ !cancelled() && !failure() }}
     needs:
       - verify-analyze-code
     runs-on:
-      - graas_ami-03dbff05cae3a30d0_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}_${{ github.run_number }}123 # Noble 6.12.62 x86_64 GRAAS AMI
+      - graas_ami-03dbff05cae3a30d0_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}_${{ github.run_number }}123 # Noble 6.12.62 x86_64 GRAAS AMI
       - EXECUTION_TYPE=SHORT
       - INSTANCE_TYPE=MEDIUM
     permissions:
@@ -357,7 +391,12 @@ jobs:
       # - name: Setup Tracee
       #   uses: ./.github/actions/setup-tracee-ubuntu
 
+      - name: Swap to upstream libbpfgo
+        if: inputs.upstream_libbpfgo == true
+        uses: ./.github/actions/swap-upstream-libbpfgo
+
       - name: Cache Go modules
+        if: inputs.upstream_libbpfgo != true
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
@@ -374,10 +413,11 @@ jobs:
 
   integration-tests-arm64:
     name: Integration Tests (ARM64)
+    if: ${{ !cancelled() && !failure() }}
     needs:
       - verify-analyze-code
     runs-on:
-      - graas_ami-07774797557132122_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}_${{ github.run_number }} # Noble 6.12 aarch64 GRAAS AMI
+      - graas_ami-07774797557132122_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}_${{ github.run_number }} # Noble 6.12 aarch64 GRAAS AMI
       - EXECUTION_TYPE=SHORT
       - INSTANCE_TYPE=MEDIUM
     permissions:
@@ -421,7 +461,12 @@ jobs:
       # - name: Setup Tracee
       #   uses: ./.github/actions/setup-tracee-ubuntu
 
+      - name: Swap to upstream libbpfgo
+        if: inputs.upstream_libbpfgo == true
+        uses: ./.github/actions/swap-upstream-libbpfgo
+
       - name: Cache Go modules
+        if: inputs.upstream_libbpfgo != true
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
@@ -442,6 +487,7 @@ jobs:
 
   performance-tests:
     name: Performance Tests
+    if: ${{ !cancelled() && !failure() }}
     needs:
       - verify-analyze-code
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
@@ -460,7 +506,12 @@ jobs:
       - name: Setup Tracee
         uses: ./.github/actions/setup-tracee-alpine
 
+      - name: Swap to upstream libbpfgo
+        if: inputs.upstream_libbpfgo == true
+        uses: ./.github/actions/swap-upstream-libbpfgo
+
       - name: Cache Go modules
+        if: inputs.upstream_libbpfgo != true
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
@@ -499,7 +550,7 @@ jobs:
     needs:
       - generate-matrix
     runs-on:
-      - graas_ami-${{ matrix.ami }}_${{ github.event.number }}${{ github.run_attempt }}-${{ github.run_id }}_${{ matrix.sufix }}
+      - graas_ami-${{ matrix.ami }}_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}_${{ matrix.sufix }}
       - EXECUTION_TYPE=LONG
       - INSTANCE_TYPE=XLARGE
     permissions:
@@ -524,7 +575,12 @@ jobs:
           submodules: true
           ref: ${{ env.TRACEE_REF }}
 
+      - name: Swap to upstream libbpfgo
+        if: inputs.upstream_libbpfgo == true
+        uses: ./.github/actions/swap-upstream-libbpfgo
+
       - name: Cache Go modules
+        if: inputs.upstream_libbpfgo != true
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |

--- a/.github/workflows/test-upstream-libbpfgo.yaml
+++ b/.github/workflows/test-upstream-libbpfgo.yaml
@@ -1,5 +1,5 @@
 #
-# Daily Test: Upstream libbpfgo compatibility
+# Daily Test: Run full PR test suite against upstream libbpfgo (main branch)
 #
 name: Upstream libbpfgo Compatibility
 
@@ -7,41 +7,15 @@ on:
   workflow_dispatch: {}
 
   schedule:
-    # Daily At 03:00
+    # Daily at 03:00 UTC
     - cron: "0 3 * * *"
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  compile-tracee:
-    name: Upstream libbpfgo Compatibility
-    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
+  pr-tests:
+    uses: ./.github/workflows/pr.yaml
+    with:
+      upstream_libbpfgo: true
     permissions:
       contents: read
-    container:
-      image: alpine/git:2.49.1@sha256:bd54f921f6d803dfa3a4fe14b7defe36df1b71349a3e416547e333aa960f86e3
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          submodules: true
-
-      - name: Setup Tracee
-        uses: ./.github/actions/setup-tracee-alpine
-
-      - name: Cache Go modules
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-${{ runner.arch }}-go-alpine-${{ hashFiles('**/go.mod') }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-${{ runner.arch }}-go-alpine-${{ hashFiles('**/go.mod') }}-
-
-      - name: Compile Tracee
-        run: make test-upstream-libbpfgo
-        shell: sh

--- a/tests/libbpfgo.sh
+++ b/tests/libbpfgo.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
 #
-# This test attempts to compile tracee using upstream libbpfgo.
-# It's run by github workflows inside action runners, just as
-# it can be run locally. In both cases it must be triggered by
-# 'make test-upstream-libbpfgo'.
+# Local validation: build and test tracee with upstream libbpfgo.
+#
+# Swaps the pinned libbpfgo dependency for upstream main, builds
+# tracee, runs unit tests, then restores go.mod/go.sum. Triggered
+# via 'make test-upstream-libbpfgo'.
+#
+# CI runs the full PR test suite (unit, integration, performance,
+# E2E/kernel) against upstream libbpfgo via workflow_call -- see
+# .github/workflows/test-upstream-libbpfgo.yaml.
 #
 
 info() {
@@ -20,8 +25,7 @@ error_exit() {
 
 git_setup() {
     git add go.mod go.sum
-    if ! go get github.com/aquasecurity/libbpfgo@main;
-    then
+    if ! go get github.com/aquasecurity/libbpfgo@main; then
         git restore --staged go.mod go.sum
         error_exit "could not go get libbpfgo@main"
     fi
@@ -34,14 +38,20 @@ git_restore() {
 
 BASE_DIR="$(dirname "$(realpath "${0}")")"
 TRACEE_DIR="$(realpath "${BASE_DIR}"/..)"
-GO_ENV_EBPF=( "$@" )
+GO_ENV_EBPF=("$@")
 export "${GO_ENV_EBPF[@]}"
 
 git_setup
 trap git_restore ERR
 
 set -e
+
+info "Building tracee with upstream libbpfgo..."
 STATIC=1 make -C "${TRACEE_DIR}"
+
+info "Running unit tests with upstream libbpfgo..."
+make -C "${TRACEE_DIR}" test-unit
+
 set +e
 
 git_restore


### PR DESCRIPTION
### 1. Explain what the PR does

47f11f079 **ci(libbpfgo): run full PR suite for upstream compat**

> Make pr.yaml reusable via workflow_call so the daily
> upstream libbpfgo check runs the complete test suite
> instead of only building. Verify/lint jobs are skipped
> for upstream runs since code analysis is unaffected by
> a dependency swap.
> 
> Go caches are skipped for upstream runs to avoid
> tainting shared caches. GRAAS runner labels fall back
> to 0 when no PR number is present.

--


### 2. Explain how to test it

https://github.com/aquasecurity/tracee/actions/runs/24370002165/job/71171226994

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
