### PR TITLE
fix(grpc): sanitize invalid UTF-8 in sockaddr conversion

### DIFF
--- a/pkg/server/grpc/event_data.go
+++ b/pkg/server/grpc/event_data.go
@@ -400,12 +400,12 @@ func getSockaddr(v map[string]string) (*pb.EventValue, error) {
 		sockaddr = &pb.SockAddr{
 			SaFamily: pb.SaFamilyT_AF_INET,
 			SinPort:  uint32(sinport),
-			SinAddr:  v["sin_addr"],
+			SinAddr:  sanitizeStringForProtobuf(v["sin_addr"]),
 		}
 	case "AF_UNIX":
 		sockaddr = &pb.SockAddr{
 			SaFamily: pb.SaFamilyT_AF_UNIX,
-			SunPath:  v["sun_path"],
+			SunPath:  sanitizeStringForProtobuf(v["sun_path"]),
 		}
 	case "AF_INET6":
 		sinport, err := strconv.ParseUint(v["sin6_port"], 10, 32)
@@ -428,7 +428,7 @@ func getSockaddr(v map[string]string) (*pb.EventValue, error) {
 			Sin6Port:     uint32(sinport),
 			Sin6Flowinfo: uint32(sin6Flowinfo),
 			Sin6Scopeid:  uint32(sin6Scopeid),
-			Sin6Addr:     v["sin6_addr"],
+			Sin6Addr:     sanitizeStringForProtobuf(v["sin6_addr"]),
 		}
 	}
 

--- a/pkg/server/grpc/event_data_test.go
+++ b/pkg/server/grpc/event_data_test.go
@@ -3,8 +3,10 @@ package grpc
 import (
 	"reflect"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -1109,6 +1111,94 @@ func Test_sanitizeValueForProtobuf(t *testing.T) {
 
 			result := sanitizeValueForProtobuf(tt.input)
 			tt.validate(t, result)
+		})
+	}
+}
+
+// Test_getSockaddr_InvalidUTF8 reproduces issue #5292: a getsockname
+// (sockaddr_t) argument can carry non-UTF-8 bytes in sun_path / sin_addr /
+// sin6_addr. Those land in proto3 string fields, which require valid UTF-8,
+// so proto.Marshal fails with "string field contains invalid UTF-8" and the
+// StreamEvents gRPC stream dies. After sanitization the resulting message must
+// marshal cleanly while valid paths stay byte-for-byte unchanged.
+func Test_getSockaddr_InvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// Abstract AF_UNIX socket paths begin with a NUL byte and may contain
+	// arbitrary binary bytes; 0x80 is a lone continuation byte and is not
+	// valid UTF-8 on its own.
+	invalidSunPath := "\x00abstract\x80\xff/sock"
+
+	tests := []struct {
+		name     string
+		argValue map[string]string
+		assertFn func(t *testing.T, sa *pb.SockAddr)
+	}{
+		{
+			name:     "AF_UNIX invalid sun_path",
+			argValue: map[string]string{"sa_family": "AF_UNIX", "sun_path": invalidSunPath},
+			assertFn: func(t *testing.T, sa *pb.SockAddr) {
+				assert.True(t, utf8.ValidString(sa.GetSunPath()), "sanitized sun_path must be valid UTF-8")
+			},
+		},
+		{
+			name:     "AF_UNIX valid sun_path unchanged",
+			argValue: map[string]string{"sa_family": "AF_UNIX", "sun_path": "/tmp/socket"},
+			assertFn: func(t *testing.T, sa *pb.SockAddr) {
+				assert.Equal(t, "/tmp/socket", sa.GetSunPath(), "valid sun_path must be unchanged")
+			},
+		},
+		{
+			name:     "AF_INET invalid sin_addr",
+			argValue: map[string]string{"sa_family": "AF_INET", "sin_addr": "1.2.3.4\xff", "sin_port": "80"},
+			assertFn: func(t *testing.T, sa *pb.SockAddr) {
+				assert.True(t, utf8.ValidString(sa.GetSinAddr()), "sanitized sin_addr must be valid UTF-8")
+				assert.Equal(t, uint32(80), sa.GetSinPort(), "valid sin_port must be unchanged")
+			},
+		},
+		{
+			name: "AF_INET6 invalid sin6_addr",
+			argValue: map[string]string{
+				"sa_family": "AF_INET6", "sin6_addr": "fe80::\xc0", "sin6_port": "443",
+				"sin6_flowinfo": "0", "sin6_scopeid": "0",
+			},
+			assertFn: func(t *testing.T, sa *pb.SockAddr) {
+				assert.True(t, utf8.ValidString(sa.GetSin6Addr()), "sanitized sin6_addr must be valid UTF-8")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := getEventData(trace.Event{
+				Args: []trace.Argument{
+					{
+						ArgMeta: trace.ArgMeta{Name: "address", Type: "struct sockaddr*"},
+						Value:   tt.argValue,
+					},
+				},
+			})
+			assert.NoError(t, err)
+
+			var sockaddr *pb.SockAddr
+			for _, d := range data {
+				if sa := d.GetSockaddr(); sa != nil {
+					sockaddr = sa
+					break
+				}
+			}
+			assert.NotNil(t, sockaddr)
+			tt.assertFn(t, sockaddr)
+
+			// The whole point of #5292: the converted message must survive
+			// proto.Marshal. Before the fix this returns
+			// "string field contains invalid UTF-8".
+			event := &pb.Event{Data: data}
+			_, err = proto.Marshal(event)
+			assert.NoError(t, err, "proto.Marshal must not fail on sanitized sockaddr")
 		})
 	}
 }


