### PR TITLE
fix(ci): skip auto-label writes for fork PRs

### DIFF
--- a/.github/scripts/ci-helpers.sh
+++ b/.github/scripts/ci-helpers.sh
@@ -52,6 +52,15 @@ ensure_label() {
         return 0
     fi
 
+    # In restricted integration contexts (e.g., fork PRs), label creation can
+    # return 403 "Resource not accessible by integration". Do not fail the
+    # workflow in this case; label add/remove operations are already best-effort.
+    if grep -q 'Resource not accessible by integration' "${err_file}"; then
+        echo "::warning::Skipping label creation for $1 due to integration permissions." >&2
+        rm -f "${err_file}"
+        return 0
+    fi
+
     echo "::warning::Failed to ensure label $1." >&2
     if [ -s "${err_file}" ]; then
         cat "${err_file}" >&2

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -26,7 +26,9 @@ permissions: {}
 jobs:
   sync-kind-area-labels:
     name: Sync kind and area labels
-    if: github.event.action != 'closed'
+    if: >-
+      github.event.action != 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
     container:
       image: alpine/git:2.49.1@sha256:bd54f921f6d803dfa3a4fe14b7defe36df1b71349a3e416547e333aa960f86e3
@@ -188,6 +190,7 @@ jobs:
     if: >-
       github.event.action == 'closed'
       && github.event.pull_request.merged == true
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
     container:
       image: alpine/git:2.49.1@sha256:bd54f921f6d803dfa3a4fe14b7defe36df1b71349a3e416547e333aa960f86e3


### PR DESCRIPTION
### 1. Explain what the PR does


### 2. Explain how to test it

e76117982 **fix(ci): skip auto-label writes for fork PRs**

> Prevent auto-label CI failures caused by restricted token permissions on
> fork-origin pull requests. Keep label handling best-effort without
> blocking workflow execution.
> 
> This could be solved by using pull_request_target, but it's better to
> continue safe.

--

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
