### PR TITLE
fix(test): replace flaky 1ms sleep with polling in engine test

### DIFF
--- a/pkg/signatures/engine/engine_test.go
+++ b/pkg/signatures/engine/engine_test.go
@@ -306,8 +306,6 @@ func TestEngine_ConsumeSources(t *testing.T) {
 		},
 	}
 
-	emptyEvent := protocol.Event{}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -343,11 +341,6 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			var sigs []detect.Signature
 			sigs = append(sigs, tc.inputSignature)
 
-			// FIXME We should use another Go concurrency pattern to make this test logically correct.
-			//       The gotNumEvents variable is causing data race, because it's accessed
-			//       by two goroutines. Temporary workaround is to change from int to uint32 and
-			//       use atomic.AddUint32 and atomic.LoadUint32 methods.
-			//       go test -v -run=TestConsumeSources -race ./pkg/signatures/engine/...
 			var gotNumEvents uint32
 			tc.inputSignature.FakeOnEvent = func(event protocol.Event) error {
 				assert.Equal(t, tc.expectedEvent, event.Payload, tc.name)
@@ -369,16 +362,14 @@ func TestEngine_ConsumeSources(t *testing.T) {
 			// send a test event
 			e.inputs.Tracee <- tc.inputEvent
 
-			// assert
-			var gotEvent protocol.Event
-			time.Sleep(time.Millisecond * 1) // wait for events to propagate
-
-			eventsCount := int(atomic.LoadUint32(&gotNumEvents))
 			if tc.expectedNumEvents <= 0 {
-				assert.Equal(t, emptyEvent, gotEvent, tc.name)
-				assert.Zero(t, eventsCount, tc.name)
+				require.Never(t, func() bool {
+					return atomic.LoadUint32(&gotNumEvents) > 0
+				}, 50*time.Millisecond, 10*time.Millisecond, tc.name)
 			} else {
-				assert.Equal(t, tc.expectedNumEvents, eventsCount, tc.name)
+				require.Eventually(t, func() bool {
+					return int(atomic.LoadUint32(&gotNumEvents)) == tc.expectedNumEvents
+				}, 5*time.Second, 10*time.Millisecond, tc.name)
 			}
 
 			if tc.expectedError != "" {


### PR DESCRIPTION
### 1. Explain what the PR does

022cbe84a **fix(test): replace flaky 1ms sleep with polling in engine test**

> The TestEngine_ConsumeSources test relied on a 1ms sleep for event
> propagation, causing intermittent failures on loaded x86_64 runners
> when the engine goroutine hadn't processed the event in time.
> 
> Use require.Eventually (5s timeout, 10ms poll) with exact count
> matching for positive-event cases, and require.Never over a 50ms
> window for zero-event assertions. Remove dead gotEvent/emptyEvent
> comparison that always passed regardless of behavior.

--
### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
