### PR TITLE
fix: reject non-directory mkdirat conflicts

### DIFF
--- a/common/fileutil/fileutil.go
+++ b/common/fileutil/fileutil.go
@@ -48,14 +48,22 @@ func MkdirAt(dir *os.File, relativePath string, perm fs.FileMode) error {
 	return unix.Mkdirat(int(dir.Fd()), relativePath, uint32(perm))
 }
 
-// MkdirAtExist is a wrapper function to the `mkdirat` syscall using golang types, ignoring EEXIST error.
+// MkdirAtExist is a wrapper function to the `mkdirat` syscall using golang types, ignoring EEXIST for directories.
 func MkdirAtExist(dir *os.File, relativePath string, perm fs.FileMode) error {
 	err := unix.Mkdirat(int(dir.Fd()), relativePath, uint32(perm))
 	if err != nil {
 		// Seems that os.ErrExist doesn't catch the error (at least on Manjaro distro)
-		if err != os.ErrExist && err.Error() != "file exists" {
+		if errors.Is(err, os.ErrExist) || err.Error() == "file exists" {
+			var stat unix.Stat_t
+			if statErr := unix.Fstatat(int(dir.Fd()), relativePath, &stat, 0); statErr != nil {
+				return errfmt.WrapError(statErr)
+			}
+			if stat.Mode&unix.S_IFMT == unix.S_IFDIR {
+				return nil
+			}
 			return errfmt.WrapError(err)
 		}
+		return errfmt.WrapError(err)
 	}
 	return nil
 }

--- a/common/fileutil/fileutil_test.go
+++ b/common/fileutil/fileutil_test.go
@@ -428,6 +428,20 @@ func TestMkdirAllAtExist(t *testing.T) {
 			t.Errorf("Should not error when path already exists: %v", err)
 		}
 	})
+
+	t.Run("existing file path - should error", func(t *testing.T) {
+		path := "existing_file"
+		fullPath := filepath.Join(tempDir, path)
+		err := os.WriteFile(fullPath, []byte("not a directory"), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create existing file: %v", err)
+		}
+
+		err = MkdirAllAtExist(dirFile, path, 0755)
+		if err == nil {
+			t.Error("Expected error when path exists as a regular file")
+		}
+	})
 }
 
 // Test CreateAt


### PR DESCRIPTION
Small fix for fileutil, no drama. `MkdirAtExist` used to swallow `EEXIST` even when the existing path was a regular file. That is a bit sus because callers can keep going as if a dir exists.

Repro:
1. create a regular file at the path `MkdirAllAtExist` is about to create
2. run `cd common && go test ./fileutil -run TestMkdirAllAtExist/'existing_file_path_-_should_error' -v`
3. before this patch it fails with `Expected error when path exists as a regular file`

Now `EEXIST` is ignored only when `fstatat` says the existing path is a directory. Existing dirs still work as before.

Checked:
- `cd common && go test ./fileutil`
- `cd common && go vet ./fileutil`
- `make test-common`