### PR TITLE
fix(detectors): match the per-thread /proc/<pid>/task/<tid>/mem alias

### DIFF
--- a/detectors/proc_mem_access.go
+++ b/detectors/proc_mem_access.go
@@ -21,7 +21,10 @@ type ProcMemAccess struct {
 	compiledRegex *regexp.Regexp
 }
 
-const procMemPathPattern = `/proc/(?:\d+|self)/mem$`
+// Matches both the per-process file and the per-thread alias. Threads share an
+// mm_struct, so /proc/<pid>/task/<tid>/mem grants the same access as
+// /proc/<pid>/mem, and /proc/thread-self/mem resolves to it.
+const procMemPathPattern = `/proc/(?:\d+|self|thread-self)(?:/task/(?:\d+|self))?/mem$`
 
 func (d *ProcMemAccess) GetDefinition() detection.DetectorDefinition {
 	return detection.DetectorDefinition{

--- a/detectors/proc_mem_access_test.go
+++ b/detectors/proc_mem_access_test.go
@@ -34,6 +34,24 @@ func TestProcMemAccess(t *testing.T) {
 			expectedOutput: true,
 		},
 		{
+			name:           "read /proc/1234/task/1235/mem",
+			pathname:       "/proc/1234/task/1235/mem",
+			flags:          0, // O_RDONLY
+			expectedOutput: true,
+		},
+		{
+			name:           "read /proc/thread-self/mem",
+			pathname:       "/proc/thread-self/mem",
+			flags:          0, // O_RDONLY
+			expectedOutput: true,
+		},
+		{
+			name:           "read /proc/1234/task/1235/maps - should not trigger",
+			pathname:       "/proc/1234/task/1235/maps",
+			flags:          0, // O_RDONLY
+			expectedOutput: false,
+		},
+		{
 			name:           "write /proc/1234/mem - should not trigger",
 			pathname:       "/proc/1234/mem",
 			flags:          1, // O_WRONLY

--- a/detectors/proc_mem_code_injection.go
+++ b/detectors/proc_mem_code_injection.go
@@ -21,7 +21,10 @@ type ProcMemCodeInjection struct {
 	compiledRegex *regexp.Regexp
 }
 
-const procMemCodeInjectionPattern = `/proc/(?:\d+|self)/mem$`
+// Matches both the per-process file and the per-thread alias. Threads share an
+// mm_struct, so /proc/<pid>/task/<tid>/mem grants the same access as
+// /proc/<pid>/mem, and /proc/thread-self/mem resolves to it.
+const procMemCodeInjectionPattern = `/proc/(?:\d+|self|thread-self)(?:/task/(?:\d+|self))?/mem$`
 
 func (d *ProcMemCodeInjection) GetDefinition() detection.DetectorDefinition {
 	return detection.DetectorDefinition{

--- a/detectors/proc_mem_code_injection_test.go
+++ b/detectors/proc_mem_code_injection_test.go
@@ -34,6 +34,24 @@ func TestProcMemCodeInjection(t *testing.T) {
 			expectedOutput: true,
 		},
 		{
+			name:           "write /proc/1234/task/1235/mem",
+			pathname:       "/proc/1234/task/1235/mem",
+			flags:          1, // O_WRONLY
+			expectedOutput: true,
+		},
+		{
+			name:           "write /proc/thread-self/mem",
+			pathname:       "/proc/thread-self/mem",
+			flags:          1, // O_WRONLY
+			expectedOutput: true,
+		},
+		{
+			name:           "write /proc/1234/task/1235/maps - should not trigger",
+			pathname:       "/proc/1234/task/1235/maps",
+			flags:          1, // O_WRONLY
+			expectedOutput: false,
+		},
+		{
 			name:           "read /proc/1234/mem - should not trigger",
 			pathname:       "/proc/1234/mem",
 			flags:          0, // O_RDONLY


### PR DESCRIPTION
### 1. Explain what the PR does

`TRC-1023` (`proc_mem_access`) and `TRC-1024` (`proc_mem_code_injection`) match on:

```go
const procMemPathPattern = `/proc/(?:\d+|self)/mem$`
```

That misses the per-thread alias. Threads in a process share an `mm_struct`, so writing to `/proc/<pid>/task/<tid>/mem` is the same primitive as writing to `/proc/<pid>/mem`, and `/proc/thread-self/mem` resolves to it. Neither currently raises a detection, so the evasion is silent: no alert, no warning, nothing in the logs.

This widens both patterns to accept an optional `/task/<tid>` segment and `thread-self`, and adds cases for both to each detector's table. I kept the matching `/maps` paths as negative controls so the anchor stays tight and the guard cannot quietly broaden.

Worth noting the codebase already models this path shape elsewhere: `common/proc/formatters.go` builds `/proc/<pid>/task/<tid>/` for tracee's own proctree reads.

### 2. Explain how to test it

```
cd detectors
go test ./... -count=1
```

Fail-before, with only the regex reverted to its current form and the new test cases left in place:

```
--- FAIL: TestProcMemCodeInjection/write_/proc/thread-self/mem
--- FAIL: TestProcMemCodeInjection/write_/proc/1234/task/1235/mem
--- FAIL: TestProcMemAccess/read_/proc/thread-self/mem
--- FAIL: TestProcMemAccess/read_/proc/1234/task/1235/mem
FAIL	github.com/aquasecurity/tracee/detectors
```

Pass-after:

```
ok  	github.com/aquasecurity/tracee/detectors	0.008s
```

`gofmt -l .` and `go vet ./...` are both clean. Note the module needs Go 1.26 per `detectors/go.mod`, and it does not build on macOS because of the Linux-only syscalls in `common/`, so I ran the above in a `golang:1.26` container rather than on the host.

End to end, a write to `/proc/<pid>/task/<tid>/mem` in a container should now raise `proc_mem_code_injection` where previously it raised nothing.

### 3. Other comments

While looking at this I noticed the released line has the opposite gap. In v0.24.1 the pattern is:

```go
sig.procMemPathPattern = `/proc/(?:\d.+)/mem$`
```

`\d.+` requires at least one character after the first digit, so a single-digit PID never matches and `/proc/1/mem` is missed. In a container the low PIDs are exactly the single-digit range and PID 1 is usually the application itself, so that one is worth knowing about even though `da8e1b0c9` already fixed it on main as a side effect of the detector migration. That commit traded the single-digit gap for the per-thread gap, which is what this PR closes. It may be worth a line in the release notes that v0.9.0 through v0.24.1 miss single-digit PIDs.

No design review link: this is a detection-coverage fix with no API or schema change. N/A.
