### PR TITLE
docs(cursor): clarify ASCII replacement rules

### DIFF
--- a/.cursor/rules/shell-style-guide.mdc
+++ b/.cursor/rules/shell-style-guide.mdc
@@ -1428,7 +1428,7 @@ var+="suffix"                  # Bash only (use var="${var}suffix" in sh)
 # BAD: No {n..m} brace expansion
 for i in {1..10}; do           # Bash only (use while loop in sh)
 
-# BAD: No ==  in [ ] for max portability
+# BAD: No == in [ ] for max portability
 [ "${a}" == "${b}" ]           # Use = instead for POSIX
 
 # BAD: No [[ ]] regex matching

--- a/.cursor/rules/text-ascii-safety.mdc
+++ b/.cursor/rules/text-ascii-safety.mdc
@@ -24,7 +24,11 @@ markdown, comments, and generated text. There are no doc-only exceptions.
   - any other non-printing Unicode control chars (except newline/tab where valid)
 
 - If a forbidden char is found, replace it with ASCII:
-  - dashes to `-`, curly single quotes to `'`, curly double quotes to `"`, and bullets/arrows to `-` or words.
+  - dashes to `-`
+  - curly single quotes to `'`
+  - curly double quotes to `"`
+  - bullets to `-`
+  - arrows to `->` or the equivalent word (e.g., "returns", "maps to") depending on context
 
 ## Mandatory Review Check
 


### PR DESCRIPTION
### 1. Explain what the PR does

0bb1fb4d6 **docs(cursor): clarify ASCII replacement rules**

> Separate bullets and arrows into distinct replacement
> items with specific guidance for each. Fix extra space
> in shell style guide comment.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
