### PR TITLE
ci(codeql): add explicit file coverage toggle

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -40,6 +40,13 @@ jobs:
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-4core') }}
 
+    env:
+      # "false" is already the default since April 2026, but having the
+      # toggle explicit makes it easy to flip for debugging. The repo
+      # property "github-codeql-file-coverage-on-prs" can still override
+      # this to true (it is evaluated after the env var).
+      CODEQL_ACTION_FILE_COVERAGE_ON_PRS: "false"
+
     permissions:
       security-events: write
       packages: read


### PR DESCRIPTION
### 1. Explain what the PR does

82a3b3367 **ci(codeql): add explicit file coverage toggle**

> Since April 2026 CodeQL skips file coverage on PRs by
> default. Make the setting explicit so it is easy to
> flip for debugging without researching the new default.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
