### PR TITLE
fix(events): coalesce ftrace hook wakeup instead of dropping it

### DIFF
--- a/pkg/events/ftrace.go
+++ b/pkg/events/ftrace.go
@@ -36,7 +36,18 @@ const (
 
 var (
 	reportedFtraceHooks *lru.Cache[string, []trace.Argument]
-	FtraceWakeupChan    = make(chan struct{})
+	// Buffered (size 1) so a module-load wakeup is COALESCED rather than
+	// dropped when the scanner goroutine is mid-scan. The sender
+	// (processDoInitModule) still does a non-blocking select-send, so this does
+	// NOT reintroduce the pipeline deadlock fixed in #5341 - a full buffer just
+	// falls through to its default. With an unbuffered channel the send lands
+	// only if the scanner happens to be parked in its select at that instant;
+	// under a slow/CPU-starved scanner it is missed, and detection then relies
+	// on the random 10-300s timer, which rarely fires inside the module's brief
+	// hook window (observed as 0 ftrace_hook events under QEMU/TCG). One slot is
+	// enough: coalescing many loads into a single pending re-scan is correct,
+	// since each scan reads the whole enabled_functions.
+	FtraceWakeupChan = make(chan struct{}, 1)
 )
 
 func init() {


### PR DESCRIPTION
### 1. Explain what the PR does

bae455649 **fix(events): coalesce ftrace hook wakeup instead of dropping it**

> FtraceWakeupChan was unbuffered, so the module-load wakeup sent by
> processDoInitModule - a non-blocking select-send since #5341 - only
> landed if the scanner goroutine happened to be parked in its select at
> that instant. Under a slow or CPU-starved scanner the wakeup was missed
> and ftrace-hook detection fell back to the random 10-300s timer, which
> rarely fires inside a module's brief hook window; a transient ftrace
> hook could load and unload without ever being detected (reproducible as
> 0 ftrace_hook events under QEMU/TCG software emulation).
> 
> Make the channel buffered (size 1) so a wakeup is retained and coalesced
> into a single pending re-scan rather than dropped. The sender still does
> a non-blocking send, so a full buffer simply falls through its default -
> this does not reintroduce the pipeline deadlock fixed in #5341. One slot
> suffices: each scan reads the whole enabled_functions, so coalescing
> multiple loads into one re-scan is correct.

--

### 2. Explain how to test it

<!--
Maintainer will review the code, and test the fix/feature, how to run Tracee ?
Give a full command line example and what to look for.
-->

### 3. Other comments

<!--
Links? References? Anything pointing to more context about the change.
-->
