### PR TITLE
Fixes tracee/filters traceectl/cli

### DIFF
--- a/cmd/traceectl/pkg/cmd/flags/output.go
+++ b/cmd/traceectl/pkg/cmd/flags/output.go
@@ -38,9 +38,11 @@ func PrepareOutput(cmd *cobra.Command, outputSlice string) (Output, error) {
 
 	cmd.SetOut(file)
 	cmd.SetErr(file)
-	// Close the file after execution
 	cmd.PersistentPostRun = func(cmd *cobra.Command, args []string) {
-		file.Close()
+		// Close the file after execution
+		if err := file.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to close output file %q: %v\n", outputSlice, err)
+		}
 	}
 	return Output{
 		Path:   outputSlice,

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -78,10 +78,7 @@ func (f *BoolFilter) Parse(operatorAndValues string) error {
 	}
 
 	// case of !=bools...
-	if operatorAndValues[0] == '!' && operatorAndValues[1] == '=' {
-		if len(operatorAndValues) < 2+len("true") {
-			return InvalidExpression(operatorAndValues)
-		}
+	if len(operatorAndValues) >= 2 && operatorAndValues[0] == '!' && operatorAndValues[1] == '=' {
 		valuesString := operatorAndValues[2:]
 		vals := strings.Split(valuesString, ",")
 		for _, val := range vals {

--- a/pkg/filters/bool.go
+++ b/pkg/filters/bool.go
@@ -59,8 +59,6 @@ func (f *BoolFilter) Parse(operatorAndValues string) error {
 		return InvalidExpression(operatorAndValues)
 	}
 
-	f.Enable()
-
 	// case of =bools...
 	if operatorAndValues[0] == '=' {
 		valuesString := operatorAndValues[1:]
@@ -74,6 +72,7 @@ func (f *BoolFilter) Parse(operatorAndValues string) error {
 				return err
 			}
 		}
+		f.Enable()
 		return nil
 	}
 
@@ -90,16 +89,19 @@ func (f *BoolFilter) Parse(operatorAndValues string) error {
 				return err
 			}
 		}
+		f.Enable()
 		return nil
 	}
 
 	// case of not-field
 	if strings.HasPrefix(operatorAndValues, "not-") {
+		f.Enable()
 		f.falseEnabled = true
 		return nil
 	}
 
 	// final case just field
+	f.Enable()
 	f.trueEnabled = true
 
 	return nil

--- a/pkg/filters/bool_test.go
+++ b/pkg/filters/bool_test.go
@@ -60,6 +60,24 @@ func TestBoolFilterParse(t *testing.T) {
 			filterResult: []bool{true, true},
 		},
 		{
+			name:         "single char bare field",
+			expressions:  []string{"x"},
+			expected:     true,
+			filterResult: []bool{true, false},
+		},
+		{
+			name:         "exclamation without equals is bare field",
+			expressions:  []string{"!x"},
+			expected:     true,
+			filterResult: []bool{true, false},
+		},
+		{
+			name:         "equal true and false",
+			expressions:  []string{"=true,false"},
+			expected:     true,
+			filterResult: []bool{true, true},
+		},
+		{
 			name:         "no values",
 			expressions:  []string{},
 			expected:     false,
@@ -87,6 +105,50 @@ func TestBoolFilterParse(t *testing.T) {
 				filterRes = append(filterRes, filter.Filter(val))
 			}
 			assert.Equal(t, tc.filterResult, filterRes)
+		})
+	}
+}
+
+func TestBoolFilterParseErrors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		expression string
+		errMsg     string
+	}{
+		{
+			name:       "empty string",
+			expression: "",
+			errMsg:     "invalid filter expression",
+		},
+		{
+			name:       "not-equal missing value",
+			expression: "!=",
+			errMsg:     "invalid filter value",
+		},
+		{
+			name:       "not-equal invalid value",
+			expression: "!=xyz",
+			errMsg:     "invalid filter value",
+		},
+		{
+			name:       "equal invalid value",
+			expression: "=xyz",
+			errMsg:     "invalid filter value",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := NewBoolFilter()
+			err := filter.Parse(tc.expression)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errMsg)
 		})
 	}
 }

--- a/pkg/filters/bool_test.go
+++ b/pkg/filters/bool_test.go
@@ -149,6 +149,7 @@ func TestBoolFilterParseErrors(t *testing.T) {
 			err := filter.Parse(tc.expression)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.errMsg)
+			assert.False(t, filter.Enabled(), "filter must not be enabled after failed Parse")
 		})
 	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

04a7dd70b **fix(cli): handle output file close error**
fd5690fb0 **fix(filters): defer BoolFilter.Enable until Parse succeeds**
bc7acf926 **fix(filters): guard BoolFilter.Parse index access**


fd5690fb0 **fix(filters): defer BoolFilter.Enable until Parse succeeds**

> Parse called Enable() before validation, leaving the
> filter enabled when parsing failed. Move Enable() to
> each success path so a failed Parse does not mutate
> the receiver.

--

bc7acf926 **fix(filters): guard BoolFilter.Parse index access**

> The != branch accessed operatorAndValues[1] after only
> checking len >= 1, causing an out-of-bounds panic on
> single-character inputs like "!". Move the length check
> into the branch condition using short-circuit evaluation.
> 
> Also remove the overly strict len < 2+len("true") guard
> that rejected valid short bool values ("0", "1", "t", "f")
> before ParseBool could validate them.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
