### PR TITLE
perf(pipeline): skip detector dispatch stage when no detectors are registered

### DIFF
--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -74,10 +74,16 @@ func (t *Tracee) handleEvents(ctx context.Context, initialized chan<- struct{}, 
 	errcList = append(errcList, errc)
 
 	// Detect events stage: ctx passed through to detector OnEvent interface.
+	// Only wire the stage when detectors are actually registered. With none
+	// (e.g. signature-based deployments), skipping the stage avoids a goroutine,
+	// a pipeline-sized channel, the per-event hand-off, and the early proto
+	// conversion it forces - the sink performs that conversion anyway.
 
-	eventsChan, errc = t.detectEvents(ctx, eventsChan)
-	t.stats.Channels["detect"] = eventsChan
-	errcList = append(errcList, errc)
+	if t.detectorEngine != nil && t.detectorEngine.GetDetectorCount() > 0 {
+		eventsChan, errc = t.detectEvents(ctx, eventsChan)
+		t.stats.Channels["detect"] = eventsChan
+		errcList = append(errcList, errc)
+	}
 
 	// Engine events stage: events go through the signatures engine for detection.
 


### PR DESCRIPTION
The detector dispatch stage was wired into the pipeline unconditionally, unlike the signature engine stage which is already gated by its config. In signature-based deployments no detectors are registered, so the stage ran as a per-event no-op: an extra goroutine, a pipeline-sized channel, a per-event hand-off, and an early trace.Event -> proto conversion it forced one stage ahead of the sink (which performs that conversion anyway).

Gate the stage on detectorEngine.GetDetectorCount() > 0, mirroring the engine stage. When detectors are present behavior is unchanged; when there are none the stage and its proto-slab residency are skipped.

Measured (live A/B, 0 detectors, 4-core, 3 reps): peak RSS 177.0 -> 170.2 MB (-3.8%), avg 155.8 -> 152.3 MB (-2.2%), CPU flat. No event-loss risk: the stage was already a no-op without detectors