### PR TITLE
fix(gomod): locally replace tracee/types like the sibling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,6 @@ toolchain go1.26.4
 require (
 	github.com/IBM/fluent-forward-go v0.3.0
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1
-	github.com/aquasecurity/tracee/api v0.0.0
-	github.com/aquasecurity/tracee/common v0.0.0
-	github.com/aquasecurity/tracee/detectors v0.0.0-00010101000000-000000000000
-	github.com/aquasecurity/tracee/types v0.0.0-20251205142631-7dc44bdb801c
 	github.com/containerd/containerd v1.7.33
 	github.com/google/cel-go v0.22.0
 	github.com/google/gopacket v1.1.19
@@ -37,6 +32,17 @@ require (
 	k8s.io/cri-api v0.32.3
 	kernel.org/pub/linux/libs/security/libcap/cap v1.2.78
 	sigs.k8s.io/controller-runtime v0.20.4
+)
+
+//
+// aquasecurity modules
+//
+require (
+	github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1
+	github.com/aquasecurity/tracee/api v0.0.0
+	github.com/aquasecurity/tracee/common v0.0.0
+	github.com/aquasecurity/tracee/detectors v0.0.0
+	github.com/aquasecurity/tracee/types v0.0.0
 )
 
 require (
@@ -176,8 +182,13 @@ require (
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.78 // indirect
 )
 
+//
+// replace statements for the aquasecurity modules
+//
 replace github.com/aquasecurity/tracee/api => ./api
 
 replace github.com/aquasecurity/tracee/common => ./common
 
 replace github.com/aquasecurity/tracee/detectors => ./detectors
+
+replace github.com/aquasecurity/tracee/types => ./types

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,6 @@ github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1 h1:i/6EeKnBR3XVeLmOyMbM0Oq+kIC08n613zwkD8lix8w=
 github.com/aquasecurity/libbpfgo v0.10.0-libbpf-1.5.1/go.mod h1:veHe4u3xEpl0TBV+wX0AFJWOsnteNPOhNklRbYf3d+k=
-github.com/aquasecurity/tracee/types v0.0.0-20251205142631-7dc44bdb801c h1:z5KtKy9rBKP6Wg8Wuok4AkfD5x86GRsw0URDor2Gxig=
-github.com/aquasecurity/tracee/types v0.0.0-20251205142631-7dc44bdb801c/go.mod h1:jnyVhf+0A1J24eD8DlmNv46yWg5I4TJkHnptkWyPOH8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
### 1. Explain what the PR does

1b275b50e **fix(gomod): locally replace tracee/types like the sibling**

> go.mod locally replaces api, common, and detectors with ./ but left types
> pinned to a published pseudo-version.
> 
> Go-plugin consumers (tracee-detectors' research.so) build types from their
> local checkout at v0.0.0 while the tracee binary builds it from the pinned
> version, so plugin.Open fails with "plugin was built with a different version
> of package types/protocol" swallowed by tracee, surfacing ~60s later as a
> misleading "event ... is not valid".
> 
> Replace types with ./types so it matches how plugin consumers resolve it.
> 
> It also regroups aquasecurity in its own block.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
