### PR TITLE
test(detectors): fix duplicate dispatch event ID

### DIFF
--- a/pkg/detectors/dispatch_test.go
+++ b/pkg/detectors/dispatch_test.go
@@ -310,7 +310,7 @@ func TestAutoPopulateFields_DetectedFrom_NoSlabAliasing(t *testing.T) {
 		},
 	}
 
-	_, err := CreateEventsFromDetectors(events.StartDetectorID+20006, []detection.EventDetector{detector})
+	_, err := CreateEventsFromDetectors(events.StartDetectorID+20007, []detection.EventDetector{detector})
 	require.NoError(t, err)
 
 	detEventID, _ := events.Core.GetDefinitionIDByName(detector.eventName)


### PR DESCRIPTION
TestAutoPopulateFields_DetectedFrom_NoSlabAliasing and TestDispatchWithDataFilter both registered event ID StartDetectorID+20006 (27506) into the shared events.Core registry. Whichever ran second failed with definitionIDAlreadyExistsErr under make test-unit's -shuffle on. Move the slab-aliasing test to the next free offset (+20007).