### PR TITLE
More fixes

### DIFF
--- a/common/capabilities/capabilities.go
+++ b/common/capabilities/capabilities.go
@@ -343,7 +343,19 @@ func (c *Capabilities) Specific(cb func() error, values ...cap.Value) error {
 	if err != nil {
 		return errfmt.WrapError(err)
 	}
-	err = c.unset(Specific, values...) // clean specific ring for next calls
+	// Clean the specific ring for next calls, but keep base-ring caps: they are
+	// propagated to every ring, and unsetting one here would drop it from the
+	// process-wide effective set during every later Specific() callback,
+	// breaking concurrent goroutines that rely on base caps (e.g. SYS_PTRACE
+	// for /proc readers).
+	toUnset := make([]cap.Value, 0, len(values))
+	for _, v := range values {
+		if m, exists := c.all[v]; exists && m[Base] {
+			continue
+		}
+		toUnset = append(toUnset, v)
+	}
+	err = c.unset(Specific, toUnset...) // clean specific ring for next calls
 	if err != nil {
 		return errfmt.WrapError(err)
 	}

--- a/common/capabilities/capabilities_test.go
+++ b/common/capabilities/capabilities_test.go
@@ -509,3 +509,24 @@ func cleanupCapabilities(c *Capabilities, values ...cap.Value) {
 		_ = c.EBPFRingRemove(v)
 	}
 }
+
+// TestSpecificPreservesBaseRingCaps pins the invariant that base-ring caps,
+// which baseRingAdd propagates into every ring, survive a Specific() window:
+// regression for Specific() unsetting a requested base cap from the Specific
+// ring, which dropped it from the process-wide effective set during every
+// later Specific() callback.
+func TestSpecificPreservesBaseRingCaps(t *testing.T) {
+	c := &Capabilities{lock: &sync.Mutex{}}
+	require.NoError(t, c.initialize(Config{Bypass: true}))
+
+	require.NoError(t, c.BaseRingAdd(cap.SYS_PTRACE))
+	require.True(t, c.all[cap.SYS_PTRACE][Specific], "base cap should propagate to the Specific ring")
+
+	require.NoError(t, c.Specific(func() error { return nil }, cap.SYS_PTRACE))
+	assert.True(t, c.all[cap.SYS_PTRACE][Specific], "base-ring cap stripped from the Specific ring by Specific()")
+	assert.True(t, c.all[cap.SYS_PTRACE][Base])
+
+	// non-base caps are still cleaned up for the next call
+	require.NoError(t, c.Specific(func() error { return nil }, cap.NET_ADMIN))
+	assert.False(t, c.all[cap.NET_ADMIN][Specific], "non-base cap should be cleaned from the Specific ring")
+}

