### PR TITLE
ci(vulncheck): fail on findings and harden checkpatch

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -197,8 +197,7 @@ jobs:
         run: |
           make check-err
 
-      - name: Check with govulncheck (informational)
-        continue-on-error: true
+      - name: Check with govulncheck
         run: |
           make check-vulncheck
 

--- a/builder/Makefile.checkers
+++ b/builder/Makefile.checkers
@@ -211,8 +211,8 @@ code-check: | \
 	$(GENERAL_MAKE) -j1 check-staticcheck; \
 	echo "Checking Golang with errcheck..."; \
 	$(GENERAL_MAKE) -j1 check-err
-	@echo "Checking Golang with govulncheck (informational)..."
-	@$(GENERAL_MAKE) -j1 check-vulncheck || true
+	@echo "Checking Golang with govulncheck..."
+	@$(GENERAL_MAKE) -j1 check-vulncheck
 
 #
 # clean

--- a/docs/contributing/checkpatch.md
+++ b/docs/contributing/checkpatch.md
@@ -72,7 +72,7 @@ make check-pr ARGS="--fast --skip-docs HEAD~1"  # Pass arguments through make
 - **Go Vet**: Static analysis via `make check-vet`
 - **StaticCheck**: Advanced static analysis via `make check-staticcheck`
 - **Error Check**: Unhandled error detection via `make check-err`
