### PR TITLE
fix(publish-helm): fix invalid concurrency group

### DIFF
--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -22,7 +22,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: publish-helm-${{ env.HELM_REP }}
+  group: publish-helm-helm-charts
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
### 1. Explain what the PR does

adc14487d **fix(publish-helm): fix invalid concurrency group**

> The workflow-level concurrency key cannot reference the env context,
> which caused GitHub Actions to reject the workflow file. Use the
> literal helm-charts repo name instead.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

This fixes:

```
 Invalid workflow file

(Line: 25, Col: 10): Unrecognized named-value: 'env'. Located at position 1 within expression: env.HELM_REP

```