### PR DESCRIPTION
## 1. Explain what the PR does

Fixes #5292.

`getSockaddr` was the one place left in the gRPC event-to-proto conversion that assigned raw `map[string]string` values straight into proto3 `string` fields without UTF-8 sanitization. A `getsockname` / `sockaddr_t` argument can carry non-UTF-8 bytes:

- `sun_path` of an abstract `AF_UNIX` socket begins with a NUL byte and can hold arbitrary binary bytes (uninitialized tail of the 108-byte `sun_path` buffer, abstract namespace names, etc.).
- `sin_addr` / `sin6_addr` can likewise contain raw bytes that are not valid UTF-8.

proto3 `string` fields must be valid UTF-8, so `proto.Marshal` rejected these values with `string field contains invalid UTF-8`. That error propagated out of `StreamEvents`, killing the stream and disconnecting clients (grpcurl and others). The reporter confirmed via bisection that simply having `getsockname` in the event list triggered the crash.

The earlier UTF-8 hardening (#4894, #4916) sanitized nearly every other string path in this file but missed `getSockaddr`. This change closes that gap by routing the three affected fields through the existing `sanitizeStringForProtobuf` helper, matching the convention already used everywhere else in `event_data.go`.

## 2. Explain how to test it

Unit test added in `pkg/server/grpc/event_data_test.go` (`Test_getSockaddr_InvalidUTF8`). It feeds `AF_UNIX`, `AF_INET`, and `AF_INET6` sockaddr arguments whose address/path fields contain invalid UTF-8 bytes through `getEventData`, then calls `proto.Marshal` on the resulting `pb.Event`.

Before this change the marshal fails:

```
proto: ...: string field contains invalid UTF-8
```

After it, marshal succeeds, the sanitized fields are valid UTF-8, and a valid `sun_path` like `/tmp/socket` is returned byte-for-byte unchanged.

```
make test-unit PKG=pkg/server/grpc TEST=Test_getSockaddr_InvalidUTF8
```

## 3. Other comments

The sanitization is lossy only for already-malformed input: invalid byte sequences are dropped (the same behavior `sanitizeStringForProtobuf` already applies to every other string field), while valid UTF-8 is preserved exactly. An alternative would be to expose the raw bytes through a dedicated `bytes` field on `SockAddr`, but that is an API/proto change; string sanitization keeps the wire format and existing consumers unchanged and is consistent with the rest of this file.
