### PR TITLE
Use available BPF module BTF fd & opportunistic changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 // aquasecurity modules
 //
 require (
-	github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1
+	github.com/aquasecurity/libbpfgo v0.11.0-libbpf-1.8-dev-2bbc483
 	github.com/aquasecurity/tracee/api v0.0.0
 	github.com/aquasecurity/tracee/common v0.0.0
 	github.com/aquasecurity/tracee/detectors v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -401,8 +401,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
-github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1 h1:i/6EeKnBR3XVeLmOyMbM0Oq+kIC08n613zwkD8lix8w=
-github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1/go.mod h1:veHe4u3xEpl0TBV+wX0AFJWOsnteNPOhNklRbYf3d+k=
+github.com/aquasecurity/libbpfgo v0.11.0-libbpf-1.8-dev-2bbc483 h1:cIVgy3qUrc/zIJQijxC+VXou00JBtegmRghdMuCrQKc=
+github.com/aquasecurity/libbpfgo v0.11.0-libbpf-1.8-dev-2bbc483/go.mod h1:bRzdRnYH24hENJCufBHJvSbtFIhtWSAGg4OSWhvyLso=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/pkg/policy/ebpf.go
+++ b/pkg/policy/ebpf.go
@@ -66,7 +66,12 @@ func createNewInnerMapEventId(m *bpf.Module, mapName string, mapVersion uint16, 
 		return nil, "", errfmt.WrapError(err)
 	}
 
-	btfFD, err := bpf.GetBTFFDByID(info.BTFID)
+	// Use module BTF fd instead of BTF_GET_FD_BY_ID (CAP_SYS_ADMIN-gated).
+	// This assumes prototype maps are created from the same loaded module BTF.
+	// Be aware: if this map prototype migrates to another module/BTF object,
+	// type IDs won't match this fd and map creation will fail. In that case,
+	// GetBTFFDByID will be required, which implies CAP_SYS_ADMIN.
+	btfFD, err := m.BTFFD()
 	if err != nil {
 		return nil, "", errfmt.WrapError(err)
 	}
@@ -111,7 +116,12 @@ func createNewInnerMap(m *bpf.Module, mapName string, mapVersion uint16) (*bpf.B
 		return nil, errfmt.WrapError(err)
 	}
 
-	btfFD, err := bpf.GetBTFFDByID(info.BTFID)
+	// Use module BTF fd instead of BTF_GET_FD_BY_ID (CAP_SYS_ADMIN-gated).
+	// This assumes prototype maps are created from the same loaded module BTF.
+	// Be aware: if this map prototype migrates to another module/BTF object,
+	// type IDs won't match this fd and map creation will fail. In that case,
+	// GetBTFFDByID will be required, which implies CAP_SYS_ADMIN.
+	btfFD, err := m.BTFFD()
 	if err != nil {
 		return nil, errfmt.WrapError(err)
 	}


### PR DESCRIPTION
Close: #5330

### 1. Explain what the PR does

6ff074cf0 **libbpfgo: bump to v0.11.0-libbpf-1.8-dev-2bbc483**

> What also bumps libbpf to 2bbc483.

--

c521e4279 **fix(policy): use module BTF fd for inner maps**

> Avoid BTF ID lookup during inner map creation by reusing the loaded module
> BTF fd, which removes dependency on BTF_GET_FD_BY_ID that would require
> CAP_SYS_ADMIN on stricter paranoid levels.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
