### PR TITLE
ci: use GitHub app for helm

### DIFF
--- a/.github/actions/test-helm-chart/action.yaml
+++ b/.github/actions/test-helm-chart/action.yaml
@@ -1,0 +1,75 @@
+name: Test Helm Chart
+description: Lint and install the Tracee Helm chart with chart-testing and KIND.
+
+inputs:
+  helm-version:
+    description: Helm CLI version
+    required: false
+    default: v3.14.3
+  python-version:
+    description: Python version for chart-testing
+    required: false
+    default: "3.12.3"
+  ct-config:
+    description: chart-testing config file
+    required: false
+    default: deploy/helm/ct.yaml
+  lint-conf:
+    description: yamllint config for chart-testing
+    required: false
+    default: deploy/helm/lintconf.yaml
+  chart-schema:
+    description: Chart.yaml JSON schema for chart-testing
+    required: false
+    default: deploy/helm/chart_schema.yaml
+  kind-version:
+    description: KIND version
+    required: false
+    default: v0.14.0
+  kind-image:
+    description: KIND node image
+    required: false
+    default: kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Helm
+      uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      with:
+        version: ${{ inputs.helm-version }}
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+    - name: Run chart-testing (lint)
+      shell: bash
+      env:
+        CT_CONFIG: ${{ inputs.ct-config }}
+        LINT_CONF: ${{ inputs.lint-conf }}
+        CHART_SCHEMA: ${{ inputs.chart-schema }}
+      run: |
+          set -euo pipefail
+          ct lint \
+              --config "${CT_CONFIG}" \
+              --lint-conf "${LINT_CONF}" \
+              --chart-yaml-schema "${CHART_SCHEMA}"
+
+    - name: Create KIND cluster
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+      with:
+        version: ${{ inputs.kind-version }}
+        node_image: ${{ inputs.kind-image }}
+
+    - name: Run chart-testing (install)
+      shell: bash
+      env:
+        CT_CONFIG: ${{ inputs.ct-config }}
+      run: |
+          set -euo pipefail
+          ct install --config "${CT_CONFIG}"

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -4,6 +4,9 @@
 # from the specified Git revision (e.g., main branch or v0.7.0 tag) to Helm
 # repository on https://github.com/aquasecurity/helm-charts.
 #
+# Set dry-run to validate the chart, app auth, and local packaging without
+# creating GitHub Releases or pushing index.yaml to gh-pages.
+#
 name: Publish Helm
 on:
   workflow_dispatch:
@@ -11,6 +14,10 @@ on:
       ref:
         description: The branch, tag or SHA to publish, e.g. v0.0.1
         required: true
+      dry-run:
+        description: Validate chart and auth WITHOUT publishing to helm-charts (dry run)
+        type: boolean
+        default: false
 permissions:
   contents: read
 env:
@@ -77,6 +84,7 @@ jobs:
           ./cr package --package-path .cr-release-packages "${CHART_DIR}"
       - name: Upload helm chart
         # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
+        if: inputs.dry-run != true
         continue-on-error: true
         env:
           CR_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -91,7 +99,79 @@ jobs:
             --git-repo "${HELM_REP}" \
             --charts-repo "https://${GH_OWNER}.github.io/${HELM_REP}/" \
             --index-path index.yaml
