### PR TITLE
perf: optimize memory profile around shared objs and kernel symbols

### DIFF
--- a/common/sharedobjs/host_symbols_loader.go
+++ b/common/sharedobjs/host_symbols_loader.go
@@ -3,12 +3,12 @@ package sharedobjs
 import (
 	"debug/elf"
 	"errors"
-	"strings"
 
 	"github.com/hashicorp/golang-lru/simplelru"
 	"golang.org/x/exp/maps"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
+	"github.com/aquasecurity/tracee/common/intern"
 	"github.com/aquasecurity/tracee/common/logger"
 )
 
@@ -150,23 +150,22 @@ func loadSharedObjectDynamicSymbols(path string) (*Symbols, error) {
 }
 
 func parseSymbols(symbols, dynamicSymbols []elf.Symbol) *Symbols {
-	objSymbols := NewSOSymbols()
+	nSym := len(symbols)
+	nDyn := len(dynamicSymbols)
+	objSymbols := Symbols{
+		Local:    make(map[string]bool, nSym+nDyn),
+		Imported: make(map[string]bool, nDyn),
+		Exported: make(map[string]bool, nDyn),
+	}
 	for i := range symbols {
 		sym := &symbols[i] // avoid copying the entire struct by taking its address
-		// NOTE(geyslan): unique.Handle might be a better choice here - and elsewhere -
-		// for deduplicating strings or avoiding retention of backing memory.
-		// Issue: #4761
 		if sym.Value != 0 {
-			name := strings.Clone(sym.Name)
-			objSymbols.Local[name] = true
+			objSymbols.Local[intern.String(sym.Name)] = true
 		}
 	}
 	for i := range dynamicSymbols {
 		sym := &dynamicSymbols[i] // avoid copying the entire struct by taking its address
-		// NOTE(geyslan): unique.Handle might be a better choice here - and elsewhere -
-		// for deduplicating strings or avoiding retention of backing memory.
-		// Issue: #4761
-		name := strings.Clone(sym.Name)
+		name := intern.String(sym.Name)
 		if sym.Library != "" || sym.Value == 0 {
 			objSymbols.Imported[name] = true
 		} else {

--- a/common/sharedobjs/host_symbols_loader.go
+++ b/common/sharedobjs/host_symbols_loader.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/hashicorp/golang-lru/simplelru"
-	"golang.org/x/exp/maps"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
 	"github.com/aquasecurity/tracee/common/intern"
@@ -30,48 +29,51 @@ func InitHostSymbolsLoader(cacheSize int) *HostSymbolsLoader {
 	}
 }
 
-// GetDynamicSymbols try to get shared objects dynamic symbols from lru, and if fails read needed information
-// from ELF file.
+// GetDynamicSymbols returns the union of imported and exported symbols of the
+// shared object. The returned map is freshly allocated on every call and is
+// safe for the caller to mutate.
 func (soLoader *HostSymbolsLoader) GetDynamicSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	dynSyms := copyMap(syms.Imported)
-	for expSym := range syms.Exported {
-		dynSyms[expSym] = true
-	}
-	return dynSyms, nil
+	return syms.View(CategoryDynamic), nil
 }
 
-// GetExportedSymbols try to get shared objects exported symbols from lru, and if fails read needed information
-// from ELF file.
-// The returned map is part of a cache, so if the user wants to modify it he should copy it and modify it there.
+// GetExportedSymbols returns the exported symbols of the shared object.
+//
+// The returned map is freshly built per call from the cached internal store;
+// callers may freely retain or mutate it.
 func (soLoader *HostSymbolsLoader) GetExportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	return syms.Exported, nil
+	return syms.View(CategoryExported), nil
 }
 
-// GetImportedSymbols try to get shared objects imported symbols from lru, and if fails read needed information
-// from ELF file.
-// The returned map is part of a cache, so if the user wants to modify it he should copy it and modify it there.
+// GetImportedSymbols returns the imported symbols of the shared object.
+//
+// The returned map is freshly built per call from the cached internal store;
+// callers may freely retain or mutate it.
 func (soLoader *HostSymbolsLoader) GetImportedSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	return syms.Imported, nil
+	return syms.View(CategoryImported), nil
 }
 
