### PR TITLE
perf(detectors): filter on proto directly, eliminate ConvertFromProto…

### DIFF
--- a/pkg/detectors/dispatch.go
+++ b/pkg/detectors/dispatch.go
@@ -131,24 +131,15 @@ func (d *dispatcher) dispatchToDetectors(ctx context.Context, inputEvent *v1beta
 			continue
 		}
 
-		// Apply filters if any are present
-		// Convert once and apply both scope and data filters
-		if sub.scopeFilter != nil || sub.dataFilter != nil {
-			// Convert v1beta1.Event to trace.Event for filter compatibility
-			traceEvent := events.ConvertFromProto(inputEvent)
-
-			// Apply scope filter
-			if sub.scopeFilter != nil && sub.scopeFilter.Enabled() {
-				if !sub.scopeFilter.Filter(*traceEvent) {
-					continue // Skip if scope filter doesn't match
-				}
+		// Apply filters directly on proto (zero allocations)
+		if sub.scopeFilter != nil && sub.scopeFilter.Enabled() {
+			if !sub.scopeFilter.FilterProto(inputEvent) {
+				continue
 			}
-
-			// Apply data filter
-			if sub.dataFilter != nil && sub.dataFilter.Enabled() {
-				if !sub.dataFilter.Filter(traceEvent.Args) {
-					continue // Skip if data filter doesn't match
-				}
+		}
+		if sub.dataFilter != nil && sub.dataFilter.Enabled() {
+			if !sub.dataFilter.FilterProto(inputEvent.Data) {
+				continue
 			}
 		}
 

--- a/pkg/detectors/dispatch_test.go
+++ b/pkg/detectors/dispatch_test.go
@@ -484,6 +484,64 @@ func TestDispatchWithScopeFilter(t *testing.T) {
 	assert.Len(t, outputs, 1) // Should pass through filter
 }
 
+func TestDispatchWithDataFilter(t *testing.T) {
+	detector := &producingDetector{
+		id:        "test_data_dispatch",
+		eventName: "test_data_dispatch_event",
+		requirements: detection.DetectorRequirements{
+			Events: []detection.EventRequirement{
+				{
+					Name:        "security_file_open",
+					Dependency:  detection.DependencyRequired,
+					DataFilters: []string{"pathname=/etc/passwd"},
+				},
+			},
+		},
+		autoPopulate: detection.AutoPopulateFields{},
+	}
+
+	_, err := CreateEventsFromDetectors(events.StartDetectorID+20006, []detection.EventDetector{detector})
+	require.NoError(t, err)
+
+	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)
+	policyMgr := newTestPolicyManager(detEventID)
+
+	engine := NewEngine(policyMgr, nil)
+	params := detection.DetectorParams{
+		Config: detection.NewEmptyDetectorConfig(),
+	}
+
+	err = engine.RegisterDetector(detector, params)
+	require.NoError(t, err)
+
+	err = engine.EnableDetector(detector.id)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	mismatchEvent := &v1beta1.Event{
+		Id:   v1beta1.EventId(events.SecurityFileOpen),
+		Name: "security_file_open",
+		Data: []*v1beta1.EventValue{
+			{Name: "pathname", Value: &v1beta1.EventValue_Str{Str: "/etc/shadow"}},
+		},
+	}
+	outputs, err := engine.DispatchToDetectors(ctx, mismatchEvent)
+	assert.NoError(t, err)
+	assert.Empty(t, outputs)
+
+	matchEvent := &v1beta1.Event{
+		Id:   v1beta1.EventId(events.SecurityFileOpen),
+		Name: "security_file_open",
+		Data: []*v1beta1.EventValue{
+			{Name: "pathname", Value: &v1beta1.EventValue_Str{Str: "/etc/passwd"}},
+		},
+	}
+	outputs, err = engine.DispatchToDetectors(ctx, matchEvent)
+	assert.NoError(t, err)
+	assert.Len(t, outputs, 1)
+}
+
 func TestCollectAllDetectors(t *testing.T) {
 	// CollectAllDetectors gathers detectors from built-in sources
 	// Since we can't easily mock the builtin module, we just verify it doesn't panic

--- a/pkg/events/conversion.go
+++ b/pkg/events/conversion.go
@@ -266,7 +266,6 @@ func ConvertFromProto(e *pb.Event) *trace.Event {
 	if e.Threat != nil {
 		event.Metadata = &trace.Metadata{
 			Description: e.Threat.Name,
-			Properties:  make(map[string]interface{}),
 		}
 	}
 

--- a/pkg/filters/data.go
+++ b/pkg/filters/data.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/exp/maps"
 
+	"github.com/aquasecurity/tracee/api/v1beta1"
 	"github.com/aquasecurity/tracee/common/errfmt"
 	"github.com/aquasecurity/tracee/common/interfaces"
 	"github.com/aquasecurity/tracee/common/logger"
@@ -157,6 +158,88 @@ func (f *DataFilter) Filter(data []trace.Argument) bool {
 	}
 
 	return true
+}
+
+// FilterProto evaluates the data filter directly against a protobuf EventValue
+// slice, avoiding the allocation of []trace.Argument that convertDataToArgs
+// would create. The matching logic mirrors Filter exactly.
+func (f *DataFilter) FilterProto(data []*v1beta1.EventValue) bool {
+	if !f.Enabled() {
+		return true
+	}
+
+	for fieldName, filter := range f.filters {
+		if !f.skipKernelFilter && f.kernelDataFilter.IsKernelFilterEnabled(fieldName) {
+			continue
+		}
+
+		found := false
+		var fieldVal interface{}
+
+		for _, ev := range data {
+			if ev == nil {
+				continue
+			}
+			// Match convertDataToArgs: returnValue is not exposed as a filterable arg.
+			if ev.GetName() == "returnValue" {
+				continue
+			}
+			if ev.GetName() == fieldName {
+				found = true
+				fieldVal = protoValueToInterface(ev)
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+
+		fieldVal = fmt.Sprint(fieldVal)
+		if !filter.Filter(fieldVal) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// protoValueToInterface extracts the Go value from a proto EventValue oneof.
+func protoValueToInterface(ev *v1beta1.EventValue) interface{} {
+	switch v := ev.GetValue().(type) {
+	case *v1beta1.EventValue_Int32:
+		return v.Int32
+	case *v1beta1.EventValue_Int64:
+		return v.Int64
+	case *v1beta1.EventValue_UInt32:
+		return v.UInt32
+	case *v1beta1.EventValue_UInt64:
+		return v.UInt64
+	case *v1beta1.EventValue_Str:
+		return v.Str
+	case *v1beta1.EventValue_Bool:
+		return v.Bool
+	case *v1beta1.EventValue_Pointer:
+		return trace.Pointer(v.Pointer)
+	case *v1beta1.EventValue_Bytes:
+		return v.Bytes
+	case *v1beta1.EventValue_StrArray:
+		if v.StrArray != nil {
+			return v.StrArray.Value
+		}
+		return nil
+	case *v1beta1.EventValue_Int32Array:
+		if v.Int32Array != nil {
+			return v.Int32Array.Value
+		}
+		return nil
+	case *v1beta1.EventValue_UInt64Array:
+		if v.UInt64Array != nil {
+			return v.UInt64Array.Value
+		}
+		return nil
+	default:
+		return ev
+	}
 }
 
 func (f *DataFilter) Parse(id events.ID, fieldName string, operatorAndValues string) error {

--- a/pkg/filters/data.go
+++ b/pkg/filters/data.go
@@ -174,6 +174,7 @@ func (f *DataFilter) FilterProto(data []*v1beta1.EventValue) bool {
 		}
 
 		found := false
+		evaluated := false
 		var fieldVal interface{}
 
 		for _, ev := range data {
@@ -186,12 +187,25 @@ func (f *DataFilter) FilterProto(data []*v1beta1.EventValue) bool {
 			}
 			if ev.GetName() == fieldName {
 				found = true
-				fieldVal = protoValueToInterface(ev)
+				if s, ok := ev.GetValue().(*v1beta1.EventValue_Str); ok {
+					// Fast path: string values need no boxing or
+					// fmt.Sprint allocation (fmt.Sprint of a string is
+					// the string itself).
+					if !filter.Filter(s.Str) {
+						return false
+					}
+					evaluated = true
+				} else {
+					fieldVal = protoValueToInterface(ev)
+				}
 				break
 			}
 		}
 		if !found {
 			return false
+		}
+		if evaluated {
+			continue
 		}
 
 		fieldVal = fmt.Sprint(fieldVal)

--- a/pkg/filters/data_proto_test.go
+++ b/pkg/filters/data_proto_test.go
@@ -1,0 +1,159 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aquasecurity/tracee/api/v1beta1"
+	"github.com/aquasecurity/tracee/pkg/events"
+	"github.com/aquasecurity/tracee/types/trace"
+)
+
+func TestDataFilterProto_Disabled(t *testing.T) {
+	t.Parallel()
+	f := NewDataFilter()
+	assert.True(t, f.FilterProto(nil))
+	assert.True(t, f.FilterProto([]*v1beta1.EventValue{}))
+}
+
+func TestDataFilterProto_StringMatch(t *testing.T) {
+	t.Parallel()
+
+	f := NewDetectorDataFilter()
+	require.NoError(t, f.Parse(events.SecurityFileOpen, "pathname", "=/etc/passwd"))
+
+	// Match
+	assert.True(t, f.FilterProto([]*v1beta1.EventValue{
+		{Name: "pathname", Value: &v1beta1.EventValue_Str{Str: "/etc/passwd"}},
+	}))
+
+	// No match
+	assert.False(t, f.FilterProto([]*v1beta1.EventValue{
+		{Name: "pathname", Value: &v1beta1.EventValue_Str{Str: "/etc/shadow"}},
+	}))
+
+	// Field missing
+	assert.False(t, f.FilterProto([]*v1beta1.EventValue{
+		{Name: "other", Value: &v1beta1.EventValue_Str{Str: "/etc/passwd"}},
+	}))
+
+	// Empty slice
+	assert.False(t, f.FilterProto([]*v1beta1.EventValue{}))
+}
+
+func TestDataFilterProto_IntMatch(t *testing.T) {
+	t.Parallel()
+
+	f := NewDetectorDataFilter()
+	require.NoError(t, f.Parse(events.Read, "fd", "=3"))
+
+	// Int32 match (fmt.Sprint(int32(3)) == "3")
+	assert.True(t, f.FilterProto([]*v1beta1.EventValue{
+		{Name: "fd", Value: &v1beta1.EventValue_Int32{Int32: 3}},
+	}))
+
+	// No match
+	assert.False(t, f.FilterProto([]*v1beta1.EventValue{
+		{Name: "fd", Value: &v1beta1.EventValue_Int32{Int32: 5}},
+	}))
+}
+
+func TestDataFilterProto_MultipleFields(t *testing.T) {
+	t.Parallel()
+
+	f := NewDetectorDataFilter()
+	require.NoError(t, f.Parse(events.SecurityFileOpen, "pathname", "=/etc/passwd"))
+
+	data := []*v1beta1.EventValue{
+		{Name: "flags", Value: &v1beta1.EventValue_Int32{Int32: 0}},
+		{Name: "pathname", Value: &v1beta1.EventValue_Str{Str: "/etc/passwd"}},
+		{Name: "dev", Value: &v1beta1.EventValue_UInt32{UInt32: 123}},
+	}
+	assert.True(t, f.FilterProto(data))
+}
+
+func TestDataFilterProto_SkipsReturnValue(t *testing.T) {
+	t.Parallel()
+
+	f := NewDetectorDataFilter()
+	require.NoError(t, f.Parse(events.Read, "fd", "=3"))
+
+	data := []*v1beta1.EventValue{
+		{Name: "returnValue", Value: &v1beta1.EventValue_Int64{Int64: -1}},
+		{Name: "fd", Value: &v1beta1.EventValue_Int32{Int32: 3}},
+	}
+
+	assert.True(t, f.FilterProto(data))
+
+	traceEvt := events.ConvertFromProto(&v1beta1.Event{Data: data})
+	assert.True(t, f.Filter(traceEvt.Args))
+	assert.Equal(t, f.Filter(traceEvt.Args), f.FilterProto(data))
+}
+
+func TestDataFilterProto_Int32ArrayMatch(t *testing.T) {
+	t.Parallel()
+
+	f := NewDetectorDataFilter()
+	require.NoError(t, f.parseFilter("argv", "=[1 2 3]", func() Filter[*StringFilter] {
+		return NewStringFilter(nil)
+	}))
+	f.Enable()
+
+	data := []*v1beta1.EventValue{
+		{Name: "argv", Value: &v1beta1.EventValue_Int32Array{
+			Int32Array: &v1beta1.Int32Array{Value: []int32{1, 2, 3}},
+		}},
+	}
+	assert.True(t, f.FilterProto(data))
+
+	traceEvt := events.ConvertFromProto(&v1beta1.Event{Data: data})
+	assert.Equal(t, f.Filter(traceEvt.Args), f.FilterProto(data))
+}
+
+func TestProtoValueToInterface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ev       *v1beta1.EventValue
+		expected interface{}
+	}{
+		{"int32", &v1beta1.EventValue{Value: &v1beta1.EventValue_Int32{Int32: 42}}, int32(42)},
+		{"int64", &v1beta1.EventValue{Value: &v1beta1.EventValue_Int64{Int64: 99}}, int64(99)},
+		{"uint32", &v1beta1.EventValue{Value: &v1beta1.EventValue_UInt32{UInt32: 7}}, uint32(7)},
+		{"uint64", &v1beta1.EventValue{Value: &v1beta1.EventValue_UInt64{UInt64: 8}}, uint64(8)},
+		{"str", &v1beta1.EventValue{Value: &v1beta1.EventValue_Str{Str: "hello"}}, "hello"},
+		{"bool", &v1beta1.EventValue{Value: &v1beta1.EventValue_Bool{Bool: true}}, true},
+		{"pointer", &v1beta1.EventValue{Value: &v1beta1.EventValue_Pointer{Pointer: 0xdead}}, trace.Pointer(0xdead)},
+		{"int32_array", &v1beta1.EventValue{Value: &v1beta1.EventValue_Int32Array{
+			Int32Array: &v1beta1.Int32Array{Value: []int32{1, 2, 3}},
+		}}, []int32{1, 2, 3}},
+		{"bytes", &v1beta1.EventValue{Value: &v1beta1.EventValue_Bytes{Bytes: []byte("abc")}}, []byte("abc")},
+		{"str_array", &v1beta1.EventValue{Value: &v1beta1.EventValue_StrArray{
+			StrArray: &v1beta1.StringArray{Value: []string{"a", "b"}},
+		}}, []string{"a", "b"}},
+		{"str_array_nil", &v1beta1.EventValue{Value: &v1beta1.EventValue_StrArray{
+			StrArray: nil,
+		}}, nil},
+		// nil oneof falls through to default, which returns the EventValue itself
+		// (matches convertDataToArgs behavior for unknown types)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := protoValueToInterface(tt.ev)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+
+	// Separate test for nil value case — returns the EventValue itself
+	t.Run("nil_value_returns_ev", func(t *testing.T) {
+		t.Parallel()
+		ev := &v1beta1.EventValue{}
+		result := protoValueToInterface(ev)
+		assert.Equal(t, ev, result)
+	})
+}

--- a/pkg/filters/filter_proto_parity_test.go
+++ b/pkg/filters/filter_proto_parity_test.go
@@ -1,0 +1,242 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/aquasecurity/tracee/api/v1beta1"
+	"github.com/aquasecurity/tracee/pkg/events"
+)
+
+// assertScopeFilterParity checks FilterProto matches Filter(ConvertFromProto(e)).
+func assertScopeFilterParity(t *testing.T, f *ScopeFilter, e *v1beta1.Event) {
+	t.Helper()
+	traceEvt := events.ConvertFromProto(e)
+	want := f.Filter(*traceEvt)
+	got := f.FilterProto(e)
+	assert.Equal(t, want, got, "FilterProto must match Filter(ConvertFromProto)")
+}
+
+func TestScopeFilterProto_ParityWithConvertFromProto(t *testing.T) {
+	t.Parallel()
+
+	fullEvent := &v1beta1.Event{
+		Timestamp: timestamppb.Now(),
+		Workload: &v1beta1.Workload{
+			Process: &v1beta1.Process{
+				Pid:     &wrapperspb.UInt32Value{Value: 42},
+				HostPid: &wrapperspb.UInt32Value{Value: 100},
+				RealUser: &v1beta1.User{
+					Id: &wrapperspb.UInt32Value{Value: 1000},
+				},
+				Thread: &v1beta1.Thread{
+					Name:    "myproc",
+					Syscall: "read",
+					Tid:     &wrapperspb.UInt32Value{Value: 43},
+					HostTid: &wrapperspb.UInt32Value{Value: 101},
+				},
+				Ancestors: []*v1beta1.Process{
+					{
+						Pid:     &wrapperspb.UInt32Value{Value: 10},
+						HostPid: &wrapperspb.UInt32Value{Value: 50},
+					},
+				},
+			},
+			Container: &v1beta1.Container{Id: "c1", Started: true},
+			K8S: &v1beta1.K8S{
+				Pod:       &v1beta1.Pod{Name: "mypod", Uid: "pod-uid-1"},
+				Namespace: &v1beta1.K8SNamespace{Name: "default"},
+			},
+		},
+	}
+
+	hostEvent := &v1beta1.Event{
+		Workload: &v1beta1.Workload{},
+	}
+
+	type filterSpec struct {
+		field string
+		op    string
+	}
+
+	cases := []struct {
+		name    string
+		filters []filterSpec
+		event   *v1beta1.Event
+	}{
+		{
+			name:    "disabled filter",
+			filters: nil,
+			event:   fullEvent,
+		},
+		{
+			name:    "container",
+			filters: []filterSpec{{field: "container"}},
+			event:   fullEvent,
+		},
+		{
+			name:    "container started",
+			filters: []filterSpec{{field: "container", op: "=started"}},
+			event:   fullEvent,
+		},
+		{
+			name:    "host",
+			filters: []filterSpec{{field: "host"}},
+			event:   hostEvent,
+		},
+		{
+			name: "pid and comm",
+			filters: []filterSpec{
+				{field: "pid", op: "=42"},
+				{field: "comm", op: "=myproc"},
+			},
+			event: fullEvent,
+		},
+		{
+			name: "ppid from ancestor",
+			filters: []filterSpec{
+				{field: "ppid", op: "=10"},
+			},
+			event: fullEvent,
+		},
+		{
+			name: "k8s and container id",
+			filters: []filterSpec{
+				{field: "podName", op: "=mypod"},
+				{field: "containerId", op: "=c1"},
+			},
+			event: fullEvent,
+		},
+		{
+			name:    "nil workload",
+			filters: []filterSpec{{field: "pid", op: "=1"}},
+			event:   &v1beta1.Event{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := NewScopeFilter()
+			for _, spec := range tc.filters {
+				require.NoError(t, f.Parse(spec.field, spec.op))
+			}
+			assertScopeFilterParity(t, f, tc.event)
+		})
+	}
+}
+
+func assertDataFilterParity(t *testing.T, f *DataFilter, data []*v1beta1.EventValue) {
+	t.Helper()
+	traceEvt := events.ConvertFromProto(&v1beta1.Event{Data: data})
+	want := f.Filter(traceEvt.Args)
+	got := f.FilterProto(data)
+	assert.Equal(t, want, got, "FilterProto must match Filter(ConvertFromProto).Args")
+}
+
+func TestDataFilterProto_ParityWithConvertFromProto(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		eventID   events.ID
+		field     string
+		expr      string
+		data      []*v1beta1.EventValue
+		setupFunc func(*DataFilter) error // when set, bypasses event field validation
+	}{
+		{
+			name:    "pathname string",
+			eventID: events.SecurityFileOpen,
+			field:   "pathname",
+			expr:    "=/etc/passwd",
+			data: []*v1beta1.EventValue{
+				{Name: "pathname", Value: &v1beta1.EventValue_Str{Str: "/etc/passwd"}},
+			},
+		},
+		{
+			name:    "int32 fd",
+			eventID: events.Read,
+			field:   "fd",
+			expr:    "=3",
+			data: []*v1beta1.EventValue{
+				{Name: "fd", Value: &v1beta1.EventValue_Int32{Int32: 3}},
+			},
+		},
+		{
+			name: "pointer",
+			data: []*v1beta1.EventValue{
+				{Name: "buf", Value: &v1beta1.EventValue_Pointer{Pointer: 0xdead}},
+			},
+			setupFunc: func(f *DataFilter) error {
+				return f.parseFilter("buf", "=57005", func() Filter[*StringFilter] {
+					return NewStringFilter(nil)
+				})
+			},
+		},
+		{
+			name: "int32 array",
+			data: []*v1beta1.EventValue{
+				{Name: "argv", Value: &v1beta1.EventValue_Int32Array{
+					Int32Array: &v1beta1.Int32Array{Value: []int32{1, 2, 3}},
+				}},
+			},
+			setupFunc: func(f *DataFilter) error {
+				return f.parseFilter("argv", "=[1 2 3]", func() Filter[*StringFilter] {
+					return NewStringFilter(nil)
+				})
+			},
+		},
+		{
+			name: "bytes",
+			data: []*v1beta1.EventValue{
+				{Name: "data", Value: &v1beta1.EventValue_Bytes{Bytes: []byte("abc")}},
+			},
+			setupFunc: func(f *DataFilter) error {
+				return f.parseFilter("data", "=[97 98 99]", func() Filter[*StringFilter] {
+					return NewStringFilter(nil)
+				})
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			f := NewDetectorDataFilter()
+			var err error
+			if tc.setupFunc != nil {
+				err = tc.setupFunc(f)
+			} else {
+				err = f.Parse(tc.eventID, tc.field, tc.expr)
+			}
+			require.NoError(t, err)
+			f.Enable()
+			assertDataFilterParity(t, f, tc.data)
+		})
+	}
+}
+
+func TestScopeFilterProto_ParityHostPpidFromAncestor(t *testing.T) {
+	t.Parallel()
+
+	f := NewScopeFilter()
+	require.NoError(t, f.hostPpidFilter.Parse("=50"))
+	f.hostPpidFilter.Enable()
+	f.Enable()
+
+	e := &v1beta1.Event{
+		Workload: &v1beta1.Workload{
+			Process: &v1beta1.Process{
+				Ancestors: []*v1beta1.Process{
+					{HostPid: &wrapperspb.UInt32Value{Value: 50}},
+				},
+			},
+		},
+	}
+	assertScopeFilterParity(t, f, e)
+}

--- a/pkg/filters/scope.go
+++ b/pkg/filters/scope.go
@@ -126,11 +126,17 @@ func (f *ScopeFilter) FilterProto(e *v1beta1.Event) bool {
 		return true
 	}
 
-	// Extract container info
 	var containerID, containerName, imageName string
 	var containerStarted bool
-	w := e.GetWorkload()
-	if w != nil {
+	var processName, syscall string
+	var pid, hostPid, tid, hostTid, uid int64
+	var ppid, hostPpid int64
+	var podName, podNS, podUID string
+
+	// A single workload nil-check covers container, process, and kubernetes
+	// extraction, saving two redundant nil checks per event.
+	if w := e.GetWorkload(); w != nil {
+		// Extract container info
 		if c := w.GetContainer(); c != nil {
 			containerID = c.GetId()
 			containerName = c.GetName()
@@ -139,13 +145,8 @@ func (f *ScopeFilter) FilterProto(e *v1beta1.Event) bool {
 				imageName = img.GetName()
 			}
 		}
-	}
 
-	// Extract process info
-	var processName, syscall string
-	var pid, hostPid, tid, hostTid, uid int64
-	var ppid, hostPpid int64
-	if w != nil {
+		// Extract process info
 		if p := w.GetProcess(); p != nil {
 			if pidW := p.GetPid(); pidW != nil {
 				pid = int64(pidW.GetValue())
@@ -179,11 +180,8 @@ func (f *ScopeFilter) FilterProto(e *v1beta1.Event) bool {
 				}
 			}
 		}
-	}
 
-	// Extract kubernetes info
-	var podName, podNS, podUID string
-	if w != nil {
+		// Extract kubernetes info
 		if k := w.GetK8S(); k != nil {
 			if pod := k.GetPod(); pod != nil {
 				podName = pod.GetName()

--- a/pkg/filters/scope.go
+++ b/pkg/filters/scope.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"github.com/aquasecurity/tracee/api/v1beta1"
 	"github.com/aquasecurity/tracee/common/errfmt"
 	"github.com/aquasecurity/tracee/common/interfaces"
 	"github.com/aquasecurity/tracee/types/trace"
@@ -112,6 +113,114 @@ func (f *ScopeFilter) Filter(evt trace.Event) bool {
 		f.podUIDFilter.Filter(evt.Kubernetes.PodUID) &&
 		f.tidFilter.Filter(int64(evt.ThreadID)) &&
 		f.uidFilter.Filter(int64(evt.UserID))
+}
+
+// FilterProto evaluates the scope filter directly against a protobuf Event,
+// avoiding the allocation of a trace.Event that ConvertFromProto would create.
+//
+// Five fields are absent from the proto schema: CgroupID, HostName, MountNS,
+// PIDNS, and ProcessorID. Zero values are passed for these, which is identical
+// to what ConvertFromProto produces (it never populates them either).
+func (f *ScopeFilter) FilterProto(e *v1beta1.Event) bool {
+	if !f.enabled {
+		return true
+	}
+
+	// Extract container info
+	var containerID, containerName, imageName string
+	var containerStarted bool
+	w := e.GetWorkload()
+	if w != nil {
+		if c := w.GetContainer(); c != nil {
+			containerID = c.GetId()
+			containerName = c.GetName()
+			containerStarted = c.GetStarted()
+			if img := c.GetImage(); img != nil {
+				imageName = img.GetName()
+			}
+		}
+	}
+
+	// Extract process info
+	var processName, syscall string
+	var pid, hostPid, tid, hostTid, uid int64
+	var ppid, hostPpid int64
+	if w != nil {
+		if p := w.GetProcess(); p != nil {
+			if p.GetPid() != nil {
+				pid = int64(p.GetPid().GetValue())
+			}
+			if p.GetHostPid() != nil {
+				hostPid = int64(p.GetHostPid().GetValue())
+			}
+			if p.GetRealUser() != nil && p.GetRealUser().GetId() != nil {
+				uid = int64(p.GetRealUser().GetId().GetValue())
+			}
+			if t := p.GetThread(); t != nil {
+				processName = t.GetName()
+				syscall = t.GetSyscall()
+				if t.GetTid() != nil {
+					tid = int64(t.GetTid().GetValue())
+				}
+				if t.GetHostTid() != nil {
+					hostTid = int64(t.GetHostTid().GetValue())
+				}
+			}
+			// Parent info from ancestors
+			if ancestors := p.GetAncestors(); len(ancestors) > 0 {
+				parent := ancestors[0]
+				if parent.GetHostPid() != nil {
+					hostPpid = int64(parent.GetHostPid().GetValue())
+				}
+				if parent.GetPid() != nil {
+					ppid = int64(parent.GetPid().GetValue())
+				}
+			}
+		}
+	}
+
+	// Extract kubernetes info
+	var podName, podNS, podUID string
+	if w != nil {
+		if k := w.GetK8S(); k != nil {
+			if pod := k.GetPod(); pod != nil {
+				podName = pod.GetName()
+				podUID = pod.GetUid()
+			}
+			if ns := k.GetNamespace(); ns != nil {
+				podNS = ns.GetName()
+			}
+		}
+	}
+
+	var ts int64
+	if e.GetTimestamp() != nil {
+		ts = e.GetTimestamp().AsTime().UnixNano()
+	}
+
+	return f.containerFilter.Filter(containerID != "") &&
+		f.containerStartedFilter.Filter(containerStarted) &&
+		f.processNameFilter.Filter(processName) &&
+		f.timestampFilter.Filter(ts) &&
+		f.cgroupIDFilter.Filter(uint64(0)) &&
+		f.containerIDFilter.Filter(containerID) &&
+		f.containerImageFilter.Filter(imageName) &&
+		f.containerNameFilter.Filter(containerName) &&
+		f.hostNameFilter.Filter("") &&
+		f.hostPidFilter.Filter(hostPid) &&
+		f.hostPpidFilter.Filter(hostPpid) &&
+		f.syscallFilter.Filter(syscall) &&
+		f.hostTidFilter.Filter(hostTid) &&
+		f.mntNSFilter.Filter(int64(0)) &&
+		f.pidFilter.Filter(pid) &&
+		f.ppidFilter.Filter(ppid) &&
+		f.pidNSFilter.Filter(int64(0)) &&
+		f.processorIDFilter.Filter(int64(0)) &&
+		f.podNameFilter.Filter(podName) &&
+		f.podNSFilter.Filter(podNS) &&
+		f.podUIDFilter.Filter(podUID) &&
+		f.tidFilter.Filter(tid) &&
+		f.uidFilter.Filter(uid)
 }
 
 func (f *ScopeFilter) Parse(field string, operatorAndValues string) error {

--- a/pkg/filters/scope.go
+++ b/pkg/filters/scope.go
@@ -147,33 +147,35 @@ func (f *ScopeFilter) FilterProto(e *v1beta1.Event) bool {
 	var ppid, hostPpid int64
 	if w != nil {
 		if p := w.GetProcess(); p != nil {
-			if p.GetPid() != nil {
-				pid = int64(p.GetPid().GetValue())
+			if pidW := p.GetPid(); pidW != nil {
+				pid = int64(pidW.GetValue())
 			}
-			if p.GetHostPid() != nil {
-				hostPid = int64(p.GetHostPid().GetValue())
+			if hostPidW := p.GetHostPid(); hostPidW != nil {
+				hostPid = int64(hostPidW.GetValue())
 			}
-			if p.GetRealUser() != nil && p.GetRealUser().GetId() != nil {
-				uid = int64(p.GetRealUser().GetId().GetValue())
+			if u := p.GetRealUser(); u != nil {
+				if uidW := u.GetId(); uidW != nil {
+					uid = int64(uidW.GetValue())
+				}
 			}
 			if t := p.GetThread(); t != nil {
 				processName = t.GetName()
 				syscall = t.GetSyscall()
-				if t.GetTid() != nil {
-					tid = int64(t.GetTid().GetValue())
+				if tidW := t.GetTid(); tidW != nil {
+					tid = int64(tidW.GetValue())
 				}
-				if t.GetHostTid() != nil {
-					hostTid = int64(t.GetHostTid().GetValue())
+				if hostTidW := t.GetHostTid(); hostTidW != nil {
+					hostTid = int64(hostTidW.GetValue())
 				}
 			}
 			// Parent info from ancestors
 			if ancestors := p.GetAncestors(); len(ancestors) > 0 {
 				parent := ancestors[0]
-				if parent.GetHostPid() != nil {
-					hostPpid = int64(parent.GetHostPid().GetValue())
+				if hostPpidW := parent.GetHostPid(); hostPpidW != nil {
+					hostPpid = int64(hostPpidW.GetValue())
 				}
-				if parent.GetPid() != nil {
-					ppid = int64(parent.GetPid().GetValue())
+				if ppidW := parent.GetPid(); ppidW != nil {
+					ppid = int64(ppidW.GetValue())
 				}
 			}
 		}

--- a/pkg/filters/scope.go
+++ b/pkg/filters/scope.go
@@ -194,8 +194,10 @@ func (f *ScopeFilter) FilterProto(e *v1beta1.Event) bool {
 	}
 
 	var ts int64
-	if e.GetTimestamp() != nil {
-		ts = e.GetTimestamp().AsTime().UnixNano()
+	if f.timestampFilter.Enabled() {
+		if t := e.GetTimestamp(); t != nil {
+			ts = t.AsTime().UnixNano()
+		}
 	}
 
 	return f.containerFilter.Filter(containerID != "") &&

--- a/pkg/filters/scope_proto_test.go
+++ b/pkg/filters/scope_proto_test.go
@@ -1,0 +1,236 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/aquasecurity/tracee/api/v1beta1"
+)
+
+func TestScopeFilterProto_Disabled(t *testing.T) {
+	t.Parallel()
+	f := NewScopeFilter()
+	// Disabled filter passes everything
+	assert.True(t, f.FilterProto(nil))
+	assert.True(t, f.FilterProto(&v1beta1.Event{}))
+}
+
+func TestScopeFilterProto_NilSafety(t *testing.T) {
+	t.Parallel()
+
+	f := NewScopeFilter()
+	require.NoError(t, f.Parse("pid", "=1"))
+
+	// Nil workload
+	assert.False(t, f.FilterProto(&v1beta1.Event{}))
+
+	// Nil process
+	assert.False(t, f.FilterProto(&v1beta1.Event{
+		Workload: &v1beta1.Workload{},
+	}))
+
+	// Nil pid wrapper
+	assert.False(t, f.FilterProto(&v1beta1.Event{
+		Workload: &v1beta1.Workload{
+			Process: &v1beta1.Process{},
+		},
+	}))
+}
+
+func TestScopeFilterProto_Container(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		field         string
+		operatorValue string
+		event         *v1beta1.Event
+		expected      bool
+	}{
+		{
+			name:  "container - matches container event",
+			field: "container",
+			event: &v1beta1.Event{
+				Workload: &v1beta1.Workload{
+					Container: &v1beta1.Container{Id: "abc123"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:  "container - rejects host event (no container)",
+			field: "container",
+			event: &v1beta1.Event{
+				Workload: &v1beta1.Workload{},
+			},
+			expected: false,
+		},
+		{
+			name:     "container - rejects nil workload",
+			field:    "container",
+			event:    &v1beta1.Event{},
+			expected: false,
+		},
+		{
+			name:          "container=started - matches started",
+			field:         "container",
+			operatorValue: "=started",
+			event: &v1beta1.Event{
+				Workload: &v1beta1.Workload{
+					Container: &v1beta1.Container{Id: "abc", Started: true},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:          "container=started - rejects not started",
+			field:         "container",
+			operatorValue: "=started",
+			event: &v1beta1.Event{
+				Workload: &v1beta1.Workload{
+					Container: &v1beta1.Container{Id: "abc", Started: false},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:  "host - matches host event",
+			field: "host",
+			event: &v1beta1.Event{
+				Workload: &v1beta1.Workload{},
+			},
+			expected: true,
+		},
+		{
+			name:  "host - rejects container event",
+			field: "host",
+			event: &v1beta1.Event{
+				Workload: &v1beta1.Workload{
+					Container: &v1beta1.Container{Id: "abc123"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := NewScopeFilter()
+			require.NoError(t, f.Parse(tt.field, tt.operatorValue))
+			assert.Equal(t, tt.expected, f.FilterProto(tt.event))
+		})
+	}
+}
+
+func TestScopeFilterProto_ProcessFields(t *testing.T) {
+	t.Parallel()
+
+	fullEvent := &v1beta1.Event{
+		Timestamp: timestamppb.Now(),
+		Workload: &v1beta1.Workload{
+			Process: &v1beta1.Process{
+				Pid:     &wrapperspb.UInt32Value{Value: 42},
+				HostPid: &wrapperspb.UInt32Value{Value: 100},
+				RealUser: &v1beta1.User{
+					Id: &wrapperspb.UInt32Value{Value: 1000},
+				},
+				Thread: &v1beta1.Thread{
+					Name:    "myproc",
+					Syscall: "read",
+					Tid:     &wrapperspb.UInt32Value{Value: 43},
+					HostTid: &wrapperspb.UInt32Value{Value: 101},
+				},
+				Ancestors: []*v1beta1.Process{
+					{
+						Pid:     &wrapperspb.UInt32Value{Value: 10},
+						HostPid: &wrapperspb.UInt32Value{Value: 50},
+					},
+				},
+			},
+			Container: &v1beta1.Container{Id: "c1"},
+			K8S: &v1beta1.K8S{
+				Pod:       &v1beta1.Pod{Name: "mypod", Uid: "pod-uid-1"},
+				Namespace: &v1beta1.K8SNamespace{Name: "default"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		field         string
+		operatorValue string
+		expected      bool
+	}{
+		{"pid match", "pid", "=42", true},
+		{"pid no match", "pid", "=99", false},
+		{"hostPid match", "hostPid", "=100", true},
+		{"hostPid no match", "hostPid", "=999", false},
+		{"tid match", "tid", "=43", true},
+		{"hostTid match", "hostTid", "=101", true},
+		{"uid match", "uid", "=1000", true},
+		{"uid no match", "uid", "=0", false},
+		{"ppid match", "ppid", "=10", true},
+		{"ppid no match", "ppid", "=99", false},
+		{"processName match", "comm", "=myproc", true},
+		{"processName no match", "comm", "=other", false},
+		{"syscall match", "syscall", "=read", true},
+		{"syscall no match", "syscall", "=write", false},
+		{"podName match", "podName", "=mypod", true},
+		{"podName no match", "podName", "=other", false},
+		{"podNamespace match", "podNamespace", "=default", true},
+		{"podUid match", "podUid", "=pod-uid-1", true},
+		{"containerId match", "containerId", "=c1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := NewScopeFilter()
+			require.NoError(t, f.Parse(tt.field, tt.operatorValue))
+			assert.Equal(t, tt.expected, f.FilterProto(fullEvent),
+				"field=%s op=%s", tt.field, tt.operatorValue)
+		})
+	}
+}
+
+func TestScopeFilterProto_MultipleFilters(t *testing.T) {
+	t.Parallel()
+
+	f := NewScopeFilter()
+	require.NoError(t, f.Parse("container", ""))
+	require.NoError(t, f.Parse("pid", "=42"))
+
+	// Both match
+	assert.True(t, f.FilterProto(&v1beta1.Event{
+		Workload: &v1beta1.Workload{
+			Container: &v1beta1.Container{Id: "c1"},
+			Process: &v1beta1.Process{
+				Pid: &wrapperspb.UInt32Value{Value: 42},
+			},
+		},
+	}))
+
+	// Container matches, pid doesn't
+	assert.False(t, f.FilterProto(&v1beta1.Event{
+		Workload: &v1beta1.Workload{
+			Container: &v1beta1.Container{Id: "c1"},
+			Process: &v1beta1.Process{
+				Pid: &wrapperspb.UInt32Value{Value: 99},
+			},
+		},
+	}))
+
+	// Pid matches, not a container
+	assert.False(t, f.FilterProto(&v1beta1.Event{
+		Workload: &v1beta1.Workload{
+			Process: &v1beta1.Process{
+				Pid: &wrapperspb.UInt32Value{Value: 42},
+			},
+		},
+	}))
+}


### PR DESCRIPTION
### What

This PR eliminates the `ConvertFromProto` allocation hotspot in the detector dispatch path by adding `FilterProto` methods that evaluate scope and data filters directly against protobuf `Event` fields, without converting to `trace.Event` first.

Changes:
1. **`ScopeFilter.FilterProto(*v1beta1.Event) bool`** — evaluates all 23 scope sub-filters by reading proto getter methods directly (nil-safe). Five fields absent from the proto schema (CgroupID, HostName, MountNS, PIDNS, ProcessorID) pass zero values, matching `ConvertFromProto` behavior exactly.
2. **`DataFilter.FilterProto([]*v1beta1.EventValue) bool`** — iterates the proto `EventValue` slice by name, extracts oneof values, and applies string filters. Same logic as `Filter([]trace.Argument)` without the intermediate allocation.
3. **`dispatch.go`** — replaces `ConvertFromProto(inputEvent)` + `Filter(*traceEvent)` with `FilterProto(inputEvent)`.
4. **`conversion.go`** — removes wasted `make(map[string]interface{})` in `ConvertFromProto`'s `Metadata.Properties` (allocated but never populated).

### Why

Profiling shows `ConvertFromProto` + `convertDataToArgs` dominate allocation churn in the detector dispatch path. Every event flowing through `dispatchToDetectors` allocates a full `trace.Event` struct, `[]trace.Argument` slice, and sub-structs (`Container`, `Kubernetes`, `Metadata`) solely for read-only filter evaluation — then immediately discards them. Under sustained load this creates massive GC pressure.

### Measured impact

Benchmarked on the same machine (Go 1.26.3, linux/amd64), identical workload (default events, 5 syscall stress workers, 3.5 min run), heap profiles compared.

**Base: PR #5309 (proto slab pooling) + symbol patch. Test: + this PR.**

#### Runtime memstats

| Metric | Base | + FilterProto | Delta |
|--------|------|---------------|-------|
| **TotalAlloc** | 29.73 GB | 13.84 GB | **−15.9 GB (−53%)** |
| **Live heap (inuse_space)** | 37.9 MB | 32.8 MB | **−5.1 MB (−13%)** |
| **HeapAlloc** | 59.0 MB | 46.1 MB | **−12.9 MB (−22%)** |
| **GC cycles** | 879 | 424 | **−52%** |
| **VmRSS** | 196 MB | 192 MB | −4 MB |

#### Allocation churn (alloc_space) — key functions

| Function | Base | + FilterProto | Delta |
|----------|------|---------------|-------|
| `ConvertFromProto` | 11.48 GB (38.6%) | 0 | **eliminated** |
| `convertDataToArgs` | 10.57 GB (35.5%) | 0 | **eliminated** |
| `DataFilter.FilterProto` (new) | — | 1.43 GB | replaces above |
| `fmt.Sprint` | 0.40 GB | 0.80 GB | +0.40 GB |
| `protoValueToInterface` (new) | — | 0.31 GB | interface boxing |

**Net churn eliminated: ~20 GB replaced by ~2 GB = 18 GB net savings in 3.5 min.**

#### Live heap (inuse_space) — key functions

| Function | Base | + FilterProto | Delta |
|----------|------|---------------|-------|
| `ConvertFromProto` | 3.6 MB | 0 | **eliminated** |
| `convertDataToArgs` | 2.0 MB | 0 | **eliminated** |

### How it works

- `FilterProto` on `ScopeFilter` extracts scalar fields from proto getters (`GetWorkload().GetProcess().GetPid()`, etc.) and passes them to the same sub-filters that `Filter(trace.Event)` uses. All proto getters are nil-safe (return zero for nil receivers).
- `FilterProto` on `DataFilter` iterates the `[]*v1beta1.EventValue` slice, matches by name, extracts the oneof value via `protoValueToInterface`, and applies `fmt.Sprint` + string filter — same logic as the existing `Filter([]trace.Argument)`.
- `dispatchToDetectors` now calls `FilterProto` directly instead of `ConvertFromProto` + `Filter`. Zero `trace.Event` allocations in the filter path.

### Testing

- Existing `TestDispatchWithScopeFilter` passes (verifies container/host filtering through the full dispatch path).
- New `TestScopeFilterProto_*` tests: disabled filter, nil safety (nil workload/process/pid), container/host filtering, all process fields (pid, hostPid, tid, hostTid, uid, ppid, comm, syscall, k8s, containerId), multiple combined filters.
- New `TestDataFilterProto_*` tests: disabled filter, string match, int match, multiple fields, field-not-found.
- New `TestProtoValueToInterface` tests: all oneof types (int32, int64, uint32, uint64, str, bool, pointer, bytes, str_array, int32_array, uint64_array, nil value).
- All existing filter and detector tests pass unchanged.