+      - name: Verify helm-charts access
+        if: inputs.dry-run == true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          repo_full_name="$(gh api "repos/${GH_OWNER}/${HELM_REP}" --jq .full_name)"
+          if [ "${repo_full_name}" != "${GH_OWNER}/${HELM_REP}" ]; then
+              echo "Unexpected repository: ${repo_full_name}" >&2
+              exit 1
+          fi
+          gh api "repos/${GH_OWNER}/${HELM_REP}/releases?per_page=1" >/dev/null
+          echo "GitHub App token can access ${GH_OWNER}/${HELM_REP}"
+      - name: Helm install dry-run
+        if: inputs.dry-run == true
+        run: |
+          set -euo pipefail
+          package_file="$(ls -1 .cr-release-packages/*.tgz | head -1)"
+          helm install --dry-run tracee "${package_file}" -n tracee --create-namespace
+      - name: Dry-run summary
+        if: inputs.dry-run == true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REF: ${{ github.event.inputs.ref }}
+          BOT_NAME: ${{ steps.bot.outputs.name }}
+          BOT_EMAIL: ${{ steps.bot.outputs.email }}
+        run: |
+          set -euo pipefail
+          chart_name="$(grep '^name:' "${CHART_DIR}/Chart.yaml" | awk '{print $2}' | tr -d '"')"
+          chart_version="$(grep '^version:' "${CHART_DIR}/Chart.yaml" | awk '{print $2}' | tr -d '"')"
+          release_tag="${chart_name}-${chart_version}"
+          if gh api "repos/${GH_OWNER}/${HELM_REP}/releases/tags/${release_tag}" >/dev/null 2>&1; then
+              release_status="exists (upload would be skipped or fail)"
+          else
+              release_status="not found (would create new release)"
+          fi
+          package_files="$(ls -1 .cr-release-packages/*.tgz)"
+          {
+              echo "## Publish Helm dry run"
+              echo ""
+              echo "**Result:** Validation passed; publish steps skipped"
+              echo ""
+              echo "| Field | Value |"
+              echo "| --- | --- |"
+              echo "| Ref | \`${REF}\` |"
+              echo "| Chart | \`${chart_name}\` |"
+              echo "| Version | \`${chart_version}\` |"
+              echo "| Release tag | \`${release_tag}\` |"
+              echo "| Release status | ${release_status} |"
+              echo "| Bot author | \`${BOT_NAME}\` |"
+              echo "| Bot email | \`${BOT_EMAIL}\` |"
+              echo "| Repository | \`${GH_OWNER}/${HELM_REP}\` |"
+              echo ""
+              echo "### Package files"
+              echo "\`\`\`"
+              echo "${package_files}"
+              echo "\`\`\`"
+              echo ""
+              echo "### Skipped steps"
+              echo "- \`cr upload\` (GitHub Release)"
+              echo "- Push \`index.yaml\` to \`gh-pages\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "Dry run complete for ${chart_name} ${chart_version}"
+      - name: Upload dry-run artifacts
+        if: inputs.dry-run == true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: helm-publish-dry-run
+          path: |
+            .cr-release-packages/
+            index.yaml
       - name: Push index file
+        if: inputs.dry-run != true
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # v1.1.1
         env:
           API_TOKEN_GITHUB: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -21,6 +21,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: publish-helm-${{ env.HELM_REP }}
+  cancel-in-progress: false
+
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
@@ -173,13 +177,46 @@ jobs:
 
       - name: Push index file
         if: inputs.dry-run != true
-        uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ steps.app-token.outputs.token }}
-        with:
-          source_file: "index.yaml"
-          destination_repo: "${{ env.GH_OWNER }}/${{ env.HELM_REP }}"
-          destination_folder: "."
-          destination_branch: "gh-pages"
-          user_email: ${{ steps.bot.outputs.email }}
-          user_name: ${{ steps.bot.outputs.name }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BOT_NAME: ${{ steps.bot.outputs.name }}
+          BOT_EMAIL: ${{ steps.bot.outputs.email }}
+        run: |
+          set -euo pipefail
+          git config --global user.email "${BOT_EMAIL}"
+          git config --global user.name "${BOT_NAME}"
+          max_attempts=3
+          attempt=1
+          while [ "${attempt}" -le "${max_attempts}" ]; do
+              if [ "${attempt}" -gt 1 ]; then
+                  ./cr index --owner "${GH_OWNER}" \
+                      --git-repo "${HELM_REP}" \
+                      --charts-repo "https://${GH_OWNER}.github.io/${HELM_REP}/" \
+                      --index-path index.yaml
+              fi
+              clone_dir="$(mktemp -d)"
+              git clone --single-branch --branch gh-pages \
+                  "https://x-access-token:${GH_TOKEN}@github.com/${GH_OWNER}/${HELM_REP}.git" \
+                  "${clone_dir}"
+              cp index.yaml "${clone_dir}/index.yaml"
+              cd "${clone_dir}"
+              git add index.yaml
+              if git diff --cached --quiet; then
+                  echo "No index changes to push"
+                  rm -rf "${clone_dir}"
+                  exit 0
+              fi
+              git commit -m "Update index.yaml from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+              if git push origin "HEAD:gh-pages"; then
+                  rm -rf "${clone_dir}"
+                  exit 0
+              fi
+              push_status=$?
+              rm -rf "${clone_dir}"
+              cd "${GITHUB_WORKSPACE}"
+              if [ "${attempt}" -eq "${max_attempts}" ]; then
+                  exit "${push_status}"
+              fi
+              echo "Push rejected (attempt ${attempt}/${max_attempts}), re-indexing and retrying..."
+              attempt=$((attempt + 1))
+          done

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -28,6 +28,24 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.HELM_CHARTS_GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HELM_CHARTS_GH_APP_PRIVATE_KEY }}
+          owner: ${{ env.GH_OWNER }}
+          repositories: ${{ env.HELM_REP }}
+      - name: Resolve bot identity
+        id: bot
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          login="${APP_SLUG}[bot]"
+          bot_id="$(gh api "/users/${login}" --jq .id)"
+          echo "name=${login}" >> "${GITHUB_OUTPUT}"
+          echo "email=${bot_id}+${login}@users.noreply.github.com" >> "${GITHUB_OUTPUT}"
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -48,7 +66,7 @@ jobs:
           version: ${{ env.KIND_VERSION }}
           node_image: ${{ env.KIND_IMAGE }}
       - name: Run chart-testing