-- **Vulnerability Check**: Known vulnerability detection via `make check-vulncheck` (informational, non-blocking — govulncheck currently has [no support for silencing findings](https://go.dev/issue/61211))
+- **Vulnerability Check**: Known vulnerability detection via `make check-vulncheck`
 
 ### 3. Unit Tests
 

--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
+#
+# checkpatch.sh - Local development script to run PR tests.
+#
+# Usage: ./scripts/checkpatch.sh [OPTIONS] [commit-ref]
+# If no commit-ref is provided, checks HEAD commit.
+#
 
-# checkpatch.sh - Local development script to run PR tests
-# Usage: ./scripts/checkpatch.sh [commit-ref]
-# If no commit-ref is provided, checks HEAD commit
-
-set -e
+set -euo pipefail
 
 # Source lib.sh for common functions
 __LIB_DIR="${0%/*}"
@@ -35,7 +37,6 @@ print_header() {
     info "=========================================="
 }
 
-# Function to show help
 show_help() {
     cat << EOF
 Usage: $0 [OPTIONS] [commit-ref]
@@ -90,6 +91,20 @@ Exit Codes:
 EOF
 }
 
+# Extracts the tool name from make output when a tool is missing.
+# Reads from stdin and prints the tool name, or prints nothing if not found.
+# shellcheck disable=SC2329 # invoked indirectly via handle_missing_tool
+extract_missing_tool() {
+    local line
+    while IFS= read -r line; do
+        if [[ "${line}" == *"missing required tool"* ]]; then
+            echo "${line##*missing required tool }"
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Options
 SKIP_DOCS=false
 SKIP_CODE_ANALYSIS=false
@@ -102,7 +117,7 @@ FAST_MODE=false
 COMMAND_MODE=""
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -h|--help)
+        -h | --help)
             show_help
             exit 0
             ;;
@@ -165,34 +180,61 @@ fi
 # Track overall success
 OVERALL_SUCCESS=true
 
-# Function to run a test section
 run_test_section() {
     local section_name=$1
     local test_function=$2
 
-    print_header "$section_name"
+    print_header "${section_name}"
 
-    if $test_function; then
-        print_success "$section_name completed successfully"
+    if "${test_function}"; then
+        print_success "${section_name} completed successfully"
         return 0
     else
-        print_error "$section_name failed"
+        print_error "${section_name} failed"
         OVERALL_SUCCESS=false
         return 1
     fi
 }
 
-# Test 1: Verify Documentation Synchronization
+# Handles the "missing required tool" pattern shared across all check targets.
+# Arguments:
+#   $1 - make output
+#   $2 - install hint (e.g. "go install <package>")
+# Returns:
+#   0 if the tool is missing AND --ignore-missing-tools is set
+#   1 if the tool is missing but we should fail
+#   2 if the output does not contain a missing-tool message
+# shellcheck disable=SC2329 # invoked indirectly via verify_analyze_code/run_check_target
+handle_missing_tool() {
+    local output="$1"
+    local install_hint="$2"
+
+    local missing_tool
+    missing_tool="$(echo "${output}" | extract_missing_tool)" || return 2
+
+    print_warning "Missing required tool: ${missing_tool}"
+    if [[ -n "${install_hint}" ]]; then
+        print_info "${install_hint}"
+    fi
+
+    if ${IGNORE_MISSING_TOOLS}; then
+        print_warning "Ignoring missing tool error and continuing..."
+        return 0
+    fi
+
+    echo "${output}"
+    return 1
+}
+
+# shellcheck disable=SC2329 # invoked indirectly via run_test_section
 verify_docs() {
     print_info "Verifying documentation synchronization..."
 
-    # Check if verify_man_md_sync.sh exists
     if [[ ! -f "scripts/verify_man_md_sync.sh" ]]; then
         print_warning "scripts/verify_man_md_sync.sh not found, skipping documentation verification"
         return 0
     fi
 
-    # Run the documentation verification script
     if ! bash scripts/verify_man_md_sync.sh --base-ref "${BASE_REF}" --target-ref "${GIT_REF}"; then
         print_error "Documentation verification failed"
         print_error "- .1.md changes require corresponding .1 changes"
@@ -203,21 +245,54 @@ verify_docs() {
     return 0
 }
 
-# Test 2: Verify and Analyze Code (equivalent to make check-pr code analysis)
+# Runs a single make check-* target with missing-tool handling.
+# Arguments:
+#   $1 - human-readable label (e.g. "Go vet")
+#   $2 - make target (e.g. "check-vet")
+#   $3 - install hint for missing tool (optional)
+# Returns 0 on success, 1 on failure.
+# shellcheck disable=SC2329 # invoked indirectly via verify_analyze_code
+run_check_target() {
+    local label="$1"
+    local target="$2"
+    local install_hint="${3:-}"
+
+    local output
+    local rc=0
+    output=$(make "${target}" 2>&1) || rc=$?
+
+    if ((rc == 0)); then
+        print_success "  [ok] ${label} passed"
+        return 0
+    fi
+
+    handle_missing_tool "${output}" "${install_hint}"
+    local mt_rc=$?
+    if ((mt_rc != 2)); then
+        return "${mt_rc}"
+    fi
+
+    echo "${output}"
+    print_error "  [fail] ${label} failed"
+    return 1
+}
+
+# shellcheck disable=SC2329 # invoked indirectly via run_test_section
 verify_analyze_code() {
     print_info "Verifying and analyzing code..."
 
-    # Run comprehensive code analysis equivalent to make check-pr
     print_info "Running formatting checks..."
+    local output
     if output=$(make -f builder/Makefile.checkers fmt-check 2>&1); then
         print_success "Code formatting passed"
     else
         print_error "Code formatting failed"
-        if echo "$output" | grep -q "missing required tool"; then
-            local missing_tool=$(echo "$output" | grep "missing required tool" | sed 's/.*missing required tool //')
-            print_warning "Missing required tool: $missing_tool"
 
-            case "$missing_tool" in
+        local missing_tool
+        if missing_tool="$(echo "${output}" | extract_missing_tool)"; then
+            print_warning "Missing required tool: ${missing_tool}"
+
+            case "${missing_tool}" in
                 "clang-format-12")
                     print_info "clang-format-12 is required for eBPF C code formatting."
                     print_info "Install using your system's official package manager:"
@@ -230,13 +305,13 @@ verify_analyze_code() {
                     ;;
             esac
 
-            if $IGNORE_MISSING_TOOLS; then
+            if ${IGNORE_MISSING_TOOLS}; then
                 print_warning "Ignoring missing tool error and continuing..."
             else
                 return 1
             fi
         else
-            echo "$output"
+            echo "${output}"
             return 1
         fi
     fi
@@ -246,125 +321,57 @@ verify_analyze_code() {
         print_success "Linting passed"
     else
         print_error "Linting failed"
-        if echo "$output" | grep -q "missing required tool"; then
-            local missing_tool=$(echo "$output" | grep "missing required tool" | sed 's/.*missing required tool //')
-            print_warning "Missing required tool: $missing_tool"
-            print_info "Install with: go install github.com/mgechev/revive@8ece20b0789c517bd3a6742db0daa4dd5928146d" # v1.7.0
-
-            if $IGNORE_MISSING_TOOLS; then
-                print_warning "Ignoring missing tool error and continuing..."
-            else
+        handle_missing_tool "${output}" \
+            "Install with: go install github.com/mgechev/revive@8ece20b0789c517bd3a6742db0daa4dd5928146d"
+        local mt_rc=$?
+        case "${mt_rc}" in
+            0) ;; # missing tool, --ignore-missing-tools is set
+            1)
                 return 1
-            fi
-        else
-            echo "$output"
-            return 1
-        fi
+                ;;
+            *)
+                echo "${output}"
+                return 1
+                ;;
+        esac
     fi
 
-    # Fast mode: skip static analysis that requires compilation
-    if $FAST_MODE; then
+    if ${FAST_MODE}; then
         print_info "Fast mode: skipping static analysis checks"
         return 0
     fi
 
     print_info "Running comprehensive code checks..."
 
-    # Run individual checks with progress reporting
-    print_info "  → Building tracee binary (this may take a moment)..."
-    print_info "  → Running Go vet analysis..."
-    if output=$(make check-vet 2>&1); then
-        print_success "  ✓ Go vet passed"
-    else
-        print_error "  ✗ Go vet failed"
-        if echo "$output" | grep -q "missing required tool"; then
-            local missing_tool=$(echo "$output" | grep "missing required tool" | sed 's/.*missing required tool //')
-            print_warning "Missing required tool: $missing_tool"
-            if $IGNORE_MISSING_TOOLS; then
-                print_warning "Ignoring missing tool error and continuing..."
-            else
-                echo "$output"
-                return 1
-            fi
-        else
-            echo "$output"
-            return 1
-        fi
-    fi
+    print_info "  -> Building tracee binary (this may take a moment)..."
 
-    print_info "  → Running StaticCheck analysis..."
-    if output=$(make check-staticcheck 2>&1); then
-        print_success "  ✓ StaticCheck passed"
-    else
-        print_error "  ✗ StaticCheck failed"
-        if echo "$output" | grep -q "missing required tool"; then
-            local missing_tool=$(echo "$output" | grep "missing required tool" | sed 's/.*missing required tool //')
-            print_warning "Missing required tool: $missing_tool"
-            print_info "Install with: go install honnef.co/go/tools/cmd/staticcheck@5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c" # 2025.1
-            if $IGNORE_MISSING_TOOLS; then
-                print_warning "Ignoring missing tool error and continuing..."
-            else
-                echo "$output"
-                return 1
-            fi
-        else
-            echo "$output"
-            return 1
-        fi
-    fi
+    print_info "  -> Running Go vet analysis..."
+    run_check_target "Go vet" "check-vet" || return 1
 
-    print_info "  → Running errcheck analysis..."
-    if output=$(make check-err 2>&1); then
-        print_success "  ✓ errcheck passed"
-    else
-        print_error "  ✗ errcheck failed"
-        if echo "$output" | grep -q "missing required tool"; then
-            local missing_tool=$(echo "$output" | grep "missing required tool" | sed 's/.*missing required tool //')
-            print_warning "Missing required tool: $missing_tool"
-            print_info "Install with: go install github.com/kisielk/errcheck@11c27a7ce69d583465d80d808817d22d6653ee34" # v1.9.0
-            if $IGNORE_MISSING_TOOLS; then
-                print_warning "Ignoring missing tool error and continuing..."
-            else
-                echo "$output"
-                return 1
-            fi
-        else
-            echo "$output"
-            return 1
-        fi
-    fi
+    print_info "  -> Running StaticCheck analysis..."
+    run_check_target "StaticCheck" "check-staticcheck" \
+        "Install with: go install honnef.co/go/tools/cmd/staticcheck@5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c" \
+        || return 1
 
-    print_info "  → Running govulncheck analysis (informational, non-blocking)..."
-    local vulncheck_rc=0
-    output=$(make check-vulncheck 2>&1) || vulncheck_rc=$?
+    print_info "  -> Running errcheck analysis..."
+    run_check_target "errcheck" "check-err" \
+        "Install with: go install github.com/kisielk/errcheck@11c27a7ce69d583465d80d808817d22d6653ee34" \
+        || return 1
 
-    if echo "$output" | grep -q "missing required tool"; then
-        local missing_tool=$(echo "$output" | grep "missing required tool" | sed 's/.*missing required tool //')
-        print_warning "Missing required tool: $missing_tool"
-        print_info "Install with: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77" # v1.1.4
-        if ! $IGNORE_MISSING_TOOLS; then
-            echo "$output"
-            return 1
-        fi
-    elif [[ $vulncheck_rc -ne 0 ]]; then
-        echo "$output"
-        print_warning "  ⚠ govulncheck found vulnerable dependencies (non-blocking)"
-        print_info "  govulncheck has no support for silencing findings (see https://go.dev/issue/61211)"
-    else
-        echo "$output"
-        print_success "  ✓ govulncheck passed"
-    fi
+    print_info "  -> Running govulncheck analysis..."
+    run_check_target "govulncheck" "check-vulncheck" \
+        "Install with: go install golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77" \
+        || return 1
 
     print_success "All code analysis checks passed"
 
     return 0
 }
 
