### PR TITLE
types/trace: fix 'occured' -> 'occurred' in EventOrigin doc comment

### DIFF
--- a/types/trace/trace.go
+++ b/types/trace/trace.go
@@ -92,7 +92,7 @@ type File struct {
 	Path string `json:"path"`
 }
 
-// EventOrigin is where a trace.Event occured, it can either be from the host machine or from a container
+// EventOrigin is where a trace.Event occurred, it can either be from the host machine or from a container
 type EventOrigin string
 
 const (


### PR DESCRIPTION
Doc comment in `types/trace/trace.go` line 95 reads `Event occured`. Fixed to `occurred`. Comment-only change.