-        run: ct lint-and-install --validate-maintainers=false --charts ${{ env.CHART_DIR }}
+        run: ct lint-and-install --validate-maintainers=false --charts "${CHART_DIR}"
       - name: Install chart-releaser
         run: |
           wget https://github.com/helm/chart-releaser/releases/download/v1.3.0/chart-releaser_1.3.0_linux_amd64.tar.gz
@@ -56,29 +74,31 @@ jobs:
           tar xzvf chart-releaser_1.3.0_linux_amd64.tar.gz cr
       - name: Package helm chart
         run: |
-          ./cr package --package-path .cr-release-packages ${{ env.CHART_DIR }}
+          ./cr package --package-path .cr-release-packages "${CHART_DIR}"
       - name: Upload helm chart
         # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
         continue-on-error: true
+        env:
+          CR_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          ./cr upload --owner ${{ env.GH_OWNER }} \
-            --git-repo ${{ env.HELM_REP }} \
+          ./cr upload --owner "${GH_OWNER}" \
+            --git-repo "${HELM_REP}" \
             --package-path .cr-release-packages \
-            --token ${{ secrets.ORG_REPO_TOKEN }}
+            --token "${CR_TOKEN}"
       - name: Index helm chart
         run: |
-          ./cr index --owner ${{ env.GH_OWNER }} \
-            --git-repo ${{ env.HELM_REP }} \
-            --charts-repo https://${{ env.GH_OWNER }}.github.io/${{ env.HELM_REP }}/ \
+          ./cr index --owner "${GH_OWNER}" \
+            --git-repo "${HELM_REP}" \
+            --charts-repo "https://${GH_OWNER}.github.io/${HELM_REP}/" \
             --index-path index.yaml
       - name: Push index file
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # v1.1.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.ORG_REPO_TOKEN }}
+          API_TOKEN_GITHUB: ${{ steps.app-token.outputs.token }}
         with:
           source_file: "index.yaml"
           destination_repo: "${{ env.GH_OWNER }}/${{ env.HELM_REP }}"
           destination_folder: "."
           destination_branch: "gh-pages"
