### PR TITLE
Use trivy action & harden release workflows

### DIFF
--- a/.github/actions/trivy-scan/action.yaml
+++ b/.github/actions/trivy-scan/action.yaml
@@ -1,0 +1,138 @@
+name: Trivy Scan
+description: |
+  Scan an image or the filesystem with Trivy once and report findings as a table in
+  the job log and job summary. Findings fail the job on pull_request events and are
+  report-only otherwise.
+
+  SARIF upload to the Security tab is OPT-IN via 'upload-sarif' (default off): enable it
+  only for codebase scans (the filesystem scan). Tooling/test image scans stay
+  report-only so code-scanning alerts are not flooded with un-actionable upstream CVEs.
+  When enabled, upload is still skipped on fork PRs (read-only token).
+
+inputs:
+  scan-type:
+    description: "Trivy scan type: 'image' or 'fs'."
+    default: "image"
+  image-ref:
+    description: "Image reference to scan (for scan-type: image)."
+    default: ""
+  scan-ref:
+    description: "Path to scan (for scan-type: fs)."
+    default: "."
+  name:
+    description: "Unique slug used for the SARIF category and output filenames."
+    required: true
+  scanners:
+    description: "Comma-separated Trivy scanners (e.g. 'vuln' or 'vuln,secret,misconfig')."
+    default: "vuln"
+  severity:
+    description: "Comma-separated severities to report."
+    default: "CRITICAL,HIGH,MEDIUM"
+  skip-dirs:
+    description: "Comma-separated directories to skip."
+    default: ""
+  upload-sarif:
+    description: "Upload SARIF to the Security tab. Enable only for codebase (filesystem) scans; leave off for tooling/test image scans."
+    default: "false"
+  gate-on-pr:
+    description: "Fail the job on a pull_request when findings exist. Off = report-only (findings still shown in the job summary). Enable only for actionable codebase scans."
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Single scan -> JSON. exit-code is forced to 0 here so results are always produced;
+    # gating happens on the report step below.
+    - name: Trivy scan (${{ inputs.name }})
+      uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0 (Trivy v0.70.0)
+      with:
+        scan-type: ${{ inputs.scan-type }}
+        image-ref: ${{ inputs.image-ref }}
+        scan-ref: ${{ inputs.scan-ref }}
+        scanners: ${{ inputs.scanners }}
+        severity: ${{ inputs.severity }}
+        skip-dirs: ${{ inputs.skip-dirs }}
+        ignore-unfixed: true
+        format: "json"
+        output: "trivy-${{ inputs.name }}.json"
+        exit-code: "0"
+        # cache: true is the action default; the DB is cached across runs via
+        # actions/cache, which mitigates GHCR rate limits (TOOMANYREQUESTS).
+        cache: "true"
+
+    # Offline conversion to SARIF (no re-scan) - only when uploading to the Security tab.
+    - name: Convert results to SARIF (${{ inputs.name }})
+      if: ${{ inputs.upload-sarif == 'true' }}
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+      run: |
+        set -euo pipefail
+        trivy convert --format sarif \
+            --output "trivy-${NAME}.sarif" \
+            "trivy-${NAME}.json"
+
+    # Opt-in (upload-sarif) and only for codebase scans, so tooling CVEs don't flood
+    # code-scanning alerts. Distinct category per target so one analysis doesn't
+    # overwrite another. Skipped on fork PRs (read-only token); the scan + gate still run.
+    - name: Upload SARIF to Security tab (${{ inputs.name }})
+      if: ${{ always() && inputs.upload-sarif == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+      uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      with:
+        sarif_file: "trivy-${{ inputs.name }}.sarif"
+        category: "trivy-${{ inputs.name }}"
+
+    # Append a findings table to the job summary, log it, then gate. Runs last so the
+    # SARIF is already uploaded before any failure. The table's Target column names
+    # the file for filesystem findings; image findings map to a package (no repo file).
+    - name: Report findings and gate (${{ inputs.name }})
+      if: ${{ always() }}
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+        # Gate only when the caller opts in (gate-on-pr) AND this is a pull request;
+        # otherwise report-only (findings are still shown in the summary + log).
+        IS_PR: ${{ github.event_name == 'pull_request' }}
+        GATE_ON_PR: ${{ inputs.gate-on-pr }}
+      run: |
+        set -euo pipefail
+
+        json="trivy-${NAME}.json"
+        table=$(trivy convert --format table "${json}")
+        count=$(jq '[.Results[]? | ((.Vulnerabilities // []) + (.Secrets // []) + (.Misconfigurations // [])) | length] | add // 0' "${json}")
+
+        # The job summary has a 1024k limit; large image tables (many OS-package CVEs)
+        # blow past it. Only embed the table in the summary when it is small; the full
+        # table always goes to the job log below, which has no such limit.
+        table_bytes=$(printf '%s' "${table}" | wc -c)
+        summary_max=800000
+
+        {
+            echo "### Trivy: ${NAME} (${count} findings)"
+            echo ""
+            if ((count == 0)); then
+                echo "No findings."
+            elif ((table_bytes > summary_max)); then
+                echo "Findings table is too large for the job summary (${table_bytes} bytes); see this job's log for the full table."
+            else
+                echo "<details><summary>Show findings table</summary>"
+                echo ""
+                echo '```'
+                printf '%s\n' "${table}"
+                echo '```'
+                echo ""
+                echo "</details>"
+            fi
+            echo ""
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+        echo "::group::Trivy results (${NAME})"
+        printf '%s\n' "${table}"
+        echo "::endgroup::"
+
+        if ((count > 0)) && [[ "${GATE_ON_PR}" == "true" && "${IS_PR}" == "true" ]]; then
+            echo "::error::${count} finding(s) for ${NAME} - failing (pull request gate)"
+            exit 1
+        elif ((count > 0)); then
+            echo "::warning::${count} finding(s) for ${NAME} (report-only - see the job summary)"
+        fi

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -11,57 +11,31 @@ on:
   schedule:
     # Daily at 05:00
     - cron: "0 5 * * *"
+
+# Serialize snapshot runs (a manual run must not overlap the daily cron); let an
+# in-progress run finish rather than cancelling it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release-snapshot-x86_64:
-    name: Release Snapshot (x86_64)
-    runs-on: 
-      # release-amd64-big-3
-      - graas_ami-0cdf7ad6d9627da45_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
-      - EXECUTION_TYPE=LONG
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          submodules: true
-          fetch-depth: 0
-      - name: Login to docker.io registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build
-        run: |
-          make -f builder/Makefile.release snapshot
-      - name: Scan Docker Image for Vulnerabilities
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          image-ref: "tracee:dev"
-          severity: "CRITICAL,HIGH,MEDIUM"
-          exit-code: "1"
-      - name: Publish to docker.io registry
-        run: |
-          docker image tag tracee:dev aquasec/tracee:x86_64-dev
-          docker image push aquasec/tracee:x86_64-dev
-        shell: bash
-      # Disabled to avoid generating too many sigstore cosign signatures
-      # - name: Sign Docker image
-      #   run: |
-      #     cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:x86_64-dev)
-      #   shell: bash
-  release-snapshot-aarch64:
-    name: Release Snapshot (aarch64)
+  release-snapshot-build:
+    name: Release Snapshot (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            ami: 0cdf7ad6d9627da45 # release-amd64-big-3
+          - arch: aarch64
+            ami: 07740487fa433aa54 # release-arm64-big-3
     runs-on:
-      # release-arm64-big-3
-      - graas_ami-07740487fa433aa54_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
+      - graas_ami-${{ matrix.ami }}_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
       - EXECUTION_TYPE=LONG
+    # docker.io push uses DOCKERHUB_* secrets (not GITHUB_TOKEN); snapshot signing is
+    # disabled, so no packages:write / id-token:write are needed.
     permissions:
       contents: read
-      packages: write
-      id-token: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -84,22 +58,22 @@ jobs:
           exit-code: "1"
       - name: Publish to docker.io registry
         run: |
-          docker image tag tracee:dev aquasec/tracee:aarch64-dev
-          docker image push aquasec/tracee:aarch64-dev
+          arch=$(uname -m)
+          docker image tag tracee:dev "aquasec/tracee:${arch}-dev"
+          docker image push "aquasec/tracee:${arch}-dev"
         shell: bash
-      # Disabled to avoid generating too many sigstore cosign signatures
+      # Disabled to avoid generating too many sigstore cosign signatures.
+      # If re-enabling: add `id-token: write` to this job's permissions.
       # - name: Sign Docker image
       #   run: |
-      #     cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:aarch64-dev)
+      #     cosign sign -y "$(docker inspect --format='{{index .RepoDigests 0}}' "aquasec/tracee:$(uname -m)-dev")"
       #   shell: bash
   release-snapshot:
     name: Release Snapshot
-    needs: [release-snapshot-x86_64, release-snapshot-aarch64]
+    needs: [release-snapshot-build]
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -120,12 +94,13 @@ jobs:
           docker manifest push aquasec/tracee:dev
 
           timestamp=$(date +%Y%m%d-%H%M%S%Z)
-          docker manifest create aquasec/tracee:dev-$timestamp \
+          docker manifest create "aquasec/tracee:dev-${timestamp}" \
             aquasec/tracee:x86_64-dev \
             aquasec/tracee:aarch64-dev
-          docker manifest push aquasec/tracee:dev-$timestamp
+          docker manifest push "aquasec/tracee:dev-${timestamp}"
         shell: bash
-      # Disabled to avoid generating too many sigstore cosign signatures
+      # Disabled to avoid generating too many sigstore cosign signatures.
+      # If re-enabling: add `id-token: write` to this job's permissions.
       # - name: Sign Docker image
       #   run: |
       #     cosign sign -y aquasec/tracee:dev

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,20 +8,34 @@ on:
       ref:
         description: The tag to be released, e.g. v0.0.1
         required: true
+
+# Serialize releases of the same tag; never cancel an in-progress release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release-x86_64:
-    name: Release (x86_64)
+  release-build:
+    name: Release (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            ami: 0cdf7ad6d9627da45 # release-amd64-big-3
+            instance: 2XLARGE
+          - arch: aarch64
+            ami: 07740487fa433aa54 # release-arm64-big-3
+            instance: LARGE
     env:
       GH_TOKEN: ${{ github.token }}
     runs-on:
-      # release-amd64-big-3
-      - graas_ami-0cdf7ad6d9627da45_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
+      - graas_ami-${{ matrix.ami }}_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
       - EXECUTION_TYPE=LONG
-      - INSTANCE_TYPE=2XLARGE
+      - INSTANCE_TYPE=${{ matrix.instance }}
     permissions:
-      contents: write
-      packages: write
-      id-token: write
+      contents: write # `make release` runs `gh release create/upload`
+      id-token: write # cosign keyless (OIDC) image signing
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,77 +60,26 @@ jobs:
         env:
           REF: ${{ github.event.inputs.ref }}
         run: |
-          TAG=$(echo "$REF" | sed -e "s/v//gI")
+          TAG="${REF#[vV]}" # strip a single leading v/V, e.g. v0.1.2 -> 0.1.2
           ARCH=$(uname -m)
-          docker image tag tracee:latest aquasec/tracee:${ARCH}-${TAG}
-          docker image push aquasec/tracee:${ARCH}-${TAG}
+          docker image tag tracee:latest "aquasec/tracee:${ARCH}-${TAG}"
+          docker image push "aquasec/tracee:${ARCH}-${TAG}"
         shell: bash
       - name: Sign Docker image
         env:
           REF: ${{ github.event.inputs.ref }}
         run: |
-          TAG=$(echo "$REF" | sed -e "s/v//gI")
+          TAG="${REF#[vV]}" # strip a single leading v/V, e.g. v0.1.2 -> 0.1.2
           ARCH=$(uname -m)
-          cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:${ARCH}-${TAG})
-        shell: bash
-  release-aarch64:
-    name: Release (aarch64)
-    env:
-      GH_TOKEN: ${{ github.token }}
-    runs-on:
-      # release-arm64-big-3
-      - graas_ami-07740487fa433aa54_${{ github.event.number || 0 }}${{ github.run_attempt }}-${{ github.run_id }}
-      - EXECUTION_TYPE=LONG
-      - INSTANCE_TYPE=LARGE
-    permissions:
-      contents: write
-      packages: write
-      id-token: write
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.inputs.ref }}
-          submodules: true
-          fetch-depth: 0
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: 'v2.2.4'
-      - name: Login to docker.io registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build
-        run: |
-          make -f builder/Makefile.release release
-        shell: bash
-      - name: Publish to docker.io registry
-        env:
-          REF: ${{ github.event.inputs.ref }}
-        run: |
-          TAG=$(echo "$REF" | sed -e "s/v//gI")
-          ARCH=$(uname -m)
-          docker image tag tracee:latest aquasec/tracee:${ARCH}-${TAG}
-          docker image push aquasec/tracee:${ARCH}-${TAG}
-        shell: bash
-      - name: Sign Docker image
-        env:
-          REF: ${{ github.event.inputs.ref }}
-        run: |
-          TAG=$(echo "$REF" | sed -e "s/v//gI")
-          ARCH=$(uname -m)
-          cosign sign -y $(docker inspect --format='{{index .RepoDigests 0}}' aquasec/tracee:${ARCH}-${TAG})
+          cosign sign -y "$(docker inspect --format='{{index .RepoDigests 0}}' "aquasec/tracee:${ARCH}-${TAG}")"
         shell: bash
   release:
     name: Release
-    needs: [release-x86_64, release-aarch64]
+    needs: [release-build]
     runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-24.04') }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
+      id-token: write # cosign keyless (OIDC) manifest signing
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -137,22 +100,22 @@ jobs:
         env:
           REF: ${{ github.event.inputs.ref }}
         run: |
-          TAG=$(echo "$REF" | sed -e "s/v//gI")
+          TAG="${REF#[vV]}" # strip a single leading v/V, e.g. v0.1.2 -> 0.1.2
           export DOCKER_CLI_EXPERIMENTAL=enabled
           docker manifest create aquasec/tracee:latest \
-            aquasec/tracee:x86_64-${TAG} \
-            aquasec/tracee:aarch64-${TAG}
-          docker manifest create aquasec/tracee:${TAG} \
-            aquasec/tracee:x86_64-${TAG} \
-            aquasec/tracee:aarch64-${TAG}
+            "aquasec/tracee:x86_64-${TAG}" \
+            "aquasec/tracee:aarch64-${TAG}"
+          docker manifest create "aquasec/tracee:${TAG}" \
+            "aquasec/tracee:x86_64-${TAG}" \
+            "aquasec/tracee:aarch64-${TAG}"
           docker manifest push aquasec/tracee:latest
-          docker manifest push aquasec/tracee:${TAG}
+          docker manifest push "aquasec/tracee:${TAG}"
         shell: bash
       - name: Sign the latest manifest with Cosign
         env:
           REF: ${{ github.event.inputs.ref }}
         run: |
-          TAG=$(echo "$REF" | sed -e "s/v//gI")
+          TAG="${REF#[vV]}" # strip a single leading v/V, e.g. v0.1.2 -> 0.1.2
           cosign sign -y aquasec/tracee:latest
-          cosign sign -y aquasec/tracee:${TAG}
+          cosign sign -y "aquasec/tracee:${TAG}"
         shell: bash

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,0 +1,514 @@
+name: Security Scan
+#
+# Continuous vulnerability / secret / misconfiguration scanning.
+#
+# Coverage split (kept intentionally to avoid redundant, expensive work):
+#   - Filesystem scan (Trivy): repo dependency vulns, secrets, and IaC/Dockerfile
+#     misconfigurations across the whole tree.
+#   - Custom build/tooling images (Trivy): image-layer CVEs for images that are NOT
+#     published or scanned elsewhere (build envs + docs/codegen tooling).
+#   - Dashboard compose images (Trivy): the third-party images we ship in
+#     performance/dashboard (already digest-pinned in docker-compose.yml).
+#   - Pinned hand-unpacked tools (OSV/NVD): version-pinned binaries Trivy cannot see
+#     because they have no package identity. See scripts/security/pinned-tools.json.
+#   - The shipped `tracee` image is intentionally NOT rebuilt here: it is built and
+#     Trivy-scanned daily by release-snapshot.yaml. Rebuilding it (a full source
+#     compile) only to re-scan it would be redundant and slow. Its Dockerfile
+#     misconfigurations are still covered by the filesystem scan below.
+#
+# Trivy scans run once via the local ./.github/actions/trivy-scan composite action and
+# report as a job-summary table. Only the filesystem (codebase) scan uploads SARIF to
+# the Security tab; image scans are report-only + PR-gating, to avoid flooding
+# code-scanning alerts with un-actionable upstream tooling/test CVEs.
+
+on:
+  # Run daily at 2 AM UTC
+  schedule:
+    - cron: "0 2 * * *"
+
+  # Manual trigger
+  workflow_dispatch:
+
+  # Run on PRs that touch a scan target OR any scan input/gate, so the gates run
+  # exactly when the files that drive them change.
+  pull_request:
+    paths:
+      - "builder/Dockerfile*"
+      - "performance/dashboard/docker-compose.yml"
+      - "scripts/installation/pull-test-images.sh"
+      - "scripts/installation/install-*.sh" # pin files mirrored in pinned-tools.json
+      - "scripts/security/**" # manifest, scanner, overlay template, .trivyignore lives at root
+      - ".trivyignore"
+      - ".github/workflows/security-scan.yaml" # the workflow itself
+      - ".github/actions/trivy-scan/**" # the composite action it uses
+
+# Least privilege: deny all by default; each job grants only what it needs.
+permissions: {}
+
+# One run per workflow+ref. Cancel superseded runs on PRs only (a new push to a PR
+# supersedes the older run); scheduled and manual (workflow_dispatch) runs are left to
+# complete rather than being cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  generate-matrix-custom-images:
+    name: Generate Custom Images Matrix
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has-changes: ${{ steps.set-matrix.outputs.has-changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Generate matrix based on changed files
+        id: set-matrix
+        env:
+          # Pass event context via env (not inline ${{ }}) to avoid shell injection.
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Dockerfiles to build and image-scan, with their build config.
+          # The shipped tracee container (Dockerfile.alpine-tracee-container) is
+          # deliberately excluded - see the header comment: release-snapshot.yaml
+          # already builds and scans it daily.
+          declare -A dockerfiles=(
+              ["Dockerfile.alpine-tracee-make"]="make -f builder/Makefile.tracee-make alpine-prepare ALPINE_MAKE_CONTNAME=alpine-tracee-make:scan|alpine-tracee-make:scan"
+              ["Dockerfile.ubuntu-tracee-make"]="make -f builder/Makefile.tracee-make ubuntu-prepare UBUNTU_MAKE_CONTNAME=ubuntu-tracee-make:scan|ubuntu-tracee-make:scan"
+              ["Dockerfile.mkdocs"]="make -f builder/Makefile.mkdocs mkdocs-build MKDOCS_CONTNAME=tracee-mkdocs:scan|tracee-mkdocs:scan"
+              ["Dockerfile.protoc"]="make -f builder/Makefile.protoc protoc-build PROTOC_CONTNAME=tracee-protoc:scan|tracee-protoc:scan"
+              ["Dockerfile.man"]="make -f builder/Makefile.man man-build MAN_CONTNAME=tracee-man:scan|tracee-man:scan"
+              ["Dockerfile.k8s"]="make -f builder/Makefile.k8s build K8S_CONTNAME=tracee-k8s:scan|tracee-k8s:scan"
+          )
+
+          # Get changed files for PRs, or all files for scheduled/manual runs
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              CHANGED_FILES=$(git diff --name-only "${BASE_SHA}" HEAD | grep "^builder/Dockerfile" || true)
+              echo "Changed Dockerfiles: ${CHANGED_FILES}"
+          else
+              echo "Running scheduled/manual scan - including all Dockerfiles"
+              CHANGED_FILES=$(printf '%s\n' "${!dockerfiles[@]}")
+          fi
+
+          # Build matrix JSON
+          matrix_json="["
+          first=true
+          has_changes=false
+
+          for dockerfile in "${!dockerfiles[@]}"; do
+              # For PRs, check if the full path (builder/Dockerfile.xxx) changed
+              full_path="builder/${dockerfile}"
+              if [[ "${EVENT_NAME}" != "pull_request" ]] || echo "${CHANGED_FILES}" | grep -qxF "${full_path}"; then
+                  IFS='|' read -r build_command image_name <<< "${dockerfiles[$dockerfile]}"
+                  clean_name="${image_name//:/-}"
+                  display_name="${image_name%:scan}"
+
+                  if [[ "${first}" == false ]]; then
+                      matrix_json+=","
+                  fi
+
+                  matrix_json+="{\"dockerfile\":\"${dockerfile}\",\"build_command\":\"${build_command}\",\"image_name\":\"${image_name}\",\"clean_name\":\"${clean_name}\",\"display_name\":\"${display_name}\"}"
+                  first=false
+                  has_changes=true
+              fi
+          done
+
+          matrix_json+="]"
+
+          echo "Generated matrix: ${matrix_json}"
+          echo "matrix=${matrix_json}" >> "${GITHUB_OUTPUT}"
+          echo "has-changes=${has_changes}" >> "${GITHUB_OUTPUT}"
+
+  generate-matrix-dashboard-images:
+    name: Generate Dashboard Images Matrix
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has-changes: ${{ steps.set-matrix.outputs.has-changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Generate matrix based on docker-compose changes
+        id: set-matrix
+        env:
+          # Pass event context via env (not inline ${{ }}) to avoid shell injection.
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          compose_file="performance/dashboard/docker-compose.yml"
+
+          # Derive the service list from the compose file itself (single source of truth),
+          # so a service added/renamed there is scanned without editing this workflow.
+          # docker is already required for the dashboard scan (image-ref resolution); a
+          # parse failure yields an empty list + warning here (empty matrix), not a crash.
+          mapfile -t dashboard_services < <(docker compose -f "${compose_file}" config --format json 2> /dev/null | jq -r '.services | keys[]' 2> /dev/null || true)
+          if [[ "${#dashboard_services[@]}" -eq 0 ]]; then
+              echo "WARN: no services derived from ${compose_file} (invalid compose or docker unavailable?)" >&2
+          fi
+
+          # Check if the compose file changed for PRs, or include all for scheduled/manual runs
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              compose_changed=$(git diff --name-only "${BASE_SHA}" HEAD | grep -Fx "${compose_file}" || true)
+              echo "Docker-compose file changed: ${compose_changed:-false}"
+          else
+              echo "Running scheduled/manual scan - including all dashboard images"
+              compose_changed="${compose_file}"
+          fi
+
+          # Always include every service so the job names expand and the job runs even
+          # when nothing changed; has-changes tells the scan job whether to pull+scan
+          # (short-circuit) - this avoids the greyed, unexpanded "Scan Image (${...})".
+          should_scan=false
+          if [[ -n "${compose_changed}" ]]; then
+              should_scan=true
+          fi
+
+          matrix_json="["
+          first=true
+          for service in "${dashboard_services[@]}"; do
+              if [[ "${first}" == false ]]; then
+                  matrix_json+=","
+              fi
+              matrix_json+="{\"service\":\"${service}\"}"
+              first=false
+          done
+          matrix_json+="]"
+
+          echo "Generated dashboard matrix: ${matrix_json}"
+          echo "matrix=${matrix_json}" >> "${GITHUB_OUTPUT}"
+          echo "has-changes=${should_scan}" >> "${GITHUB_OUTPUT}"
+
+  scan-custom-images:
+    name: Scan Image (${{ matrix.display_name }})
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read # image scans are report-only; no SARIF upload -> no extra scopes
+    needs: generate-matrix-custom-images
+    if: needs.generate-matrix-custom-images.outputs.has-changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix-custom-images.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build image
+        env:
+          # matrix values are repo-defined; passed via env for clean, injection-safe shell.
+          BUILD_COMMAND: ${{ matrix.build_command }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: |
+          set -euo pipefail
+          echo "Building ${IMAGE_NAME} from ${DOCKERFILE}"
+          echo "Build command: ${BUILD_COMMAND}"
+          # Single parse (vs eval) - BUILD_COMMAND is repo-defined make invocations.
+          bash -c "${BUILD_COMMAND}"
+
+      - name: Scan image with Trivy
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan-type: "image"
+          image-ref: ${{ matrix.image_name }}
+          name: ${{ matrix.clean_name }}
+          scanners: "vuln"
+
+  scan-dashboard-images:
+    name: Scan Image (${{ matrix.service }})
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read # image scans are report-only; no SARIF upload -> no extra scopes
+    needs: generate-matrix-dashboard-images
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix-dashboard-images.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # The job always runs (so its name expands); the scan is short-circuited when the
+      # compose file didn't change on this PR (has-changes == 'false').
+      - name: Resolve pinned image reference
+        id: image_info
+        if: needs.generate-matrix-dashboard-images.outputs.has-changes == 'true'
+        working-directory: performance/dashboard
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          set -euo pipefail
+          # Resolve the digest-pinned image from the compose config (robust JSON parse).
+          IMAGE_REF=$(docker compose config --format json | jq -r --arg s "${SERVICE}" '.services[$s].image')
+          if [[ -z "${IMAGE_REF}" || "${IMAGE_REF}" == "null" ]]; then
+              echo "Could not resolve image for service ${SERVICE}" >&2
+              exit 1
+          fi
+          echo "ref=${IMAGE_REF}" >> "${GITHUB_OUTPUT}"
+          echo "Image reference that will be scanned: ${IMAGE_REF}"
+
+      - name: Scan image with Trivy
+        if: needs.generate-matrix-dashboard-images.outputs.has-changes == 'true'
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan-type: "image"
+          image-ref: ${{ steps.image_info.outputs.ref }}
+          name: ${{ matrix.service }}
+          scanners: "vuln"
+
+  generate-matrix-test-images:
+    name: Generate Test Images Matrix
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has-changes: ${{ steps.set-matrix.outputs.has-changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Generate matrix from pull-test-images.sh
+        id: set-matrix
+        env:
+          # Pass event context via env (not inline ${{ }}) to avoid shell injection.
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Single source of truth: the digest-pinned images the tests actually pull.
+          images_file="scripts/installation/pull-test-images.sh"
+
+          # On PRs scan only when that file changed; always on scheduled/manual runs.
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              changed=$(git diff --name-only "${BASE_SHA}" HEAD | grep -Fx "${images_file}" || true)
+              echo "Test images file changed: ${changed:-false}"
+          else
+              echo "Running scheduled/manual scan - including all test images"
+              changed="${images_file}"
+          fi
+
+          matrix_json="["
+          first=true
+          has_changes=false
+
+          if [[ -n "${changed}" ]]; then
+              # Extract every "<ref>@sha256:<digest>" token from the images list. A
+              # zero-match grep in a process substitution does NOT trip `set -e`, so an
+              # empty list yields an empty matrix (no scans) rather than a failure.
+              mapfile -t images < <(grep -oE '[^[:space:]"]+@sha256:[a-f0-9]+' "${images_file}")
+              if [[ "${#images[@]}" -eq 0 ]]; then
+                  echo "WARN: no @sha256-pinned images found in ${images_file}; nothing to scan" >&2
+              fi
+              for image in "${images[@]}"; do
+                  name="${image##*/}" # strip registry/path
+                  name="${name%%:*}"  # strip tag + digest -> bare image name
+                  if [[ "${first}" == false ]]; then
+                      matrix_json+=","
+                  fi
+                  matrix_json+="{\"name\":\"${name}\",\"image\":\"${image}\"}"
+                  first=false
+                  has_changes=true
+              done
+          fi
+
+          matrix_json+="]"
+
+          echo "Generated test-images matrix: ${matrix_json}"
+          echo "matrix=${matrix_json}" >> "${GITHUB_OUTPUT}"
+          echo "has-changes=${has_changes}" >> "${GITHUB_OUTPUT}"
+
+  scan-test-images:
+    name: Scan Image (${{ matrix.name }})
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read # image scans are report-only; no SARIF upload -> no extra scopes
+    needs: generate-matrix-test-images
+    if: needs.generate-matrix-test-images.outputs.has-changes == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate-matrix-test-images.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Scan image with Trivy
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan-type: "image"
+          image-ref: ${{ matrix.image }}
+          name: ${{ matrix.name }}
+          scanners: "vuln"
+
+  scan-filesystem:
+    name: Scan Repository (vuln, secret, misconfig)
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to the Security tab
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Scan filesystem with Trivy
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          name: "filesystem"
+          scanners: "vuln,secret,misconfig"
+          skip-dirs: "dist,3rdparty"
+          upload-sarif: "true" # codebase scan -> Security tab (image scans stay report-only)
+          gate-on-pr: "true" # the one scan that fails a PR; image scans are report-only
+
+  scan-pinned-tools:
+    name: Scan Pinned Hand-Unpacked Tools
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read
+    # Covers version-pinned tools Trivy cannot see (hand-unpacked / source-built
+    # binaries with no package identity). See scripts/security/pinned-tools.json.
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Verify manifest matches real pins
+        # Offline drift check: fails if a real pin was bumped without updating the
+        # manifest. Deterministic, so it gates like the other scans.
+        run: |
+          set -euo pipefail
+          python3 scripts/security/scan-pinned-tools.py --verify
+
+      - name: Query CVE databases (OSV / NVD)
+        env:
+          # Not set in this repo -> the job runs keyless. OSV needs no auth; NVD is
+          # free and the key only raises the rate limit (5->50 req/30s), so without
+          # it the script just sleeps between CPE lookups. Add the secret to speed up.
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        # Report-only: CVE findings for these tools are shown in the job summary but do
+        # not fail the PR (upstream CVEs are largely un-actionable here). The gating
+        # correctness check is the deterministic --verify (drift) step above; only the
+        # filesystem scan gates PRs on findings.
+        run: |
+          set -euo pipefail
+          python3 scripts/security/scan-pinned-tools.py || true
+
+  generate-sbom:
+    name: Generate Software Bill of Materials
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions:
+      contents: read
+    needs:
+      [
+        generate-matrix-custom-images,
+        generate-matrix-dashboard-images,
+        generate-matrix-test-images,
+        scan-custom-images,
+        scan-dashboard-images,
+        scan-test-images,
+        scan-filesystem,
+      ]
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate SBOM for repository
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0 (Trivy v0.70.0)
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "spdx-json"
+          output: "tracee-sbom.spdx.json"
+          scanners: "vuln"
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tracee-sbom
+          path: tracee-sbom.spdx.json
+          retention-days: 30
+
+  summary:
+    name: Security Scan Summary
+    runs-on: ${{ vars.UBUNTU_X86_RUNNER_LABEL || (github.repository_owner == 'aquasecurity' && 'ubuntu-2404-2core') }}
+    permissions: {} # writes only to GITHUB_STEP_SUMMARY; no token scope needed
+    needs:
+      [
+        generate-matrix-custom-images,
+        generate-matrix-dashboard-images,
+        generate-matrix-test-images,
+        scan-custom-images,
+        scan-dashboard-images,
+        scan-test-images,
+        scan-filesystem,
+        scan-pinned-tools,
+      ]
+    if: always()
+
+    steps:
+      - name: Generate summary
+        env:
+          CUSTOM_HAS_CHANGES: ${{ needs.generate-matrix-custom-images.outputs.has-changes }}
+          CUSTOM_RESULT: ${{ needs.scan-custom-images.result }}
+          DASHBOARD_HAS_CHANGES: ${{ needs.generate-matrix-dashboard-images.outputs.has-changes }}
+          DASHBOARD_RESULT: ${{ needs.scan-dashboard-images.result }}
+          TEST_HAS_CHANGES: ${{ needs.generate-matrix-test-images.outputs.has-changes }}
+          TEST_RESULT: ${{ needs.scan-test-images.result }}
+          FS_RESULT: ${{ needs.scan-filesystem.result }}
+          PINNED_RESULT: ${{ needs.scan-pinned-tools.result }}
+        run: |
+          set -euo pipefail
+          {
+              echo "## Security Scan Summary"
+              echo ""
+              echo "### Job results"
+              if [[ "${CUSTOM_HAS_CHANGES}" == "true" ]]; then
+                  echo "- Custom images: ${CUSTOM_RESULT}"
+              else
+                  echo "- Custom images: skipped (no changes)"
+              fi
+              if [[ "${DASHBOARD_HAS_CHANGES}" == "true" ]]; then
+                  echo "- Dashboard images: ${DASHBOARD_RESULT}"
+              else
+                  echo "- Dashboard images: skipped (no changes)"
+              fi
+              if [[ "${TEST_HAS_CHANGES}" == "true" ]]; then
+                  echo "- Test images: ${TEST_RESULT}"
+              else
+                  echo "- Test images: skipped (no changes)"
+              fi
+              echo "- Repository filesystem: ${FS_RESULT}"
+              echo "- Pinned hand-unpacked tools: ${PINNED_RESULT}"
+              echo ""
+              echo "> The shipped \`tracee\` image is scanned separately by release-snapshot.yaml."
+              echo ""
+              echo "### Where to see findings"
+              echo "- Per-scan findings tables: each scan job's own summary (all scans)."
+              echo "- Security tab / PR annotations: filesystem (codebase) scan only."
+              echo "- Image scans (tooling/dashboard/test): report-only, gated on PRs."
+              echo "- Pinned-tools findings link to the source file that owns each pin."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,13 @@
+# Trivy ignore file - accepted / triaged findings.
+#
+# Trivy auto-detects this file at the repository root. List one finding ID per
+# line to suppress it from scans (vulnerabilities, secrets, and misconfigurations).
+# Always add a comment explaining WHY a finding is accepted and, where possible, an
+# expiry so suppressions are revisited.
+#
+# Examples:
+#   CVE-2024-12345   # no fixed version; not reachable from our code paths - review 2026-Q1
+#   AVD-DS-0002      # Dockerfile misconfig accepted for the build-only image
+#
+# Prefer fixing over ignoring. Keep this file empty unless a finding is genuinely
+# accepted.

--- a/builder/Dockerfile.k8s
+++ b/builder/Dockerfile.k8s
@@ -1,5 +1,6 @@
 FROM golang:1.26.5@sha256:d52df9c279840adf958d017ebb275651ed8338b953d39817bc3633a2e6b1bbcc
 
+# controller-gen is mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@c71f90318f2c818b93a4458e42f7c4da416d5368 # v0.17.0
 
 WORKDIR /tracee

--- a/builder/Dockerfile.man
+++ b/builder/Dockerfile.man
@@ -6,6 +6,7 @@ ENV DEBCONF_NOWARNINGS="yes"
 RUN apt-get update -y && \
     apt-get install -y make wget
 
+# Also mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 ARG PANDOC_VERSION="3.2"
 ARG PANDOC_DEB="pandoc-${PANDOC_VERSION}-1-amd64.deb"
 

--- a/builder/Dockerfile.mkdocs
+++ b/builder/Dockerfile.mkdocs
@@ -1,5 +1,6 @@
 FROM squidfunk/mkdocs-material:9.7.6@sha256:868ad4d39fb5865b72d00173ade00f4eae2b38dde7ff790a011cc44ce4a8ff8e
 
 RUN pip install --upgrade pip
+# mike and mkdocs-macros-plugin are mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 RUN pip install git+https://github.com/jimporter/mike.git@6b876a40892f6d16d984247821d5a3ae85745e36 # v2.1.3
 RUN pip install git+https://github.com/fralau/mkdocs-macros-plugin.git@b906a368ecfd5cd25abcbea0a37f7a23944a8355 # v1.3.7

--- a/builder/Dockerfile.protoc
+++ b/builder/Dockerfile.protoc
@@ -2,6 +2,8 @@ FROM golang:1.26.5@sha256:d52df9c279840adf958d017ebb275651ed8338b953d39817bc3633
 
 # Release tag (shared minor.patch): the per-language major is not part of it,
 # e.g. release 35.1 is C++ 7.35.1 - https://protobuf.dev/support/version-support
+# protoc and protoc-gen-go-json (below) are mirrored in
+# scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 ARG PROTOC_VERSION="35.1"
 ARG PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip"
 

--- a/builder/Dockerfile.ubuntu-tracee-make
+++ b/builder/Dockerfile.ubuntu-tracee-make
@@ -20,11 +20,18 @@ COPY scripts/ /tmp/scripts/
 RUN /tmp/scripts/installation/install-clang.sh
 
 # install bpftool from btfhub
-
+#
+# EXTRA_CFLAGS relaxes -Werror for this build only: btfhub's pinned libbpf predates
+# glibc 2.43's const-preserving strstr/strchr overloads, which the newer toolchain now
+# flags. bpftool builds libbpf twice - the main copy with clang and a bootstrap copy
+# with the host gcc - so a clang-specific -Wno-error=<name> breaks the gcc pass (gcc
+# hard-errors on the unknown option name). Bare -Wno-error is understood by both and,
+# appended after -Werror in libbpf's ALL_CFLAGS, demotes the errors to warnings without
+# patching the pinned source.
 RUN cd /tmp && \
     git clone https://github.com/aquasecurity/btfhub.git && \
     cd ./btfhub && \
-    ./3rdparty/bpftool.sh
+    EXTRA_CFLAGS="-Wno-error" ./3rdparty/bpftool.sh
 
 # extra tools for testing things
 

--- a/builder/Makefile.k8s
+++ b/builder/Makefile.k8s
@@ -67,7 +67,7 @@ help:
 		exit 1
 	fi
 
-K8S_CONTNAME = tracee-k8s:latest
+K8S_CONTNAME ?= tracee-k8s:latest
 
 .PHONY: build
 build: \

--- a/builder/Makefile.man
+++ b/builder/Makefile.man
@@ -61,7 +61,7 @@ help:
 		exit 1
 	fi
 
-MAN_CONTNAME = tracee-man:latest
+MAN_CONTNAME ?= tracee-man:latest
 
 .PHONY: man-build
 man-build: \

--- a/builder/Makefile.mkdocs
+++ b/builder/Makefile.mkdocs
@@ -65,7 +65,7 @@ help:
 # mkdocs dev server
 #
 
-MKDOCS_CONTNAME = tracee-mkdocs:latest
+MKDOCS_CONTNAME ?= tracee-mkdocs:latest
 
 .PHONY: mkdocs-build
 mkdocs-build: \

--- a/builder/Makefile.protoc
+++ b/builder/Makefile.protoc
@@ -61,7 +61,7 @@ help:
 		exit 1
 	fi
 
-PROTOC_CONTNAME = tracee-protoc:latest
+PROTOC_CONTNAME ?= tracee-protoc:latest
 
 .PHONY: protoc-build
 protoc-build: \

--- a/builder/Makefile.tracee-container
+++ b/builder/Makefile.tracee-container
@@ -112,8 +112,8 @@ ifeq ($(SNAPSHOT),1)
 	TAG=dev
 endif
 
-TRACEE_CONT_NAME = tracee:$(TAG)
-TRACEE_CONT_DOCKERFILE = builder/Dockerfile.alpine-tracee-container
+TRACEE_CONT_NAME ?= tracee:$(TAG)
+TRACEE_CONT_DOCKERFILE = $(abspath $(shell find -name Dockerfile.alpine-tracee-container))
 
 .PHONY: build-tracee
 build-tracee: \

--- a/builder/Makefile.tracee-make
+++ b/builder/Makefile.tracee-make
@@ -120,7 +120,9 @@ UID = $(shell id -u)
 GID = $(shell id -g)
 PWD = $(shell pwd)
 
-ALPINE_MAKE_CONTNAME = alpine-tracee-make
+TAG ?= latest
+
+ALPINE_MAKE_CONTNAME ?= alpine-tracee-make:$(TAG)
 ALPINE_MAKE_DOCKERFILE = $(abspath $(shell find -name Dockerfile.alpine-tracee-make))
 
 .PHONY: alpine-prepare
@@ -131,12 +133,12 @@ alpine-prepare: \
 	$(CMD_DOCKER) build \
 		--network host \
 		-f $(ALPINE_MAKE_DOCKERFILE) \
-		-t $(ALPINE_MAKE_CONTNAME):latest \
+		-t $(ALPINE_MAKE_CONTNAME) \
 		--build-arg uid=$(UID) \
 		--build-arg gid=$(GID) \
 		.
 
-UBUNTU_MAKE_CONTNAME = ubuntu-tracee-make
+UBUNTU_MAKE_CONTNAME ?= ubuntu-tracee-make:$(TAG)
 UBUNTU_MAKE_DOCKERFILE = $(abspath $(shell find -name Dockerfile.ubuntu-tracee-make))
 
 .PHONY: ubuntu-prepare
@@ -147,7 +149,7 @@ ubuntu-prepare: \
 	$(CMD_DOCKER) build \
 		--network host \
 		-f $(UBUNTU_MAKE_DOCKERFILE) \
-		-t $(UBUNTU_MAKE_CONTNAME):latest \
+		-t $(UBUNTU_MAKE_CONTNAME) \
 		--build-arg uid=$(UID) \
 		--build-arg gid=$(GID) \
 		.

--- a/scripts/installation/install-ami-tooling.sh
+++ b/scripts/installation/install-ami-tooling.sh
@@ -20,6 +20,7 @@ __LIB_DIR="${SCRIPT_DIR}/.."
 # corresponding checksum files in scripts/installation/checksums/:
 #   - actions-runner-linux-x64-{VERSION}.sha256
 #   - actions-runner-linux-arm64-{VERSION}.sha256
+# Also mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 readonly ACTIONS_RUNNER_VERSION="2.330.0"
 
 # Path to AWS CLI GPG public key for signature verification

--- a/scripts/installation/install-clang.sh
+++ b/scripts/installation/install-clang.sh
@@ -16,8 +16,15 @@ __LIB_DIR="${0%/*}/.."
 # to match the latest point release available at:
 #   https://github.com/llvm/llvm-project/releases
 #
+# Also mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 CLANG_VERSION=19
 LLVM_FULL_VERSION="19.1.7"
+
+# apt.llvm.org publishes a repo per Ubuntu codename but lags brand-new releases (e.g.
+# resolute / 26.04 has none yet). add_llvm_apt_repo() probes the codename's repo and,
+# only when it is genuinely missing, falls back to this LTS (safe because in practice
+# only newer-than-LTS releases hit the fallback).
+CLANG_APT_FALLBACK_CODENAME="noble"
 
 # Path to LLVM release signing GPG key for signature verification
 # Official source: https://llvm.org/release-keys.asc
@@ -164,6 +171,16 @@ add_llvm_apt_repo() {
     fi
 
     info "Detected Ubuntu codename: ${codename}"
+
+    # Use this codename's own apt.llvm.org repo when it exists; only fall back when it
+    # is genuinely missing. Probing (rather than a static allowlist) avoids rerouting a
+    # codename that DOES have a repo (e.g. lunar/mantic) onto an LTS whose libc it can't
+    # satisfy.
+    local llvm_release_url="https://apt.llvm.org/${codename}/dists/llvm-toolchain-${codename}-${CLANG_VERSION}/Release"
+    if ! wget -q --spider "${llvm_release_url}"; then
+        warn "apt.llvm.org has no clang-${CLANG_VERSION} repo for '${codename}'; falling back to '${CLANG_APT_FALLBACK_CODENAME}'"
+        codename="${CLANG_APT_FALLBACK_CODENAME}"
+    fi
 
     # Add LLVM repository
     echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${CLANG_VERSION} main" > /etc/apt/sources.list.d/llvm.list

--- a/scripts/installation/install-go-tools.sh
+++ b/scripts/installation/install-go-tools.sh
@@ -12,6 +12,8 @@ __LIB_DIR="${SCRIPT_DIR}/.."
 . "${__LIB_DIR}/lib.sh"
 
 # Pinned versions (commit hashes) - do not allow external overrides
+# The versions below are mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE
+# scan) - bump there too.
 STATICCHECK_VERSION="5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c" # 2025.1
 REVIVE_VERSION="8ece20b0789c517bd3a6742db0daa4dd5928146d" # v1.7.0
 GOIMPORTS_REVISER_VERSION="fa5587e51ba33c58734984cb41370a5b2582d5b7" # v3.12.6

--- a/scripts/installation/install-golang.sh
+++ b/scripts/installation/install-golang.sh
@@ -16,6 +16,7 @@ __LIB_DIR="${SCRIPT_DIR}/.."
 #   scripts/installation/checksums/go${GOLANG_VERSION}.linux-amd64.tar.gz.sha256
 #   scripts/installation/checksums/go${GOLANG_VERSION}.linux-arm64.tar.gz.sha256
 # Get checksums from: https://go.dev/dl/ (click "Show checksum" for each file)
+# Also mirrored in scripts/security/pinned-tools.json (OSV/NVD CVE scan) - bump there too.
 GOLANG_VERSION="1.26.5"
 
 install_golang() {

--- a/scripts/installation/pull-test-images.sh
+++ b/scripts/installation/pull-test-images.sh
@@ -19,6 +19,10 @@ require_cmds docker
 
 # List of container images required for tests
 # Using ECR Public mirrors where possible to avoid Docker Hub rate limits
+#
+# This list is the single source of truth for the Trivy "Scan Image" jobs in
+# .github/workflows/security-scan.yaml (it parses the @sha256-pinned refs below), so
+# any image added/bumped here is scanned automatically - no workflow change needed.
 IMAGES="
 public.ecr.aws/docker/library/busybox:1.37.0@sha256:e3652a00a2fabd16ce889f0aa32c38eec347b997e73bd09e69c962ec7f8732ee
 public.ecr.aws/docker/library/ubuntu:jammy-20240911.1@sha256:0e5e4a57c2499249aafc3b40fcd541e9a456aab7296681a3994d631587203f97

--- a/scripts/security/pinned-tools.extended.json.example
+++ b/scripts/security/pinned-tools.extended.json.example
@@ -1,0 +1,26 @@
+{
+  "_readme": [
+    "EXTENDED overlay for pinned-tools scanning (mirrors tests/e2e/lib-extended.sh).",
+    "",
+    "HOW TO USE (in a downstream/private repo):",
+    "  1. Copy this file to: scripts/security/pinned-tools.extended.json (drop .example).",
+    "     Commit the copy in your private repo; the public repo ships only this .example.",
+    "  2. Add your private version-pinned tools to 'tools' below, same schema as",
+    "     scripts/security/pinned-tools.json.",
+    "  3. scan-pinned-tools.py loads it automatically if present and appends its 'tools'",
+    "     to the core set (--verify drift-checks them too).",
+    "",
+    "Each entry: name, version, source (file that owns the real pin), match (verbatim",
+    "string to find in source), and ONE identity: osv {ecosystem,name} or cpe."
+  ],
+
+  "tools": [
+    {
+      "name": "example-private-tool",
+      "version": "1.2.3",
+      "source": "path/in/private/repo/Dockerfile.example",
+      "match": "EXAMPLE_TOOL_VERSION=\"1.2.3\"",
+      "osv": { "ecosystem": "Go", "name": "example.com/org/tool" }
+    }
+  ]
+}

--- a/scripts/security/pinned-tools.json
+++ b/scripts/security/pinned-tools.json
@@ -1,0 +1,161 @@
+{
+  "_readme": [
+    "Scanning index for version-pinned tools that Trivy CANNOT see because they are",
+    "hand-unpacked / built from source / installed outside a package manager (no",
+    "package-manager identity). This file does NOT drive any build - the authoritative",
+    "pins still live in the 'source' file of each entry. scan-pinned-tools.py mirrors",
+    "them here only so their versions can be queried against a CVE database (OSV/NVD).",
+    "",
+    "Invariant (enforced by --verify): for every entry, 'match' must be found verbatim",
+    "in 'source'. If someone bumps the real pin without updating this file, verify fails.",
+    "",
+    "Identity: give ONE of 'osv' {ecosystem,name} (preferred; reliable version match) or",
+    "'cpe' (for standalone tools OSV does not index; verify vendor:product against NVD).",
+    "",
+    "EXTENSIBILITY: an optional 'pinned-tools.extended.json' (committed by a downstream/",
+    "private repo, template in pinned-tools.extended.json.example) is merged on top of",
+    "this file - its 'tools' are appended. Not gitignored, so the private repo can track",
+    "it; the public repo ships only the .example. See scan-pinned-tools.py.",
+    "",
+    "COVERED ELSEWHERE (intentionally NOT listed as entries):",
+    "- protoc-gen-go / protoc-gen-go-grpc: identical to the google.golang.org/protobuf",
+    "  and google.golang.org/grpc modules already in go.mod (Trivy + govulncheck).",
+    "- Go module dependencies at large: go.mod/go.sum (Trivy fs scan + govulncheck).",
+    "",
+    "NOT TRACKABLE BY VERSION (see _disabled entries): tools installed as 'latest' with",
+    "no version pin (AWS CLI v2, gh CLI) or built from source with no advisory identity",
+    "(bpftool). Integrity of pinned downloads (go, actions-runner) is covered separately",
+    "by the sha256 files in scripts/installation/checksums/."
+  ],
+
+  "tools": [
+    {
+      "name": "protoc (protobuf compiler)",
+      "version": "35.1",
+      "source": "builder/Dockerfile.protoc",
+      "match": "PROTOC_VERSION=\"35.1\"",
+      "cpe": "cpe:2.3:a:google:protobuf:35.1:*:*:*:*:*:*:*",
+      "note": "Unzipped to /usr/local -> invisible to Trivy. protobuf runtime/codegen (google.golang.org/protobuf v1.36.11) is already in go.mod; this catches compiler-specific advisories."
+    },
+    {
+      "name": "pandoc",
+      "version": "3.2",
+      "source": "builder/Dockerfile.man",
+      "match": "PANDOC_VERSION=\"3.2\"",
+      "cpe": "cpe:2.3:a:pandoc:pandoc:3.2:*:*:*:*:*:*:*",
+      "covered_elsewhere": "Installed via 'dpkg -i' -> also visible in the man image's dpkg DB when Trivy scans that image. Kept here as a cross-check."
+    },
+    {
+      "name": "clang / llvm",
+      "version": "19.1.7",
+      "source": "scripts/installation/install-clang.sh",
+      "match": "LLVM_FULL_VERSION=\"19.1.7\"",
+      "cpe": "cpe:2.3:a:llvm:clang:19.1.7:*:*:*:*:*:*:*",
+      "covered_elsewhere": "Installed via apk/apt (or an llvm-project release tarball) -> visible as OS packages in the tracee-make images. Cross-check.",
+      "note": "NVD product for the compiler is llvm:clang; LLVM library-level advisories may also appear under cpe:2.3:a:llvm:llvm."
+    },
+    {
+      "name": "go toolchain",
+      "version": "1.26.5",
+      "source": "scripts/installation/install-golang.sh",
+      "match": "GOLANG_VERSION=\"1.26.5\"",
+      "osv": { "ecosystem": "Go", "name": "stdlib" },
+      "covered_elsewhere": "govulncheck (pr.yaml) already covers the Go stdlib with reachability. Integrity pinned by scripts/installation/checksums/go1.26.5.*.sha256."
+    },
+    {
+      "name": "staticcheck",
+      "version": "2025.1",
+      "source": "scripts/installation/install-go-tools.sh",
+      "match": "STATICCHECK_VERSION=\"5af2e5fc3b08ba46027eb48ebddeba34dc0bd02c\"",
+      "osv": { "ecosystem": "Go", "name": "honnef.co/go/tools" }
+    },
+    {
+      "name": "revive",
+      "version": "1.7.0",
+      "source": "scripts/installation/install-go-tools.sh",
+      "match": "REVIVE_VERSION=\"8ece20b0789c517bd3a6742db0daa4dd5928146d\"",
+      "osv": { "ecosystem": "Go", "name": "github.com/mgechev/revive" }
+    },
+    {
+      "name": "goimports-reviser",
+      "version": "3.12.6",
+      "source": "scripts/installation/install-go-tools.sh",
+      "match": "GOIMPORTS_REVISER_VERSION=\"fa5587e51ba33c58734984cb41370a5b2582d5b7\"",
+      "osv": { "ecosystem": "Go", "name": "github.com/incu6us/goimports-reviser/v3" }
+    },
+    {
+      "name": "errcheck",
+      "version": "1.9.0",
+      "source": "scripts/installation/install-go-tools.sh",
+      "match": "ERRCHECK_VERSION=\"11c27a7ce69d583465d80d808817d22d6653ee34\"",
+      "osv": { "ecosystem": "Go", "name": "github.com/kisielk/errcheck" }
+    },
+    {
+      "name": "govulncheck (dev tool)",
+      "version": "1.1.4",
+      "source": "scripts/installation/install-go-tools.sh",
+      "match": "GOVULNCHECK_VERSION=\"d1f380186385b4f64e00313f31743df8e4b89a77\"",
+      "osv": { "ecosystem": "Go", "name": "golang.org/x/vuln" }
+    },
+    {
+      "name": "controller-gen",
+      "version": "0.17.0",
+      "source": "builder/Dockerfile.k8s",
+      "match": "controller-gen@c71f90318f2c818b93a4458e42f7c4da416d5368",
+      "osv": { "ecosystem": "Go", "name": "sigs.k8s.io/controller-tools" }
+    },
+    {
+      "name": "protoc-gen-go-json",
+      "version": "1.6.0",
+      "source": "builder/Dockerfile.protoc",
+      "match": "protoc-gen-go-json@d4d13d829d9034a255ae5ab0568876d5da33f6ef",
+      "osv": { "ecosystem": "Go", "name": "github.com/mfridman/protoc-gen-go-json" }
+    },
+    {
+      "name": "mike (mkdocs versioning)",
+      "version": "2.1.3",
+      "source": "builder/Dockerfile.mkdocs",
+      "match": "mike.git@6b876a40892f6d16d984247821d5a3ae85745e36",
+      "osv": { "ecosystem": "PyPI", "name": "mike" },
+      "covered_elsewhere": "Installed via pip into the mkdocs image -> also visible to Trivy's image scan via pip metadata."
+    },
+    {
+      "name": "mkdocs-macros-plugin",
+      "version": "1.3.7",
+      "source": "builder/Dockerfile.mkdocs",
+      "match": "mkdocs-macros-plugin.git@b906a368ecfd5cd25abcbea0a37f7a23944a8355",
+      "osv": { "ecosystem": "PyPI", "name": "mkdocs-macros-plugin" },
+      "covered_elsewhere": "Installed via pip into the mkdocs image -> also visible to Trivy's image scan via pip metadata."
+    },
+    {
+      "name": "actions/runner (CI runner binary)",
+      "version": "2.330.0",
+      "source": "scripts/installation/install-ami-tooling.sh",
+      "match": "ACTIONS_RUNNER_VERSION=\"2.330.0\"",
+      "cpe": "cpe:2.3:a:github:runner:2.330.0:*:*:*:*:*:*:*",
+      "note": "Downloaded onto the CI AMI; not present in any Trivy-scanned image, so this is the only signal for it. Integrity pinned by scripts/installation/checksums/actions-runner-*.sha256."
+    },
+
+    {
+      "_disabled": true,
+      "name": "bpftool (from btfhub)",
+      "version": "n/a",
+      "source": "builder/Dockerfile.alpine-tracee-make",
+      "note": "Built from source via btfhub bpftool.sh with no version pin and no advisory-backed identity. No scanner can match it. Track via upstream libbpf/bpftool GitHub Security Advisories instead."
+    },
+    {
+      "_disabled": true,
+      "name": "AWS CLI v2",
+      "version": "latest",
+      "source": "scripts/installation/install-ami-tooling.sh",
+      "note": "Downloaded as awscli-exe-linux-*.zip (always latest, GPG-verified). No version pin, so nothing to query; it auto-updates. Left disabled as documentation."
+    },
+    {
+      "_disabled": true,
+      "name": "gh CLI",
+      "version": "latest",
+      "source": "scripts/installation/install-ami-tooling.sh",
+      "note": "Installed via apt from cli.github.com (latest). No version pin; covered by OS package scanning only if the host is scanned. Documentation only."
+    }
+  ]
+}

--- a/scripts/security/scan-pinned-tools.py
+++ b/scripts/security/scan-pinned-tools.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Scan version-pinned tools that Trivy cannot see (hand-unpacked / source-built
+binaries) against a CVE database, using the versions we already pin.
+
+Two modes:
+  --verify   Drift check only: assert every manifest 'match' string is present in
+             its 'source' file. Fast, offline, safe to gate PRs on.
+  (default)  Verify, then query OSV (and NVD for 'cpe' entries) for known vulns.
+
+Each finding is reported with the 'source' file that owns the pin, so a CVE can be
+traced straight back to the file to bump. When GITHUB_STEP_SUMMARY is set, a markdown
+findings table is appended to the job summary.
+
+Reads scripts/security/pinned-tools.json. Standard library only.
+
+Exit codes: 0 = clean; 1 = vulnerabilities found; 2 = could not complete a trustworthy
+scan (manifest drift/error, or a CVE-database lookup failed - fail closed, not clean).
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SECURITY_DIR = os.path.join(ROOT, "scripts", "security")
+MANIFEST = os.path.join(SECURITY_DIR, "pinned-tools.json")
+# Optional overlay: a downstream/private repo commits this file to add its own pinned
+# tools (mirrors tests/e2e/lib-extended.sh). Deliberately NOT gitignored, so the private
+# repo can track it; this public repo just ships the .example. Loaded here if present.
+EXTENDED_MANIFEST = os.path.join(SECURITY_DIR, "pinned-tools.extended.json")
+
+OSV_URL = "https://api.osv.dev/v1/query"
+NVD_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+# Optional: set NVD_API_KEY to raise the anonymous rate limit (5 req / 30s).
+NVD_KEY = os.environ.get("NVD_API_KEY", "")
+
+
+def _read_tools(path):
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh).get("tools", [])
+
+
+def load_tools():
+    """Core tools plus the optional extended overlay (if present), disabled removed."""
+    tools = _read_tools(MANIFEST)
+    if os.path.isfile(EXTENDED_MANIFEST):
+        print(f"loading extended manifest: {os.path.relpath(EXTENDED_MANIFEST, ROOT)}")
+        tools += _read_tools(EXTENDED_MANIFEST)
+    return [t for t in tools if not t.get("_disabled")]
+
+
+def verify_drift(tools):
+    """Ensure each manifest entry still matches the real pin in its source file."""
+    problems = []
+    for t in tools:
+        name = t.get("name", "<unnamed>")  # tolerate a malformed overlay entry
+        match, source = t.get("match"), t.get("source")
+        if not match or not source:
+            continue  # entries without a concrete pin (e.g. bpftool) are informational
+        path = os.path.join(ROOT, source)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                if match not in fh.read():
+                    problems.append(f"{name}: '{match}' not found in {source} (pin drifted?)")
+        except FileNotFoundError:
+            problems.append(f"{name}: source file not found: {source}")
+    return problems
+
+
+def query_osv(ecosystem, name, version):
+    body = json.dumps({"version": version, "package": {"ecosystem": ecosystem, "name": name}}).encode()
+    req = urllib.request.Request(OSV_URL, data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        vulns = json.load(resp).get("vulns", [])
+    return [v.get("id", "?") for v in vulns]
+
+
+def query_nvd(cpe):
+    url = f"{NVD_URL}?cpeName={urllib.parse.quote(cpe)}"
+    headers = {"apiKey": NVD_KEY} if NVD_KEY else {}
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        items = json.load(resp).get("vulnerabilities", [])
+    if not NVD_KEY:
+        time.sleep(6)  # stay under the anonymous rate limit
+    return [i["cve"]["id"] for i in items]
+
+
+def status_str(ids):
+    """Human-readable finding status: None -> query failed, [] -> clean, else CVE ids."""
+    if ids is None:
+        return "query failed"
+    return ", ".join(ids) if ids else "clean"
+
+
+def scan(tools):
+    """Query each tool; return a list of result rows (with source file and CVE ids).
+
+    Malformed entries (e.g. an overlay entry missing 'version') are reported as
+    unchecked (ids=None) rather than crashing, so the run still fails closed (exit 2).
+    """
+    results = []
+    for t in tools:
+        name = t.get("name", "<unnamed>")
+        version = t.get("version", "")
+        source = t.get("source", "?")
+        osv, cpe = t.get("osv"), t.get("cpe")
+        ids = None
+
+        try:
+            if isinstance(osv, dict) and osv.get("ecosystem") and osv.get("name"):
+                if not version:
+                    raise ValueError("missing 'version' for OSV query")
+                ids = query_osv(osv["ecosystem"], osv["name"], version)
+            elif isinstance(cpe, str) and cpe:
+                ids = query_nvd(cpe)  # version is embedded in the CPE
+            else:
+                # No usable identity (documented-only entry) - skip, don't report.
+                continue
+        except (urllib.error.URLError, KeyError, ValueError) as e:
+            print(f"  ! {name}: could not check ({e})", file=sys.stderr)
+            ids = None
+
+        results.append({"name": name, "version": version, "source": source, "ids": ids})
+        print(f"  {name} {version} [{source}]: {status_str(ids)}")
+    return results
+
+
+def render_summary(results):
+    lines = ["## Pinned Hand-Unpacked Tools (OSV / NVD)", ""]
+    if not results:
+        lines.append("_No queryable entries in the manifest._")
+        return "\n".join(lines) + "\n"
+    lines += ["| Tool | Version | Pinned in | Findings |", "|------|---------|-----------|----------|"]
+    for r in results:
+        lines.append(f"| {r['name']} | `{r['version']}` | `{r['source']}` | {status_str(r['ids'])} |")
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def emit_step_summary(markdown):
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(markdown)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--verify", action="store_true", help="drift check only, no network")
+    args = ap.parse_args()
+
+    # A malformed/unreadable manifest means we cannot run a trustworthy scan -> fail
+    # closed (exit 2) with a clear message instead of a bare traceback. json.JSONDecodeError
+    # is a subclass of ValueError.
+    try:
+        tools = load_tools()
+    except (OSError, ValueError) as e:
+        print(f"ERROR: could not load the pinned-tools manifest: {e}", file=sys.stderr)
+        return 2
+
+    drift = verify_drift(tools)
+    if drift:
+        print("DRIFT / manifest errors:", file=sys.stderr)
+        for d in drift:
+            print(f"  - {d}", file=sys.stderr)
+        return 2
+    print(f"verify: {len(tools)} entries consistent with their source files")
+    if args.verify:
+        return 0
+
+    results = scan(tools)
+    emit_step_summary(render_summary(results))
+
+    vulnerable = [r for r in results if r["ids"]]
+    if vulnerable:
+        print(f"\n{len(vulnerable)} tool(s) with known vulnerabilities:", file=sys.stderr)
+        for r in vulnerable:
+            print(f"  - {r['name']} {r['version']} (pinned in {r['source']}): {', '.join(r['ids'])}", file=sys.stderr)
+        return 1
+
+    # A failed CVE lookup (ids is None) means we could NOT verify the tool - do not
+    # report it as clean. Exit 2 signals "untrustworthy scan" so a caller CAN fail
+    # closed on OSV/NVD outages or schema changes. (The security-scan workflow currently
+    # runs this step report-only via `|| true`, by policy, so it does not gate on this.)
+    unchecked = [r for r in results if r["ids"] is None]
+    if unchecked:
+        print(f"\n{len(unchecked)} tool(s) could not be checked (CVE lookup failed):", file=sys.stderr)
+        for r in unchecked:
+            print(f"  - {r['name']} {r['version']} (pinned in {r['source']})", file=sys.stderr)
+        return 2
+
+    print("\nNo known vulnerabilities for pinned hand-unpacked tools.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### 1. Explain what the PR does

01b410555 **refactor(ci): harden and dedup release workflows**

> Prepare the currently-disabled release.yaml and release-snapshot.yaml for
> enabling, with a security-focused sweep.
> 
> - Collapse the per-arch x86_64/aarch64 jobs into a single build matrix
>   (arch/ami/instance), removing the duplicated steps.
> - Least-privilege permissions: drop packages:write everywhere (pushes go
>   to docker.io via DOCKERHUB_* secrets, not GHCR) and keep id-token:write
>   only where cosign keyless signing actually runs, documenting each grant.
>   release-snapshot needs no id-token (its signing stays disabled).
> - Add concurrency guards that serialize same-tag / same-ref runs without
>   cancelling an in-progress release.
> - Replace `sed -e s/v//gI` with `${REF#[vV]}` (strip only a single leading
>   v/V) and quote all shell variable expansions.

--

81fa7bce2 **feat(ci): add Trivy security scan workflow**

> Add a daily/PR "Security Scan" workflow that runs Trivy across the custom
> tooling Dockerfiles, the dashboard compose images, the test images, and
> the repository filesystem, plus a stdlib-only scanner for version-pinned
> tools Trivy cannot see (hand-unpacked / source-built binaries) queried
> against OSV and NVD.
> 
> - .github/actions/trivy-scan: composite action that scans once, reports a
>   findings table to the job summary and log, uploads SARIF to the Security
>   tab only for the codebase (filesystem) scan, and gates PRs only when the
>   caller opts in. Trivy is SHA-pinned (which transitively pins the binary);
>   the vulnerability DB is still fetched fresh each run.
> - scripts/security: pinned-tools.json manifest (each tool's own file stays
>   the authoritative pin; --verify enforces no drift), scan-pinned-tools.py
>   (OSV/NVD scanner, fail-closed on drift or lookup failure), and a
>   gitignored private overlay with a committed .example template.
> - Tracker comments point every hand-unpacked pin back to the manifest so
>   bumps stay mirrored; pull-test-images.sh notes it feeds the image scan.
> - builder/Makefile.*: make image tags overridable (?=) so the workflow can
>   build with :scan tags without changing the default :latest builds.
> 
> Also fix two toolchain build breaks surfaced by the scan's image builds:
> probe apt.llvm.org per Ubuntu codename before falling back to noble (so a
> codename that has its own clang-19 repo is not rerouted onto an LTS whose
> libc it cannot satisfy), and relax -Werror for btfhub's pinned libbpf
> under glibc 2.43 via a bare EXTRA_CFLAGS=-Wno-error understood by both the
> clang and gcc bootstrap passes.

--

### 2. Explain how to test it

https://github.com/aquasecurity/tracee/actions/runs/30098921540

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
