### PR TITLE
perf/fix(events): ftrace optimisation & fix for 6.19 up

### DIFF
--- a/pkg/events/ftrace.go
+++ b/pkg/events/ftrace.go
@@ -3,8 +3,9 @@ package events
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,13 +36,13 @@ const (
 )
 
 var (
-	reportedFtraceHooks *lru.Cache[string, []trace.Argument]
+	reportedFtraceHooks *lru.Cache[string, reportedFtraceHook]
 	FtraceWakeupChan    = make(chan struct{})
 )
 
 func init() {
 	var err error
-	reportedFtraceHooks, err = lru.New[string, []trace.Argument](2048)
+	reportedFtraceHooks, err = lru.New[string, reportedFtraceHook](2048)
 	if err != nil {
 		logger.Errorw("ftrace: failed allocating cache... stopping")
 		reportedFtraceHooks = nil
@@ -77,6 +78,13 @@ func FtraceHookEvent(ctx context.Context, wg *sync.WaitGroup, out chan *Pipeline
 
 	// Trigger from time to time or on demand
 	for {
+		// bail before starting a scan if a wakeup and
+		// ctx cancellation raced in the wait select below,
+		// avoiding the initial sysfs read on shutdown.
+		if ctx.Err() != nil {
+			return
+		}
+
 		err := checkFtraceHooks(ctx, out, baseEvent, &def, selfLoadedProgs)
 		if err != nil {
 			// Context cancelled - exit gracefully
@@ -95,9 +103,10 @@ func FtraceHookEvent(ctx context.Context, wg *sync.WaitGroup, out chan *Pipeline
 	}
 }
 
-// readSysKernelFile gets file data corresponding to a path. The path should be what is after /sys/kernel/. If initial path not found, checks for
-// the path with /sys/kernel/debug for older kernels.
-// Assumes debugfs is mounted under /sys/kernel/debug
+// readSysKernelFile reads a sysfs file. path is the suffix after /sys/kernel/
+// (e.g. "tracing/enabled_functions"). It tries /sys/kernel/<path> first; if
+// that file is missing, it falls back to /sys/kernel/debug/<path> for kernels
+// where tracing is only exposed under debugfs. Requires cap.SYSLOG.
 func readSysKernelFile(path string) ([]byte, error) {
 	var data []byte
 	err := capabilities.GetInstance().Specific(
@@ -128,18 +137,93 @@ func getFtraceHooksData() ([]byte, error) {
 	return data, err
 }
 
-func initFtraceArgs(fields []DataField) []trace.Argument {
-	args := []trace.Argument{ // Init empty args
-		{ArgMeta: fields[symbolIndex].ArgMeta, Value: nil},
-		{ArgMeta: fields[trampIndex].ArgMeta, Value: nil},
-		{ArgMeta: fields[callbackFuncIndex].ArgMeta, Value: nil},
-		{ArgMeta: fields[callbackOffsetIndex].ArgMeta, Value: nil},
-		{ArgMeta: fields[callbackOwnerIndex].ArgMeta, Value: nil},
-		{ArgMeta: fields[flagsIndex].ArgMeta, Value: nil},
-		{ArgMeta: fields[countIndex].ArgMeta, Value: nil},
+// buildFtraceArgs materializes the reported event arguments from a parsed hook.
+// It is only called when a hook is actually reported, so the per-line parse path
+// avoids the []trace.Argument allocation and interface boxing entirely.
+func buildFtraceArgs(fields []DataField, hook reportedFtraceHook) []trace.Argument {
+	return []trace.Argument{
+		{ArgMeta: fields[symbolIndex].ArgMeta, Value: hook.symbol},
+		{ArgMeta: fields[trampIndex].ArgMeta, Value: hook.trampoline},
+		{ArgMeta: fields[callbackFuncIndex].ArgMeta, Value: hook.callbackFunc},
+		{ArgMeta: fields[callbackOffsetIndex].ArgMeta, Value: int64(hook.callbackOffset)},
+		{ArgMeta: fields[callbackOwnerIndex].ArgMeta, Value: hook.callbackOwner},
+		{ArgMeta: fields[flagsIndex].ArgMeta, Value: hook.flags.String()},
+		{ArgMeta: fields[countIndex].ArgMeta, Value: int(hook.count)},
+	}
+}
+
+// ftraceFlags is a compact bitmask of the per-hook flag characters the kernel
+// prints in the enabled_functions "flags" column, stored as a single byte instead
+// of a string. The bits are declared in the kernel's fixed emission order
+// (R, I, D, O, M - matching the FTRACE_FL_* order in t_show), so String()
+// reproduces the original flags column exactly.
+type ftraceFlags uint8
+
+const (
+	ftraceFlagRegs     ftraceFlags = 1 << iota // R: FTRACE_FL_REGS
+	ftraceFlagIPModify                         // I: FTRACE_FL_IPMODIFY
+	ftraceFlagDirect                           // D: FTRACE_FL_DIRECT
+	ftraceFlagCallOps                          // O: FTRACE_FL_CALL_OPS
+	ftraceFlagModified                         // M: FTRACE_FL_MODIFIED
+)
+
+// String renders the flags back to the kernel's textual form (e.g. "RID"),
+// emitting characters in the kernel's fixed order so the output matches the
+// original enabled_functions column. Returns "" when no flags are set.
+func (f ftraceFlags) String() string {
+	var buf [5]byte
+	n := 0
+
+	for _, fc := range []struct {
+		bit ftraceFlags
+		c   byte
+	}{
+		{ftraceFlagRegs, 'R'},
+		{ftraceFlagIPModify, 'I'},
+		{ftraceFlagDirect, 'D'},
+		{ftraceFlagCallOps, 'O'},
+		{ftraceFlagModified, 'M'},
+	} {
+		if f&fc.bit != 0 {
+			buf[n] = fc.c
+			n++
+		}
 	}
 
-	return args
+	return string(buf[:n])
+}
+
+// reportedFtraceHook is a compact snapshot of a reported hook kept in the dedup LRU.
+// It holds only the reportable values (mirroring the *Index args) and drops
+// the constant ArgMeta and interface boxing carried by []trace.Argument, so each
+// long-lived cache entry stays small. All fields are comparable.
+//
+// Field order is deliberate: the string headers (8-byte aligned) come first, the
+// two int32 numeric fields are grouped next so they share a single 8-byte slot,
+// and the 1-byte flags bitmask trails them (80 bytes total). count and offset are
+// int32 because both hold small values and flags is a uint8 bitmask;
+// buildFtraceArgs converts them back to the int/int64/string the event arguments
+// expose. callbackOffset is an in-function displacement (always < the function
+// size, i.e. KB-scale), so it fits int32 with ~5 orders of magnitude of headroom
+// (overflow would require a >2 GiB function); parseFtraceHook guards the narrowing.
+type reportedFtraceHook struct {
+	symbol         string
+	trampoline     string
+	callbackFunc   string
+	callbackOwner  string
+	count          int32
+	callbackOffset int32
+	flags          ftraceFlags
+}
+
+// detach returns a copy whose strings are cloned off the source buffer, so a
+// long-lived LRU entry doesn't pin the large enabled_functions contents.
+func (h reportedFtraceHook) detach() reportedFtraceHook {
+	h.symbol = strings.Clone(h.symbol)
+	h.trampoline = strings.Clone(h.trampoline)
+	h.callbackFunc = strings.Clone(h.callbackFunc)
+	h.callbackOwner = strings.Clone(h.callbackOwner)
+	return h
 }
 
 // checkFtraceHooks checks for ftrace hooks
@@ -149,9 +233,21 @@ func checkFtraceHooks(ctx context.Context, out chan *PipelineEvent, baseEvent *t
 		return err
 	}
 
+	// Read tracee's own kprobe list once per scan (instead of once per hooked
+	// symbol) to know how many ftrace-based kprobes tracee itself installed on
+	// each symbol. Only needed when tracee self-loaded programs exist.
+	var kprobeFtraceCounts map[string]int
+	if len(selfLoadedProgs) > 0 {
+		kprobeData, err := readSysKernelFile("kprobes/list")
+		if err != nil {
+			return err
+		}
+		kprobeFtraceCounts = parseKprobeFtraceCounts(kprobeData)
+	}
+
 	directArg := false // Direct arg flag
 
-	for _, ftraceLine := range strings.Split(string(ftraceHooksBytes), "\n") {
+	for ftraceLine := range strings.SplitSeq(string(ftraceHooksBytes), "\n") {
 		// Check for context cancellation early to avoid unnecessary work
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -168,49 +264,44 @@ func checkFtraceHooks(ctx context.Context, out chan *PipelineEvent, baseEvent *t
 
 		ftraceLine = strings.ReplaceAll(ftraceLine, "\t", " ")
 
-		fields := ftraceDef.GetFields()
-		args := initFtraceArgs(fields)
-		err = parseEventArgs(ftraceLine, args) // Fill args
+		// Parse into a typed snapshot (no interface boxing / args allocation on
+		// the per-line path); the full []trace.Argument is built only on report.
+		hook, err := parseFtraceHook(ftraceLine)
 		if err != nil {
 			return err
 		}
 
-		if strings.Contains(args[flagsIndex].Value.(string), "D") {
+		if hook.flags&ftraceFlagDirect != 0 {
 			// On some kernels, a line follows after a hook with D (direct) parameter. Prepare to skip it.
 			directArg = true // To be used in the next line (next iteration)
 		}
 
-		causedByTracee, newCount, err := isCausedBySelfLoadedProg(selfLoadedProgs, args[symbolIndex].Value.(string), args[countIndex].Value.(int))
-		if err != nil {
-			return err
-		}
-
+		causedByTracee, newCount := isCausedBySelfLoadedProg(selfLoadedProgs, kprobeFtraceCounts, hook.symbol, int(hook.count))
 		if causedByTracee {
 			continue
 		}
 
-		args[countIndex].Value = newCount
-		symbol, ok := args[symbolIndex].Value.(string)
-		if !ok {
-			return errors.New("failed to cast symbol's value")
-		}
+		hook.count = int32(newCount)
 
 		// Verify that we didn't report this symbol already, and it wasn't changed.
 		// If we reported the symbol in the past, and now the count has reduced - report only if the callback was changed
-		if existingEntry, found := reportedFtraceHooks.Get(symbol); found {
-			if reflect.DeepEqual(existingEntry, args) ||
-				(args[countIndex].Value.(int) < existingEntry[countIndex].Value.(int) &&
-					args[callbackFuncIndex].Value == existingEntry[callbackFuncIndex].Value) {
+		if existing, found := reportedFtraceHooks.Get(hook.symbol); found {
+			if existing == hook ||
+				(hook.count < existing.count && hook.callbackFunc == existing.callbackFunc) {
 				continue
 			}
 		}
 
-		reportedFtraceHooks.Add(symbol, args) // Mark that we're reporting this hook, so we won't report it multiple times
+		// Store a detached copy so the long-lived cache entry doesn't pin the
+		// large enabled_functions buffer the hook's strings point into.
+		stored := hook.detach()
+		reportedFtraceHooks.Add(stored.symbol, stored) // Mark that we're reporting this hook, so we won't report it multiple times
 
+		// Materialize the full args only now that we're actually reporting.
 		event := *baseEvent // shallow copy
 		event.Timestamp = int(time.Now().UnixNano())
-		event.Args = args
-		event.ArgsNum = len(args)
+		event.Args = buildFtraceArgs(ftraceDef.GetFields(), hook)
+		event.ArgsNum = len(event.Args)
 
 		// Safe to send: processEvents waits for our WaitGroup before
 		// closing the out channel, so out is guaranteed to be open.
@@ -221,56 +312,69 @@ func checkFtraceHooks(ctx context.Context, out chan *PipelineEvent, baseEvent *t
 }
 
 // isCausedBySelfLoadedProg checks if the hook is caused solely by tracee.
-// Returns the effective count taking into consideration the hooks by tracee and ftrace based k[ret]probes
-func isCausedBySelfLoadedProg(selfLoadedProgs map[string]int, symbol string, oldCount int) (bool, int, error) {
-	newCount := oldCount
-
+// Returns the effective count taking into consideration the hooks by tracee and ftrace based k[ret]probes.
+// kprobeFtraceCounts maps each symbol to the number of ftrace-based kprobes installed on it (see
+// parseKprobeFtraceCounts); it is built once per scan and may be nil when tracee self-loaded no programs.
+func isCausedBySelfLoadedProg(selfLoadedProgs, kprobeFtraceCounts map[string]int, symbol string, oldCount int) (bool, int) {
 	numHooksFromTracee, found := selfLoadedProgs[symbol]
-	if found { // Tracee uses this hook
-		// In case of k[ret]probe, there might be multiple hooks on same symbol and the ftrace count will still be 1. Check kprobe list directly.
-		numKprobes, err := numKprobesOnSymbol(symbol)
-		if err != nil {
-			return false, -1, err
-		}
-
-		if oldCount != 1 { // Someone else must be hooking using ftrace since tracee only causes 1 ftrace hook
-			newCount = oldCount - 1 + (numKprobes - numHooksFromTracee) // Reduce count caused by tracee and add the number of k[ret]probes (other than tracee's)
-		} else {
-			if numKprobes == numHooksFromTracee { // count is 1 and all k[ret]probes are caused by us... there's nothing to report
-				return true, -1, nil
-			}
-			newCount = numKprobes - numHooksFromTracee // The amount of k[ret]probes other than tracee's
-		}
+	if !found {
+		return false, oldCount
 	}
 
-	return false, newCount, nil
+	// Tracee uses this hook
+	// In case of k[ret]probe, there might be multiple hooks on same symbol and the ftrace count will still be 1.
+	numKprobes := kprobeFtraceCounts[symbol]
+
+	newCount := oldCount
+	if oldCount != 1 { // Someone else must be hooking using ftrace since tracee only causes 1 ftrace hook
+		newCount = oldCount - 1 + (numKprobes - numHooksFromTracee) // Reduce count caused by tracee and add the number of k[ret]probes (other than tracee's)
+	} else {
+		if numKprobes == numHooksFromTracee { // count is 1 and all k[ret]probes are caused by us... there's nothing to report
+			return true, -1
+		}
+
+		newCount = numKprobes - numHooksFromTracee // The amount of k[ret]probes other than tracee's
+	}
+
+	return false, newCount
 }
 
-// parseEventArgs extract the event arguments from the ftrace line
-func parseEventArgs(ftraceLine string, args []trace.Argument) error {
+// parseFtraceHook parses a single (tab-normalized) enabled_functions line into a
+// reportedFtraceHook snapshot, parsing into typed fields to avoid the interface
+// boxing of []trace.Argument on every line.
+func parseFtraceHook(ftraceLine string) (reportedFtraceHook, error) {
 	ftraceParts := strings.Split(ftraceLine, " ")
 
 	if len(ftraceParts) < 4 {
-		return errors.New("ftrace: unexpected format of file... " + ftraceLine)
+		return reportedFtraceHook{}, errors.New("ftrace: unexpected format of file... " + ftraceLine)
 	}
 
-	args[symbolIndex].Value = ftraceParts[0]
+	hook := reportedFtraceHook{symbol: ftraceParts[0]}
 
-	count, err := strconv.Atoi(ftraceParts[1][1 : len(ftraceParts[1])-1]) // Remove parenthesis
+	// ParseInt with bitSize 32 errors on overflow, so the result fits int32 safely.
+	count, err := strconv.ParseInt(ftraceParts[1][1:len(ftraceParts[1])-1], 10, 32) // Remove parenthesis
 	if err != nil {
-		return err
+		return reportedFtraceHook{}, err
 	}
-	args[countIndex].Value = count
+	hook.count = int32(count)
 
 	index := 2
 
-	args[flagsIndex].Value = getFtraceFlags(ftraceParts, &index)
+	hook.flags = getFtraceFlags(ftraceParts, &index)
 
 	var callback string
-	args[trampIndex].Value, callback = fetchTrampAndCallback(ftraceParts, &index)
-	args[callbackFuncIndex].Value, args[callbackOffsetIndex].Value, args[callbackOwnerIndex].Value = splitCallback(callback)
+	hook.trampoline, callback = fetchTrampAndCallback(ftraceParts, &index)
+	var callbackOffset int64
+	hook.callbackFunc, callbackOffset, hook.callbackOwner = splitCallback(callback)
+	// callbackOffset is an in-function displacement (bounded by the function
+	// size), so it always fits int32 in practice; guard against silent
+	// truncation on unexpected/malformed input rather than storing a wrong value.
+	if callbackOffset > math.MaxInt32 {
+		return reportedFtraceHook{}, fmt.Errorf("ftrace: callback offset 0x%x exceeds int32 range", callbackOffset)
+	}
+	hook.callbackOffset = int32(callbackOffset)
 
-	return nil
+	return hook, nil
 }
 
 type dupSymbolEntry struct {
@@ -278,74 +382,68 @@ type dupSymbolEntry struct {
 	hookType string
 }
 
-// numKprobesOnSymbol checks if there are multiple kprobes that are ftrace based on the ftrace symbol.
+// parseKprobeFtraceCounts parses the kprobe list once and returns, per symbol, the number of
+// ftrace-based kprobes installed on it. Reading and parsing the file a single time per scan
+// avoids the previous O(symbols x file) cost of re-reading it for every hooked symbol.
+//
 // The kprobe list file may have the following formats:
 // c015d71a  k  vfs_read+0x0
 // c015d71a  r  vfs_read+0x0 [FTRACE]
-func numKprobesOnSymbol(ftracedSymbol string) (int, error) {
-	data, err := readSysKernelFile("kprobes/list")
-	if err != nil {
-		return -1, err
-	}
+//
+// There may be multiple symbols at different addresses in the kernel. When attaching a hook on
+// such a symbol, the kernel attaches multiple kprobes at those locations:
+// ffffffff9fd44d20  k  load_elf_phdrs+0x0    [FTRACE]
+// ffffffff9fd47b60  k  load_elf_phdrs+0x0    [FTRACE]
+// so we deduplicate per (symbol, hookType): the first address seen counts, and subsequent lines
+// only count when they repeat that same address (avoiding counting distinct locations as separate probes).
+func parseKprobeFtraceCounts(data []byte) map[string]int {
+	counts := map[string]int{}
+	firstAddr := map[dupSymbolEntry]string{}
 
-	numKprobesOnSymbol := 0
-
-	// There may be multiple symbols in different addresses in the kernel.
-	// When attaching a hook on such symbol, the kernel will attach multiple kprobes at those locations:
-	// ffffffff9fd44d20  k  load_elf_phdrs+0x0    [FTRACE]
-	// ffffffff9fd47b60  k  load_elf_phdrs+0x0    [FTRACE]
-	// so we need to address this situation and not mark it as 2 or more different probes
-	dupSymbolMap := map[dupSymbolEntry]string{}
-
-	for _, kprobeLine := range strings.Split(string(data), "\n") {
+	for kprobeLine := range strings.SplitSeq(string(data), "\n") {
 		if len(kprobeLine) == 0 {
 			continue
 		}
 
 		lineSplit := strings.Fields(kprobeLine)
-		addr := lineSplit[0]
-		hookType := lineSplit[1]
-
-		// Verify the current kprobe is on our ftrace symbol
-		kprobedSymbol := lineSplit[2][:strings.Index(lineSplit[2], "+")]
-		if kprobedSymbol != ftracedSymbol {
+		// Need at least: address, type, symbol+offset, and a [FTRACE] status.
+		if len(lineSplit) < 4 {
 			continue
 		}
 
-		// Verify this is an ftrace based kprobe
-		if len(lineSplit) < 4 {
-			continue // Not ftrace based as there is no [FTRACE] status
-		}
+		addr := lineSplit[0]
+		hookType := lineSplit[1]
 
+		plusIdx := strings.Index(lineSplit[2], "+")
+		if plusIdx == -1 {
+			continue // unexpected format: no symbol+offset
+		}
+		symbol := lineSplit[2][:plusIdx]
+
+		// Verify this is an ftrace based kprobe
+		isFtrace := false
 		for _, status := range lineSplit[3:] {
 			if status == "[FTRACE]" {
-				key := dupSymbolEntry{
-					name:     kprobedSymbol,
-					hookType: hookType,
-				}
-
-				countedSymbolAddr, found := dupSymbolMap[key]
-				if !found {
-					// Not found - inc and add to map
-					numKprobesOnSymbol++
-					dupSymbolMap[key] = addr
-				} else {
-					// Same address - multiple hooks on same symbol - increment counter
-					if addr == countedSymbolAddr {
-						numKprobesOnSymbol++
-					}
-				}
+				isFtrace = true
 				break
 			}
 		}
+		if !isFtrace {
+			continue
+		}
+
+		key := dupSymbolEntry{name: symbol, hookType: hookType}
+		countedSymbolAddr, found := firstAddr[key]
+		if !found {
+			firstAddr[key] = addr
+			counts[symbol]++
+		} else if addr == countedSymbolAddr {
+			// Same address - multiple hooks on same symbol - increment counter
+			counts[symbol]++
+		}
 	}
 
-	// Sanity check
-	if numKprobesOnSymbol == 0 {
-		logger.Debugw("Did not see our ftrace symbol in the kprobe list.. is ftrace based kprobe disabled? or the file is hooked")
-	}
-
-	return numKprobesOnSymbol, nil
+	return counts
 }
 
 // splitCallback splits it into separate parts
@@ -353,6 +451,9 @@ func numKprobesOnSymbol(ftracedSymbol string) (int, error) {
 // - some_func+0x0/0x10 [rootkit]
 // - some_func+0x0/0x10
 // - 0xffffffffc0637000
+// The returned offset is the callback's displacement within its function (the
+// value between '+' and '/', e.g. 0x1d0), bounded by the function size; it is 0
+// for the bare-address form and -1 when the offset cannot be parsed.
 func splitCallback(callback string) (string, int64, string) {
 	index := strings.Index(callback, "+")
 	if index == -1 {
@@ -423,21 +524,33 @@ func getCallback(ftraceParts []string) string {
 	return callback
 }
 
-// getFtraceFlags extracts the flags
-func getFtraceFlags(ftraceParts []string, index *int) string {
-	flags := ""
+// getFtraceFlags extracts the flag bitmask, advancing *index to the first token
+// past the flags section (matching the previous break-on-non-flag behavior so
+// fetchTrampAndCallback resumes at the right token). The caller derives the
+// direct-hook signal from the returned ftraceFlagDirect bit.
+func getFtraceFlags(ftraceParts []string, index *int) ftraceFlags {
+	var flags ftraceFlags
 	for ; *index < len(ftraceParts); *index++ {
 		flag := strings.TrimSpace(ftraceParts[*index])
 		if flag == "" {
 			continue
 		}
 
-		if flag != "R" && flag != "I" && flag != "D" && flag != "O" && flag != "M" {
-			// Assumes we've reached the end of flags section
-			break
+		switch flag {
+		case "R":
+			flags |= ftraceFlagRegs
+		case "I":
+			flags |= ftraceFlagIPModify
+		case "D":
+			flags |= ftraceFlagDirect
+		case "O":
+			flags |= ftraceFlagCallOps
+		case "M":
+			flags |= ftraceFlagModified
+		default:
+			// Reached the end of the flags section; leave *index here.
+			return flags
 		}
-
-		flags += flag
 	}
 
 	return flags

--- a/pkg/events/ftrace.go
+++ b/pkg/events/ftrace.go
@@ -257,7 +257,7 @@ func checkFtraceHooks(ctx context.Context, out chan *PipelineEvent, baseEvent *t
 			continue
 		}
 
-		if directArg && strings.HasPrefix(ftraceLine, "\tdirect-->") {
+		if directArg && isDirectContinuationLine(ftraceLine) {
 			directArg = false // Turn off flag
 			continue
 		}
@@ -522,6 +522,15 @@ func getCallback(ftraceParts []string) string {
 	}
 
 	return callback
+}
+
+// isDirectContinuationLine reports whether the raw (pre-tab-normalization) line is
+// the "direct" continuation line emitted after a D-flagged hook. It is the only
+// field the kernel prints on its own line ("\n\tdirect%s-->"); tramp/ops/subops stay
+// inline on the function line. The qualifier is empty for a plain direct call or
+// "(jmp)" in jump mode (FTRACE_OPS_FL_JMP, v6.19), so the "\tdirect" prefix matches both.
+func isDirectContinuationLine(ftraceLine string) bool {
+	return strings.HasPrefix(ftraceLine, "\tdirect")
 }
 
 // getFtraceFlags extracts the flag bitmask, advancing *index to the first token

--- a/pkg/events/ftrace_test.go
+++ b/pkg/events/ftrace_test.go
@@ -246,6 +246,35 @@ func TestParseFtraceHook(t *testing.T) {
 	}
 }
 
+// TestIsDirectContinuationLine locks the detection of the tab-indented "direct"
+// continuation line that follows a D-flagged hook, including the jmp-mode form
+// ("\tdirect(jmp)-->") so it is skipped instead of being mis-parsed as a hook.
+func TestIsDirectContinuationLine(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{name: "plain direct", line: "\tdirect-->bpf_trampoline_6442559287+0x0/0xa4", want: true},
+		{name: "jmp direct", line: "\tdirect(jmp)-->bpf_trampoline_6442523382+0x0/0x114", want: true},
+		{name: "tramp line", line: "\ttramp: ftrace_regs_caller+0x0/0x61 (call_direct_funcs+0x0/0x20)", want: false},
+		{name: "hook line", line: "vfs_write (1) R   D   M  tramp: ftrace_regs_caller+0x0/0x61", want: false},
+		{name: "empty", line: "", want: false},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.want, isDirectContinuationLine(testCase.line))
+		})
+	}
+}
+
 // TestFtraceFlagsString locks the textual rendering of the flag bitmask: it must
 // emit characters in the kernel's fixed R,I,D,O,M order regardless of set order,
 // so the reported "flags" argument matches the original enabled_functions column.

--- a/pkg/events/ftrace_test.go
+++ b/pkg/events/ftrace_test.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +33,7 @@ func TestGetFtraceFlags(t *testing.T) {
 				t.Parallel()
 
 				flags := getFtraceFlags(testCase.ftraceParts, &testCase.index)
-				assert.Equal(t, testCase.expectedFlags, flags)
+				assert.Equal(t, testCase.expectedFlags, flags.String())
 			})
 		}
 	})
@@ -127,4 +129,227 @@ func TestSplitCallback(t *testing.T) {
 			})
 		}
 	})
+}
+
+// TestParseFtraceHook locks the end-to-end parsing behavior of a single
+// enabled_functions line (as fed by checkFtraceHooks, i.e. after tabs are
+// turned into spaces) across every callback shape the parser handles.
+func TestParseFtraceHook(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		rawLine   string
+		expectErr bool
+		expected  reportedFtraceHook
+	}{
+		{
+			name:    "tramp form",
+			rawLine: "load_elf_phdrs (1) R \ttramp: 0xffffffffc0241000 (kprobe_ftrace_handler+0x0/0x1d0) ->kprobe_ftrace_handler+0x0/0x1d0",
+			expected: reportedFtraceHook{
+				symbol:       "load_elf_phdrs",
+				count:        1,
+				flags:        ftraceFlagRegs,
+				trampoline:   "0xffffffffc0241000",
+				callbackFunc: "kprobe_ftrace_handler",
+			},
+		},
+		{
+			name:    "ops form",
+			rawLine: "tcp_sendmsg (1) R \tops: 0xffffffffc0500000 (bpf_kprobe_handler+0x0/0x80)",
+			expected: reportedFtraceHook{
+				symbol:       "tcp_sendmsg",
+				count:        1,
+				flags:        ftraceFlagRegs,
+				callbackFunc: "bpf_kprobe_handler",
+			},
+		},
+		{
+			name:    "arrow form",
+			rawLine: "sys_open (1) R ->security_file_open+0x0/0x90",
+			expected: reportedFtraceHook{
+				symbol:       "sys_open",
+				count:        1,
+				flags:        ftraceFlagRegs,
+				callbackFunc: "security_file_open",
+			},
+		},
+		{
+			name:    "callback with owner",
+			rawLine: "evil_sym (1) R \ttramp: 0xffffffffc0637000 (some_func+0x1/0x10 [rootkit])",
+			expected: reportedFtraceHook{
+				symbol:         "evil_sym",
+				count:          1,
+				flags:          ftraceFlagRegs,
+				trampoline:     "0xffffffffc0637000",
+				callbackFunc:   "some_func",
+				callbackOffset: 1,
+				callbackOwner:  "rootkit",
+			},
+		},
+		{
+			name:    "address only callback",
+			rawLine: "mystery (1) R \ttramp: 0xffffffffc0241000 (0xffffffffc0637000)",
+			expected: reportedFtraceHook{
+				symbol:       "mystery",
+				count:        1,
+				flags:        ftraceFlagRegs,
+				trampoline:   "0xffffffffc0241000",
+				callbackFunc: "0xffffffffc0637000",
+			},
+		},
+		{
+			name:    "multiple flags including direct",
+			rawLine: "vfs_write (3) R I D ->callback_func+0x0/0x0",
+			expected: reportedFtraceHook{
+				symbol:       "vfs_write",
+				count:        3,
+				flags:        ftraceFlagRegs | ftraceFlagIPModify | ftraceFlagDirect,
+				callbackFunc: "callback_func",
+			},
+		},
+		{
+			name:      "too few fields",
+			rawLine:   "incomplete (1)",
+			expectErr: true,
+		},
+		{
+			name:      "non-numeric count",
+			rawLine:   "sym (x) R ->cb+0x0/0x0",
+			expectErr: true,
+		},
+		{
+			name:      "callback offset exceeds int32",
+			rawLine:   "sym (1) R ->cb+0x100000000/0x100000001",
+			expectErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Mirror checkFtraceHooks: tabs are normalized to spaces before parsing.
+			line := strings.ReplaceAll(testCase.rawLine, "\t", " ")
+			hook, err := parseFtraceHook(line)
+
+			if testCase.expectErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expected, hook)
+		})
+	}
+}
+
+// TestFtraceFlagsString locks the textual rendering of the flag bitmask: it must
+// emit characters in the kernel's fixed R,I,D,O,M order regardless of set order,
+// so the reported "flags" argument matches the original enabled_functions column.
+func TestFtraceFlagsString(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		flags    ftraceFlags
+		expected string
+	}{
+		{name: "none", flags: 0, expected: ""},
+		{name: "single R", flags: ftraceFlagRegs, expected: "R"},
+		{name: "single M", flags: ftraceFlagModified, expected: "M"},
+		{name: "RID", flags: ftraceFlagRegs | ftraceFlagIPModify | ftraceFlagDirect, expected: "RID"},
+		{name: "all", flags: ftraceFlagRegs | ftraceFlagIPModify | ftraceFlagDirect | ftraceFlagCallOps | ftraceFlagModified, expected: "RIDOM"},
+		{name: "order independent", flags: ftraceFlagModified | ftraceFlagRegs | ftraceFlagDirect, expected: "RDM"},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, testCase.expected, testCase.flags.String())
+		})
+	}
+}
+
+// TestParseKprobeFtraceCounts locks the per-symbol counting and deduplication
+// semantics: only [FTRACE] kprobes count, the first address per (symbol,hookType)
+// counts, and subsequent lines only count when they repeat that same address.
+func TestParseKprobeFtraceCounts(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(strings.Join([]string{
+		"ffffffff9fd44d20  k  load_elf_phdrs+0x0    [FTRACE]",
+		"ffffffff9fd47b60  k  load_elf_phdrs+0x0    [FTRACE]", // different addr, same symbol+type -> not counted again
+		"aaaaaaaaaaaaaaaa  k  vfs_read+0x0    [FTRACE]",
+		"aaaaaaaaaaaaaaaa  k  vfs_read+0x0    [FTRACE]", // same addr -> counted again
+		"bbbbbbbbbbbbbbbb  k  tcp_v4_connect+0x0    [FTRACE]",
+		"cccccccccccccccc  r  tcp_v4_connect+0x0    [FTRACE]", // different hook type -> counted
+		"c015d71a  k  do_exit+0x0",                            // not ftrace based -> skipped
+		"dddddddddddddddd  k  weirdsym    [FTRACE]",           // no '+' offset -> skipped
+		"eeee k", // too few fields -> skipped
+		"",       // empty line -> skipped
+	}, "\n"))
+
+	counts := parseKprobeFtraceCounts(data)
+
+	assert.Equal(t, 1, counts["load_elf_phdrs"])
+	assert.Equal(t, 2, counts["vfs_read"])
+	assert.Equal(t, 2, counts["tcp_v4_connect"])
+
+	_, hasDoExit := counts["do_exit"]
+	assert.False(t, hasDoExit, "non-ftrace kprobe must not be counted")
+
+	_, hasWeird := counts["weirdsym"]
+	assert.False(t, hasWeird, "malformed symbol+offset must be skipped")
+}
+
+// TestReportedFtraceHookDetachAndEquality locks the dedup-cache snapshot
+// behavior: snapshots are comparable with == and detach preserves all values
+// (it only relocates the strings off the source buffer).
+func TestReportedFtraceHookDetachAndEquality(t *testing.T) {
+	t.Parallel()
+
+	line := strings.ReplaceAll("evil_sym (1) R \ttramp: 0xffffffffc0637000 (some_func+0x1/0x10 [rootkit])", "\t", " ")
+	h1, err := parseFtraceHook(line)
+	assert.NoError(t, err)
+	h2, err := parseFtraceHook(line)
+	assert.NoError(t, err)
+	assert.True(t, h1 == h2, "identical lines must produce equal snapshots")
+
+	detached := h1.detach()
+	assert.True(t, h1 == detached, "detach must preserve all field values")
+
+	// A changed callback must break equality (drives re-reporting).
+	changed := h1
+	changed.callbackFunc = "different_func"
+	assert.False(t, h1 == changed, "a changed callback must not compare equal")
+}
+
+func BenchmarkParseFtraceHook(b *testing.B) {
+	line := strings.ReplaceAll("load_elf_phdrs (1) R \ttramp: 0xffffffffc0241000 (kprobe_ftrace_handler+0x0/0x1d0) ->kprobe_ftrace_handler+0x0/0x1d0", "\t", " ")
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parseFtraceHook(line); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseKprobeFtraceCounts(b *testing.B) {
+	var sb strings.Builder
+	for i := 0; i < 500; i++ {
+		fmt.Fprintf(&sb, "ffffffff9fd4%04x  k  sym_%d+0x0    [FTRACE]\n", i, i)
+	}
+	data := []byte(sb.String())
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = parseKprobeFtraceCounts(data)
+	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

c12a96b6b **fix(events): skip direct(jmp) ftrace continuation lines**

> Kernels with FTRACE_OPS_FL_JMP (from v6.19) can print the direct-call
> continuation line in enabled_functions as "\tdirect(jmp)-->" instead of
> the plain "\tdirect-->" (the jmp bit is encoded in the trampoline address).
> 
> The hook scan only skipped the plain form, so the jmp form fell through to
> the line parser, failed the field-count check, and aborted the whole
> scan -- disabling ftrace hook detection on affected kernels.
> 
> Match the "\tdirect" prefix to cover both forms.
> 
> References (torvalds/linux):
> - 25e4e3565d45 ("ftrace: Introduce FTRACE_OPS_FL_JMP")
> - 39263f986da5 ("ftrace: Fix address for jmp mode in t_show()")

--

4f519e691 **perf(events): slim ftrace scan and dedup cache**

> The ftrace hook check runs periodically and re-scans the whole
> enabled_functions file each time. Tracee self-loads many kprobes, so
> most scanned lines are discarded, yet the old path did redundant work:
> it re-read and parsed kprobes/list once per hooked symbol, allocated
> and interface-boxed a []trace.Argument for every line (even discarded
> ones), and kept those full arg slices in a long-lived dedup LRU.
> 
> - Parse kprobes/list once per scan into a per-symbol count map
> - Iterate enabled_functions with SplitSeq (no []string allocation)
> - Parse each line into a compact, comparable reportedFtraceHook and
>   build the []trace.Argument only when a hook is actually reported
> - Cache the snapshot instead of []trace.Argument and compare with ==
>   instead of reflect.DeepEqual
> - Clone the snapshot strings before caching: parsed fields are
>   substrings of the large enabled_functions read, so caching them
>   directly would pin the whole buffer per LRU entry
> - Store count/offset as int32 and flags as a uint8 bitmask (with a
>   String() method) to shrink the snapshot; guard the offset narrowing
>   against overflow
> - Skip a scan when the context is already cancelled
> 
> Per-entry dedup-cache footprint drops from ~552 B (7-elem
> []trace.Argument + slice header + string boxing) to 80 B (~85%), or
> ~0.9 MiB at the 2048-entry capacity. Per-line parsing drops from 5 to
> 1 allocation (232 -> 162 ns/op, 192 -> 128 B/op).
> 
> Add characterization tests and benchmarks for the parsing, counting,
> flag rendering, and snapshot detach/equality behavior.

--
### 2. Explain how to test it


### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