--- a/pkg/datastores/container/containers.go
+++ b/pkg/datastores/container/containers.go
@@ -273,14 +273,18 @@ func (c *Manager) cgroupUpdate(
 // If the given cgroup does not belong to a container, no error will be returned, but the
 // returned metadata's containerId will be empty. This should be checked separately.
 func (c *Manager) EnrichCgroupInfo(cgroupId uint64) (Container, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
 	var cont Container
+
+	// Snapshot and validate under the lock, then release it: the runtime RPC
+	// below must not run while holding the lock, or every reader (event
+	// decoding, signature data-source queries) stalls for up to the RPC
+	// deadline, backpressuring the pipeline.
+	c.lock.Lock()
 	info, ok := c.cgroupsMap[uint32(cgroupId)]
 
 	// if there is no cgroup anymore for some reason, return early
 	if !ok {
+		c.lock.Unlock()
 		return cont, errfmt.Errorf("cgroup %d not found, won't enrich", cgroupId)
 	}
 
@@ -288,40 +292,62 @@ func (c *Manager) EnrichCgroupInfo(cgroupId uint64) (Container, error) {
 
 	if containerId == "" {
 		// not a container, nothing to do
+		c.lock.Unlock()
 		cont.ContainerId = ""
 		return cont, nil
 	}
 
-	container := c.containerMap[containerId]
+	container, containerTracked := c.containerMap[containerId]
+	if !containerTracked {
+		// already purged while a stale cgroup entry lingers: don't burn an
+		// RPC for a container that no longer exists (its zero Runtime would
+		// make the service try every registered enricher)
+		c.lock.Unlock()
+		return cont, errfmt.Errorf("container %s no longer tracked, won't enrich", containerId)
+	}
 
 	isMikubeOrKind := k8s.IsMinkube() || k8s.IsKind()
 	if info.Dead && !isMikubeOrKind {
+		c.lock.Unlock()
 		return cont, errfmt.Errorf("container %s already deleted in path %s", containerId, info.Path)
 	}
 
 	if container.Image != "" {
 		// If already enriched (from control plane) - short circuit and return
+		c.lock.Unlock()
 		return container, nil
 	}
+	containerRuntime := container.Runtime
+	c.lock.Unlock()
 
 	// There might be a performance overhead with the cancel
 	// But, I think it will be negligible since this code path shouldn't be reached too frequently
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	enrichRes, err := c.enricher.Get(ctx, containerId, container.Runtime)
+	enrichRes, err := c.enricher.Get(ctx, containerId, containerRuntime)
 	defer cancel()
 	// if enrichment fails, just return early
 	if err != nil {
 		return cont, errfmt.WrapError(err)
 	}
 
-	// we read the dictionary again to make sure the cgroup still exists
-	// otherwise we risk reintroducing it despite not existing
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// we read both dictionaries again to make sure the cgroup AND the
+	// container still exist - otherwise we risk reintroducing a purged
+	// container (e.g. root expired while a stale sub-cgroup entry lingers)
+	// with zero CreatedAt/Runtime
 	_, ok = c.cgroupsMap[uint32(cgroupId)]
-	if ok {
+	current, containerExists := c.containerMap[containerId]
+	if ok && containerExists {
+		// merge onto the CURRENT entry: a concurrent cgroupUpdate may have
+		// improved CreatedAt/Runtime while the RPC was in flight (and the old
+		// info snapshot is not written back - a concurrent CgroupRemove may
+		// have marked it dead meanwhile)
 		container = Container{
 			ContainerId: intern.String(containerId),
-			Runtime:     container.Runtime,
-			CreatedAt:   container.CreatedAt,
+			Runtime:     current.Runtime,
+			CreatedAt:   current.CreatedAt,
 			Name:        intern.String(enrichRes.ContName),
 			Image:       intern.String(enrichRes.Image),
 			ImageDigest: intern.String(enrichRes.ImageDigest),
@@ -332,7 +358,6 @@ func (c *Manager) EnrichCgroupInfo(cgroupId uint64) (Container, error) {
 				Sandbox:   enrichRes.Sandbox,
 			},
 		}
-		c.cgroupsMap[uint32(cgroupId)] = info
 		c.containerMap[containerId] = container
 		cont = container
 	}

--- a/pkg/datastores/container/containers.go
+++ b/pkg/datastores/container/containers.go
@@ -243,6 +243,22 @@ func (c *Manager) cgroupUpdate(
 		CreatedAt:   ctime,
 	}
 
+	// A container spans several cgroup dirs, and lazy lookups can stat a dir
+	// long after creation: keep the earliest CreatedAt (consumers compare file
+	// ctimes against it, e.g. drift detections) and never wipe enrichment data.
+	if existing, ok := c.containerMap[containerId]; ok && containerId != "" {
+		if !existing.CreatedAt.IsZero() && existing.CreatedAt.Before(ctime) {
+			container.CreatedAt = existing.CreatedAt
+		}
+		if container.Runtime == runtime.Unknown {
+			container.Runtime = existing.Runtime
+		}
+		container.Name = existing.Name
+		container.Image = existing.Image
+		container.ImageDigest = existing.ImageDigest
+		container.Pod = existing.Pod
+	}
+
 	c.cgroupsMap[uint32(cgroupId)] = info
 	c.containerMap[containerId] = container
 
@@ -428,22 +444,11 @@ func (c *Manager) CgroupRemove(cgroupId uint64, hierarchyID uint32) {
 	}
 
 	now := time.Now()
-	var deleted []uint64
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	// process previously deleted cgroupInfo data (deleted cgroup dirs)
-	for _, id := range c.deleted {
-		info := c.cgroupsMap[uint32(id)]
-		if now.After(info.expiresAt) {
-			contId := c.cgroupsMap[uint32(id)].ContainerId
-			delete(c.cgroupsMap, uint32(id))
-			delete(c.containerMap, contId)
-		} else {
-			deleted = append(deleted, id)
-		}
-	}
-	c.deleted = deleted
+	c.purgeExpired(now)
 
 	if info, ok := c.cgroupsMap[uint32(cgroupId)]; ok {
 		info.expiresAt = now.Add(expiryTime)
@@ -451,6 +456,27 @@ func (c *Manager) CgroupRemove(cgroupId uint64, hierarchyID uint32) {
 		c.cgroupsMap[uint32(cgroupId)] = info
 		c.deleted = append(c.deleted, cgroupId)
 	}
+}
+
+// purgeExpired deletes previously removed cgroup dirs whose grace period
+// elapsed. Only a container-root expiry removes the container entry: a
+// transient sub-cgroup removal must not purge a live container, or its
+// CreatedAt/enrichment would later be rebuilt with a postdated ctime.
+// NOTE: not thread-safe, lock handled by the calling function.
+func (c *Manager) purgeExpired(now time.Time) {
+	var remaining []uint64
+	for _, id := range c.deleted {
+		info := c.cgroupsMap[uint32(id)]
+		if now.After(info.expiresAt) {
+			if info.ContainerRoot {
+				delete(c.containerMap, info.ContainerId)
+			}
+			delete(c.cgroupsMap, uint32(id))
+		} else {
+			remaining = append(remaining, id)
+		}
+	}
+	c.deleted = remaining
 }
 
 // CgroupMkdir adds cgroupInfo of a created cgroup dir to Containers struct.

--- a/pkg/datastores/container/containers_test.go
+++ b/pkg/datastores/container/containers_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -106,4 +107,47 @@ func TestParseContainerIdFromCgroupPath(t *testing.T) {
 			assert.Equal(t, tt.expectedIsRoot, isRoot, "IsRoot mismatch")
 		})
 	}
+}
+
+func TestPurgeExpiredKeepsLiveContainerOnSubCgroupExpiry(t *testing.T) {
+	const cid = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	now := time.Now()
+	mgr := &Manager{
+		cgroupsMap: map[uint32]CgroupDir{
+			1: {Path: "/docker-" + cid + ".scope", ContainerId: cid, ContainerRoot: true, Ctime: now.Add(-time.Minute)},
+			2: {Path: "/docker-" + cid + ".scope/sub", ContainerId: cid, ContainerRoot: false,
+				Ctime: now, Dead: true, expiresAt: now.Add(-time.Second)},
+		},
+		containerMap: map[string]Container{
+			cid: {ContainerId: cid, CreatedAt: now.Add(-time.Minute), Name: "live"},
+		},
+		deleted: []uint64{2},
+	}
+
+	// a sub-cgroup expiry must not purge the live container's entry
+	mgr.purgeExpired(now)
+	_, subExists := mgr.cgroupsMap[2]
+	assert.False(t, subExists, "expired sub-cgroup dir should be deleted")
+	cont, ok := mgr.containerMap[cid]
+	assert.True(t, ok, "live container entry purged by sub-cgroup expiry")
+	assert.Equal(t, "live", cont.Name)
+	assert.Empty(t, mgr.deleted)
+
+	// the container root's expiry ends the container
+	root := mgr.cgroupsMap[1]
+	root.Dead = true
+	root.expiresAt = now.Add(-time.Second)
+	mgr.cgroupsMap[1] = root
+	mgr.deleted = []uint64{1}
+	mgr.purgeExpired(now)
+	_, ok = mgr.containerMap[cid]
+	assert.False(t, ok, "container entry should be purged on root expiry")
+
+	// not-yet-expired entries stay scheduled
+	mgr.cgroupsMap[3] = CgroupDir{ContainerId: cid, Dead: true, expiresAt: now.Add(time.Hour)}
+	mgr.deleted = []uint64{3}
+	mgr.purgeExpired(now)
+	_, ok = mgr.cgroupsMap[3]
+	assert.True(t, ok)
+	assert.Equal(t, []uint64{3}, mgr.deleted)
 }

--- a/pkg/datastores/container/containers_test.go
+++ b/pkg/datastores/container/containers_test.go
@@ -1,6 +1,9 @@
 package container
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -150,4 +153,392 @@ func TestPurgeExpiredKeepsLiveContainerOnSubCgroupExpiry(t *testing.T) {
 	_, ok = mgr.cgroupsMap[3]
 	assert.True(t, ok)
 	assert.Equal(t, []uint64{3}, mgr.deleted)
+}
+
+type blockingEnricher struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingEnricher) Get(ctx context.Context, containerId string) (runtime.EnrichResult, error) {
+	close(b.entered)
+	<-b.release
+	return runtime.EnrichResult{ContName: "enriched-name", Image: "img:1"}, nil
+}
+
+func (b *blockingEnricher) Close() error { return nil }
+
+func TestEnrichCgroupInfoDoesNotHoldLockDuringRPC(t *testing.T) {
+	const cid = "feed567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	fake := &blockingEnricher{entered: make(chan struct{}), release: make(chan struct{})}
+
+	var sockets runtime.Sockets
+	assert.NoError(t, sockets.Register(runtime.Docker, "/dev/null"))
+	svc := runtime.NewService(sockets)
+	assert.NoError(t, svc.Register(runtime.Docker,
+		func(socket string) (runtime.ContainerEnricher, error) { return fake, nil }))
+
+	now := time.Now()
+	mgr := &Manager{
+		enricher: svc,
+		cgroupsMap: map[uint32]CgroupDir{
+			7: {Path: "/docker-" + cid + ".scope", ContainerId: cid, ContainerRoot: true, Ctime: now},
+		},
+		containerMap: map[string]Container{
+			cid: {ContainerId: cid, Runtime: runtime.Docker, CreatedAt: now},
+		},
+	}
+
+	type result struct {
+		cont Container
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		cont, err := mgr.EnrichCgroupInfo(7)
+		done <- result{cont, err}
+	}()
+
+	<-fake.entered
+	// the manager lock must be free while the RPC is in flight
+	if !mgr.lock.TryLock() {
+		t.Fatal("manager lock held across the enrichment RPC")
+	}
+	// concurrent update while the RPC runs: enrichment must merge onto it
+	earlier := now.Add(-time.Minute)
+	entry := mgr.containerMap[cid]
+	entry.CreatedAt = earlier
+	mgr.containerMap[cid] = entry
+	mgr.lock.Unlock()
+
+	close(fake.release)
+	res := <-done
+	assert.NoError(t, res.err)
+	assert.Equal(t, "enriched-name", res.cont.Name)
+	assert.Equal(t, earlier, res.cont.CreatedAt, "enrichment must not overwrite a concurrently improved CreatedAt")
+	assert.Equal(t, "img:1", mgr.containerMap[cid].Image)
+}
+
+// stubEnricher returns a fixed result/error, counting calls; if block is
+// non-nil, Get waits on it (signal entry via entered, cap >= expected calls).
+type stubEnricher struct {
+	res     runtime.EnrichResult
+	err     error
+	calls   atomic.Int32
+	entered chan struct{}
+	block   chan struct{}
+}
+
+func (s *stubEnricher) Get(ctx context.Context, containerId string) (runtime.EnrichResult, error) {
+	s.calls.Add(1)
+	if s.entered != nil {
+		s.entered <- struct{}{}
+	}
+	if s.block != nil {
+		<-s.block
+	}
+	return s.res, s.err
+}
+
+func (s *stubEnricher) Close() error { return nil }
+
+func newTestManager(t *testing.T, enricher runtime.ContainerEnricher) *Manager {
+	t.Helper()
+	var sockets runtime.Sockets
+	if err := sockets.Register(runtime.Docker, "/dev/null"); err != nil {
+		t.Fatal(err)
+	}
+	svc := runtime.NewService(sockets)
+	err := svc.Register(runtime.Docker, func(string) (runtime.ContainerEnricher, error) { return enricher, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Manager{
+		enricher:     svc,
+		cgroupsMap:   make(map[uint32]CgroupDir),
+		containerMap: make(map[string]Container),
+	}
+}
+
+// waitOrFatal fails the test instead of hanging when a lock-ordering bug
+// deadlocks the operation under test.
+func waitOrFatal[T any](t *testing.T, ch <-chan T, msg string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(10 * time.Second):
+		t.Fatal(msg)
+		panic("unreachable")
+	}
+}
+
+var errFakeDaemon = errors.New("daemon down")
+
+const enrichTestCid = "beef567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+
+func seedContainer(mgr *Manager, cgroupId uint32, ctime time.Time) {
+	mgr.cgroupsMap[cgroupId] = CgroupDir{
+		Path: "/docker-" + enrichTestCid + ".scope", ContainerId: enrichTestCid,
+		ContainerRoot: true, Ctime: ctime,
+	}
+	mgr.containerMap[enrichTestCid] = Container{
+		ContainerId: enrichTestCid, Runtime: runtime.Docker, CreatedAt: ctime,
+	}
+}
+
+// TestEnrichCgroupInfoBehaviour pins the pre-restructure semantics of every
+// early-return path and of the happy path.
+func TestEnrichCgroupInfoBehaviour(t *testing.T) {
+	now := time.Now()
+
+	t.Run("unknown cgroup errors without RPC", func(t *testing.T) {
+		stub := &stubEnricher{}
+		mgr := newTestManager(t, stub)
+		_, err := mgr.EnrichCgroupInfo(99)
+		assert.ErrorContains(t, err, "not found")
+		assert.Zero(t, stub.calls.Load())
+	})
+
+	t.Run("non-container cgroup is a no-op", func(t *testing.T) {
+		stub := &stubEnricher{}
+		mgr := newTestManager(t, stub)
+		mgr.cgroupsMap[5] = CgroupDir{Path: "/system.slice/ssh.service", ContainerId: ""}
+		cont, err := mgr.EnrichCgroupInfo(5)
+		assert.NoError(t, err)
+		assert.Empty(t, cont.ContainerId)
+		assert.Zero(t, stub.calls.Load())
+	})
+
+	t.Run("untracked container errors without RPC", func(t *testing.T) {
+		stub := &stubEnricher{}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+		// purged container, lingering cgroup entry
+		delete(mgr.containerMap, enrichTestCid)
+		_, err := mgr.EnrichCgroupInfo(7)
+		assert.ErrorContains(t, err, "no longer tracked")
+		assert.Zero(t, stub.calls.Load())
+	})
+
+	t.Run("dead cgroup errors without RPC", func(t *testing.T) {
+		stub := &stubEnricher{}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+		info := mgr.cgroupsMap[7]
+		info.Dead = true
+		mgr.cgroupsMap[7] = info
+		_, err := mgr.EnrichCgroupInfo(7)
+		assert.ErrorContains(t, err, "already deleted")
+		assert.Zero(t, stub.calls.Load())
+	})
+
+	t.Run("already enriched short-circuits", func(t *testing.T) {
+		stub := &stubEnricher{}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+		entry := mgr.containerMap[enrichTestCid]
+		entry.Image = "cached:img"
+		mgr.containerMap[enrichTestCid] = entry
+		cont, err := mgr.EnrichCgroupInfo(7)
+		assert.NoError(t, err)
+		assert.Equal(t, "cached:img", cont.Image)
+		assert.Zero(t, stub.calls.Load())
+	})
+
+	t.Run("enricher error leaves state untouched", func(t *testing.T) {
+		stub := &stubEnricher{err: errFakeDaemon}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+		_, err := mgr.EnrichCgroupInfo(7)
+		assert.ErrorContains(t, err, "daemon down")
+		assert.Empty(t, mgr.containerMap[enrichTestCid].Image)
+		assert.Equal(t, now, mgr.containerMap[enrichTestCid].CreatedAt)
+	})
+
+	t.Run("happy path merges enrichment and preserves identity", func(t *testing.T) {
+		stub := &stubEnricher{res: runtime.EnrichResult{ContName: "n1", Image: "img:2"}}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+		cont, err := mgr.EnrichCgroupInfo(7)
+		assert.NoError(t, err)
+		assert.Equal(t, "n1", cont.Name)
+		assert.Equal(t, "img:2", cont.Image)
+		assert.Equal(t, enrichTestCid, cont.ContainerId)
+		assert.Equal(t, now, cont.CreatedAt)
+		assert.Equal(t, runtime.Docker, cont.Runtime)
+		assert.Equal(t, cont, mgr.containerMap[enrichTestCid])
+		assert.Equal(t, int32(1), stub.calls.Load())
+	})
+}
+
+// TestEnrichCgroupInfoConcurrentReaders encodes the pipeline-stall regression:
+// while the enrichment RPC is in flight, readers (the signatures data source)
+// and the removal purge must proceed, not queue behind the RPC.
+func TestEnrichCgroupInfoConcurrentReaders(t *testing.T) {
+	stub := &stubEnricher{
+		res:     runtime.EnrichResult{ContName: "n"},
+		entered: make(chan struct{}, 1),
+		block:   make(chan struct{}),
+	}
+	mgr := newTestManager(t, stub)
+	seedContainer(mgr, 7, time.Now())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := mgr.EnrichCgroupInfo(7)
+		done <- err
+	}()
+	waitOrFatal(t, stub.entered, "enrichment RPC never entered")
+
+	dsDone := make(chan struct{})
+	go func() {
+		ds := NewDataSource(mgr)
+		for i := 0; i < 100; i++ {
+			if _, err := ds.Get(enrichTestCid); err != nil {
+				break
+			}
+		}
+		close(dsDone)
+	}()
+	waitOrFatal(t, dsDone, "data source Get blocked behind the enrichment RPC")
+
+	purgeDone := make(chan struct{})
+	go func() {
+		mgr.lock.Lock()
+		mgr.purgeExpired(time.Now())
+		mgr.lock.Unlock()
+		close(purgeDone)
+	}()
+	waitOrFatal(t, purgeDone, "purgeExpired blocked behind the enrichment RPC")
+
+	close(stub.block)
+	assert.NoError(t, waitOrFatal(t, done, "enrichment never completed"))
+	assert.Equal(t, "n", mgr.containerMap[enrichTestCid].Name)
+}
+
+// TestEnrichCgroupInfoConcurrentSameCgroup: with the lock released during the
+// RPC, two enrichments of the same cgroup may both pass the short-circuit and
+// both query - the outcome must be idempotent and deadlock-free.
+func TestEnrichCgroupInfoConcurrentSameCgroup(t *testing.T) {
+	stub := &stubEnricher{
+		res:     runtime.EnrichResult{ContName: "n", Image: "img:1"},
+		entered: make(chan struct{}, 2),
+		block:   make(chan struct{}),
+	}
+	mgr := newTestManager(t, stub)
+	seedContainer(mgr, 7, time.Now())
+
+	done := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, err := mgr.EnrichCgroupInfo(7)
+			done <- err
+		}()
+	}
+	waitOrFatal(t, stub.entered, "first enrichment never entered the RPC")
+	waitOrFatal(t, stub.entered, "second enrichment serialized behind the first RPC")
+
+	close(stub.block)
+	assert.NoError(t, waitOrFatal(t, done, "first enrichment never completed"))
+	assert.NoError(t, waitOrFatal(t, done, "second enrichment never completed"))
+	assert.Equal(t, "img:1", mgr.containerMap[enrichTestCid].Image)
+	assert.Equal(t, int32(2), stub.calls.Load())
+}
+
+// TestEnrichCgroupInfoConcurrentRemoval pins the no-resurrection semantics:
+// dead/expiry marks set while the RPC runs survive (the stale pre-RPC info is
+// not written back), and a cgroup purged mid-RPC is not reintroduced.
+func TestEnrichCgroupInfoConcurrentRemoval(t *testing.T) {
+	now := time.Now()
+
+	t.Run("dead mark set during RPC survives", func(t *testing.T) {
+		stub := &stubEnricher{
+			res:     runtime.EnrichResult{ContName: "n", Image: "img:1"},
+			entered: make(chan struct{}, 1),
+			block:   make(chan struct{}),
+		}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := mgr.EnrichCgroupInfo(7)
+			done <- err
+		}()
+		waitOrFatal(t, stub.entered, "enrichment RPC never entered")
+
+		mgr.lock.Lock()
+		info := mgr.cgroupsMap[7]
+		info.Dead = true
+		info.expiresAt = now.Add(30 * time.Second)
+		mgr.cgroupsMap[7] = info
+		mgr.lock.Unlock()
+
+		close(stub.block)
+		assert.NoError(t, waitOrFatal(t, done, "enrichment never completed"))
+		assert.True(t, mgr.cgroupsMap[7].Dead, "stale info snapshot written back cleared the Dead mark")
+		assert.False(t, mgr.cgroupsMap[7].expiresAt.IsZero())
+	})
+
+	t.Run("cgroup purged during RPC is not reintroduced", func(t *testing.T) {
+		stub := &stubEnricher{
+			res:     runtime.EnrichResult{ContName: "n", Image: "img:1"},
+			entered: make(chan struct{}, 1),
+			block:   make(chan struct{}),
+		}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := mgr.EnrichCgroupInfo(7)
+			done <- err
+		}()
+		waitOrFatal(t, stub.entered, "enrichment RPC never entered")
+
+		mgr.lock.Lock()
+		delete(mgr.cgroupsMap, 7)
+		delete(mgr.containerMap, enrichTestCid)
+		mgr.lock.Unlock()
+
+		close(stub.block)
+		assert.NoError(t, waitOrFatal(t, done, "enrichment never completed"))
+		_, exists := mgr.containerMap[enrichTestCid]
+		assert.False(t, exists, "purged container reintroduced by in-flight enrichment")
+	})
+
+	t.Run("container purged during RPC while a sub-cgroup entry lingers", func(t *testing.T) {
+		stub := &stubEnricher{
+			res:     runtime.EnrichResult{ContName: "n", Image: "img:1"},
+			entered: make(chan struct{}, 1),
+			block:   make(chan struct{}),
+		}
+		mgr := newTestManager(t, stub)
+		seedContainer(mgr, 7, now)
+		// enrichment keyed on a sub-cgroup dir of the same container
+		mgr.cgroupsMap[8] = CgroupDir{
+			Path: "/docker-" + enrichTestCid + ".scope/sub", ContainerId: enrichTestCid,
+			ContainerRoot: false, Ctime: now,
+		}
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := mgr.EnrichCgroupInfo(8)
+			done <- err
+		}()
+		waitOrFatal(t, stub.entered, "enrichment RPC never entered")
+
+		// root expiry purges the container and the root dir; the sub lingers
+		mgr.lock.Lock()
+		delete(mgr.cgroupsMap, 7)
+		delete(mgr.containerMap, enrichTestCid)
+		mgr.lock.Unlock()
+
+		close(stub.block)
+		assert.NoError(t, waitOrFatal(t, done, "enrichment never completed"))
+		_, exists := mgr.containerMap[enrichTestCid]
+		assert.False(t, exists,
+			"purged container resurrected with zero CreatedAt via a lingering sub-cgroup entry")
+	})
 }

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -2194,10 +2194,18 @@ func (t *Tracee) invokeInitEvents(ctx gocontext.Context, out chan *events.Pipeli
 
 	matchedPolicies = policiesMatch(events.InitNamespaces)
 	if matchedPolicies > 0 {
-		systemInfoEvent := events.InitNamespacesEvent()
-		setMatchedPolicies(&systemInfoEvent, matchedPolicies)
-		out <- events.NewPipelineEvent(&systemInfoEvent)
-		// Note: EventCount is incremented in sinkEvents stage, not here
+		// The values are authoritative host namespace ids for downstream
+		// consumers (e.g. escape-to-host signatures): drop the event with an
+		// error rather than emit zeroed ids. Failures here are deterministic
+		// (missing capability, hardened kernel), so there is no point retrying.
+		systemInfoEvent, err := events.InitNamespacesEvent()
+		if err != nil {
+			logger.Errorw("init_namespaces event dropped", "error", err)
+		} else {
+			setMatchedPolicies(&systemInfoEvent, matchedPolicies)
+			out <- events.NewPipelineEvent(&systemInfoEvent)
+			// Note: EventCount is incremented in sinkEvents stage, not here
+		}
 	}
 
 	// Initial existing containers events (1 event per container)

--- a/pkg/events/definition_test.go
+++ b/pkg/events/definition_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDefinition(t *testing.T) {
@@ -47,6 +48,13 @@ func TestNewDefinition(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	t.Parallel()
+
+	// Operate on a local group, not the global Core: Add mutates the
+	// registry, so a second in-process run (go test -count>1) would trip
+	// over the first run's additions. Seed the two collision targets.
+	group := NewDefinitionGroup()
+	require.NoError(t, group.Add(ID(700), Definition{id32Bit: ID(700), name: "existing_event"}))
+	require.NoError(t, group.Add(ID(710), Definition{id32Bit: ID(710), name: "net_packet"}))
 
 	tests := []struct {
 		name string
@@ -105,16 +113,16 @@ func TestAdd(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := Core.Add(test.evt.GetID32Bit(), test.evt)
+			err := group.Add(test.evt.GetID32Bit(), test.evt)
 			if err != nil {
 				assert.ErrorContains(t, err, test.err)
 				return
 			}
 
-			eventDefID, ok := Core.GetDefinitionIDByName(test.evt.GetName())
+			eventDefID, ok := group.GetDefinitionIDByName(test.evt.GetName())
 			assert.True(t, ok)
 
-			eventDefinition := Core.GetDefinitionByID(eventDefID)
+			eventDefinition := group.GetDefinitionByID(eventDefID)
 			assert.Equal(t, test.evt, eventDefinition)
 		})
 	}

--- a/pkg/events/usermode.go
+++ b/pkg/events/usermode.go
@@ -16,6 +16,7 @@
 package events
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -32,10 +33,16 @@ import (
 const InitProcNsDir = "/proc/1/ns"
 
 // InitNamespacesEvent collect the init process namespaces and create event from
-// them.
-func InitNamespacesEvent() trace.Event {
+// them. An error is returned instead of an event with zeroed namespace ids:
+// consumers treat the values as authoritative host namespace ids and silently
+// misbehave on zeros. Failures are deterministic on a given host (missing
+// capability, hardened kernel), so callers should log and drop, not retry.
+func InitNamespacesEvent() (trace.Event, error) {
 	initNamespacesDef := Core.GetDefinitionByID(InitNamespaces)
-	initNamespacesArgs := getInitNamespaceArguments()
+	initNamespacesArgs, err := getInitNamespaceArguments()
+	if err != nil {
+		return trace.Event{}, err
+	}
 
 	initNamespacesEvent := trace.Event{
 		Timestamp:   int(time.Now().UnixNano()),
@@ -46,7 +53,7 @@ func InitNamespacesEvent() trace.Event {
 		Args:        initNamespacesArgs,
 	}
 
-	return initNamespacesEvent
+	return initNamespacesEvent, nil
 }
 
 // TraceeInfoEvent exports data related to Tracee's initialization
@@ -71,10 +78,23 @@ func TraceeInfoEvent(bootTime uint64, startTime uint64) trace.Event {
 	return traceeInfoEvent
 }
 
+// requiredInitNamespaces exist on every supported kernel and are the ones
+// consumers compare against (switch_task_ns carries mnt/pid/uts/ipc/net/cgroup).
+// The remaining fields (user, time namespaces, pid_for_children) may
+// legitimately be absent (e.g. CONFIG_USER_NS=n) and default to 0.
+var requiredInitNamespaces = map[string]bool{
+	"cgroup": true, "ipc": true, "mnt": true, "net": true,
+	"pid": true, "uts": true,
+}
+
 // getInitNamespaceArguments fetches the namespaces of the init process and
-// parse them into event arguments.
-func getInitNamespaceArguments() []trace.Argument {
-	initNamespaces := fetchInitNamespaces()
+// parse them into event arguments. It errors if any always-present namespace
+// could not be resolved, rather than filling the argument with 0.
+func getInitNamespaceArguments() ([]trace.Argument, error) {
+	initNamespaces, err := fetchInitNamespaces()
+	if err != nil {
+		return nil, err
+	}
 	eventDefinition := Core.GetDefinitionByID(InitNamespaces)
 	initNamespacesArgs := make([]trace.Argument, len(eventDefinition.GetFields()))
 
@@ -82,34 +102,63 @@ func getInitNamespaceArguments() []trace.Argument {
 
 	for i, arg := range initNamespacesArgs {
 		arg.ArgMeta = fields[i].ArgMeta
-		arg.Value = initNamespaces[arg.Name]
+		value, ok := initNamespaces[arg.Name]
+		if !ok && requiredInitNamespaces[arg.Name] {
+			return nil, fmt.Errorf("init namespace %s could not be resolved from %s", arg.Name, InitProcNsDir)
+		}
+		arg.Value = value
 		initNamespacesArgs[i] = arg
 	}
 
-	return initNamespacesArgs
+	return initNamespacesArgs, nil
+}
+
+// initNsValueRe matches the bracketed inode of a /proc/*/ns symlink target,
+// e.g. "mnt:[4026531840]". (The previous ":[[[:digit:]]*]" form worked too -
+// the unescaped '[' was consumed by the character class - but only by
+// accident.)
+var initNsValueRe = regexp.MustCompile(`:\[[[:digit:]]+\]`)
+
+// parseNamespaceInode extracts the namespace inode from a /proc/*/ns symlink
+// target of the form "name:[inode]". Zero is never returned as a value.
+func parseNamespaceInode(link string) (uint32, error) {
+	trim := strings.Trim(initNsValueRe.FindString(link), "[]:")
+	namespaceNumber, err := strconv.ParseUint(trim, 10, 32)
+	if err != nil || namespaceNumber == 0 {
+		return 0, fmt.Errorf("malformed namespace link %q", link)
+	}
+	return uint32(namespaceNumber), nil
 }
 
 // fetchInitNamespaces fetches the namespaces values from the /proc/1/ns
-// directory
-func fetchInitNamespaces() map[string]uint32 {
-	var err error
-	var namespacesLinks []os.DirEntry
-
+// directory. Entries that cannot be read or parsed are omitted (never stored
+// as 0); an error is returned when nothing could be read at all.
+func fetchInitNamespaces() (map[string]uint32, error) {
 	initNamespacesMap := make(map[string]uint32)
-	namespaceValueReg := regexp.MustCompile(":[[[:digit:]]*]")
 
-	namespacesLinks, err = os.ReadDir(InitProcNsDir)
+	namespacesLinks, err := os.ReadDir(InitProcNsDir)
 	if err != nil {
-		logger.Errorw("fetching init namespaces", "error", err)
+		return nil, fmt.Errorf("fetching init namespaces: %w", err)
 	}
 	for _, namespaceLink := range namespacesLinks {
-		linkString, _ := os.Readlink(filepath.Join(InitProcNsDir, namespaceLink.Name()))
-		trim := strings.Trim(namespaceValueReg.FindString(linkString), "[]:")
-		namespaceNumber, _ := strconv.ParseUint(trim, 10, 32)
-		initNamespacesMap[namespaceLink.Name()] = uint32(namespaceNumber)
+		linkString, err := os.Readlink(filepath.Join(InitProcNsDir, namespaceLink.Name()))
+		if err != nil {
+			// per-entry detail only; the caller's aggregate error carries the consequence
+			logger.Debugw("reading init namespace link", "namespace", namespaceLink.Name(), "error", err)
+			continue
+		}
+		namespaceNumber, err := parseNamespaceInode(linkString)
+		if err != nil {
+			logger.Debugw("parsing init namespace link", "namespace", namespaceLink.Name(), "error", err)
+			continue
+		}
+		initNamespacesMap[namespaceLink.Name()] = namespaceNumber
+	}
+	if len(initNamespacesMap) == 0 {
+		return nil, fmt.Errorf("no init namespaces could be read from %s", InitProcNsDir)
 	}
 
-	return initNamespacesMap
+	return initNamespacesMap, nil
 }
 
 // ExistingContainersEvents returns a list of events for each existing container

--- a/pkg/events/usermode_test.go
+++ b/pkg/events/usermode_test.go
@@ -1,0 +1,39 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseNamespaceInode pins the /proc/*/ns symlink-target parse: real
+// targets must yield their inode, malformed ones must error (never 0-as-value,
+// which downstream consumers treat as authoritative).
+func TestParseNamespaceInode(t *testing.T) {
+	t.Parallel()
+
+	valid := map[string]uint32{
+		"mnt:[4026531840]":    4026531840,
+		"pid:[4026531836]":    4026531836,
+		"cgroup:[4026531835]": 4026531835,
+		"time:[4026531834]":   4026531834,
+	}
+	for link, want := range valid {
+		got, err := parseNamespaceInode(link)
+		assert.NoError(t, err, link)
+		assert.Equal(t, want, got, link)
+	}
+
+	malformed := []string{
+		"",
+		"garbage",
+		"mnt:[]",
+		"mnt:[0]",
+		"mnt:4026531840",
+		"mnt:[abc]",
+	}
+	for _, link := range malformed {
+		_, err := parseNamespaceInode(link)
+		assert.Error(t, err, link)
+	}
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/aquasecurity/tracee/pkg/events"
 	"github.com/aquasecurity/tracee/tests/testutils"
@@ -15,8 +16,14 @@ func Test_InitNamespacesEvent(t *testing.T) {
 
 	testutils.AssureIsRoot(t)
 
-	procNamespaces := [...]string{"mnt", "cgroup", "pid", "pid_for_children", "time", "time_for_children", "user", "ipc", "net", "uts"}
-	evts := events.InitNamespacesEvent()
+	// Mirrors requiredInitNamespaces in pkg/events/usermode.go: present and
+	// non-zero on every supported kernel.
+	requiredNamespaces := [...]string{"cgroup", "ipc", "mnt", "net", "pid", "uts"}
+	// May legitimately be 0 (CONFIG_USER_NS=n, pre-5.6 time namespaces).
+	optionalNamespaces := [...]string{"pid_for_children", "time", "time_for_children", "user"}
+
+	evts, err := events.InitNamespacesEvent()
+	require.NoError(t, err)
 	initNamespaces := make(map[string]uint32)
 
 	for _, arg := range evts.Args {
@@ -25,8 +32,11 @@ func Test_InitNamespacesEvent(t *testing.T) {
 		initNamespaces[arg.Name] = namespaceVale
 	}
 
-	for _, namespace := range procNamespaces {
+	for _, namespace := range requiredNamespaces {
 		assert.Contains(t, initNamespaces, namespace)
 		assert.NotZero(t, initNamespaces[namespace])
+	}
+	for _, namespace := range optionalNamespaces {
+		assert.Contains(t, initNamespaces, namespace)
 	}
 }


### PR DESCRIPTION
### 1. Explain what the PR does

dbdda1402 **fix(tests): make TestAdd hermetic**

> The test called Add on the global Core registry, so the successful
> "new definition" case permanently registered id 6000/new_event and any
> in-process rerun (go test -count>1) tripped over the leftovers.
> 
> Run the same cases against a local DefinitionGroup seeded with the two
> collision targets instead.

--

9e4a77264 **fix(containers): don't hold the manager lock across the enrichment RPC**

> EnrichCgroupInfo held the manager's write lock for the whole
> container-runtime query (10s context deadline). Every reader blocks
> behind it: the decode stage's cgroup lookup and signature data-source
> queries stall for up to the RPC deadline whenever a runtime daemon is
> slow, backpressuring the pipeline and, with several containers
> enriching concurrently, risking kernel-side event drops.
> 
> Snapshot and validate under the lock, release it for the RPC, then
> re-acquire to merge. The merge lands on the CURRENT entry (a
> concurrent cgroupUpdate may have improved CreatedAt/Runtime while the
> RPC ran), and the pre-RPC info snapshot is no longer written back to
> cgroupsMap - after unlocking it can be stale and would clear a
> concurrent CgroupRemove's dead/expiry marks.
> 
> Tests (race-detector clean): the lock is free during the RPC; the
> signatures data source and the removal purge proceed while an RPC is
> in flight; two concurrent enrichments of the same cgroup stay
> idempotent and deadlock-free; dead/expiry marks set mid-RPC survive; a
> cgroup purged mid-RPC is not reintroduced; and a behaviour table pins
> every early-return path (unknown cgroup, non-container, dead, already
> enriched, enricher error) plus the happy-path merge semantics.
> 
> The post-RPC re-check requires both the cgroup and the container
> entries to still exist, so a container purged mid-RPC - even with a
> lingering sub-cgroup entry keyed to the same container - is not
> resurrected with zero CreatedAt/Runtime.
> 
> A container that is no longer tracked (purged while a stale cgroup
> entry lingers) returns early before the RPC - its zero Runtime would
> otherwise make the service try every registered enricher for a
> container that no longer exists.

--

12e4355cc **fix(containers): keep CreatedAt and enrichment stable across cgroup churn**

> A container's containerMap entry was rebuilt or dropped by unrelated
> cgroup-dir activity, corrupting CreatedAt - which drift detections
> compare file ctimes against - and the Name/Image/Pod enrichment:
> 
> - cgroupUpdate overwrote the entry for EVERY cgroup dir of the
>   container: a child dir or a lazy GetCgroupInfo stat processed later
>   moved CreatedAt forward (observed 156ms past the container's own
>   first events) and wiped the enrichment.
> 
> - CgroupRemove's deferred purge deleted the entry for ANY expired
>   cgroup dir of the container: a transient sub-cgroup removed inside a
>   live container (systemd-in-container scopes, kubelet churn) purged
>   it ~30s later, and the next lookup rebuilt it with the lookup-time
>   ctime - postdated by the container's whole lifetime - and empty
>   enrichment. It also deleted the containerMap[""] catch-all whenever
>   an expired entry was already gone from cgroupsMap.
> 
> cgroupUpdate now preserves the existing entry's enrichment, keeps the
> earliest CreatedAt, and keeps the previously parsed runtime when the
> update carries none. The purge (extracted to purgeExpired, with a
> regression test) removes the container entry only when the expired dir
> is the container root. Trade-off: if a root cgroup_rmdir is lost, the
> entry now lingers until process exit (before, any sub-cgroup expiry
> would incidentally collect it) - entries are small and that situation
> was already an event-loss anomaly.

--

9bff80720 **fix(events): never emit init_namespaces with zeroed namespace ids**

> fetchInitNamespaces swallowed every error: a failed ReadDir yielded an
> empty map, a failed Readlink/ParseUint stored 0, and the arg builder
> filled missing fields with 0. Consumers treat these values as the
> authoritative host namespace ids, so a transient /proc/1/ns read
> failure at startup silently disabled namespace-escape detections for
> the whole run (observed in e2e artifacts: all ten args zero).
> 
> Skip unreadable entries (per-entry detail at debug level), error when
> an always-present namespace (cgroup/ipc/mnt/net/pid/uts) is
> unresolved, and keep the user/time namespaces optional
> (CONFIG_USER_NS=n, pre-5.6 kernels). The emitter drops the event with
> a single error log - the one operator-visible line, since a detection
> class going dark must not be silent - instead of emitting zeros. No
> retries: the transient cause (a Specific() window stripping a base
> capability) is fixed by the previous commit, and the remaining failure
> modes (capability deliberately dropped, hardened kernel) are
> deterministic.
> 
> Cost: the happy path is unchanged (same reads plus a 6-entry map
> lookup per field, once at startup); log output is bounded to at most
> ~11 lines once per process start on a broken host, zero on a healthy
> one. No added memory.
> 
> The namespace-inode parse is factored into parseNamespaceInode with an
> intent-revealing regex - the previous ":[[[:digit:]]*]" form matched
> correctly, but only because the unescaped bracket landed inside the
> character class - and is pinned by unit tests.
> 
> The integration test asserts non-zero ids only for the required
> namespaces; the optional ones (user, time namespaces, pid_for_children)
> are asserted present but may legitimately be 0 on older kernels or
> CONFIG_USER_NS=n - old-kernel CI legs would otherwise fail a healthy
> host.

--

3498b2ccc **fix(capabilities): keep base ring caps effective in Specific() windows**

> Specific() unset the requested caps from the Specific ring after
> applying it, even when they are base-ring caps. Since baseRingAdd
> propagates base caps to every ring, the first Specific(cb, SYS_PTRACE)
> permanently stripped SYS_PTRACE from the Specific ring: every later
> Specific() call then dropped it from the process-wide effective set
> for the duration of its callback, breaking concurrent goroutines that
> rely on base caps - the suspected cause of observed all-zero
> init_namespaces events (/proc/1/ns readlinks failing during another
> goroutine's Specific() window).
> 
> Only unset caps that are not base-ring members, preserving the
> invariant that every ring contains the base caps, and add a regression
> test pinning it (existing tests only exercised non-base caps).

--



### 2. Explain how to test it


### 3. Other comments

