### PR TITLE
fix(grpc): handle non-primitive arg types in detectedFrom protobuf co…

### DIFF
--- a/pkg/events/conversion_test.go
+++ b/pkg/events/conversion_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -1041,4 +1042,278 @@ func TestConvertTraceeEventToProto_Threat(t *testing.T) {
 	assert.Equal(t, "privilege-escalation", protoEvent.Threat.Mitre.Tactic.Name)
 	assert.Equal(t, "Exploitation for Privilege Escalation", protoEvent.Threat.Mitre.Technique.Name)
 	assert.Equal(t, "T1068", protoEvent.Threat.Mitre.Technique.Id)
+}
+
+// TestConvertTraceeEventToProto_DetectedFrom_TracePointer verifies nested
+// detectedFrom maps convert without error. Nested map[string]interface{} uses
+// sanitizeMapForProtobuf -> sanitizeArgumentsForProtobuf, which stringifies
+// types like trace.Pointer for structpb (not full parseArgument encoding).
+// Source event: security_task_prctl.
+func TestConvertTraceeEventToProto_DetectedFrom_TracePointer(t *testing.T) {
+	t.Parallel()
+
+	traceEvent := trace.Event{
+		EventID:   int(SecurityTaskPrctl),
+		EventName: "security_task_prctl",
+		Args: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+				Value: map[string]interface{}{
+					"id":   int(SecurityTaskPrctl),
+					"name": "security_task_prctl",
+					"args": []trace.Argument{
+						{ArgMeta: trace.ArgMeta{Name: "option", Type: "int32"}, Value: int32(35)},
+						{
+							ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+							Value: map[string]interface{}{
+								"id":   int(SecurityTaskPrctl),
+								"name": "security_task_prctl",
+								"args": []trace.Argument{
+									{ArgMeta: trace.ArgMeta{Name: "old_start_code", Type: "trace.Pointer"}, Value: trace.Pointer(0xC2AD00BF0040)},
+									{ArgMeta: trace.ArgMeta{Name: "old_end_code", Type: "trace.Pointer"}, Value: trace.Pointer(0xC2AD00D66A28)},
+								},
+								"returnValue": 0,
+							},
+						},
+					},
+					"returnValue": 0,
+				},
+			},
+		},
+	}
+
+	protoEvent, err := ConvertTraceeEventToProto(traceEvent)
+	require.NoError(t, err)
+	require.NotNil(t, protoEvent)
+	require.NotNil(t, protoEvent.DetectedFrom)
+	assert.Equal(t, "security_task_prctl", protoEvent.DetectedFrom.Name)
+
+	var nestedDF *pb.EventValue
+	for _, d := range protoEvent.DetectedFrom.Data {
+		if d.Name == "detectedFrom" {
+			nestedDF = d
+			break
+		}
+	}
+	require.NotNil(t, nestedDF, "nested detectedFrom should be present")
+
+	s := nestedDF.GetStruct()
+	require.NotNil(t, s)
+
+	argsField := s.GetFields()["args"]
+	require.NotNil(t, argsField)
+
+	argsList := argsField.GetListValue().GetValues()
+	require.Len(t, argsList, 2)
+
+	for _, argVal := range argsList {
+		fields := argVal.GetStructValue().GetFields()
+		name := fields["name"].GetStringValue()
+		v := fields["value"].GetStringValue()
+		switch name {
+		case "old_start_code":
+			assert.Equal(t, fmt.Sprintf("%v", trace.Pointer(0xC2AD00BF0040)), v)
+		case "old_end_code":
+			assert.Equal(t, fmt.Sprintf("%v", trace.Pointer(0xC2AD00D66A28)), v)
+		default:
+			t.Errorf("unexpected arg name: %s", name)
+		}
+	}
+}
+
+// TestConvertTraceeEventToProto_DetectedFrom_Uint64Slice verifies nested
+// []uint64 in a detectedFrom map is stringified for structpb (see
+// sanitizeArgumentsForProtobuf). Source event: security_bpf_prog.
+func TestConvertTraceeEventToProto_DetectedFrom_Uint64Slice(t *testing.T) {
+	t.Parallel()
+
+	traceEvent := trace.Event{
+		EventID:   int(SecurityBpfProg),
+		EventName: "security_bpf_prog",
+		Args: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+				Value: map[string]interface{}{
+					"id":   int(SecurityBpfProg),
+					"name": "security_bpf_prog",
+					"args": []trace.Argument{
+						{ArgMeta: trace.ArgMeta{Name: "type", Type: "int32"}, Value: int32(1)},
+						{
+							ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+							Value: map[string]interface{}{
+								"id":   int(SecurityBpfProg),
+								"name": "security_bpf_prog",
+								"args": []trace.Argument{
+									{ArgMeta: trace.ArgMeta{Name: "helpers", Type: "[]uint64"}, Value: []uint64{0, 0, 0, 0}},
+								},
+								"returnValue": 0,
+							},
+						},
+					},
+					"returnValue": 0,
+				},
+			},
+		},
+	}
+
+	protoEvent, err := ConvertTraceeEventToProto(traceEvent)
+	require.NoError(t, err)
+	require.NotNil(t, protoEvent)
+	require.NotNil(t, protoEvent.DetectedFrom)
+	assert.Equal(t, "security_bpf_prog", protoEvent.DetectedFrom.Name)
+
+	var nestedDF *pb.EventValue
+	for _, d := range protoEvent.DetectedFrom.Data {
+		if d.Name == "detectedFrom" {
+			nestedDF = d
+			break
+		}
+	}
+	require.NotNil(t, nestedDF, "nested detectedFrom should be present")
+
+	s := nestedDF.GetStruct()
+	require.NotNil(t, s)
+
+	argsField := s.GetFields()["args"]
+	require.NotNil(t, argsField)
+
+	argsList := argsField.GetListValue().GetValues()
+	require.Len(t, argsList, 1)
+
+	fields := argsList[0].GetStructValue().GetFields()
+	assert.Equal(t, "helpers", fields["name"].GetStringValue())
+	assert.Equal(t, fmt.Sprintf("%v", []uint64{0, 0, 0, 0}), fields["value"].GetStringValue())
+}
+
+// TestConvertTraceeEventToProto_DetectedFrom_SockAddr verifies SockAddr
+// (map[string]string) inside nested detectedFrom is stringified for structpb.
+// Source event: security_socket_connect.
+func TestConvertTraceeEventToProto_DetectedFrom_SockAddr(t *testing.T) {
+	t.Parallel()
+
+	traceEvent := trace.Event{
+		EventID:   int(SecuritySocketConnect),
+		EventName: "security_socket_connect",
+		Args: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+				Value: map[string]interface{}{
+					"id":   int(SecuritySocketConnect),
+					"name": "security_socket_connect",
+					"args": []trace.Argument{
+						{ArgMeta: trace.ArgMeta{Name: "sockfd", Type: "int32"}, Value: int32(3)},
+						{
+							ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+							Value: map[string]interface{}{
+								"id":   int(SecuritySocketConnect),
+								"name": "security_socket_connect",
+								"args": []trace.Argument{
+									{ArgMeta: trace.ArgMeta{Name: "remote_addr", Type: "SockAddr"}, Value: map[string]string{
+										"sa_family": "AF_INET",
+										"sin_addr":  "142.250.185.206",
+										"sin_port":  "443",
+									}},
+								},
+								"returnValue": 0,
+							},
+						},
+					},
+					"returnValue": 0,
+				},
+			},
+		},
+	}
+
+	protoEvent, err := ConvertTraceeEventToProto(traceEvent)
+	require.NoError(t, err)
+	require.NotNil(t, protoEvent)
+	require.NotNil(t, protoEvent.DetectedFrom)
+	assert.Equal(t, "security_socket_connect", protoEvent.DetectedFrom.Name)
+
+	var nestedDF *pb.EventValue
+	for _, d := range protoEvent.DetectedFrom.Data {
+		if d.Name == "detectedFrom" {
+			nestedDF = d
+			break
+		}
+	}
+	require.NotNil(t, nestedDF, "nested detectedFrom should be present")
+
+	s := nestedDF.GetStruct()
+	require.NotNil(t, s)
+
+	argsField := s.GetFields()["args"]
+	require.NotNil(t, argsField)
+
+	argsList := argsField.GetListValue().GetValues()
+	require.Len(t, argsList, 1)
+
+	fields := argsList[0].GetStructValue().GetFields()
+	assert.Equal(t, "remote_addr", fields["name"].GetStringValue())
+	addrStr := fields["value"].GetStringValue()
+	assert.Contains(t, addrStr, "AF_INET")
+	assert.Contains(t, addrStr, "142.250.185.206")
+	assert.Contains(t, addrStr, "443")
+}
+
+// TestConvertTraceeEventToProto_DetectedFrom_IntArray verifies [2]int32 in nested
+// detectedFrom is stringified for structpb. Source event: pipe.
+func TestConvertTraceeEventToProto_DetectedFrom_IntArray(t *testing.T) {
+	t.Parallel()
+
+	traceEvent := trace.Event{
+		EventID:   int(Pipe),
+		EventName: "pipe",
+		Args: []trace.Argument{
+			{
+				ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+				Value: map[string]interface{}{
+					"id":   int(Pipe),
+					"name": "pipe",
+					"args": []trace.Argument{
+						{
+							ArgMeta: trace.ArgMeta{Name: "detectedFrom", Type: "unknown"},
+							Value: map[string]interface{}{
+								"id":   int(Pipe),
+								"name": "pipe",
+								"args": []trace.Argument{
+									{ArgMeta: trace.ArgMeta{Name: "pipefd", Type: "[2]int"}, Value: [2]int32{3, 4}},
+								},
+								"returnValue": 0,
+							},
+						},
+					},
+					"returnValue": 0,
+				},
+			},
+		},
+	}
+
+	protoEvent, err := ConvertTraceeEventToProto(traceEvent)
+	require.NoError(t, err)
+	require.NotNil(t, protoEvent)
+	require.NotNil(t, protoEvent.DetectedFrom)
+	assert.Equal(t, "pipe", protoEvent.DetectedFrom.Name)
+
+	var nestedDF *pb.EventValue
+	for _, d := range protoEvent.DetectedFrom.Data {
+		if d.Name == "detectedFrom" {
+			nestedDF = d
+			break
+		}
+	}
+	require.NotNil(t, nestedDF, "nested detectedFrom should be present")
+
+	s := nestedDF.GetStruct()
+	require.NotNil(t, s)
+
+	argsField := s.GetFields()["args"]
+	require.NotNil(t, argsField)
+
+	argsList := argsField.GetListValue().GetValues()
+	require.Len(t, argsList, 1)
+
+	fields := argsList[0].GetStructValue().GetFields()
+	assert.Equal(t, "pipefd", fields["name"].GetStringValue())
+	assert.Equal(t, fmt.Sprintf("%v", [2]int32{3, 4}), fields["value"].GetStringValue())
 }