-          user_email: aqua-bot@users.noreply.github.com
-          user_name: "aqua-bot"
+          user_email: ${{ steps.bot.outputs.email }}
+          user_name: ${{ steps.bot.outputs.name }}

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -18,16 +18,19 @@ on:
         description: Validate chart and auth WITHOUT publishing to helm-charts (dry run)
         type: boolean
         default: false
-permissions:
-  contents: read
+
+permissions: {}
+
 env:
   HELM_REP: helm-charts
   GH_OWNER: aquasecurity
   CHART_DIR: deploy/helm/tracee
-  KIND_VERSION: "v0.14.0"
-  KIND_IMAGE: "kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae"
+
 jobs:
   publish:
+    name: ${{ inputs.dry-run && 'Publish Helm (dry run)' || 'Publish Helm' }}
+    permissions:
+      contents: read
     runs-on:
       # Ubuntu 24.04 generic (6.11.0-29) [x86_64]
       - graas_ami-03dbff05cae3a30d0_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
@@ -39,6 +42,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -47,6 +51,7 @@ jobs:
           private-key: ${{ secrets.HELM_CHARTS_GH_APP_PRIVATE_KEY }}
           owner: ${{ env.GH_OWNER }}
           repositories: ${{ env.HELM_REP }}
+
       - name: Resolve bot identity
         id: bot
         env:
@@ -57,35 +62,20 @@ jobs:
           bot_id="$(gh api "/users/${login}" --jq .id)"
           echo "name=${login}" >> "${GITHUB_OUTPUT}"
           echo "email=${bot_id}+${login}@users.noreply.github.com" >> "${GITHUB_OUTPUT}"
-      - name: Install Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.14.3
-      - name: Set up python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.12.3
-      - name: Set up aqua charts
-        run: |
-          helm repo add aqua https://aquasecurity.github.io/helm-charts
-      - name: Setup Chart Linting
-        id: lint
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
-      - name: Setup Kubernetes cluster (KIND)
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-        with:
-          version: ${{ env.KIND_VERSION }}
-          node_image: ${{ env.KIND_IMAGE }}
-      - name: Run chart-testing
-        run: ct lint-and-install --validate-maintainers=false --charts "${CHART_DIR}"
+
+      - name: Test Helm chart
+        uses: ./.github/actions/test-helm-chart
+
       - name: Install chart-releaser
         run: |
           wget https://github.com/helm/chart-releaser/releases/download/v1.3.0/chart-releaser_1.3.0_linux_amd64.tar.gz
           echo "baed2315a9bb799efb71d512c5198a2a3b8dcd139d7f22f878777cffcd649a37  chart-releaser_1.3.0_linux_amd64.tar.gz" | sha256sum -c -
           tar xzvf chart-releaser_1.3.0_linux_amd64.tar.gz cr
+
       - name: Package helm chart
         run: |
           ./cr package --package-path .cr-release-packages "${CHART_DIR}"
+
       - name: Upload helm chart
         # Failed with upload the same version: https://github.com/helm/chart-releaser/issues/101
         if: inputs.dry-run != true
@@ -97,12 +87,14 @@ jobs:
             --git-repo "${HELM_REP}" \
             --package-path .cr-release-packages \
             --token "${CR_TOKEN}"
+
       - name: Index helm chart
         run: |
           ./cr index --owner "${GH_OWNER}" \
             --git-repo "${HELM_REP}" \
             --charts-repo "https://${GH_OWNER}.github.io/${HELM_REP}/" \
             --index-path index.yaml
+
       - name: Verify helm-charts access
         if: inputs.dry-run == true
         env:
@@ -116,12 +108,14 @@ jobs:
           fi
           gh api "repos/${GH_OWNER}/${HELM_REP}/releases?per_page=1" >/dev/null
           echo "GitHub App token can access ${GH_OWNER}/${HELM_REP}"