+// GetLocalSymbols returns the local symbols of the shared object.
+//
+// The returned map is freshly built per call from the cached internal store;
+// callers may freely retain or mutate it.
 func (soLoader *HostSymbolsLoader) GetLocalSymbols(soInfo ObjInfo) (map[string]bool, error) {
 	syms, err := soLoader.loadSOSymbols(soInfo)
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}
-	return syms.Local, nil
+	return syms.View(CategoryLocal), nil
 }
 
 func (soLoader *HostSymbolsLoader) loadSOSymbols(soInfo ObjInfo) (*Symbols, error) {
@@ -149,35 +151,31 @@ func loadSharedObjectDynamicSymbols(path string) (*Symbols, error) {
 	return parseSymbols(symbols, dynamicSymbols), nil
 }
 
+// parseSymbols classifies ELF symbols into a compact Symbols store.
+//
+// All names are canonicalized via intern.String (Geyslan, issue #4761) so
+// identical symbols across SOs share one backing buffer, and a symbol that
+// belongs to more than one category (e.g. Local + Exported) occupies a single
+// map entry whose category bits are OR'd together.
 func parseSymbols(symbols, dynamicSymbols []elf.Symbol) *Symbols {
-	nSym := len(symbols)
-	nDyn := len(dynamicSymbols)
-	objSymbols := Symbols{
-		Local:    make(map[string]bool, nSym+nDyn),
-		Imported: make(map[string]bool, nDyn),
-		Exported: make(map[string]bool, nDyn),
-	}
+	// Upper bound: every symbol contributes at most one map entry. Pre-sizing
+	// to the sum keeps map growth out of the parse hot path even when there is
+	// no overlap between the two input slices.
+	objSymbols := newSymbolsWithCapacity(len(symbols) + len(dynamicSymbols))
 	for i := range symbols {
 		sym := &symbols[i] // avoid copying the entire struct by taking its address
 		if sym.Value != 0 {
-			objSymbols.Local[intern.String(sym.Name)] = true
+			objSymbols.add(intern.String(sym.Name), CategoryLocal)
 		}
 	}
 	for i := range dynamicSymbols {
 		sym := &dynamicSymbols[i] // avoid copying the entire struct by taking its address
 		name := intern.String(sym.Name)
 		if sym.Library != "" || sym.Value == 0 {
-			objSymbols.Imported[name] = true
+			objSymbols.add(name, CategoryImported)
 		} else {
-			objSymbols.Local[name] = true
-			objSymbols.Exported[name] = true
+			objSymbols.add(name, CategoryLocal|CategoryExported)
 		}
 	}
-	return &objSymbols
-}
-
-func copyMap(source map[string]bool) map[string]bool {
-	copiedMap := make(map[string]bool, len(source))
-	maps.Copy(copiedMap, source)
-	return copiedMap
+	return objSymbols
 }

--- a/common/sharedobjs/host_symbols_loader_bench_test.go
+++ b/common/sharedobjs/host_symbols_loader_bench_test.go
@@ -57,6 +57,7 @@ func benchSymbolSetUnique(n int) (static, dyn []elf.Symbol) {
 
 func BenchmarkParseSymbols(b *testing.B) {
 	static, dyn := benchSymbolSetDeduped(4000)
+	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		parseSymbols(static, dyn)
@@ -65,6 +66,7 @@ func BenchmarkParseSymbols(b *testing.B) {
 
 func BenchmarkParseSymbolsUniqueNames(b *testing.B) {
 	static, dyn := benchSymbolSetUnique(4000)
+	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		parseSymbols(static, dyn)

--- a/common/sharedobjs/host_symbols_loader_bench_test.go
+++ b/common/sharedobjs/host_symbols_loader_bench_test.go
@@ -1,0 +1,72 @@
+package sharedobjs
+
+import (
+	"debug/elf"
+	"fmt"
+	"testing"
+)
+
+// benchSymbolSetDeduped builds inputs where every name repeats. This stresses
+// the intern (unique) deduplication path because intern.String can fold every
+// occurrence onto one canonical handle.
+func benchSymbolSetDeduped(n int) (static, dyn []elf.Symbol) {
+	static = make([]elf.Symbol, 0, n/2)
+	dyn = make([]elf.Symbol, 0, n/2)
+	for i := 0; i < n/2; i++ {
+		static = append(static, elf.Symbol{Name: "local_sym", Value: uint64(i + 1)})
+	}
+	for i := 0; i < n/2; i++ {
+		if i%3 == 0 {
+			dyn = append(dyn, elf.Symbol{Name: "import_sym", Library: "libc.so.6", Value: 0})
+		} else {
+			dyn = append(dyn, elf.Symbol{Name: "export_sym", Value: uint64(i + 1)})
+		}
+	}
+	return static, dyn
+}
+
+// benchSymbolSetUnique builds inputs where every name is distinct. This is the
+// pessimistic case for intern dedup (no folding possible) and the realistic
+// stress case for the single-map layout, because every name produces
+// exactly one map entry instead of up to three.
+func benchSymbolSetUnique(n int) (static, dyn []elf.Symbol) {
+	static = make([]elf.Symbol, 0, n/2)
+	dyn = make([]elf.Symbol, 0, n/2)
+	for i := 0; i < n/2; i++ {
+		static = append(static, elf.Symbol{
+			Name:  fmt.Sprintf("local_sym_%06d", i),
+			Value: uint64(i + 1),
+		})
+	}
+	for i := 0; i < n/2; i++ {
+		if i%3 == 0 {
+			dyn = append(dyn, elf.Symbol{
+				Name:    fmt.Sprintf("import_sym_%06d", i),
+				Library: "libc.so.6",
+				Value:   0,
+			})
+		} else {
+			dyn = append(dyn, elf.Symbol{
+				Name:  fmt.Sprintf("export_sym_%06d", i),
+				Value: uint64(i + 1),
+			})
+		}
+	}
+	return static, dyn
+}
+
+func BenchmarkParseSymbols(b *testing.B) {
+	static, dyn := benchSymbolSetDeduped(4000)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseSymbols(static, dyn)
+	}
+}
+
+func BenchmarkParseSymbolsUniqueNames(b *testing.B) {
+	static, dyn := benchSymbolSetUnique(4000)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseSymbols(static, dyn)
+	}
+}

--- a/common/sharedobjs/host_symbols_loader_test.go
+++ b/common/sharedobjs/host_symbols_loader_test.go
@@ -29,6 +29,23 @@ func (s soCacheMock) Add(obj ObjInfo, dynamicSymbols *Symbols) {
 	}
 }
 
+// newTestSymbols builds a *Symbols populated with the given category
+// memberships. It is the test-only counterpart of the legacy literal
+// constructor `&Symbols{Exported: ..., Imported: ..., Local: ...}`.
+func newTestSymbols(local, imported, exported []string) *Symbols {
+	s := &Symbols{m: make(map[string]SymbolCategory)}
+	for _, name := range local {
+		s.add(name, CategoryLocal)
+	}
+	for _, name := range imported {
+		s.add(name, CategoryImported)
+	}
+	for _, name := range exported {
+		s.add(name, CategoryExported)
+	}
+	return s
+}
+
 var testLoadedObjectInfo = ObjInfo{
 	Id: ObjID{
 		Inode:  10,
@@ -39,10 +56,7 @@ var testLoadedObjectInfo = ObjInfo{
 	MountNS: 1,
 }
 
-var testDynamicSymbols = &Symbols{
-	Exported: map[string]bool{"open": true, "close": true},
-	Imported: map[string]bool{"syscall": true},
-}
+var testDynamicSymbols = newTestSymbols(nil, []string{"syscall"}, []string{"open", "close"})
 
 func TestHostSharedObjectSymbolsLoader_GetDynamicSymbols(t *testing.T) {
 	t.Parallel()
@@ -237,44 +251,34 @@ func TestParseDynamicSymbols(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		Name          string
-		Input         []elf.Symbol
-		ExpecteResult Symbols
+		Name           string
+		Input          []elf.Symbol
+		ExpectedImport map[string]bool
+		ExpectedExport map[string]bool
 	}{
 		{
-			Name:          "No symbols",
-			Input:         []elf.Symbol{},
-			ExpecteResult: NewSOSymbols(),
+			Name:           "No symbols",
+			Input:          []elf.Symbol{},
+			ExpectedImport: map[string]bool{},
+			ExpectedExport: map[string]bool{},
 		},
 		{
-			Name:  "Full details import symbols",
-			Input: []elf.Symbol{{Name: "__ctype_toupper_loc", Info: 18, Section: elf.SHN_UNDEF + 12, Version: "GLIBC_2.3", Library: "libc.so.6"}},
-			ExpecteResult: Symbols{
-				Exported: make(map[string]bool),
-				Imported: map[string]bool{
-					"__ctype_toupper_loc": true,
-				},
-			},
+			Name:           "Full details import symbols",
+			Input:          []elf.Symbol{{Name: "__ctype_toupper_loc", Info: 18, Section: elf.SHN_UNDEF + 12, Version: "GLIBC_2.3", Library: "libc.so.6"}},
+			ExpectedImport: map[string]bool{"__ctype_toupper_loc": true},
+			ExpectedExport: map[string]bool{},
 		},
 		{
-			Name:  "Missing details import symbol",
-			Input: []elf.Symbol{{Name: "cap_to_text", Info: 18, Section: elf.SHN_UNDEF}},
-			ExpecteResult: Symbols{
-				Exported: make(map[string]bool),
-				Imported: map[string]bool{
-					"cap_to_text": true,
-				},
-			},
+			Name:           "Missing details import symbol",
+			Input:          []elf.Symbol{{Name: "cap_to_text", Info: 18, Section: elf.SHN_UNDEF}},
+			ExpectedImport: map[string]bool{"cap_to_text": true},
+			ExpectedExport: map[string]bool{},
 		},
 		{
-			Name:  "Export import symbol",
-			Input: []elf.Symbol{{Name: "_obstack_memory_used", Info: 18, Section: elf.SHN_UNDEF + 12, Value: 55424, Size: 38}},
-			ExpecteResult: Symbols{
-				Exported: map[string]bool{
-					"_obstack_memory_used": true,
-				},
-				Imported: make(map[string]bool),
-			},
+			Name:           "Export import symbol",
+			Input:          []elf.Symbol{{Name: "_obstack_memory_used", Info: 18, Section: elf.SHN_UNDEF + 12, Value: 55424, Size: 38}},
+			ExpectedImport: map[string]bool{},
+			ExpectedExport: map[string]bool{"_obstack_memory_used": true},
 		},
 		{
 			Name: "Mixed symbols",
@@ -283,14 +287,12 @@ func TestParseDynamicSymbols(t *testing.T) {
 				{Name: "cap_to_text", Info: 18, Section: elf.SHN_UNDEF},
 				{Name: "_obstack_memory_used", Info: 18, Section: elf.SHN_UNDEF + 12, Value: 55424, Size: 38},
 			},
-			ExpecteResult: Symbols{
-				Exported: map[string]bool{
-					"_obstack_memory_used": true,
-				},
-				Imported: map[string]bool{
-					"__ctype_toupper_loc": true,
-					"cap_to_text":         true,
-				},
+			ExpectedImport: map[string]bool{
+				"__ctype_toupper_loc": true,
+				"cap_to_text":         true,
+			},
+			ExpectedExport: map[string]bool{
+				"_obstack_memory_used": true,
 			},
 		},
 	}
@@ -302,8 +304,8 @@ func TestParseDynamicSymbols(t *testing.T) {
 			t.Parallel()
 
 			dynamicSymbols := parseSymbols([]elf.Symbol{}, testCase.Input)
-			assert.Equal(t, fmt.Sprint(testCase.ExpecteResult.Imported), fmt.Sprint(dynamicSymbols.Imported))
-			assert.Equal(t, fmt.Sprint(testCase.ExpecteResult.Exported), fmt.Sprint(dynamicSymbols.Exported))
+			assert.Equal(t, fmt.Sprint(testCase.ExpectedImport), fmt.Sprint(dynamicSymbols.View(CategoryImported)))
+			assert.Equal(t, fmt.Sprint(testCase.ExpectedExport), fmt.Sprint(dynamicSymbols.View(CategoryExported)))
 		})
 	}
 }
@@ -333,11 +335,11 @@ func TestInitHostSymbolsLoader(t *testing.T) {
 func TestHostSharedObjectSymbolsLoader_GetLocalSymbols(t *testing.T) {
 	t.Parallel()
 
-	testSymbols := &Symbols{
-		Exported: map[string]bool{"open": true},
-		Imported: map[string]bool{"syscall": true},
-		Local:    map[string]bool{"local_func": true, "local_var": true},
-	}
+	testSymbols := newTestSymbols(
+		[]string{"local_func", "local_var"},
+		[]string{"syscall"},
+		[]string{"open"},
+	)
 
 	t.Run("Happy flow", func(t *testing.T) {
 		t.Parallel()
@@ -358,7 +360,7 @@ func TestHostSharedObjectSymbolsLoader_GetLocalSymbols(t *testing.T) {
 		result, err := loader.GetLocalSymbols(testLoadedObjectInfo)
 
 		require.NoError(t, err)
-		assert.Equal(t, testSymbols.Local, result)
+		assert.Equal(t, testSymbols.View(CategoryLocal), result)
 	})
 
 	t.Run("Sad flow", func(t *testing.T) {
@@ -389,11 +391,11 @@ func TestDynamicSymbolsLRUCache_Get(t *testing.T) {
 	cache, ok := loader.soCache.(*dynamicSymbolsLRUCache)
 	require.True(t, ok)
 
-	testSymbols := &Symbols{
-		Exported: map[string]bool{"test": true},
-		Imported: map[string]bool{"import": true},
-		Local:    map[string]bool{"local": true},
-	}
+	testSymbols := newTestSymbols(
+		[]string{"local"},
+		[]string{"import"},
+		[]string{"test"},
+	)
 
 	// Test cache miss
 	result, found := cache.Get(testLoadedObjectInfo.Id)
@@ -414,17 +416,8 @@ func TestDynamicSymbolsLRUCache_Add(t *testing.T) {
 	cache, ok := loader.soCache.(*dynamicSymbolsLRUCache)
 	require.True(t, ok)
 
-	testSymbols1 := &Symbols{
-		Exported: map[string]bool{"test1": true},
-		Imported: map[string]bool{"import1": true},
-		Local:    map[string]bool{"local1": true},
-	}
-
-	testSymbols2 := &Symbols{
-		Exported: map[string]bool{"test2": true},
-		Imported: map[string]bool{"import2": true},
-		Local:    map[string]bool{"local2": true},
-	}
+	testSymbols1 := newTestSymbols([]string{"local1"}, []string{"import1"}, []string{"test1"})
+	testSymbols2 := newTestSymbols([]string{"local2"}, []string{"import2"}, []string{"test2"})
 
 	obj1 := ObjInfo{Id: ObjID{Inode: 1, Device: 1, Ctime: 1}, Path: "/test1.so"}
 	obj2 := ObjInfo{Id: ObjID{Inode: 2, Device: 2, Ctime: 2}, Path: "/test2.so"}
@@ -502,12 +495,13 @@ func TestParseSymbols_LocalSymbols(t *testing.T) {
 
 	result := parseSymbols(localSymbols, []elf.Symbol{})
 
-	assert.Len(t, result.Local, 2)
-	assert.True(t, result.Local["local_func1"])
-	assert.True(t, result.Local["local_func2"])
-	assert.False(t, result.Local["zero_value_func"])
-	assert.Empty(t, result.Imported)
-	assert.Empty(t, result.Exported)
+	local := result.View(CategoryLocal)
+	assert.Len(t, local, 2)
+	assert.True(t, local["local_func1"])
+	assert.True(t, local["local_func2"])
+	assert.False(t, local["zero_value_func"])
+	assert.Empty(t, result.View(CategoryImported))
+	assert.Empty(t, result.View(CategoryExported))
 }
 
 func TestParseSymbols_MixedSymbols(t *testing.T) {
@@ -526,31 +520,83 @@ func TestParseSymbols_MixedSymbols(t *testing.T) {
 	result := parseSymbols(localSymbols, dynamicSymbols)
 
 	// Local symbols
-	assert.Len(t, result.Local, 3) // local_func, export_func, both_func
-	assert.True(t, result.Local["local_func"])
-	assert.True(t, result.Local["export_func"])
-	assert.True(t, result.Local["both_func"])
-	assert.False(t, result.Local["zero_local"])
+	local := result.View(CategoryLocal)
+	assert.Len(t, local, 3) // local_func, export_func, both_func
+	assert.True(t, local["local_func"])
+	assert.True(t, local["export_func"])
+	assert.True(t, local["both_func"])
+	assert.False(t, local["zero_local"])
 
 	// Imported symbols
-	assert.Len(t, result.Imported, 1)
-	assert.True(t, result.Imported["import_func"])
+	imported := result.View(CategoryImported)
+	assert.Len(t, imported, 1)
+	assert.True(t, imported["import_func"])
 
 	// Exported symbols
-	assert.Len(t, result.Exported, 2) // export_func, both_func
-	assert.True(t, result.Exported["export_func"])
-	assert.True(t, result.Exported["both_func"])
+	exported := result.View(CategoryExported)
+	assert.Len(t, exported, 2) // export_func, both_func
+	assert.True(t, exported["export_func"])
+	assert.True(t, exported["both_func"])
+}
+
+func TestParseSymbols_OverlapDedupesEntries(t *testing.T) {
+	// A symbol that is both Local (static) and Exported (dynamic) should occupy
+	// a single internal map entry whose category bits are OR'd together.
+	localSymbols := []elf.Symbol{
+		{Name: "shared_sym", Value: 0x1000},
+	}
+	dynamicSymbols := []elf.Symbol{
+		{Name: "shared_sym", Value: 0x1000}, // local + exported
+	}
+
+	result := parseSymbols(localSymbols, dynamicSymbols)
+
+	assert.Equal(t, 1, result.Len(), "overlapping name must collapse to one entry")
+	assert.True(t, result.Has("shared_sym", CategoryLocal))
+	assert.True(t, result.Has("shared_sym", CategoryExported))
+	assert.False(t, result.Has("shared_sym", CategoryImported))
 }
 
 func TestNewSOSymbols(t *testing.T) {
 	symbols := NewSOSymbols()
 
-	assert.NotNil(t, symbols.Exported)
-	assert.NotNil(t, symbols.Imported)
-	assert.NotNil(t, symbols.Local)
-	assert.Empty(t, symbols.Exported)
-	assert.Empty(t, symbols.Imported)
-	assert.Empty(t, symbols.Local)
+	assert.NotNil(t, symbols.m)
+	assert.Equal(t, 0, symbols.Len())
+	assert.Empty(t, symbols.View(CategoryLocal))
+	assert.Empty(t, symbols.View(CategoryImported))
+	assert.Empty(t, symbols.View(CategoryExported))
+	assert.Empty(t, symbols.View(CategoryDynamic))
+}
+
+func TestSymbols_View(t *testing.T) {
+	s := newTestSymbols(
+		[]string{"a", "shared"},
+		[]string{"b"},
+		[]string{"c", "shared"},
+	)
+
+	// shared is Local|Exported, so it appears in both views.
+	assert.Equal(t, map[string]bool{"a": true, "shared": true}, s.View(CategoryLocal))
+	assert.Equal(t, map[string]bool{"b": true}, s.View(CategoryImported))
+	assert.Equal(t, map[string]bool{"c": true, "shared": true}, s.View(CategoryExported))
+	assert.Equal(t, map[string]bool{"b": true, "c": true, "shared": true}, s.View(CategoryDynamic))
+
+	// View returns a fresh map: mutating it must not change subsequent views.
+	v := s.View(CategoryLocal)
+	v["new"] = true
+	assert.False(t, s.Has("new", CategoryLocal))
+}
+
+func TestSymbols_Has(t *testing.T) {
+	s := newTestSymbols([]string{"a"}, []string{"b"}, []string{"c"})
+
+	assert.True(t, s.Has("a", CategoryLocal))
+	assert.False(t, s.Has("a", CategoryExported))
+	assert.True(t, s.Has("b", CategoryImported))
+	assert.True(t, s.Has("b", CategoryDynamic))
+	assert.True(t, s.Has("c", CategoryExported))
+	assert.True(t, s.Has("c", CategoryDynamic))
+	assert.False(t, s.Has("missing", CategoryLocal|CategoryImported|CategoryExported))
 }
 
 func TestInitUnsupportedFileError(t *testing.T) {
@@ -574,28 +620,4 @@ func TestUnsupportedFileError_Unwrap(t *testing.T) {
 
 	unwrapped := unsupportedErr.Unwrap()
 	assert.Equal(t, originalErr, unwrapped)
-}
-
-func TestCopyMap(t *testing.T) {
-	original := map[string]bool{
-		"key1": true,
-		"key2": false,
-		"key3": true,
-	}
-
-	copied := copyMap(original)
-
-	// Check that all values are copied
-	assert.Equal(t, original, copied)
-
-	// Check that it's a different map (modifying one doesn't affect the other)
-	copied["key4"] = true
-	assert.False(t, original["key4"])
-	assert.True(t, copied["key4"])
-
-	// Test with empty map
-	emptyOriginal := map[string]bool{}
-	emptyCopied := copyMap(emptyOriginal)
-	assert.Equal(t, emptyOriginal, emptyCopied)
-	assert.Len(t, emptyCopied, 0)
 }

--- a/common/sharedobjs/shared_object.go
+++ b/common/sharedobjs/shared_object.go
@@ -21,18 +21,80 @@ type DynamicSymbolsLoader interface {
 	GetLocalSymbols(info ObjInfo) (map[string]bool, error)
 }
 
+// SymbolCategory is a bitmask describing how a symbol participates in a
+// shared object: it may be Local, Imported, Exported, or any combination.
+//
+// Using a bitmask keeps a single map entry per symbol name even when the same
+// name belongs to multiple categories (e.g. an Exported symbol is also Local).
+// Storing one entry instead of three independent map entries is the primary
+// memory win behind the redesign tracked by issue #4761.
+type SymbolCategory uint8
+
+const (
+	CategoryLocal SymbolCategory = 1 << iota
+	CategoryImported
+	CategoryExported
+
+	// CategoryDynamic is a convenience mask matching anything that appears in
+	// the dynamic symbol table: imports plus exports.
+	CategoryDynamic = CategoryImported | CategoryExported
+)
+
+// Symbols holds the classified symbols of a single shared object.
+//
+// Internally each unique symbol name maps to a SymbolCategory bitmask. Views
+// onto a specific category (Local / Imported / Exported / Dynamic) are
+// materialized on demand via View and are owned by the caller.
 type Symbols struct {
-	Exported map[string]bool
-	Imported map[string]bool
-	Local    map[string]bool
+	m map[string]SymbolCategory
 }
 
+// NewSOSymbols returns an empty Symbols container.
 func NewSOSymbols() Symbols {
-	return Symbols{
-		Exported: make(map[string]bool),
-		Imported: make(map[string]bool),
-		Local:    make(map[string]bool),
+	return Symbols{m: make(map[string]SymbolCategory)}
+}
+
+// newSymbolsWithCapacity returns an empty Symbols container with the map
+// pre-sized to at least capacity entries. Used by the parser to avoid map
+// growth churn on large ELF symbol tables.
+func newSymbolsWithCapacity(capacity int) *Symbols {
+	return &Symbols{m: make(map[string]SymbolCategory, capacity)}
+}
+
+// add records name as belonging to cat. If name already exists, the new bits
+// are OR'd into the existing categories.
+func (s *Symbols) add(name string, cat SymbolCategory) {
+	s.m[name] |= cat
+}
+
+// Has reports whether name matches any of the bits in mask.
+func (s *Symbols) Has(name string, mask SymbolCategory) bool {
+	return s.m[name]&mask != 0
+}
+
+// Len returns the number of distinct symbol names stored across all
+// categories.
+func (s *Symbols) Len() int { return len(s.m) }
+
+// View returns a fresh map[string]bool of all names matching any of the bits
+// in mask. The returned map is owned by the caller and is safe to mutate; it
+// is recomputed on every call.
+//
+// View intentionally allocates: the live-heap footprint of cached Symbols is
+// constant in the number of unique names, regardless of how many categories
+// each name belongs to. Callers that need repeated category iteration over
+// the same object should cache the result themselves.
+func (s *Symbols) View(mask SymbolCategory) map[string]bool {
+	if len(s.m) == 0 {
+		return map[string]bool{}
 	}
+	out := make(map[string]bool, len(s.m))
+	for name, c := range s.m {
+		if c&mask != 0 {
+			out[name] = true
+		}
+	}
+	return out
 }
 
 type UnsupportedFileError struct {

--- a/common/sharedobjs/shared_object.go
+++ b/common/sharedobjs/shared_object.go
@@ -80,10 +80,11 @@ func (s *Symbols) Len() int { return len(s.m) }
 // in mask. The returned map is owned by the caller and is safe to mutate; it
 // is recomputed on every call.
 //
-// View intentionally allocates: the live-heap footprint of cached Symbols is
-// constant in the number of unique names, regardless of how many categories
-// each name belongs to. Callers that need repeated category iteration over
-// the same object should cache the result themselves.
+// View allocates a fresh map on every call by design. The layout collapses
+// three parallel maps (Local / Imported / Exported) into one bitmask-backed
+// store, saving two map headers and bucket arrays per cached Symbols.
+// Callers that iterate the same category repeatedly should cache the
+// returned map.
 func (s *Symbols) View(mask SymbolCategory) map[string]bool {
 	if len(s.m) == 0 {
 		return map[string]bool{}

--- a/pkg/datastores/symbol/kernel.go
+++ b/pkg/datastores/symbol/kernel.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/aquasecurity/tracee/common/errfmt"
+	"github.com/aquasecurity/tracee/common/intern"
 )
 
 const (
@@ -122,7 +123,7 @@ func NewKernelSymbolTable(lazyNameLookup bool, requiredDataSymbolsOnly bool, req
 // Read the contents of the given buffer and update the symbol table
 func (kst *KernelSymbolTable) update(reader io.Reader, requiredDataSymbolsOnly bool, requiredDataSymbols []string) error {
 	// Build set of required data symbols for efficient lookup
-	requiredDataSymbolsSet := make(map[string]struct{})
+	requiredDataSymbolsSet := make(map[string]struct{}, len(requiredDataSymbols))
 	for _, symbolName := range requiredDataSymbols {
 		requiredDataSymbolsSet[symbolName] = struct{}{}
 	}
@@ -162,17 +163,27 @@ func (kst *KernelSymbolTable) update(reader io.Reader, requiredDataSymbolsOnly b
 			symbolOwner = strings.TrimSuffix(symbolOwner, "]")
 		}
 
-		// This is a data symbol, requiredDataSymbolsOnly is true, and this symbol isn't required
+		// This is a data symbol, requiredDataSymbolsOnly is true, and this symbol isn't required.
+		// Filter using the scanner-substring view to avoid an intern allocation for skipped symbols.
 		if requiredDataSymbolsOnly && strings.ContainsAny(symbolType, "DdBbRr") {
 			if _, exists := requiredDataSymbolsSet[symbolName]; !exists {
 				continue
 			}
 		}
 
+		// Detach the name from the per-line scanner.Text() allocation: fields[2]
+		// is a substring of that buffer, so retaining it would pin the whole line
+		// for the lifetime of the symbol table. Kernel symbol names are mostly
+		// unique (~200K distinct entries), so we use strings.Clone rather than the
+		// intern table — interning here was measured to cost ~25 MiB and ~870k
+		// extra allocations per load with no dedup benefit (see issue #4761
+		// discussion and pkg/datastores/symbol bench history).
+		ownedName := strings.Clone(symbolName)
+
 		// Get index of symbol owner, or add it if it doesn't exist
 		ownerIdx := kst.getOrAddSymbolOwner(symbolOwner)
 
-		symbols = append(symbols, newKernelSymbolInternal(symbolName, symbolAddr, ownerIdx))
+		symbols = append(symbols, newKernelSymbolInternal(ownedName, symbolAddr, ownerIdx))
 	}
 
 	// We didn't hold the required privileges
@@ -189,6 +200,12 @@ func (kst *KernelSymbolTable) update(reader io.Reader, requiredDataSymbolsOnly b
 func (kst *KernelSymbolTable) getOrAddSymbolOwner(ownerStr string) uint16 {
 	ownerIdx, found := kst.symbolOwnerToIdx[ownerStr]
 	if !found {
+		// First time we see this owner. ownerStr is a substring of the scanner's
+		// per-line buffer; intern it so we don't pin the line and so subsequent
+		// modules with the same owner string share one canonical copy. Owners
+		// form a small set (tens of modules) with very high reuse, which is
+		// exactly the workload intern.String is good at.
+		ownerStr = intern.String(ownerStr)
 		kst.idxToSymbolOwner = append(kst.idxToSymbolOwner, ownerStr)
 		ownerIdx = uint16(len(kst.idxToSymbolOwner) - 1)
 		kst.symbolOwnerToIdx[ownerStr] = ownerIdx

--- a/pkg/datastores/symbol/kernel_bench_test.go
+++ b/pkg/datastores/symbol/kernel_bench_test.go
@@ -1,0 +1,80 @@
+package symbol
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// buildKallsymsBuffer produces a synthetic /proc/kallsyms-like buffer with the
+// given number of symbol lines, simulating a realistic mix of name lengths and
+// owners. A handful of owner strings are reused across many symbols (matching
+// how real kallsyms looks: most modules contribute multiple symbols).
+func buildKallsymsBuffer(numSymbols int) string {
+	owners := []string{
+		"system",
+		"libbpf",
+		"bpf",
+		"nf_tables",
+		"i915",
+		"snd_hda_intel",
+		"kvm_intel",
+		"ext4",
+		"overlay",
+	}
+
+	var b strings.Builder
+	b.Grow(numSymbols * 64)
+	for i := 0; i < numSymbols; i++ {
+		addr := uint64(0xffffffff00000000) | uint64(i+1)
+		// Sprinkle some name reuse to exercise intern dedup
+		var name string
+		switch i % 5 {
+		case 0:
+			name = fmt.Sprintf("sys_call_%06d", i)
+		case 1:
+			name = fmt.Sprintf("__do_softirq_%06d", i)
+		case 2:
+			name = "kfree" // repeats: identical name across many addresses
+		case 3:
+			name = fmt.Sprintf("vfs_read_%06d", i)
+		default:
+			name = "schedule" // repeats
+		}
+
+		if i%7 == 0 {
+			// System symbol (no owner column)
+			fmt.Fprintf(&b, "%016x t %s\n", addr, name)
+		} else {
+			owner := owners[i%len(owners)]
+			fmt.Fprintf(&b, "%016x t %s [%s]\n", addr, name, owner)
+		}
+	}
+	return b.String()
+}
+
+func BenchmarkKernelSymbolTableUpdate(b *testing.B) {
+	buf := buildKallsymsBuffer(200_000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := NewKernelSymbolTableFromReader(strings.NewReader(buf), false, false)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkKernelSymbolTableUpdateLazy exercises the lazy-name-lookup path
+// used by most production callers (cheaper map maintenance during load).
+func BenchmarkKernelSymbolTableUpdateLazy(b *testing.B) {
+	buf := buildKallsymsBuffer(200_000)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := NewKernelSymbolTableFromReader(strings.NewReader(buf), true, false)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
### 1. Explain what the PR does

52b153b2c **perf(datastores): break per-line scanner buffer retention**
5259d0c4c **perf(common): collapsed the three parallel maps from shareobjs into one bitmask-backed store**
eaf43f2a2 **perf(common): optimize parseSymbols for better heap live cost**

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