--- a/pkg/server/grpc/event_data.go
+++ b/pkg/server/grpc/event_data.go
@@ -354,6 +354,18 @@ func parseArgument(arg trace.Argument) (*pb.EventValue, error) {
 				Str: v.String(),
 			},
 		}, nil
+	case map[string]interface{}:
+		// Handle raw map[string]interface{} values (e.g., detectedFrom argument)
+		sanitizedMap := sanitizeMapForProtobuf(v)
+		structValue, err := structpb.NewStruct(sanitizedMap)
+		if err != nil {
+			return nil, err
+		}
+		return &pb.EventValue{
+			Value: &pb.EventValue_Struct{
+				Struct: structValue,
+			},
+		}, nil
 	}
 
 	return convertToStruct(arg)
@@ -738,17 +750,55 @@ func sanitizeMapForProtobuf(m map[string]interface{}) map[string]interface{} {
 	sanitizedMap := make(map[string]interface{}, len(m))
 
 	for k, v := range m {
-		switch val := v.(type) {
-		case string:
-			sanitizedMap[k] = sanitizeStringForProtobuf(val)
-		case map[string]interface{}:
-			sanitizedMap[k] = sanitizeMapForProtobuf(val)
-		default:
-			sanitizedMap[k] = val
-		}
+		sanitizedMap[k] = sanitizeValueForProtobuf(v)
 	}
 
 	return sanitizedMap
+}
+
+// sanitizeValueForProtobuf converts a value to a protobuf-compatible format
+func sanitizeValueForProtobuf(v interface{}) interface{} {
+	switch val := v.(type) {
+	case string:
+		return sanitizeStringForProtobuf(val)
+	case map[string]interface{}:
+		return sanitizeMapForProtobuf(val)
+	case []trace.Argument:
+		args := make([]interface{}, 0, len(val))
+		for _, arg := range val {
+			argMap := map[string]interface{}{
+				"name":  sanitizeStringForProtobuf(arg.ArgMeta.Name),
+				"type":  sanitizeStringForProtobuf(arg.ArgMeta.Type),
+				"value": sanitizeValueForProtobuf(arg.Value),
+			}
+			args = append(args, argMap)
+		}
+		return args
+	case trace.Pointer:
+		return uint64(val)
+	case []string:
+		result := make([]interface{}, len(val))
+		for i, s := range val {
+			result[i] = sanitizeStringForProtobuf(s)
+		}
+		return result
+	case []uint64:
+		result := make([]interface{}, len(val))
+		for i, v := range val {
+			result[i] = v
+		}
+		return result
+	case [2]int32:
+		return []interface{}{val[0], val[1]}
+	case map[string]string:
+		m := make(map[string]interface{}, len(val))
+		for k, v := range val {
+			m[k] = sanitizeStringForProtobuf(v)
+		}
+		return m
+	default:
+		return val
+	}
 }
 
 func convertToStruct(arg trace.Argument) (*pb.EventValue, error) {

--- a/pkg/server/grpc/event_data_test.go
+++ b/pkg/server/grpc/event_data_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	pb "github.com/aquasecurity/tracee/api/v1beta1"
@@ -779,4 +780,335 @@ func TestEventTrigger(t *testing.T) {
 	expectedArg1Value := expectedTriggerEvent.Data[1].GetValue().(*pb.EventValue_Int64).Int64
 	assert.Equal(t, expectedArg1Name, actualArg1Name)
 	assert.Equal(t, expectedArg1Value, int64(actualArg1Value))
+}
+
+func Test_parseArgument_MapStringInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		arg      trace.Argument
+		wantErr  bool
+		wantNil  bool
+		validate func(t *testing.T, ev *pb.EventValue)
+	}{
+		{
+			name: "simple map[string]interface{}",
+			arg: trace.Argument{
+				ArgMeta: trace.ArgMeta{
+					Name: "detectedFrom",
+					Type: "unknown",
+				},
+				Value: map[string]interface{}{
+					"id":          715,
+					"name":        "sched_process_exec",
+					"returnValue": 0,
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			validate: func(t *testing.T, ev *pb.EventValue) {
+				assert.NotNil(t, ev.GetStruct())
+				fields := ev.GetStruct().GetFields()
+				assert.Equal(t, float64(715), fields["id"].GetNumberValue())
+				assert.Equal(t, "sched_process_exec", fields["name"].GetStringValue())
+				assert.Equal(t, float64(0), fields["returnValue"].GetNumberValue())
+			},
+		},
+		{
+			name: "map with nested []trace.Argument",
+			arg: trace.Argument{
+				ArgMeta: trace.ArgMeta{
+					Name: "detectedFrom",
+					Type: "unknown",
+				},
+				Value: map[string]interface{}{
+					"id":   715,
+					"name": "sched_process_exec",
+					"args": []trace.Argument{
+						{
+							ArgMeta: trace.ArgMeta{
+								Name: "cmdpath",
+								Type: "string",
+							},
+							Value: "/usr/bin/bash",
+						},
+						{
+							ArgMeta: trace.ArgMeta{
+								Name: "argv",
+								Type: "[]string",
+							},
+							Value: []string{"bash", "-c", "echo hello"},
+						},
+					},
+					"returnValue": 0,
+				},
+			},
+			wantErr: false,
+			wantNil: false,
+			validate: func(t *testing.T, ev *pb.EventValue) {
+				assert.NotNil(t, ev.GetStruct())
+				fields := ev.GetStruct().GetFields()
+				assert.Equal(t, float64(715), fields["id"].GetNumberValue())
+				assert.Equal(t, "sched_process_exec", fields["name"].GetStringValue())
+
+				// Verify args were converted
+				argsValue := fields["args"].GetListValue()
+				assert.NotNil(t, argsValue)
+				assert.Len(t, argsValue.GetValues(), 2)
+
+				// Check first arg
+				arg0 := argsValue.GetValues()[0].GetStructValue()
+				assert.Equal(t, "cmdpath", arg0.GetFields()["name"].GetStringValue())
+				assert.Equal(t, "string", arg0.GetFields()["type"].GetStringValue())
+				assert.Equal(t, "/usr/bin/bash", arg0.GetFields()["value"].GetStringValue())
+
+				// Check second arg with []string value
+				arg1 := argsValue.GetValues()[1].GetStructValue()
+				assert.Equal(t, "argv", arg1.GetFields()["name"].GetStringValue())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parseArgument(tt.arg)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NotNil(t, result)
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+func Test_sanitizeMapForProtobuf_WithTraceArguments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		validate func(t *testing.T, result map[string]interface{})
+	}{
+		{
+			name: "map with []trace.Argument",
+			input: map[string]interface{}{
+				"id":   715,
+				"name": "test_event",
+				"args": []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{
+							Name: "path",
+							Type: "string",
+						},
+						Value: "/tmp/test",
+					},
+				},
+			},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, 715, result["id"])
+				assert.Equal(t, "test_event", result["name"])
+
+				args, ok := result["args"].([]interface{})
+				assert.True(t, ok, "args should be []interface{}")
+				assert.Len(t, args, 1)
+
+				arg0, ok := args[0].(map[string]interface{})
+				assert.True(t, ok, "arg should be map[string]interface{}")
+				assert.Equal(t, "path", arg0["name"])
+				assert.Equal(t, "string", arg0["type"])
+				assert.Equal(t, "/tmp/test", arg0["value"])
+			},
+		},
+		{
+			name: "string sanitization",
+			input: map[string]interface{}{
+				"valid":   "hello",
+				"invalid": "test\x80\x81invalid",
+			},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, "hello", result["valid"])
+				// Invalid UTF-8 bytes should be replaced
+				sanitized, ok := result["invalid"].(string)
+				assert.True(t, ok, "invalid should be a string")
+				assert.NotContains(t, sanitized, "\x80")
+			},
+		},
+		{
+			name: "nested maps",
+			input: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+				},
+			},
+			validate: func(t *testing.T, result map[string]interface{}) {
+				outer, ok := result["outer"].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, "value", outer["inner"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := sanitizeMapForProtobuf(tt.input)
+			tt.validate(t, result)
+		})
+	}
+}
+
+func Test_sanitizeValueForProtobuf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		validate func(t *testing.T, result interface{})
+	}{
+		{
+			name:  "string value",
+			input: "hello",
+			validate: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "hello", result)
+			},
+		},
+		{
+			name: "[]trace.Argument value",
+			input: []trace.Argument{
+				{
+					ArgMeta: trace.ArgMeta{
+						Name: "test",
+						Type: "int",
+					},
+					Value: 42,
+				},
+			},
+			validate: func(t *testing.T, result interface{}) {
+				arr, ok := result.([]interface{})
+				assert.True(t, ok)
+				assert.Len(t, arr, 1)
+
+				arg, ok := arr[0].(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, "test", arg["name"])
+				assert.Equal(t, "int", arg["type"])
+				assert.Equal(t, 42, arg["value"])
+			},
+		},
+		{
+			name: "map[string]interface{} value",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			validate: func(t *testing.T, result interface{}) {
+				m, ok := result.(map[string]interface{})
+				assert.True(t, ok)
+				assert.Equal(t, "value", m["key"])
+			},
+		},
+		{
+			name:  "int value passthrough",
+			input: 123,
+			validate: func(t *testing.T, result interface{}) {
+				assert.Equal(t, 123, result)
+			},
+		},
+		{
+			name:  "trace.Pointer unwraps to uint64",
+			input: trace.Pointer(0xC2AD00BF0040),
+			validate: func(t *testing.T, result interface{}) {
+				v, ok := result.(uint64)
+				assert.True(t, ok, "trace.Pointer should be unwrapped to uint64")
+				assert.Equal(t, uint64(0xC2AD00BF0040), v)
+				_, err := structpb.NewValue(result)
+				assert.NoError(t, err, "sanitized trace.Pointer should be accepted by structpb")
+			},
+		},
+		{
+			name:  "[]string converts to []interface{}",
+			input: []string{"a", "b", "c"},
+			validate: func(t *testing.T, result interface{}) {
+				arr, ok := result.([]interface{})
+				assert.True(t, ok)
+				assert.Len(t, arr, 3)
+				assert.Equal(t, "a", arr[0])
+				assert.Equal(t, "b", arr[1])
+				assert.Equal(t, "c", arr[2])
+				_, err := structpb.NewValue(result)
+				assert.NoError(t, err, "sanitized []string should be accepted by structpb")
+			},
+		},
+		{
+			name:  "[]uint64 converts to []interface{}",
+			input: []uint64{0, 0, 0, 0},
+			validate: func(t *testing.T, result interface{}) {
+				arr, ok := result.([]interface{})
+				assert.True(t, ok, "[]uint64 should become []interface{}")
+				assert.Len(t, arr, 4)
+				for _, v := range arr {
+					assert.Equal(t, uint64(0), v)
+				}
+				_, err := structpb.NewValue(result)
+				assert.NoError(t, err, "sanitized []uint64 should be accepted by structpb")
+			},
+		},
+		{
+			name:  "[2]int32 converts to []interface{}",
+			input: [2]int32{10, 20},
+			validate: func(t *testing.T, result interface{}) {
+				arr, ok := result.([]interface{})
+				assert.True(t, ok, "[2]int32 should become []interface{}")
+				assert.Len(t, arr, 2)
+				assert.Equal(t, int32(10), arr[0])
+				assert.Equal(t, int32(20), arr[1])
+				_, err := structpb.NewValue(result)
+				assert.NoError(t, err, "sanitized [2]int32 should be accepted by structpb")
+			},
+		},
+		{
+			name: "map[string]string converts to map[string]interface{}",
+			input: map[string]string{
+				"sa_family": "AF_INET",
+				"sin_addr":  "127.0.0.1",
+				"sin_port":  "8080",
+			},
+			validate: func(t *testing.T, result interface{}) {
+				m, ok := result.(map[string]interface{})
+				assert.True(t, ok, "map[string]string should become map[string]interface{}")
+				assert.Equal(t, "AF_INET", m["sa_family"])
+				assert.Equal(t, "127.0.0.1", m["sin_addr"])
+				assert.Equal(t, "8080", m["sin_port"])
+				_, err := structpb.NewStruct(m)
+				assert.NoError(t, err, "sanitized map[string]string should be accepted by structpb")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := sanitizeValueForProtobuf(tt.input)
+			tt.validate(t, result)
+		})
+	}
 }


### PR DESCRIPTION
Close: #5298 

### 1. Explain what the PR does

27c46125f **fix(grpc): handle non-primitive types in detectedFrom conversion**

> When a chained detection flows through gRPC streaming, nested
> detectedFrom maps carry arg values (trace.Pointer, []uint64,
> [2]int32, map[string]string, []trace.Argument) that structpb
> rejects as invalid types.
> 
> - Add sanitizeValueForProtobuf to recursively unwrap non-primitive
>   values into structpb-compatible equivalents (uint64, []interface{},
>   map[string]interface{}).
> - Wire sanitizeMapForProtobuf to delegate every value through
>   sanitizeValueForProtobuf instead of only handling string and
>   nested maps.
> - Add case map[string]interface{} to parseArgument so raw maps
>   (e.g. detectedFrom) convert to pb.EventValue_Struct directly.
> - pkg/events: add DetectedFrom chain coverage in conversion_test.go.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
