### PR TITLE
add ci auto-label, updates docs/templates

### DIFF
--- a/.cursor/rules/commit-pr-conventions.mdc
+++ b/.cursor/rules/commit-pr-conventions.mdc
@@ -16,3 +16,15 @@ When preparing commits or PR text in this repository, follow these rules from `d
 - For cross-area work, suggest splitting into self-contained commits when possible.
 - Remind contributors that commits must be signed (GPG/SSH/S/MIME).
 
+## Jira Ticket References
+
+When a commit resolves or is tracked by a Jira ticket, place the ticket ID in
+brackets immediately after `type(scope): `, before the description:
+
+```
+type(optional scope): [JIRA-XXX] description
+```
+
+- Brackets are required: `[ENF-123]` not `ENF-123`.
+- Place it in the subject only, never in the body or footer.
+- Omit entirely when no Jira ticket applies.

--- a/.github/DISCUSSION_TEMPLATE/design-tier1.yml
+++ b/.github/DISCUSSION_TEMPLATE/design-tier1.yml
@@ -1,0 +1,99 @@
+title: "Tier 1 Design Note: <short title>"
+labels: ["design-review", "tier/1"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for default feature design review.
+        - Human-first discussion is mandatory before implementation work.
+        - LLM can help drafting/ideation, but not implementation before ACK.
+        - Expected review window: up to 2 business days.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: "Problem statement"
+      description: "Who is affected and what pain are we solving?"
+      placeholder: "2-4 lines describing user/system impact."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: "Proposal"
+      description: "What change are we making?"
+      placeholder: "Short paragraph with scope and approach."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives considered"
+      description: "List at least one alternative and why it was not chosen."
+      placeholder: "- Option A: ...\n- Option B: ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ff_needed
+    attributes:
+      label: "Feature flag needed?"
+      options:
+        - "Yes"
+        - "No"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ff_category
+    attributes:
+      label: "If yes, feature flag category"
+      description: "Select category when flag is needed."
+      options:
+        - "release"
+        - "ops"
+        - "permission"
+        - "N/A"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ff_stage
+    attributes:
+      label: "Initial feature flag stage"
+      options:
+        - "experimental"
+        - "preview"
+        - "stable"
+        - "N/A"
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: "Validation plan"
+      description: "How will we test/verify this change?"
+      placeholder: "- Test 1\n- Test 2"
+    validations:
+      required: true
+
+  - type: input
+    id: requested_ack
+    attributes:
+      label: "Requested maintainer ACK"
+      description: "Tag at least one maintainer."
+      placeholder: "@maintainer"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Decision summary (to fill when accepted)
+        - Decision:
+        - ACK by:
+        - Tracking issue/PR:
+        - Feature flag plan:

--- a/.github/DISCUSSION_TEMPLATE/design-tier2.yml
+++ b/.github/DISCUSSION_TEMPLATE/design-tier2.yml
@@ -1,0 +1,115 @@
+title: "Tier 2 Design Doc: <short title>"
+labels: ["design-review", "tier/2"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for major or hard-to-reverse decisions.
+        Examples: architecture shifts, security model changes, persistent format changes,
+        or multi-release strategy/vision work.
+        - Human-first discussion is mandatory before implementation work.
+        - LLM can help strategy drafting/options analysis, but not implementation before ACKs.
+        - Expected review window: 3-5 business days.
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: "Status"
+      options:
+        - "Draft"
+        - "In Review"
+        - "Accepted"
+        - "Rejected"
+        - "Superseded"
+    validations:
+      required: true
+
+  - type: input
+    id: owner
+    attributes:
+      label: "Owner"
+      placeholder: "@owner"
+    validations:
+      required: true
+
+  - type: input
+    id: deciders
+    attributes:
+      label: "Deciders"
+      description: "Tag maintainers expected to ACK."
+      placeholder: "@maintainer1, @maintainer2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: "Context / problem"
+      placeholder: "Current constraints and why this is needed now."
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: "Goals"
+      placeholder: "- Goal 1\n- Goal 2"
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: "Non-goals"
+      placeholder: "- Explicitly out of scope"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_design
+    attributes:
+      label: "Proposed design"
+      placeholder: "Core approach, boundaries, and flow."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Alternatives considered"
+      placeholder: "- Option A: pros/cons\n- Option B: pros/cons"
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: "Risks and trade-offs"
+      placeholder: "- Risk 1 + mitigation\n- Risk 2 + mitigation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: migration_rollback
+    attributes:
+      label: "Migration / rollback"
+      placeholder: "Roll-forward and rollback plan."
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollout
+    attributes:
+      label: "Rollout and observability"
+      placeholder: "Feature flag strategy, metrics, alerts, success criteria."
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Decision summary (to fill when accepted)
+        - Decision:
+        - ACK by:
+        - Tracking issue/PR:
+        - Feature flag plan:

--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -8,3 +8,10 @@ about: I have a suggestion
 Describe in detail what is the new functionality. How is the user experience affected?
 -->
 
+### Design context (optional)
+
+- Design link (Discussion or prior Issue): <!-- e.g. https://github.com/aquasecurity/tracee/discussions/123 -->
+- Design tier: <!-- 1 | 2 | N/A -->
+
+### Feature request details
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 Checklist:
 
   1. Make sure the PR fixes an issue, if that is the case, so issue can be closed.
-  2. Flag your PR with at least one label "kind/xxx".
-  3. Flag your PR with at least one label "area/xxx".
+  2. Use a conventional PR title/commit scope so auto-label can apply "kind/xxx" and "area/xxx".
+  3. If auto-label did not infer the right labels, add/fix labels manually.
   4. Do not use "kind/feature" without explicitly adding a release feature.
   5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
   6. Make sure all tests pass before asking for review.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,9 @@ Checklist:
   4. Do not use "kind/feature" without explicitly adding a release feature.
   5. Add "milestone/v0.x.y" label if you want it in milestone 0.x.y.
   6. Make sure all tests pass before asking for review.
-  7. Explicitly asking a maintainer for review might block you more time.
-  8. Be mindful about rebases, try to provide them asap so merges can be done.
+  7. Add design review link or N/A exemption.
+  8. Explicitly asking a maintainer for review might block you more time.
+  9. Be mindful about rebases, try to provide them asap so merges can be done.
 
 PS: DO NOT JUMP THE CHECKLIST. GO BACK AND READ, ALWAYS!
 -->

--- a/.github/scripts/ci-helpers.sh
+++ b/.github/scripts/ci-helpers.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+#
+# Reusable helpers for GitHub Actions workflows.
+# Source this file in a step, then call the helpers as needed.
+#
+# Usage (in a workflow step):
+#   . .github/scripts/ci-helpers.sh
+#   GH_REPO="${GITHUB_REPOSITORY}"  # or owner/repo
+#   ensure_label "my-label" "ededed" "Description"
+#   add_label "${PR_NUMBER}" "my-label"
+#   remove_label "${PR_NUMBER}" "stale-label"
+#
+# Label helpers require GH_REPO and GH_TOKEN in the environment.
+#
+
+# URL-encode a label name for DELETE /issues/{n}/labels/{name}.
+# Arguments:
+#   $1 - label name
+encode_label() {
+    if command -v jq > /dev/null 2>&1; then
+        printf '%s' "$1" | jq -sRr @uri
+    else
+        # Best-effort fallback if jq is unavailable.
+        printf '%s' "$1" \
+            | sed -e 's|%|%25|g' \
+                -e 's| |%20|g' \
+                -e 's|/|%2F|g'
+    fi
+}
+
+# Create a repo label if it does not exist (422 is ignored).
+# Arguments:
+#   $1 - label name
+#   $2 - color (hex, no #)
+#   $3 - description
+ensure_label() {
+    err_file="$(mktemp)"
+
+    if gh api --method POST "repos/${GH_REPO}/labels" \
+        -f "name=$1" \
+        -f "color=$2" \
+        -f "description=$3" \
+        > "${err_file}" 2>&1; then
+        rm -f "${err_file}"
+        return 0
+    fi
+
+    # Ignore 422 only when the error code is "already_exists".
+    # Other 422s (invalid field, rate limit, auth) are real failures.
+    if grep -q '"already_exists"' "${err_file}"; then
+        rm -f "${err_file}"
+        return 0
+    fi
+
+    echo "::warning::Failed to ensure label $1." >&2
+    if [ -s "${err_file}" ]; then
+        cat "${err_file}" >&2
+    fi
+    rm -f "${err_file}"
+    return 1
+}
+
+# Add a label to an issue or PR (same REST endpoint).
+# Arguments:
+#   $1 - issue/PR number
+#   $2 - label name
+add_label() {
+    gh api --method POST "repos/${GH_REPO}/issues/$1/labels" \
+        -f "labels[]=$2" \
+        --silent 2> /dev/null \
+        || echo "::warning::Failed to add label $2 on #$1."
+}
+
+# Remove a label from an issue or PR.
+# Arguments:
+#   $1 - issue/PR number
+#   $2 - label name
+remove_label() {
+    gh api --method DELETE \
+        "repos/${GH_REPO}/issues/$1/labels/$(encode_label "$2")" \
+        --silent 2> /dev/null || true
+}

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,0 +1,287 @@
+#
+# Auto-label PRs from title, commits, and merge conventions.
+# Runs identically in OSS and private repos.
+#
+# Rules:
+#   1. kind/*  - on PR update; union of title + commit types
+#   2. area/*  - on PR update; union of title + commit scopes
+#   3. hotfix + port-to-main/needed - on merge; [hotfix] + release-v* target
+#   4. backport cross-ref - on merge; body "Backport of #NNN"
+#   5. port-to-main cross-ref - on merge; body "Port of #NNN" into main
+#      (#NNN must target release-v* or the update is skipped with a warning)
+#
+
+name: Auto Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened, closed]
+
+permissions: {}
+
+jobs:
+  sync-kind-area-labels:
+    name: Sync kind and area labels
+    if: github.event.action != 'closed'
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL }}
+    container:
+      image: alpine/git:2.49.1@sha256:bd54f921f6d803dfa3a4fe14b7defe36df1b71349a3e416547e333aa960f86e3
+    permissions:
+      contents: read
+      issues: write        # POST /repos/.../labels (create label) uses Issues API
+      pull-requests: write # add/remove labels on PR via Issues endpoint
+    timeout-minutes: 5
+    steps:
+      - name: Install tools
+        run: apk add --no-cache github-cli
+        shell: sh
+
+      - name: Checkout helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Sync kind and area from title and commits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: sh
+        run: |
+          set -eu
+          . .github/scripts/ci-helpers.sh
+
+          type_to_kind() {
+              case "${1}" in
+                  fix)       printf '%s' "kind/bug" ;;
+                  feat)      printf '%s' "kind/enhancement" ;;
+                  chore)     printf '%s' "kind/chore" ;;
+                  ci)        printf '%s' "kind/ci" ;;
+                  docs)      printf '%s' "kind/docs" ;;
+                  test)      printf '%s' "kind/test" ;;
+                  perf)      printf '%s' "kind/perf" ;;
+                  refactor)  printf '%s' "kind/refactor" ;;
+                  build)     printf '%s' "kind/build" ;;
+                  revert)    printf '%s' "kind/revert" ;;
+                  *)         printf '%s' "" ;;
+              esac
+          }
+
+          kinds_file="$(mktemp)"
+          areas_file="$(mktemp)"
+          desired_kinds_file="$(mktemp)"
+          desired_areas_file="$(mktemp)"
+          current_kinds_file="$(mktemp)"
+          current_areas_file="$(mktemp)"
+          trap 'rm -f "${kinds_file}" "${areas_file}" "${desired_kinds_file}" "${desired_areas_file}" "${current_kinds_file}" "${current_areas_file}"' EXIT
+
+          label_in_file() {
+              _needle="${1}"
+              _haystack="${2}"
+              [ -s "${_haystack}" ] && grep -Fxq "${_needle}" "${_haystack}"
+          }
+
+          collect_from_line() {
+              _line="${1}"
+              _core="$(printf '%s' "${_line}" \
+                  | sed 's/^\(\[[^]]*\]\)*[[:space:]]*//')"
+              _type="$(printf '%s' "${_core}" \
+                  | sed -n 's/^\(fix\|feat\|chore\|ci\|docs\|test\|perf\|refactor\|build\|revert\)\(([^)]*)\)\{0,1\}!*\:.*/\1/p' \
+                  | head -1)"
+              _scope="$(printf '%s' "${_core}" \
+                  | sed -n 's/^[a-z]*(\([^)]*\)).*/\1/p' \
+                  | head -1)"
+              _kind="$(type_to_kind "${_type}")"
+              if [ -n "${_kind}" ]; then
+                  printf '%s\n' "${_kind}" >> "${kinds_file}"
+              fi
+              if [ -n "${_scope}" ]; then
+                  printf '%s\n' "area/${_scope}" >> "${areas_file}"
+              fi
+          }
+
+          collect_from_line "${PR_TITLE}"
+
+          gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/commits" \
+              --jq '.[] | (.commit.message | split("\n") | .[0])' \
+              | while IFS= read -r _subject; do
+                  [ -n "${_subject}" ] && collect_from_line "${_subject}"
+              done
+
+          sort -u "${kinds_file}" > "${desired_kinds_file}" 2> /dev/null || : > "${desired_kinds_file}"
+          sort -u "${areas_file}" > "${desired_areas_file}" 2> /dev/null || : > "${desired_areas_file}"
+
+          gh api "repos/${GH_REPO}/issues/${PR_NUMBER}/labels" \
+              --jq '.[].name' \
+              | while IFS= read -r _existing; do
+                  case "${_existing}" in
+                      kind/*)
+                          printf '%s\n' "${_existing}" >> "${current_kinds_file}"
+                          ;;
+                      area/*)
+                          printf '%s\n' "${_existing}" >> "${current_areas_file}"
+                          ;;
+                  esac
+              done
+
+          if [ -s "${current_kinds_file}" ]; then
+              sort -u -o "${current_kinds_file}" "${current_kinds_file}"
+          fi
+          if [ -s "${current_areas_file}" ]; then
+              sort -u -o "${current_areas_file}" "${current_areas_file}"
+          fi
+
+          # Diff sync: remove only stale kind/* and area/*; add only missing.
+          if [ -s "${current_kinds_file}" ]; then
+              while IFS= read -r _existing; do
+                  [ -z "${_existing}" ] && continue
+                  if ! label_in_file "${_existing}" "${desired_kinds_file}"; then
+                      remove_label "${PR_NUMBER}" "${_existing}"
+                      echo "Removed ${_existing} from #${PR_NUMBER}."
+                  fi
+              done < "${current_kinds_file}"
+          fi
+
+          if [ -s "${current_areas_file}" ]; then
+              while IFS= read -r _existing; do
+                  [ -z "${_existing}" ] && continue
+                  if ! label_in_file "${_existing}" "${desired_areas_file}"; then
+                      remove_label "${PR_NUMBER}" "${_existing}"
+                      echo "Removed ${_existing} from #${PR_NUMBER}."
+                  fi
+              done < "${current_areas_file}"
+          fi
+
+          if [ -s "${desired_kinds_file}" ]; then
+              while IFS= read -r _kind_label; do
+                  [ -z "${_kind_label}" ] && continue
+                  if label_in_file "${_kind_label}" "${current_kinds_file}"; then
+                      continue
+                  fi
+                  ensure_label "${_kind_label}" "ededed" "Auto-applied from PR title or commits"
+                  add_label "${PR_NUMBER}" "${_kind_label}"
+                  echo "Added ${_kind_label} to #${PR_NUMBER}."
+              done < "${desired_kinds_file}"
+          fi
+
+          if [ -s "${desired_areas_file}" ]; then
+              while IFS= read -r _area_label; do
+                  [ -z "${_area_label}" ] && continue
+                  if label_in_file "${_area_label}" "${current_areas_file}"; then
+                      continue
+                  fi
+                  ensure_label "${_area_label}" "0075ca" "Auto-applied from PR title or commits"
+                  add_label "${PR_NUMBER}" "${_area_label}"
+                  echo "Added ${_area_label} to #${PR_NUMBER}."
+              done < "${desired_areas_file}"
+          fi
+
+  label-on-merge:
+    name: Auto-label merged PR
+    if: >-
+      github.event.action == 'closed'
+      && github.event.pull_request.merged == true
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL }}
+    container:
+      image: alpine/git:2.49.1@sha256:bd54f921f6d803dfa3a4fe14b7defe36df1b71349a3e416547e333aa960f86e3
+    permissions:
+      contents: read
+      issues: write        # POST /repos/.../labels (create label) uses Issues API
+      pull-requests: write # add/remove labels on PR via Issues endpoint
+    timeout-minutes: 5
+    steps:
+      - name: Install tools
+        run: apk add --no-cache github-cli
+        shell: sh
+
+      - name: Checkout helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Apply merge labels from title and body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        shell: sh
+        run: |
+          set -eu
+          . .github/scripts/ci-helpers.sh
+
+          extract_pr_refs() {
+              _pattern="${1}"
+              printf '%s' "${PR_BODY}" \
+                  | grep -iE "${_pattern}" \
+                  | head -1 \
+                  | grep -oE '#[0-9]+' \
+                  | tr -d '#' \
+                  || true
+          }
+
+          ensure_label "hotfix" "d73a4a" "Urgent fix on release branch before OSS/main"
+          ensure_label "port-to-main/needed" "7057ff" "Hotfix still needs porting to main"
+          ensure_label "port-to-main/done" "7057ff" "Hotfix ported to main"
+
+          # Rule 3: hotfix detection
+          case "${PR_TITLE}" in
+              *"[hotfix]"*)
+                  case "${BASE_REF}" in
+                      release-v*)
+                          add_label "${PR_NUMBER}" "hotfix"
+                          add_label "${PR_NUMBER}" "port-to-main/needed"
+                          echo "Hotfix labels applied to #${PR_NUMBER}."
+                          ;;
+                  esac
+                  ;;
+          esac
+
+          # Rule 4: backport cross-reference
+          backport_refs="$(extract_pr_refs 'backport of #')"
+          if [ -n "${backport_refs}" ]; then
+              backport_label="backport/${BASE_REF}"
+              backport_done="backport-done/${BASE_REF}"
+              backport_needed="backport-needed/${BASE_REF}"
+
+              ensure_label "${backport_label}" "0e8a16" "Backport PR for ${BASE_REF}"
+              ensure_label "${backport_done}" "0e8a16" "Backport to ${BASE_REF} complete"
+              ensure_label "${backport_needed}" "fbca04" "Backport to ${BASE_REF} needed"
+
+              add_label "${PR_NUMBER}" "${backport_label}"
+              echo "Added ${backport_label} to #${PR_NUMBER}."
+
+              for ref in ${backport_refs}; do
+                  add_label "${ref}" "${backport_done}"
+                  remove_label "${ref}" "${backport_needed}"
+                  echo "Updated #${ref}: +${backport_done}, -${backport_needed}."
+              done
+          fi
+
+          # Rule 5: port-to-main cross-reference (#NNN must target release-v*)
+          if [ "${BASE_REF}" = "main" ]; then
+              port_refs="$(extract_pr_refs 'port of #')"
+              if [ -n "${port_refs}" ]; then
+                  for ref in ${port_refs}; do
+                      ref_base="$(gh api "repos/${GH_REPO}/pulls/${ref}" \
+                          --jq '.base.ref' 2> /dev/null || printf '%s' "")"
+                      case "${ref_base}" in
+                          release-v*)
+                              add_label "${ref}" "port-to-main/done"
+                              remove_label "${ref}" "port-to-main/needed"
+                              echo "Updated #${ref}: +port-to-main/done, -port-to-main/needed."
+                              ;;
+                          *)
+                              echo "::warning::Port of #${ref} skipped: #${ref} targets '${ref_base:-unknown}', expected release-v*."
+                              ;;
+                      esac
+                  done
+              fi
+          fi

--- a/.github/workflows/trigger-pr-sync.yaml
+++ b/.github/workflows/trigger-pr-sync.yaml
@@ -17,13 +17,14 @@ permissions: {}
 jobs:
   pr-sync:
     name: Trigger PR Sync
-    environment: private-sync
+    environment: pr-sync
     runs-on:
       # Ubuntu 24.04 generic (6.11.0-29) [x86_64]
       - graas_ami-03dbff05cae3a30d0_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
       - EXECUTION_TYPE=SHORT
       - INSTANCE_TYPE=MICRO
     permissions:
+      contents: read # sparse checkout for ci-helpers.sh
       issues: write # gh label create
       pull-requests: write # gh pr list, comment, edit labels
     container:
@@ -91,7 +92,7 @@ jobs:
         run: |
           set -eu
 
-          readonly LABEL_SYNCED="private-synced"
+          readonly LABEL_SYNCED="pr-synced"
 
           already_synced=$(
               gh pr view "${PR_NUMBER}" \
@@ -109,7 +110,7 @@ jobs:
                   ;;
           esac
 
-      - name: Validate private-sync configuration
+      - name: Validate pr-sync configuration
         if: >-
           steps.pr-number.outcome == 'success' &&
           steps.check-synced.outputs.already_synced != 'true'
@@ -129,8 +130,8 @@ jobs:
               "${GH_APP_CLIENT_ID}" \
               "${GH_APP_PRIVATE_KEY}"; do
               if [ -z "${v}" ]; then
-                  echo "ERROR: One or more required private-sync secrets are not configured." >&2
-                  echo "Set them under Environments -> private-sync -> Environment secrets." >&2
+                  echo "ERROR: One or more required pr-sync secrets are not configured." >&2
+                  echo "Set them under Environments -> pr-sync -> Environment secrets." >&2
                   exit 1
               fi
           done
@@ -155,7 +156,7 @@ jobs:
           repositories: ${{ secrets.TRACEE_PRIVATE_REPO }}
           permission-actions: write
 
-      - name: Trigger private sync workflow
+      - name: Trigger pr sync workflow
         id: sync
         if: >-
           steps.pr-number.outcome == 'success' &&
@@ -190,7 +191,7 @@ jobs:
                   break
               fi
 
-              echo "Attempt ${attempts}/${max_attempts} failed to dispatch private sync workflow." >&2
+              echo "Attempt ${attempts}/${max_attempts} failed to dispatch pr sync workflow." >&2
               if [ -s "${gh_err_file}" ]; then
                   echo "gh error output:" >&2
                   cat "${gh_err_file}" >&2
@@ -201,12 +202,12 @@ jobs:
           done
 
           if [ "${succeeded}" != true ]; then
-              echo "ERROR: Failed to dispatch private sync workflow after ${max_attempts} attempts." >&2
+              echo "ERROR: Failed to dispatch pr sync workflow after ${max_attempts} attempts." >&2
               {
                   echo ""
                   echo "### Workflow dispatch failure"
                   echo ""
-                  echo "Could not trigger the private sync workflow for OSS PR #${PR_NUMBER}."
+                  echo "Could not trigger the pr sync workflow for OSS PR #${PR_NUMBER}."
                   if [ -s "${gh_err_file}" ]; then
                       echo ""
                       echo "<details><summary>Last gh error output</summary>"
@@ -221,6 +222,13 @@ jobs:
               exit 1
           fi
 
+      - name: Checkout helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+
       - name: Update PR sync labels
         if: >-
           always() &&
@@ -234,67 +242,24 @@ jobs:
         shell: sh
         run: |
           set -eu
+          . .github/scripts/ci-helpers.sh
 
-          readonly LABEL_SYNCED="private-synced"
-          readonly LABEL_NOT_SYNCED="private-non-synced"
-          readonly LABEL_COLOR_BLUE="1d76db"
-          readonly LABEL_COLOR_RED="d73a4a"
+          readonly LABEL_SYNCED="pr-synced"
+          readonly LABEL_NOT_SYNCED="pr-non-synced"
 
-          ensure_label() {
-              name="${1}"
-              color="${2}"
-              description="${3}"
-
-              exists=$(
-                  gh label list \
-                      --repo "${GH_REPO}" \
-                      --json name \
-                      --jq "any(.[]; .name == \"${name}\")"
-              )
-              case "${exists}" in
-                  true)
-                      echo "Label ${name} already exists."
-                      return 0
-                      ;;
-              esac
-
-              err_file=$(mktemp)
-              if gh label create "${name}" \
-                  --repo "${GH_REPO}" \
-                  --color "${color}" \
-                  --description "${description}" \
-                  2> "${err_file}"; then
-                  rm -f "${err_file}"
-                  return 0
-              fi
-              if grep -qi 'already exists' "${err_file}"; then
-                  echo "Label ${name} already exists."
-                  rm -f "${err_file}"
-                  return 0
-              fi
-              echo "ERROR: Failed to create label ${name}." >&2
-              cat "${err_file}" >&2
-              rm -f "${err_file}"
-              exit 1
-          }
-
-          ensure_label "${LABEL_SYNCED}" "${LABEL_COLOR_BLUE}" \
-              "Private mirror sync dispatch succeeded"
-          ensure_label "${LABEL_NOT_SYNCED}" "${LABEL_COLOR_RED}" \
-              "Private mirror sync dispatch failed"
+          ensure_label "${LABEL_SYNCED}" "1d76db" \
+              "PR sync dispatch succeeded"
+          ensure_label "${LABEL_NOT_SYNCED}" "d73a4a" \
+              "PR sync dispatch failed"
 
           case "${SYNC_RESULT}" in
               success)
-                  gh pr edit "${PR_NUMBER}" \
-                      --repo "${GH_REPO}" \
-                      --add-label "${LABEL_SYNCED}" \
-                      --remove-label "${LABEL_NOT_SYNCED}"
+                  add_label "${PR_NUMBER}" "${LABEL_SYNCED}"
+                  remove_label "${PR_NUMBER}" "${LABEL_NOT_SYNCED}"
                   ;;
               *)
-                  gh pr edit "${PR_NUMBER}" \
-                      --repo "${GH_REPO}" \
-                      --add-label "${LABEL_NOT_SYNCED}" \
-                      --remove-label "${LABEL_SYNCED}"
+                  add_label "${PR_NUMBER}" "${LABEL_NOT_SYNCED}"
+                  remove_label "${PR_NUMBER}" "${LABEL_SYNCED}"
                   ;;
           esac
 
@@ -312,20 +277,20 @@ jobs:
           set -eu
 
           if [ "${ALREADY_SYNCED}" = "true" ]; then
-              body="Private mirror sync was already completed for this PR (label \`private-synced\`). Skipping sync dispatch."
+              body="PR sync was already completed for this PR (label \`pr-synced\`). Skipping sync dispatch."
           else
               case "${SYNC_RESULT}" in
                   success)
-                      body="Private mirror sync was triggered successfully."
+                      body="PR sync was triggered successfully."
                       ;;
                   failure)
-                      body="Private mirror sync could not be triggered. See [workflow run](${RUN_URL}) for details."
+                      body="PR sync could not be triggered. See [workflow run](${RUN_URL}) for details."
                       ;;
                   skipped|cancelled)
-                      body="Private mirror sync was not run (an earlier step failed or was skipped). See [workflow run](${RUN_URL})."
+                      body="PR sync was not run (an earlier step failed or was skipped). See [workflow run](${RUN_URL})."
                       ;;
                   *)
-                      body="Private mirror sync status is unknown. See [workflow run](${RUN_URL})."
+                      body="PR sync status is unknown. See [workflow run](${RUN_URL})."
                       ;;
               esac
           fi
@@ -349,12 +314,12 @@ jobs:
               if [ "${PR_NUMBER_OUTCOME}" != "success" ]; then
                   echo "Did not run: merged PR number could not be determined."
               elif [ "${ALREADY_SYNCED}" = "true" ]; then
-                  echo "Skipped: OSS PR **#${PR_NUMBER}** already has the \`private-synced\` label."
+                  echo "Skipped: OSS PR **#${PR_NUMBER}** already has the \`pr-synced\` label."
               elif [ "${SYNC_RESULT}" = "success" ]; then
-                  echo "Triggered the private sync workflow for OSS PR **#${PR_NUMBER}**."
+                  echo "Triggered the pr sync workflow for OSS PR **#${PR_NUMBER}**."
               elif [ "${SYNC_RESULT}" = "skipped" ]; then
                   echo "Did not run: a step before sync failed or was skipped."
               else
-                  echo "Failed to trigger the private sync workflow for OSS PR **#${PR_NUMBER}**."
+                  echo "Failed to trigger the pr sync workflow for OSS PR **#${PR_NUMBER}**."
               fi
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
### 1. Explain what the PR does

c33b753ff **docs(templates): add tiered design review templates**

> Add Tier 1 and Tier 2 GitHub Discussion templates to standardize
> human-first design reviews for a small team workflow.
> 
> Update feature/PR templates to link design context so decisions are
> traceable before implementation begins.

--

dad404186 **ci(labels): add auto-label workflow and shared gh api helpers**

> Add .github/scripts/ci-helpers.sh with POSIX sh helpers
> (encode_label, ensure_label, add_label, remove_label) using gh api
> REST endpoints; replaces inline gh label create / gh pr edit calls
> that hit a deprecated GraphQL field (projectCards).
> 
> Add .github/workflows/auto-label.yaml with all 5 labeling rules
> (kind/area diff-sync on update; hotfix, backport cross-ref, and
> port-to-main cross-ref on merge). OSS-eligible: no private guards,
> runs identically in both repos. Sparse-checkouts .github/scripts to
> source the helpers.
> 
> Update trigger-pr-sync.yaml to sparse-checkout and source
> ci-helpers.sh in the Update PR sync labels step.

--

d1c458644 **docs(cursor): document Jira ticket refs in commits**

> Private commits that track Enforcer or other Jira work should include
> [JIRA-XXX] after the Conventional Commits prefix.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