+
       - name: Helm install dry-run
         if: inputs.dry-run == true
         run: |
           set -euo pipefail
           package_file="$(ls -1 .cr-release-packages/*.tgz | head -1)"
           helm install --dry-run tracee "${package_file}" -n tracee --create-namespace
+
       - name: Dry-run summary
         if: inputs.dry-run == true
         env:
@@ -129,6 +123,7 @@ jobs:
           REF: ${{ github.event.inputs.ref }}
           BOT_NAME: ${{ steps.bot.outputs.name }}
           BOT_EMAIL: ${{ steps.bot.outputs.email }}
+
         run: |
           set -euo pipefail
           chart_name="$(grep '^name:' "${CHART_DIR}/Chart.yaml" | awk '{print $2}' | tr -d '"')"
@@ -166,6 +161,7 @@ jobs:
               echo "- Push \`index.yaml\` to \`gh-pages\`"
           } >> "${GITHUB_STEP_SUMMARY}"
           echo "Dry run complete for ${chart_name} ${chart_version}"
+
       - name: Upload dry-run artifacts
         if: inputs.dry-run == true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -174,6 +170,7 @@ jobs:
           path: |
             .cr-release-packages/
             index.yaml
+
       - name: Push index file
         if: inputs.dry-run != true
         uses: dmnemec/copy_file_to_another_repo_action@c93037aa10fa8893de271f19978c980d0c1a9b37 # v1.1.1

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -28,7 +28,11 @@ env:
   KIND_IMAGE: "kindest/node:v1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae"
 jobs:
   publish:
-    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
+    runs-on:
+      # Ubuntu 24.04 generic (6.11.0-29) [x86_64]
+      - graas_ami-03dbff05cae3a30d0_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
+      - EXECUTION_TYPE=SHORT
+      - INSTANCE_TYPE=MEDIUM
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-helm-chart.yaml
+++ b/.github/workflows/test-helm-chart.yaml
@@ -4,10 +4,13 @@ on:
   pull_request:
     paths:
       - "deploy/helm/**"
-permissions:
-  contents: read
+
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
     steps:
       - name: Checkout
@@ -15,23 +18,5 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Helm
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: v3.14.3
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.12.3
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
-
-      - name: Run chart-testing (lint)
-        run: ct lint --config deploy/helm/ct.yaml --lint-conf  deploy/helm/lintconf.yaml --chart-yaml-schema deploy/helm/chart_schema.yaml
-
-      - name: Create KIND Cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
-
-      - name: Run chart-testing (install)
-        run: ct install --config deploy/helm/ct.yaml
+      - name: Test Helm chart
+        uses: ./.github/actions/test-helm-chart


### PR DESCRIPTION
### 1. Explain what the PR does

ae71ce80f **ci(publish-helm): add concurrency control**
51ed9c844 **ci(helm): extract shared chart test action**
8b174b85e **ci(publish-helm): use GRaaS**
c2dbf8dd4 **ci(publish-helm): add dry-run workflow input**
d9de7fd19 **ci(publish-helm): auth helm publish with GitHub App**


51ed9c844 **ci(helm): extract shared chart test action**

> Move Helm lint and KIND install checks into a composite action
> used by PR and publish workflows. Name the publish job for dry
> runs so manual validation runs are easy to spot.

--

c2dbf8dd4 **ci(publish-helm): add dry-run workflow input**

> Add a workflow_dispatch dry-run option to validate chart lint,
> app auth, and local packaging without uploading releases or
> pushing index.yaml. Report release collision status, upload
> artifacts, and write a job summary for review.

--

d9de7fd19 **ci(publish-helm): auth helm publish with GitHub App**

> Replace ORG_REPO_TOKEN with a scoped GitHub App installation
> token for chart upload and gh-pages index updates. Resolve the
> commit author from the app slug so index pushes are attributed
> to the correct bot user.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
