### PR TITLE
ci: promote githubb app & improve sync workflow

### DIFF
--- a/.github/workflows/trigger-pr-sync.yaml
+++ b/.github/workflows/trigger-pr-sync.yaml
@@ -17,6 +17,7 @@ permissions: {}
 jobs:
   pr-sync:
     name: Trigger PR Sync
+    environment: private-sync
     runs-on:
       # Ubuntu 24.04 generic (6.11.0-29) [x86_64]
       - graas_ami-03dbff05cae3a30d0_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
@@ -29,7 +30,7 @@ jobs:
 
     steps:
       - name: Install tools
-        run: apk add --no-cache bash curl github-cli
+        run: apk add --no-cache github-cli
         shell: sh
 
       - name: Determine PR Number
@@ -78,130 +79,105 @@ jobs:
           echo "Found PR number: ${num}"
           echo "pr_number=${num}" >> "${GITHUB_OUTPUT}"
 
-      - name: Prepare sync request
-        id: prepare-sync
+      - name: Validate private-sync configuration
         env:
-          PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
-          SYNC_URL: ${{ secrets.PRIV_SYNC_WORKFLOW_URL }}
-          SYNC_TOKEN: ${{ secrets.PRIV_PAT }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # JSON body must not be passed as "-d {...}" inside curl --config: a leading "{" starts a
-          # curl config scope. Put the body in a file and reference it with --data-binary "@path".
-          #
-          # Payload is non-secret (ref + PR number): write normally, owner-read only.
-          # Config holds URL and Bearer token: open write fd, chmod 000 on path, write via fd,
-          # close; stays 000 until Sync PR chmod 400 immediately before curl.
-          sync_dir=$(mktemp -d /tmp/workflow-sync-XXXXXX)
-          chmod 700 "${sync_dir}"
-          payload_file="${sync_dir}/payload.json"
-          curl_cfg="${sync_dir}/curl.cfg"
-
-          printf '%s' "{\"ref\":\"main\",\"inputs\":{\"oss_pr_number\":\"${PR_NUMBER}\"}}" > "${payload_file}"
-          chmod 400 "${payload_file}"
-
-          exec {curl_cfg_fd}> "${curl_cfg}"
-          chmod 000 "${curl_cfg}"
-          cat << 'CFG_PART' >&"${curl_cfg_fd}"
-          request = "POST"
-          max-time = 30
-          silent
-          show-error
-          header = "Accept: application/vnd.github+json"
-          header = "Content-Type: application/json"
-          header = "X-GitHub-Api-Version: 2022-11-28"
-          CFG_PART
-          {
-              printf 'header = "Authorization: Bearer %s"\n' "${SYNC_TOKEN}"
-              printf 'url = "%s"\n' "${SYNC_URL}"
-              printf '%s "@%s"\n' '--data-binary' "${payload_file}"
-          } >&"${curl_cfg_fd}"
-          exec {curl_cfg_fd}>&-
-
-          {
-              echo "sync_dir=${sync_dir}"
-              echo "curl_config=${curl_cfg}"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Sync PR
-        id: sync
-        env:
-          SYNC_DIR: ${{ steps.prepare-sync.outputs.sync_dir }}
-          CURL_CONFIG_FILE: ${{ steps.prepare-sync.outputs.curl_config }}
+          TRACEE_PRIVATE_REPO_OWNER: ${{ secrets.TRACEE_PRIVATE_REPO_OWNER }}
+          TRACEE_PRIVATE_REPO: ${{ secrets.TRACEE_PRIVATE_REPO }}
+          TRACEE_PRIVATE_SYNC_WORKFLOW: ${{ secrets.TRACEE_PRIVATE_SYNC_WORKFLOW }}
+          GH_APP_CLIENT_ID: ${{ secrets.ACTIONS_TRACEE_WRITE_GH_APP_CLIENT_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.ACTIONS_TRACEE_WRITE_GH_APP_PRIVATE_KEY }}
         shell: sh
         run: |
           set -eu
 
-          response_body_file="${SYNC_DIR}/response.body"
+          for v in "${TRACEE_PRIVATE_REPO_OWNER}" \
+              "${TRACEE_PRIVATE_REPO}" \
+              "${TRACEE_PRIVATE_SYNC_WORKFLOW}" \
+              "${GH_APP_CLIENT_ID}" \
+              "${GH_APP_PRIVATE_KEY}"; do
+              if [ -z "${v}" ]; then
+                  echo "ERROR: One or more required private-sync secrets are not configured." >&2
+                  echo "Set them under Environments -> private-sync -> Environment secrets." >&2
+                  exit 1
+              fi
+          done
 
-          reveal_curl_cfg() {
-              chmod 400 "${CURL_CONFIG_FILE}"
-          }
+          case "${TRACEE_PRIVATE_REPO}" in
+              */*)
+                  echo "ERROR: TRACEE_PRIVATE_REPO must be the repository name only (no owner/ prefix)." >&2
+                  exit 1
+                  ;;
+          esac
 
-          lock_curl_cfg() {
-              chmod 000 "${CURL_CONFIG_FILE}"
-          }
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.ACTIONS_TRACEE_WRITE_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ACTIONS_TRACEE_WRITE_GH_APP_PRIVATE_KEY }}
+          owner: ${{ secrets.TRACEE_PRIVATE_REPO_OWNER }}
+          repositories: ${{ secrets.TRACEE_PRIVATE_REPO }}
+          permission-actions: write
 
-          cleanup_sync_dir() {
-              [ -n "${SYNC_DIR}" ] && rm -rf "${SYNC_DIR}"
-          }
+      - name: Trigger private sync workflow
+        id: sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TRACEE_PRIVATE_REPO_OWNER: ${{ secrets.TRACEE_PRIVATE_REPO_OWNER }}
+          TRACEE_PRIVATE_REPO: ${{ secrets.TRACEE_PRIVATE_REPO }}
+          TRACEE_PRIVATE_SYNC_WORKFLOW: ${{ secrets.TRACEE_PRIVATE_SYNC_WORKFLOW }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+        shell: sh
+        run: |
+          set -eu
 
-          trap cleanup_sync_dir EXIT
+          gh_repo="${TRACEE_PRIVATE_REPO_OWNER}/${TRACEE_PRIVATE_REPO}"
+          gh_err_file=$(mktemp)
+          trap 'rm -f "${gh_err_file}"' EXIT
 
           max_attempts=5
           attempts=0
-          rc=0
-          http_code=""
           succeeded=false
 
           while [ "${attempts}" -lt "${max_attempts}" ]; do
               attempts=$((attempts + 1))
-              rc=0
-              reveal_curl_cfg
-              http_code=$(curl --config "${CURL_CONFIG_FILE}" \
-                  --output "${response_body_file}" \
-                  --write-out "%{http_code}") \
-                  || rc=$?
-              lock_curl_cfg
-
-              if [ "${rc}" -eq 0 ] \
-                  && [ "${http_code}" -ge 200 ] \
-                  && [ "${http_code}" -lt 300 ]; then
+              : > "${gh_err_file}"
+              if gh workflow run "${TRACEE_PRIVATE_SYNC_WORKFLOW}" \
+                  --repo "${gh_repo}" \
+                  --ref main \
+                  -f "oss_pr_number=${PR_NUMBER}" \
+                  2> "${gh_err_file}"; then
                   succeeded=true
                   break
               fi
 
-              echo "Attempt ${attempts}/${max_attempts} failed (rc=${rc}, http=${http_code})." >&2
-              if [ -s "${response_body_file}" ]; then
-                  echo "Response body:" >&2
-                  cat "${response_body_file}" >&2
+              echo "Attempt ${attempts}/${max_attempts} failed to dispatch private sync workflow." >&2
+              if [ -s "${gh_err_file}" ]; then
+                  echo "gh error output:" >&2
+                  cat "${gh_err_file}" >&2
               fi
               if [ "${attempts}" -lt "${max_attempts}" ]; then
                   sleep 1
               fi
           done
-          rm -f "${CURL_CONFIG_FILE}"
 
           if [ "${succeeded}" != true ]; then
-              echo "ERROR: Failed after ${max_attempts} attempts (rc=${rc}, http=${http_code})." >&2
-              echo "Last response body (for IT / GitHub support):" >&2
-              cat "${response_body_file}" >&2
+              echo "ERROR: Failed to dispatch private sync workflow after ${max_attempts} attempts." >&2
               {
                   echo ""
                   echo "### Workflow dispatch failure"
                   echo ""
-                  echo "Last HTTP status: \`${http_code}\`"
-                  echo ""
-                  echo "<details><summary>Last response body from GitHub API</summary>"
-                  echo ""
-                  echo '```'
-                  cat "${response_body_file}"
-                  echo ""
-                  echo '```'
-                  echo ""
-                  echo "</details>"
+                  echo "Could not trigger the private sync workflow for OSS PR #${PR_NUMBER}."
+                  if [ -s "${gh_err_file}" ]; then
+                      echo ""
+                      echo "<details><summary>Last gh error output</summary>"
+                      echo ""
+                      echo '```'
+                      cat "${gh_err_file}"
+                      echo '```'
+                      echo ""
+                      echo "</details>"
+                  fi
               } >> "${GITHUB_STEP_SUMMARY}"
               exit 1
           fi
@@ -210,17 +186,20 @@ jobs:
         if: always()
         env:
           PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+          PR_NUMBER_OUTCOME: ${{ steps.pr-number.outcome }}
           SYNC_RESULT: ${{ steps.sync.outcome }}
         shell: sh
         run: |
           {
               echo "## PR Sync"
               echo ""
-              if [ "${SYNC_RESULT}" = "success" ]; then
-                  echo "Sync triggered for PR **#${PR_NUMBER}**."
+              if [ "${PR_NUMBER_OUTCOME}" != "success" ]; then
+                  echo "Did not run: merged PR number could not be determined."
+              elif [ "${SYNC_RESULT}" = "success" ]; then
+                  echo "Triggered the private sync workflow for OSS PR **#${PR_NUMBER}**."
               elif [ "${SYNC_RESULT}" = "skipped" ]; then
-                  echo "Sync skipped (PR number could not be determined)."
+                  echo "Did not run: a step before sync failed or was skipped."
               else
-                  echo "Failed to trigger sync for PR **#${PR_NUMBER}**."
+                  echo "Failed to trigger the private sync workflow for OSS PR **#${PR_NUMBER}**."
               fi
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/trigger-pr-sync.yaml
+++ b/.github/workflows/trigger-pr-sync.yaml
@@ -24,7 +24,7 @@ jobs:
       - EXECUTION_TYPE=SHORT
       - INSTANCE_TYPE=MICRO
     permissions:
-      pull-requests: read # gh pr list
+      pull-requests: write # gh pr list, gh pr comment
     container:
       image: alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
@@ -181,6 +181,37 @@ jobs:
               } >> "${GITHUB_STEP_SUMMARY}"
               exit 1
           fi
+
+      - name: Comment on original PR
+        if: always() && steps.pr-number.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+          SYNC_RESULT: ${{ steps.sync.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: sh
+        run: |
+          set -eu
+
+          case "${SYNC_RESULT}" in
+              success)
+                  body="Private mirror sync was triggered successfully."
+                  ;;
+              failure)
+                  body="Private mirror sync could not be triggered. See [workflow run](${RUN_URL}) for details."
+                  ;;
+              skipped|cancelled)
+                  body="Private mirror sync was not run (an earlier step failed or was skipped). See [workflow run](${RUN_URL})."
+                  ;;
+              *)
+                  body="Private mirror sync status is unknown. See [workflow run](${RUN_URL})."
+                  ;;
+          esac
+
+          gh pr comment "${PR_NUMBER}" \
+              --repo "${GH_REPO}" \
+              --body "${body}"
 
       - name: Summary
         if: always()

--- a/.github/workflows/trigger-pr-sync.yaml
+++ b/.github/workflows/trigger-pr-sync.yaml
@@ -24,7 +24,8 @@ jobs:
       - EXECUTION_TYPE=SHORT
       - INSTANCE_TYPE=MICRO
     permissions:
-      pull-requests: write # gh pr list, gh pr comment
+      issues: write # gh label create
+      pull-requests: write # gh pr list, comment, edit labels
     container:
       image: alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
@@ -79,7 +80,39 @@ jobs:
           echo "Found PR number: ${num}"
           echo "pr_number=${num}" >> "${GITHUB_OUTPUT}"
 
+      - name: Check if PR already synced
+        id: check-synced
+        if: steps.pr-number.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+        shell: sh
+        run: |
+          set -eu
+
+          readonly LABEL_SYNCED="private-synced"
+
+          already_synced=$(
+              gh pr view "${PR_NUMBER}" \
+                  --repo "${GH_REPO}" \
+                  --json labels \
+                  --jq "any(.labels[]; .name == \"${LABEL_SYNCED}\")"
+          )
+          case "${already_synced}" in
+              true)
+                  echo "PR #${PR_NUMBER} already has label ${LABEL_SYNCED}; skipping sync."
+                  echo "already_synced=true" >> "${GITHUB_OUTPUT}"
+                  ;;
+              *)
+                  echo "already_synced=false" >> "${GITHUB_OUTPUT}"
+                  ;;
+          esac
+
       - name: Validate private-sync configuration
+        if: >-
+          steps.pr-number.outcome == 'success' &&
+          steps.check-synced.outputs.already_synced != 'true'
         env:
           TRACEE_PRIVATE_REPO_OWNER: ${{ secrets.TRACEE_PRIVATE_REPO_OWNER }}
           TRACEE_PRIVATE_REPO: ${{ secrets.TRACEE_PRIVATE_REPO }}
@@ -111,6 +144,9 @@ jobs:
 
       - name: Create GitHub App token
         id: app-token
+        if: >-
+          steps.pr-number.outcome == 'success' &&
+          steps.check-synced.outputs.already_synced != 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.ACTIONS_TRACEE_WRITE_GH_APP_CLIENT_ID }}
@@ -121,6 +157,9 @@ jobs:
 
       - name: Trigger private sync workflow
         id: sync
+        if: >-
+          steps.pr-number.outcome == 'success' &&
+          steps.check-synced.outputs.already_synced != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TRACEE_PRIVATE_REPO_OWNER: ${{ secrets.TRACEE_PRIVATE_REPO_OWNER }}
@@ -182,32 +221,114 @@ jobs:
               exit 1
           fi
 
+      - name: Update PR sync labels
+        if: >-
+          always() &&
+          steps.pr-number.outcome == 'success' &&
+          steps.check-synced.outputs.already_synced != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+          SYNC_RESULT: ${{ steps.sync.outcome }}
+        shell: sh
+        run: |
+          set -eu
+
+          readonly LABEL_SYNCED="private-synced"
+          readonly LABEL_NOT_SYNCED="private-non-synced"
+          readonly LABEL_COLOR_BLUE="1d76db"
+          readonly LABEL_COLOR_RED="d73a4a"
+
+          ensure_label() {
+              name="${1}"
+              color="${2}"
+              description="${3}"
+
+              exists=$(
+                  gh label list \
+                      --repo "${GH_REPO}" \
+                      --json name \
+                      --jq "any(.[]; .name == \"${name}\")"
+              )
+              case "${exists}" in
+                  true)
+                      echo "Label ${name} already exists."
+                      return 0
+                      ;;
+              esac
+
+              err_file=$(mktemp)
+              if gh label create "${name}" \
+                  --repo "${GH_REPO}" \
+                  --color "${color}" \
+                  --description "${description}" \
+                  2> "${err_file}"; then
+                  rm -f "${err_file}"
+                  return 0
+              fi
+              if grep -qi 'already exists' "${err_file}"; then
+                  echo "Label ${name} already exists."
+                  rm -f "${err_file}"
+                  return 0
+              fi
+              echo "ERROR: Failed to create label ${name}." >&2
+              cat "${err_file}" >&2
+              rm -f "${err_file}"
+              exit 1
+          }
+
+          ensure_label "${LABEL_SYNCED}" "${LABEL_COLOR_BLUE}" \
+              "Private mirror sync dispatch succeeded"
+          ensure_label "${LABEL_NOT_SYNCED}" "${LABEL_COLOR_RED}" \
+              "Private mirror sync dispatch failed"
+
+          case "${SYNC_RESULT}" in
+              success)
+                  gh pr edit "${PR_NUMBER}" \
+                      --repo "${GH_REPO}" \
+                      --add-label "${LABEL_SYNCED}" \
+                      --remove-label "${LABEL_NOT_SYNCED}"
+                  ;;
+              *)
+                  gh pr edit "${PR_NUMBER}" \
+                      --repo "${GH_REPO}" \
+                      --add-label "${LABEL_NOT_SYNCED}" \
+                      --remove-label "${LABEL_SYNCED}"
+                  ;;
+          esac
+
       - name: Comment on original PR
         if: always() && steps.pr-number.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+          ALREADY_SYNCED: ${{ steps.check-synced.outputs.already_synced }}
           SYNC_RESULT: ${{ steps.sync.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: sh
         run: |
           set -eu
 
-          case "${SYNC_RESULT}" in
-              success)
-                  body="Private mirror sync was triggered successfully."
-                  ;;
-              failure)
-                  body="Private mirror sync could not be triggered. See [workflow run](${RUN_URL}) for details."
-                  ;;
-              skipped|cancelled)
-                  body="Private mirror sync was not run (an earlier step failed or was skipped). See [workflow run](${RUN_URL})."
-                  ;;
-              *)
-                  body="Private mirror sync status is unknown. See [workflow run](${RUN_URL})."
-                  ;;
-          esac
+          if [ "${ALREADY_SYNCED}" = "true" ]; then
+              body="Private mirror sync was already completed for this PR (label \`private-synced\`). Skipping sync dispatch."
+          else
+              case "${SYNC_RESULT}" in
+                  success)
+                      body="Private mirror sync was triggered successfully."
+                      ;;
+                  failure)
+                      body="Private mirror sync could not be triggered. See [workflow run](${RUN_URL}) for details."
+                      ;;
+                  skipped|cancelled)
+                      body="Private mirror sync was not run (an earlier step failed or was skipped). See [workflow run](${RUN_URL})."
+                      ;;
+                  *)
+                      body="Private mirror sync status is unknown. See [workflow run](${RUN_URL})."
+                      ;;
+              esac
+          fi
 
           gh pr comment "${PR_NUMBER}" \
               --repo "${GH_REPO}" \
@@ -218,6 +339,7 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr-number.outputs.pr_number }}
           PR_NUMBER_OUTCOME: ${{ steps.pr-number.outcome }}
+          ALREADY_SYNCED: ${{ steps.check-synced.outputs.already_synced }}
           SYNC_RESULT: ${{ steps.sync.outcome }}
         shell: sh
         run: |
@@ -226,6 +348,8 @@ jobs:
               echo ""
               if [ "${PR_NUMBER_OUTCOME}" != "success" ]; then
                   echo "Did not run: merged PR number could not be determined."
+              elif [ "${ALREADY_SYNCED}" = "true" ]; then
+                  echo "Skipped: OSS PR **#${PR_NUMBER}** already has the \`private-synced\` label."
               elif [ "${SYNC_RESULT}" = "success" ]; then
                   echo "Triggered the private sync workflow for OSS PR **#${PR_NUMBER}**."
               elif [ "${SYNC_RESULT}" = "skipped" ]; then


### PR DESCRIPTION
### 1. Explain what the PR does

cc11e3de3 **ci(trigger-pr-sync): label PRs after sync dispatch**

> Apply private-synced or private-non-synced on the source PR
> when mirror sync succeeds or fails so sync state is visible
> without reading workflow comments.

--

73a32a611 **ci(trigger-pr-sync): comment on original PR after sync dispatch**

> Post success or failure on the merged PR so authors see whether the
> private mirror sync was triggered, with a link to the workflow run.

--

4b4568c3b **ci(trigger-pr-sync): dispatch private sync via GitHub App**

> Replace PRIV_PAT and PRIV_SYNC_WORKFLOW_URL with a scoped app
> installation token (actions: write) and gh workflow run. Private
> repo, owner, and workflow file come from secrets.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
