### PR TITLE
fix(ebpf): avoid panic in UpdateKallsyms on missing dependency nodes

### DIFF
--- a/pkg/ebpf/ksymbols.go
+++ b/pkg/ebpf/ksymbols.go
@@ -1,11 +1,13 @@
 package ebpf
 
 import (
+	"errors"
 	"unsafe"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
 	"github.com/aquasecurity/tracee/common/logger"
 	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/pkg/events/dependencies"
 )
 
 // TODO: Just like recent change in `KernelSymbolTable`, in kernel_symbols.go,
@@ -34,9 +36,18 @@ func (t *Tracee) UpdateKallsyms() error {
 
 	// Wrap long method names.
 	evtDefSymDeps := func(id events.ID) []events.KSymbol {
-		depsNode, _ := t.eventsDependencies.GetEvent(id)
-		deps := depsNode.GetDependencies()
-		return deps.GetKSymbols()
+		depsNode, err := t.eventsDependencies.GetEvent(id)
+		if err != nil {
+			if !errors.Is(err, dependencies.ErrNodeNotFound) {
+				logger.Debugw("GetEvent for ksymbols", "event_id", id, "error", err)
+			}
+			return nil
+		}
+		if depsNode == nil {
+			return nil
+		}
+
+		return depsNode.GetDependencies().GetKSymbols()
 	}
 
 	// Get the symbols all events being traced require (t.eventsState already


### PR DESCRIPTION
### 1. Explain what the PR does

b734a92d9 **fix(ebpf): avoid panic in UpdateKallsyms on missing dependency nodes**

> UpdateKallsyms iterated policy-selected event IDs and called GetEvent
> without checking errors, so IDs present in the policy manager but absent
> from the dependencies tree caused a nil EventNode dereference.
> 
> Handle GetEvent errors explicitly: treat ErrNodeNotFound as a no-op for
> ksymbol collection, log unexpected errors at debug, and skip nil nodes
> defensively.

--


### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