-# Test 3: Unit Tests
+# shellcheck disable=SC2329 # invoked indirectly via run_test_section
 unit_tests() {
     print_info "Running unit tests..."
 
-    # Run unit tests
     print_info "Running Go unit tests..."
     if make test-unit; then
         print_success "Go unit tests passed"
@@ -373,7 +380,6 @@ unit_tests() {
         return 1
     fi
 
-    # Run script unit tests (tests lib.sh infrastructure functions)
     print_info "Running script infrastructure tests..."
     if make run-scripts-test-unit > /dev/null 2>&1; then
         print_success "Script infrastructure tests passed"
@@ -385,96 +391,95 @@ unit_tests() {
     return 0
 }
 
-# Test 3: PR Formatting (equivalent to make format-pr)
 pr_format() {
     print_info "Generating PR commit format..."
 
-    if ! command -v git &> /dev/null; then
+    if ! command -v git > /dev/null 2>&1; then
         print_error "git is required for PR formatting"
         return 1
     fi
 
     print_info "PR Comment Format:"
     echo ""
-    echo "👇 PR Comment BEGIN"
+    echo "--- PR Comment BEGIN ---"
     echo ""
 
-    # Display commits in PR format (without colors for PR comment)
-    git log $BASE_REF..HEAD --pretty=format:'%h **%s**' 2>/dev/null || {
-        print_warning "Could not generate commit log from $BASE_REF to HEAD"
-        print_info "This might be because you're not on a branch that diverges from $BASE_REF"
+    git log "${BASE_REF}..HEAD" --pretty=format:'%h **%s**' 2> /dev/null || {
+        print_warning "Could not generate commit log from ${BASE_REF} to HEAD"
+        print_info "This might be because you're not on a branch that diverges from ${BASE_REF}"
         return 0
     }
 
     echo ""
     echo ""
 
-    # Display commit bodies if they exist (with color for terminal, quote prefix for PR)
-    output=$(git rev-list $BASE_REF..HEAD 2>/dev/null | while read commit; do
-        body="$(git show --no-patch --format=%b $commit | sed ':a;N;$!ba;s/\n$//')"
-        if [ -n "$body" ]; then
-            git show -s $commit --color=always --format='%C(auto,yellow)%h%Creset **%C(auto,red)%s%Creset**%n'
-            echo "$body" | sed 's/^/> /'
+    local output
+    local commit
+    local body
+    output=$(git rev-list "${BASE_REF}..HEAD" 2> /dev/null | while IFS= read -r commit; do
+        body="$(git show --no-patch --format=%b "${commit}" | sed ':a;N;$!ba;s/\n$//')"
+        if [[ -n "${body}" ]]; then
+            git show -s "${commit}" --color=always --format='%C(auto,yellow)%h%Creset **%C(auto,red)%s%Creset**%n'
+            echo "> ${body//$'\n'/$'\n'> }"
             echo
             echo "--"
             echo
         fi
     done)
 
-    echo "$output"
+    echo "${output}"
     echo ""
-    echo "👆 PR Comment END"
+    echo "--- PR Comment END ---"
     echo ""
 
     return 0
 }
 
-# Check for required dependencies
 check_dependencies() {
     print_info "Checking dependencies..."
 
-    # Check for basic tools
     local basic_tools=("go" "make" "git")
+    local tool
     for tool in "${basic_tools[@]}"; do
-        if ! command -v "$tool" &> /dev/null; then
-            print_error "$tool is required but not installed"
+        if ! command -v "${tool}" > /dev/null 2>&1; then
+            print_error "${tool} is required but not installed"
             return 1
         fi
     done
 
-    # Ensure Go bin directory is in PATH for Go tools
-    local go_bin_path="$(go env GOPATH)/bin"
-    if [[ ":$PATH:" != *":$go_bin_path:"* ]]; then
-        print_info "Adding Go bin directory to PATH: $go_bin_path"
-        export PATH="$PATH:$go_bin_path"
+    local go_bin_path
+    go_bin_path="$(go env GOPATH)/bin"
+    if [[ ":${PATH}:" != *":${go_bin_path}:"* ]]; then
+        print_info "Adding Go bin directory to PATH: ${go_bin_path}"
+        export PATH="${PATH}:${go_bin_path}"
     fi
 
-    # Check Go version
-    local go_version=$(go version | grep -o 'go[0-9]\+\.[0-9]\+')
-    print_info "Go version: $go_version"
+    local go_version
+    go_version=$(go version | grep -o 'go[0-9]\+\.[0-9]\+')
+    print_info "Go version: ${go_version}"
 
-    # Check for optional tools and warn if missing
     local optional_tools=(
-        "revive:github.com/mgechev/revive@8ece20b0789c517bd3a6742db0daa4dd5928146d:go install" # v1.7.0
+        "revive:github.com/mgechev/revive@8ece20b0789c517bd3a6742db0daa4dd5928146d:go install"               # v1.7.0
         "staticcheck:honnef.co/go/tools/cmd/staticcheck@5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c:go install" # 2025.1
-        "errcheck:github.com/kisielk/errcheck@11c27a7ce69d583465d80d808817d22d6653ee34:go install" # v1.9.0
-        "govulncheck:golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77:go install" # v1.1.4
+        "errcheck:github.com/kisielk/errcheck@11c27a7ce69d583465d80d808817d22d6653ee34:go install"           # v1.9.0
+        "govulncheck:golang.org/x/vuln/cmd/govulncheck@d1f380186385b4f64e00313f31743df8e4b89a77:go install"  # v1.1.4
         "clang-format-12:Install via official package manager (e.g., 'sudo apt-get install clang-format-12'):Refer to your OS package manager"
         "goimports-reviser:github.com/incu6us/goimports-reviser/v3@fa5587e51ba33c58734984cb41370a5b2582d5b7:go install" # v3.12.6
     )
 
+    local tool_info tool_name tool_package install_method
     for tool_info in "${optional_tools[@]}"; do
-        local tool_name="${tool_info%%:*}"
-        local tool_package="${tool_info#*:}"
-        local install_method="${tool_info##*:}"
+        tool_name="${tool_info%%:*}"
+        tool_package="${tool_info#*:}"
+        install_method="${tool_info##*:}"
         tool_package="${tool_package%:*}"
 
-        if ! command -v "$tool_name" &> /dev/null; then
-            print_warning "$tool_name not found."
-            if [[ "$install_method" == "go install" ]]; then
-                print_info "  Install with: $install_method $tool_package"
+        if ! command -v "${tool_name}" > /dev/null 2>&1; then
+            print_warning "${tool_name} not found."
+            if [[ "${install_method}" == "go install" ]]; then
+                print_info "  Install with: ${install_method} ${tool_package}"
             else
-                print_info "  $install_method $tool_package"
+                print_info "  ${install_method} ${tool_package}"
             fi
         fi
     done
@@ -482,7 +487,6 @@ check_dependencies() {
     return 0
 }
 
-# Main execution
 main() {
     print_header "Dependency Check"
     if ! check_dependencies; then
@@ -491,50 +495,47 @@ main() {
     fi
     print_success "Dependencies check completed"
 
-    # Run the main test categories
-    if ! $SKIP_DOCS; then
+    if ! ${SKIP_DOCS}; then
         run_test_section "Documentation Verification" verify_docs
     else
         print_info "Skipping documentation verification"
     fi
 
-    if ! $SKIP_CODE_ANALYSIS; then
+    if ! ${SKIP_CODE_ANALYSIS}; then
         run_test_section "Code Analysis" verify_analyze_code
     else
         print_info "Skipping code analysis"
     fi
 
-    if ! $SKIP_UNIT_TESTS; then
+    if ! ${SKIP_UNIT_TESTS}; then
         run_test_section "Unit Tests" unit_tests
     else
         print_info "Skipping unit tests"
     fi
 
-    if ! $SKIP_PR_FORMAT; then
+    if ! ${SKIP_PR_FORMAT}; then
         run_test_section "PR Formatting" pr_format
     else
         print_info "Skipping PR formatting"
     fi
 
-    # Final summary
     print_header "Summary"
-    if $OVERALL_SUCCESS; then
+    if ${OVERALL_SUCCESS}; then
         print_success "All checks passed!"
         print_info "Your commit is ready for PR submission."
         exit 0
     else
-        print_error "Some checks failed! ❌"
+        print_error "Some checks failed."
         print_info "Please fix the issues above before submitting a PR."
         exit 1
     fi
 }
 
 # If pr-format command mode, just run that and exit
-if [ "$COMMAND_MODE" = "pr-format" ]; then
+if [[ "${COMMAND_MODE}" = "pr-format" ]]; then
     BASE_REF="${BASE_REF:-origin/main}"
     pr_format
     exit $?
 fi
 
-# Run main function
 main "$@"


### PR DESCRIPTION
### 1. Explain what the PR does

2aed2739c **ci(vulncheck): fail on findings and harden checkpatch**

govulncheck was informational with continue-on-error, silently
> passing when vulnerabilities were found. Make it blocking across
> the PR workflow, builder Makefile, and checkpatch script.
> 
> Refactor checkpatch.sh to comply with shell style guide and ASCII
> safety rules: enable pipefail, brace-quote all variables, replace
> Unicode glyphs with ASCII, fix shellcheck warnings, and extract
> shared helpers to deduplicate missing-tool handling.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
